### PR TITLE
UI branch cleanup

### DIFF
--- a/bisqapps/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
+++ b/bisqapps/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
@@ -1,8 +1,11 @@
 package network.bisq.mobile.client
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.MainPresenter
@@ -15,6 +18,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         presenter.attachView(this)
+        enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT), SystemBarStyle.dark(Color.TRANSPARENT))
 
         setContent {
             App()

--- a/bisqapps/androidNode/build.gradle.kts
+++ b/bisqapps/androidNode/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(compose.preview)
+            implementation(libs.navigation.compose)
             implementation(libs.androidx.activity.compose)
         }
         val androidMain by getting {
@@ -122,6 +123,7 @@ protobuf {
 dependencies {
     implementation(project(":shared:presentation"))
     implementation(project(":shared:domain"))
+    implementation(libs.navigation.compose)
     debugImplementation(compose.uiTooling)
 
     // bisq2 core dependencies

--- a/bisqapps/androidNode/build.gradle.kts
+++ b/bisqapps/androidNode/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(compose.preview)
-            implementation(libs.navigation.compose)
             implementation(libs.androidx.activity.compose)
         }
         val androidMain by getting {
@@ -123,7 +122,6 @@ protobuf {
 dependencies {
     implementation(project(":shared:presentation"))
     implementation(project(":shared:domain"))
-    implementation(libs.navigation.compose)
     debugImplementation(compose.uiTooling)
 
     // bisq2 core dependencies

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -5,11 +5,13 @@ import network.bisq.mobile.android.node.domain.bootstrap.NodeApplicationBootstra
 import network.bisq.mobile.android.node.domain.data.repository.NodeGreetingRepository
 import network.bisq.mobile.android.node.domain.user_profile.NodeUserProfileServiceFacade
 import network.bisq.mobile.android.node.presentation.NodeMainPresenter
+import network.bisq.mobile.android.node.presentation.OnBoardingNodePresenter
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.domain.data.repository.main.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -32,4 +34,6 @@ val androidNodeModule = module {
     // this line showcases both, the possibility to change behaviour of the app by changing one definition
     // and binding the same obj to 2 different abstractions
     single<MainPresenter> { NodeMainPresenter(get(), get(), get()) } bind AppPresenter::class
+
+    single<IOnboardingPresenter> { OnBoardingNodePresenter(get()) } bind IOnboardingPresenter::class
 }

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -9,23 +9,16 @@ import network.bisq.mobile.presentation.MainPresenter
 class NodeMainPresenter(
     private val supplier: AndroidApplicationService.Supplier,
     private val androidMemoryReportService: AndroidMemoryReportService,
-    private val applicationBootstrapFacade: ApplicationBootstrapFacade
+    applicationBootstrapFacade: ApplicationBootstrapFacade
 ) : MainPresenter(applicationBootstrapFacade) {
 
-    var applicationServiceInited = false
-    override fun onViewAttached() {
-//        full override
-//        super.onViewAttached()
-
-        if (!applicationServiceInited) {
-            applicationServiceInited = true
-            val context = (view as Activity).applicationContext
-            val filesDirsPath = (view as Activity).filesDir.toPath()
-            supplier.applicationService =
-                AndroidApplicationService(androidMemoryReportService, filesDirsPath)
-            applicationBootstrapFacade.initialize()
-            supplier.applicationService.initialize()
-        }
+    override fun initializeServices() {
+        val context = (view as Activity).applicationContext
+        val filesDirsPath = (view as Activity).filesDir.toPath()
+        supplier.applicationService =
+            AndroidApplicationService(androidMemoryReportService, filesDirsPath)
+        supplier.applicationService.initialize()
+        super.initializeServices()
     }
 
     override fun onDestroying() {

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/OnBoardingNodePresenter.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/OnBoardingNodePresenter.kt
@@ -1,0 +1,11 @@
+package network.bisq.mobile.android.node.presentation
+
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
+import network.bisq.mobile.presentation.ui.uicases.startup.OnBoardingPresenter
+
+class OnBoardingNodePresenter(
+    mainPresenter: MainPresenter
+) : OnBoardingPresenter(mainPresenter), IOnboardingPresenter {
+    override val indexesToShow = listOf(1, 2)
+}

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -13,7 +13,7 @@ import network.bisq.mobile.presentation.ui.AppPresenter
  */
 open class MainPresenter(private val applicationBootstrapFacade: ApplicationBootstrapFacade) : BasePresenter(null), AppPresenter {
     lateinit var navController: NavHostController
-        private set
+    private set
 
     override fun setNavController(controller: NavHostController) {
         navController = controller
@@ -24,32 +24,37 @@ open class MainPresenter(private val applicationBootstrapFacade: ApplicationBoot
     private val _isContentVisible = MutableStateFlow(false)
     override val isContentVisible: StateFlow<Boolean> = _isContentVisible
 
-   private var applicationServiceInited = false
-    override fun onViewAttached() {
-        super.onViewAttached()
-
-        if (!applicationServiceInited) {
-            applicationServiceInited = true
-            applicationBootstrapFacade.initialize()
-        }
-    }
+    private var applicationServiceInited = false
 
     // passthrough example
-//    private val _greetingText: StateFlow<String> = stateFlowFromRepository(
-//        repositoryFlow = greetingRepository.data,
-//        transform = { it?.greet() ?: "" },
-//        initialValue = "Welcome!"
-//    )
-//    override val greetingText: StateFlow<String> = _greetingText
+    //    private val _greetingText: StateFlow<String> = stateFlowFromRepository(
+    //        repositoryFlow = greetingRepository.data,
+    //        transform = { it?.greet() ?: "" },
+    //        initialValue = "Welcome!"
+    //    )
+    //    override val greetingText: StateFlow<String> = _greetingText
 
     init {
         log.i { "Shared Version: ${BuildConfig.SHARED_LIBS_VERSION}" }
         log.i { "iOS Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Node Version: ${BuildNodeConfig.APP_VERSION}" }
-//        CoroutineScope(BackgroundDispatcher).launch {
-//            greetingRepository.create(Greeting())
-//        }
+    //        CoroutineScope(BackgroundDispatcher).launch {
+    //            greetingRepository.create(Greeting())
+    //        }
+    }
+
+    override fun onViewAttached() {
+        super.onViewAttached()
+
+        if (!applicationServiceInited) {
+            initializeServices()
+            applicationServiceInited = true
+        }
+    }
+
+    protected open fun initializeServices() {
+        applicationBootstrapFacade.initialize()
     }
 
     // Toggle action

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -47,7 +47,6 @@ fun App() {
     }
 
     val lyricist = rememberStrings()
-    // lyricist.languageTag = Locales.FR
 
     BisqTheme(darkTheme = true) {
         ProvideStrings(lyricist) {

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -51,9 +51,7 @@ fun App() {
     BisqTheme(darkTheme = true) {
         ProvideStrings(lyricist) {
             if (isNavControllerSet) {
-                RootNavGraph(
-                    startDestination = Routes.Splash.name
-                )
+                RootNavGraph()
             }
         }
     }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/README.md
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/README.md
@@ -1,0 +1,17 @@
+# Components
+
+This folder has all components that can be (re)used across the application
+
+### Atoms
+ - This are very simplistic controls, that shows / does just one simple thing.
+ - They are mostly extensions of basic Compose components like text, button, etc.,, that are customized with Bisq look and feel.
+ - They are not aware of Presenter or any state management classes.
+
+### Molecules
+ [TODO]
+
+### Organisms
+ [TODO]
+
+### Layout
+ - Container layout components

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Button.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Button.kt
@@ -11,26 +11,29 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
-// TODO:
-// leftIcon, rightIcon -> Not happening right
-// Icon Button should be a separate component?
+/**
+ * Either pass
+ *  - text for regular button (or)
+ *  - iconOnly for Icon only button.
+ * If both are given, iconOnly takes precedence
+ */
 @Composable
 fun BisqButton(
-    text: String,
+    text: String? = "Button",
     onClick: () -> Unit,
     color: Color = BisqTheme.colors.light1,
     backgroundColor: Color = BisqTheme.colors.primary,
     padding: PaddingValues = PaddingValues(horizontal = 48.dp, vertical = 4.dp),
+    iconOnly: (@Composable () -> Unit)? = null,
     leftIcon: (@Composable () -> Unit)? = null,
-    rightIcon:(@Composable () -> Unit)? = null,
+    rightIcon: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
     cornerRadius: Dp = 8.dp
 ) {
 
-    // Apply proper rounded corner
     Button(
         onClick = { onClick() },
-        contentPadding = padding,
+        contentPadding = if(iconOnly != null) PaddingValues(horizontal = 0.dp, vertical = 0.dp) else padding,
         colors = ButtonColors(
             containerColor = backgroundColor,
             disabledContainerColor = backgroundColor,
@@ -38,15 +41,23 @@ fun BisqButton(
             disabledContentColor = color),
         shape = RoundedCornerShape(cornerRadius),
     ) {
-        Row {
-            if(leftIcon != null) leftIcon()
-            if(leftIcon != null) Spacer(modifier = Modifier.width(10.dp))
-            BisqText.baseMedium(
-                text = text,
-                color = BisqTheme.colors.light1,
-                )
-            if(rightIcon != null) Spacer(modifier = Modifier.width(10.dp))
-            if(rightIcon != null) rightIcon()
+        if (iconOnly == null && text == null) {
+            BisqText.baseMedium("Error: Pass either text or icon")
+        }
+
+        if (iconOnly != null) {
+            iconOnly()
+        } else if (text != null) {
+            Row {
+                if(leftIcon != null) leftIcon()
+                if(leftIcon != null) Spacer(modifier = Modifier.width(10.dp))
+                BisqText.baseMedium(
+                    text = text,
+                    color = BisqTheme.colors.light1,
+                    )
+                if(rightIcon != null) Spacer(modifier = Modifier.width(10.dp))
+                if(rightIcon != null) rightIcon()
+            }
         }
     }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Button.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Button.kt
@@ -1,16 +1,19 @@
 package network.bisq.mobile.presentation.ui.components.atoms
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 // TODO:
 // leftIcon, rightIcon -> Not happening right
+// Icon Button should be a separate component?
 @Composable
 fun BisqButton(
     text: String,
@@ -18,9 +21,10 @@ fun BisqButton(
     color: Color = BisqTheme.colors.light1,
     backgroundColor: Color = BisqTheme.colors.primary,
     padding: PaddingValues = PaddingValues(horizontal = 48.dp, vertical = 4.dp),
-    leftIcon: Unit? = null,
-    rightIcon: Unit? = null,
-    modifier: Modifier = Modifier
+    leftIcon: (@Composable () -> Unit)? = null,
+    rightIcon:(@Composable () -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    cornerRadius: Dp = 8.dp
 ) {
 
     // Apply proper rounded corner
@@ -31,17 +35,18 @@ fun BisqButton(
             containerColor = backgroundColor,
             disabledContainerColor = backgroundColor,
             contentColor = color,
-            disabledContentColor = color)
+            disabledContentColor = color),
+        shape = RoundedCornerShape(cornerRadius),
     ) {
         Row {
-            if(leftIcon != null) leftIcon
+            if(leftIcon != null) leftIcon()
             if(leftIcon != null) Spacer(modifier = Modifier.width(10.dp))
             BisqText.baseMedium(
                 text = text,
                 color = BisqTheme.colors.light1,
                 )
             if(rightIcon != null) Spacer(modifier = Modifier.width(10.dp))
-            if(rightIcon != null) rightIcon
+            if(rightIcon != null) rightIcon()
         }
     }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import network.bisq.mobile.components.MaterialTextField
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
-// TODO: Label suffix component
 @Composable
 fun BisqTextField(
     label: String,

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -1,0 +1,39 @@
+package network.bisq.mobile.presentation.ui.components.atoms
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import network.bisq.mobile.components.MaterialTextField
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+
+// TODO: Label suffix component
+@Composable
+fun BisqTextField(
+    label: String,
+    value: String,
+    onValueChanged: (String) -> Unit,
+    placeholder: String?,
+    labelRightSuffix: (@Composable () -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row (
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BisqText.baseRegular(
+                text = label,
+                color = BisqTheme.colors.light2,
+                )
+            if (labelRightSuffix != null) {
+                labelRightSuffix()
+            }
+        }
+        MaterialTextField(
+            text = value,
+            placeholder = placeholder ?: "",
+            onValueChanged = { onValueChanged(it) })
+    }
+}

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
@@ -17,8 +17,17 @@ fun UserIcon(modifier: Modifier = Modifier) {
     Image(painterResource(Res.drawable.img_bot_image), "User icon", modifier = modifier)
 }
 
-
 @Composable
 fun SortIcon(modifier: Modifier = Modifier) {
     Image(painterResource(Res.drawable.icon_sort), "Sort icon", modifier = modifier)
+}
+
+@Composable
+fun CopyIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.icon_copy), "Copy icon", modifier = modifier)
+}
+
+@Composable
+fun ScanIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.icon_qr), "Scan icon", modifier = modifier)
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
@@ -13,8 +13,18 @@ fun BellIcon(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun UserIcon(modifier: Modifier = Modifier) {
-    Image(painterResource(Res.drawable.img_bot_image), "User icon", modifier = modifier)
+fun CopyIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.icon_copy), "Copy icon", modifier = modifier)
+}
+
+@Composable
+fun QuestionIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.icon_question_mark), "Question icon", modifier = modifier)
+}
+
+@Composable
+fun ScanIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.icon_qr), "Scan icon", modifier = modifier)
 }
 
 @Composable
@@ -23,11 +33,6 @@ fun SortIcon(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun CopyIcon(modifier: Modifier = Modifier) {
-    Image(painterResource(Res.drawable.icon_copy), "Copy icon", modifier = modifier)
-}
-
-@Composable
-fun ScanIcon(modifier: Modifier = Modifier) {
-    Image(painterResource(Res.drawable.icon_qr), "Scan icon", modifier = modifier)
+fun UserIcon(modifier: Modifier = Modifier) {
+    Image(painterResource(Res.drawable.img_bot_image), "User icon", modifier = modifier)
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
@@ -12,20 +12,27 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
-fun BisqScrollLayout(
+fun BisqScrollScaffold(
     innerPadding: PaddingValues = PaddingValues(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
-    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = verticalArrangement ?: Arrangement.Top,
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = BisqTheme.colors.backgroundColor)
-            .padding(innerPadding)
-            .verticalScroll(rememberScrollState())
-    ) {
-        content()
-    }
+    Scaffold(
+        containerColor = BisqTheme.colors.backgroundColor,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        content = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = BisqTheme.colors.backgroundColor)
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                content()
+            }
+        },
+    )
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
@@ -10,22 +10,27 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
-fun BisqStaticLayout(
+fun BisqStaticScaffold(
     innerPadding: PaddingValues = PaddingValues(top = 48.dp, bottom = 30.dp),
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit
 ) {
     Scaffold(
         containerColor = BisqTheme.colors.backgroundColor,
-    ) {
-        Column(
-            verticalArrangement = Arrangement.SpaceBetween,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(color = BisqTheme.colors.backgroundColor)
-                .padding(innerPadding)
-        ) {
+        topBar = topBar,
+        bottomBar = bottomBar,
+        content = {
+            Column(
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = BisqTheme.colors.backgroundColor)
+                    .padding(innerPadding)
+            ) {
                 content()
+            }
         }
-    }
+    )
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/Form.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/Form.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.ui.components.molecules
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun BisqForm() {
+    Text("TODO: Form implementation")
+}

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/startup/BisqPagerView.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/startup/BisqPagerView.kt
@@ -1,0 +1,146 @@
+package network.bisq.mobile.presentation.ui.components.organisms.startup
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
+import network.bisq.mobile.presentation.ui.theme.*
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BisqPagerView(pagerState: PagerState, pageItems: List<PagerViewItem>) {
+
+    CompositionLocalProvider(values = arrayOf()) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(36.dp, Alignment.CenterVertically),
+            ) {
+            HorizontalPager(
+                pageSpacing = 56.dp,
+                contentPadding = PaddingValues(horizontal = 36.dp),
+                pageSize = PageSize.Fill,
+                verticalAlignment = Alignment.CenterVertically,
+                state = pagerState
+            ) { index ->
+                pageItems.getOrNull(
+                    index % (pageItems.size)
+                )?.let { item ->
+                    PagerSingleItem(
+                        image = item.image,
+                        title = item.title,
+                        desc = item.desc,
+                        index = index,
+                        )
+                }
+            }
+                PagerLineIndicator(pagerState = pagerState)
+        }
+    }
+
+}
+
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+fun PagerSingleItem(
+    title: String,
+    image: DrawableResource,
+    desc: String,
+    index: Int
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(18.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = BisqTheme.colors.dark3)
+                .padding(vertical = 56.dp)
+        ) {
+            Image(painterResource(image), title, modifier = Modifier.size(120.dp),)
+            Spacer(modifier = Modifier.height(if (index == 1) 48.dp else 70.dp))
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                BisqText.h4Regular(
+                    text = title,
+                    color = BisqTheme.colors.light1,
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                BisqText.largeRegular(
+                    text = desc,
+                    color = BisqTheme.colors.grey2,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun PagerLineIndicator(pagerState: PagerState) {
+    Box(
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            repeat(pagerState.pageCount) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 76.dp, height = 2.dp)
+                        .background(
+                            color = BisqTheme.colors.grey2,
+                        )
+                )
+            }
+        }
+        Box(
+            Modifier
+                .slidingLineTransition(
+                    pagerState,
+                    76f * LocalDensity.current.density
+                )
+                .size(width = 76.dp, height = 3.dp)
+                .background(
+                    color = BisqTheme.colors.primary,
+                    shape = RoundedCornerShape(4.dp),
+                )
+        )
+    }
+}
+
+fun Modifier.slidingLineTransition(pagerState: PagerState, distance: Float) =
+    graphicsLayer {
+        val scrollPosition = pagerState.currentPage + pagerState.currentPageOffsetFraction
+        translationX = scrollPosition * distance
+    }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/composeModels/model.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/composeModels/model.kt
@@ -3,4 +3,4 @@ package network.bisq.mobile.presentation.ui.composeModels
 import org.jetbrains.compose.resources.DrawableResource
 
 data class BottomNavigationItem(val title: String, val route: String, val icon: DrawableResource)
-data class OnBoardingPage(val title: String, val image: DrawableResource, val desc: String)
+data class PagerViewItem(val title: String, val image: DrawableResource, val desc: String)

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/README.md
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/README.md
@@ -22,6 +22,20 @@ The app uses **Jetpack Compose Navigation**.
 - Composable that renders the bottom navigation bar.
 - Exact tabbar items are received via `items` prop.
 
+###
+
+```
+[Root Nav] -> Splash | Tab Container Screen | (Screens from any of the tabs will be pushed here)
+                                |
+                                v
+                            [Tab Nav]
+                                |
+                                |- [Tab1] Getting Started
+                                |- [Tab2] Buy / Sell
+                                |- [Tab3] My Trades
+                                |- [Tab4] Settings
+```
+
 Ref links:
  - https://developer.android.com/develop/ui/compose/navigation
  - https://developer.android.com/codelabs/basic-android-kotlin-compose-navigation#0

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/RootNavGraph.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/RootNavGraph.kt
@@ -3,10 +3,8 @@ package network.bisq.mobile.presentation.ui.navigation.graph
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -21,21 +19,13 @@ import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
 @Composable
-fun RootNavGraph(
-    startDestination: String
-) {
-    val navControllerDIName = if (startDestination == Routes.Splash.name) "RootNavController" else "TabNavController"
-    val navController: NavHostController = koinInject(named(navControllerDIName))
-
-    //TODO: [Need refactor] This is confusing / not proper. But for now, it works!
-    //To have both primary screens and Tab bar screens inside a single NavHost.
-    //At runtime, 2 actually instances are created.
-    //If the code also reflects the same, it will be even easy to understand.
+fun RootNavGraph() {
+    val navController: NavHostController = koinInject(named("RootNavController"))
 
     NavHost(
         modifier = Modifier.background(color = BisqTheme.colors.backgroundColor),
         navController = navController,
-        startDestination = startDestination,
+        startDestination = Routes.Splash.name,
     ) {
         composable(route = Routes.Splash.name) {
             SplashScreen()
@@ -67,6 +57,5 @@ fun RootNavGraph(
         composable(route = Routes.TabContainer.name) {
             TabContainerScreen()
         }
-        TabNavGraph()
     }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
@@ -1,31 +1,48 @@
 package network.bisq.mobile.presentation.ui.navigation.graph
 
-import androidx.navigation.NavGraphBuilder
+import androidx.compose.foundation.background
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.compose.runtime.Composable
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.navigation.Graph
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.uicases.GettingStartedScreen
 import network.bisq.mobile.presentation.ui.uicases.exchange.ExchangeScreen
 import network.bisq.mobile.presentation.ui.uicases.settings.SettingsScreen
 import network.bisq.mobile.presentation.ui.uicases.trades.MyTradesScreen
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 
-fun NavGraphBuilder.TabNavGraph() {
-    navigation(
-        startDestination = Routes.TabHome.name,
-        route = Graph.MAIN_SCREEN_GRAPH_KEY
+@Composable
+fun TabNavGraph() {
+
+    val navController: NavHostController = koinInject(named("TabNavController"))
+
+    NavHost(
+        modifier = Modifier.background(color = BisqTheme.colors.backgroundColor),
+        navController = navController,
+        startDestination = Graph.MAIN_SCREEN_GRAPH_KEY,
     ) {
-        composable(route = Routes.TabHome.name) {
-            GettingStartedScreen()
-        }
-        composable(route = Routes.TabExchange.name) {
-            ExchangeScreen()
-        }
-        composable(route = Routes.TabMyTrades.name) {
-            MyTradesScreen()
-        }
-        composable(route = Routes.TabSettings.name) {
-            SettingsScreen()
+        navigation(
+            startDestination = Routes.TabHome.name,
+            route = Graph.MAIN_SCREEN_GRAPH_KEY
+        ) {
+            composable(route = Routes.TabHome.name) {
+                GettingStartedScreen()
+            }
+            composable(route = Routes.TabExchange.name) {
+                ExchangeScreen()
+            }
+            composable(route = Routes.TabMyTrades.name) {
+                MyTradesScreen()
+            }
+            composable(route = Routes.TabSettings.name) {
+                SettingsScreen()
+            }
         }
     }
 

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
@@ -190,11 +190,6 @@ fun PriceProfileCard(price: String, priceText: String) {
 @Composable
 fun FeatureCard(image: DrawableResource, title: String) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-//        AsyncImage(
-//            model = Res.getUri(imagePath),
-//            contentDescription = null,
-//            modifier = Modifier.size(20.dp)
-//        )
         Image(painterResource(image), null, Modifier.size(20.dp))
         Spacer(modifier = Modifier.width(9.dp))
         BisqText.smallRegular(
@@ -214,11 +209,6 @@ fun InstructionCard(image: DrawableResource, title: String, description: String,
             .padding(vertical = 18.dp, horizontal = 12.dp),
         verticalArrangement = Arrangement.spacedBy(18.dp)
     ) {
-//        AsyncImage(
-//            model = Res.getUri(imagePath),
-//            contentDescription = null,
-//            modifier = Modifier.size(50.dp)
-//        )
         Image(painterResource(image), "")
         BisqText.baseRegular(
             text = title,

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,15 +35,17 @@ import bisqapps.shared.presentation.generated.resources.icon_tag_outlined
 import bisqapps.shared.presentation.generated.resources.img_fiat_btc
 import bisqapps.shared.presentation.generated.resources.img_learn_and_discover
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
-interface IGettingStarted {
+interface IGettingStarted: ViewPresenter {
     val btcPrice: StateFlow<String>
     val offersOnline: StateFlow<Number>
     val publishedProfiles: StateFlow<Number>
@@ -51,73 +54,71 @@ interface IGettingStarted {
 @Composable
 fun GettingStartedScreen() {
     val presenter: IGettingStarted = koinInject()
-    val btcPrice:String = presenter.btcPrice.collectAsState().value
-    val offersOnline:Number = presenter.offersOnline.collectAsState().value
-    val publishedProfiles:Number = presenter.publishedProfiles.collectAsState().value
+    val btcPrice: String = presenter.btcPrice.collectAsState().value
+    val offersOnline: Number = presenter.offersOnline.collectAsState().value
+    val publishedProfiles: Number = presenter.publishedProfiles.collectAsState().value
 
     // TODO attach view should happen here to let the presenter know?
+    // buddha: So here we have 2 screens actually.
+    //  - TabContainerScreen that has Scaffold, Topbar, Bottom bar (with 4 tabs)
+    //  - Indidivual tab screens like current GettingStartedScreen, which is technically
+    //  - not an indpendent screen. Since it doesn't have scaffold, topbar on it's own.
 
-    Column(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        // TODO: Should be a child of Scaffold, in TabContainerScreen
-        TopBar(isHome = true)
+    //  - So I guess, TabContainerScreen will have it's own TabContainerPresenter
+    //  - GettingStartedScreen (and other 3 tabs) will have it's own IGettingStarted
+    LaunchedEffect(Unit) {
+        presenter.onViewAttached()
+    }
 
-        // TODO: Should use BisqScrollLayout. But it has Scaffold inside it already!
-        Column(
-            modifier = Modifier.padding(horizontal = 32.dp, vertical = 15.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
-        ) {
+    BisqScrollLayout(verticalArrangement = Arrangement.spacedBy(24.dp)) {
 
-            Column {
-                PriceProfileCard(
-                    price = btcPrice,
-                    priceText = "Market price"
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    Box(modifier = Modifier.weight(1f)) {
-                        PriceProfileCard(
-                            price = offersOnline.toString(),
-                            priceText = "Offers online"
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Box(modifier = Modifier.weight(1f)) {
-                        PriceProfileCard(
-                            price = publishedProfiles.toString(),
-                            priceText = "Published profiles"
-                        )
-                    }
+        Column {
+            PriceProfileCard(
+                price = btcPrice,
+                priceText = "Market price"
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Box(modifier = Modifier.weight(1f)) {
+                    PriceProfileCard(
+                        price = offersOnline.toString(),
+                        priceText = "Offers online"
+                    )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                Box(modifier = Modifier.weight(1f)) {
+                    PriceProfileCard(
+                        price = publishedProfiles.toString(),
+                        priceText = "Published profiles"
+                    )
                 }
             }
-            WelcomeCard(
-                title = "Get your first BTC",
-                buttonText = "Enter Bisq Easy"
+        }
+        WelcomeCard(
+            title = "Get your first BTC",
+            buttonText = "Enter Bisq Easy"
+        )
+        Column {
+            InstructionCard(
+                image = Res.drawable.img_fiat_btc,
+                title = "Multiple trade protocols",
+                description = "Checkout the roadmap for upcoming trade protocols. Get an overview about the features of the different protocols.",
+                buttonText = "Explore trade protocols"
             )
-            Column {
-                InstructionCard(
-                    image = Res.drawable.img_fiat_btc,
-                    title = "Multiple trade protocols",
-                    description = "Checkout the roadmap for upcoming trade protocols. Get an overview about the features of the different protocols.",
-                    buttonText = "Explore trade protocols"
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                InstructionCard(
-                    image = Res.drawable.img_learn_and_discover,
-                    title = "Learn & discover",
-                    description = "Learn about Bitcoin and checkout upcoming events. Meet other Bisq users in the discussion chat.",
-                    buttonText = "Learn more"
-                )
-            }
+            Spacer(modifier = Modifier.height(24.dp))
+            InstructionCard(
+                image = Res.drawable.img_learn_and_discover,
+                title = "Learn & discover",
+                description = "Learn about Bitcoin and checkout upcoming events. Meet other Bisq users in the discussion chat.",
+                buttonText = "Learn more"
+            )
         }
     }
 }
 
 @Composable
 fun WelcomeCard(title: String, buttonText: String) {
-    NeumorphicCard{
+    NeumorphicCard {
         Column(
             modifier = Modifier.shadow(
                 ambientColor = Color.Blue, spotColor = BisqTheme.colors.primary,
@@ -236,12 +237,12 @@ fun NeumorphicCard(
     content: @Composable () -> Unit
 ) {
 
-        Box(
-            modifier = modifier
-                .shadow(elevation = 8.dp, shape = RoundedCornerShape(5.dp), spotColor = BisqTheme.colors.primary)
-                .padding(2.dp)
-        ) {
-            content()
-        }
+    Box(
+        modifier = modifier
+            .shadow(elevation = 8.dp, shape = RoundedCornerShape(5.dp), spotColor = BisqTheme.colors.primary)
+            .padding(2.dp)
+    ) {
+        content()
+    }
 
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -1,22 +1,18 @@
 package network.bisq.mobile.presentation.ui.uicases
 
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import bisqapps.shared.presentation.generated.resources.*
 import bisqapps.shared.presentation.generated.resources.Res
+import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
+import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.composeModels.BottomNavigationItem
 import network.bisq.mobile.presentation.ui.navigation.BottomNavigation
-import network.bisq.mobile.presentation.ui.navigation.Graph
 import network.bisq.mobile.presentation.ui.navigation.Routes
-import network.bisq.mobile.presentation.ui.navigation.graph.RootNavGraph
-import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.navigation.graph.TabNavGraph
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
-import org.koin.mp.KoinPlatform.getKoin
 
 val navigationListItem = listOf(
     BottomNavigationItem("Home", Routes.TabHome.name, Res.drawable.icon_home),
@@ -36,8 +32,25 @@ fun TabContainerScreen() {
         }
     }
 
-    Scaffold(
-        containerColor = BisqTheme.colors.dark3,
+    BisqStaticScaffold(
+        topBar = {
+            // TODO: Since Topbar should go inside Scaffold
+            // the TopBar is written here commonly for all 4 tabs.
+            // Based on currentRoute, TopBar customization is done.
+            // Ideally, if this goes inside each Tabpage, it will look better.
+            // But it's a trade off.
+            TopBar(
+                isHome = currentRoute == Routes.TabHome.name,
+                title = when (currentRoute) {
+                    Routes.TabHome.name -> "Home"
+                    Routes.TabExchange.name -> "Buy/Sell"
+                    Routes.TabMyTrades.name -> "My Trades"
+                    Routes.TabSettings.name -> "Settings"
+                    else -> "App"
+                },
+            )
+
+        },
         bottomBar = {
             BottomNavigation(
                 items = navigationListItem,
@@ -55,7 +68,5 @@ fun TabContainerScreen() {
                 })
         }
 
-    ) { innerPadding ->
-        RootNavGraph(startDestination = Graph.MAIN_SCREEN_GRAPH_KEY)
-    }
+    ) { TabNavGraph() }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/exchange/ExchangeScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/exchange/ExchangeScreen.kt
@@ -36,7 +36,7 @@ fun ExchangeScreen() {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
-        TopBar("Buy/Sell")
+//        TopBar("Buy/Sell")
         Column(modifier = Modifier.padding(vertical = 12.dp, horizontal = 32.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -1,16 +1,14 @@
 
 package network.bisq.mobile.presentation.ui.uicases.settings
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.koin.compose.koinInject
@@ -20,15 +18,16 @@ import org.koin.core.qualifier.named
 @Composable
 fun SettingsScreen(
 ) {
-    val navController: NavHostController = koinInject(named("RootNavController"))
-    Box(
-        modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center // Centers the content within the Box
-    ) {
-        BisqText.h2Regular(
-            text = "Settings",
-            color = BisqTheme.colors.light1,
-        )
+    BisqScrollLayout(verticalArrangement = Arrangement.Center) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center // Centers the content within the Box
+        ) {
+            BisqText.h2Regular(
+                text = "Settings",
+                color = BisqTheme.colors.light1,
+            )
+        }
     }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -16,18 +15,16 @@ import androidx.navigation.NavHostController
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bot_image
 import cafe.adriel.lyricist.LocalStrings
-import network.bisq.mobile.components.MaterialTextField
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
-import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
-import kotlinx.coroutines.flow.StateFlow
 import cafe.adriel.lyricist.LocalStrings
 import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
@@ -44,7 +41,7 @@ fun CreateProfileScreen(
         presenter.onViewAttached()
     }
 
-    BisqScrollLayout() {
+    BisqScrollScaffold() {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
         BisqText.h1Light(

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -24,6 +24,10 @@ import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+import kotlinx.coroutines.flow.StateFlow
+import cafe.adriel.lyricist.LocalStrings
+import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
@@ -55,19 +59,17 @@ fun CreateProfileScreen(
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(36.dp))
-        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-            //TODO: Convert this into a Form field component, which is Label + TextField
-            BisqText.baseRegular(
-                text = strings.onboarding_createProfile_nickName,
-                color = BisqTheme.colors.light2,
-            )
-            MaterialTextField(
-                text = presenter.nickName.collectAsState().value,
-                placeholder = strings.onboarding_createProfile_nickName_prompt,
-                onValueChanged = { presenter.setNickname(it) })
-        }
+        BisqTextField(
+            label = strings.onboarding_createProfile_nickName,
+            value = presenter.nickName.collectAsState().value,
+            onValueChanged = { presenter.setNickname(it) },
+            placeholder = strings.onboarding_createProfile_nickName_prompt
+        )
         Spacer(modifier = Modifier.height(36.dp))
-        Image(painterResource(Res.drawable.img_bot_image), "User profile icon generated from the hash of the public key") // TODO: Translation
+        Image(
+            painterResource(Res.drawable.img_bot_image),
+            "User profile icon generated from the hash of the public key"
+        ) // TODO: Translation
         Spacer(modifier = Modifier.height(32.dp))
         BisqText.baseRegular(
             text = presenter.nym.collectAsState().value,
@@ -83,7 +85,7 @@ fun CreateProfileScreen(
             text = strings.onboarding_createProfile_regenerate,
             backgroundColor = BisqTheme.colors.dark5,
             padding = PaddingValues(horizontal = 64.dp, vertical = 12.dp),
-            onClick = {presenter.onGenerateKeyPair() }
+            onClick = { presenter.onGenerateKeyPair() }
         )
         Spacer(modifier = Modifier.height(40.dp))
         BisqButton(

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
@@ -7,40 +7,44 @@ import bisqapps.shared.presentation.generated.resources.img_bisq_Easy
 import bisqapps.shared.presentation.generated.resources.img_fiat_btc
 import bisqapps.shared.presentation.generated.resources.img_learn_and_discover
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
-val onBoardingPages = listOf(
-    PagerViewItem(
-        title = "Introducing Bisq Easy",
-        image = Res.drawable.img_bisq_Easy,
-        desc = "Getting your first Bitcoin privately has never been easier"
-    ),
-    PagerViewItem(
-        title = "Learn & Discover",
-        image = Res.drawable.img_learn_and_discover,
-        desc = "Get a gentle introduction into Bitcoin through our guides and community chat"
-    ),
-    PagerViewItem(
-        title = "Coming soon",
-        image = Res.drawable.img_fiat_btc,
-        desc = "Choose how to trade: Bisq MuSig, Lightning, Submarine Swaps,..."
-    )
-)
 
 open class OnBoardingPresenter(
     mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), IOnboardingPresenter {
 
+    override val indexesToShow = listOf(0)
+
+    // TODO: Ideally slide content for xClients should only be here.
+    // Android node content (along with resources), should be moved to `androidNode`
+    // Then remove `indexesToShow`
+    override val onBoardingData = listOf(
+        PagerViewItem(
+            title = "Introducing Bisq Easy",
+            image = Res.drawable.img_bisq_Easy,
+            desc = "Getting your first Bitcoin privately has never been easier"
+        ),
+        PagerViewItem(
+            title = "Bisp p2p in mobile",
+            image = Res.drawable.img_learn_and_discover,
+            desc = "All the awesomeness of Bisq desktop now in your mobile. Android only. (TODO: Show apt image)"
+        ),
+        PagerViewItem(
+            title = "Coming soon",
+            image = Res.drawable.img_fiat_btc,
+            desc = "Choose how to trade: Bisq MuSig, Lightning, Submarine Swaps,..."
+        )
+    )
+
     override fun onNextButtonClick(coroutineScope: CoroutineScope, pagerState: PagerState) {
         coroutineScope.launch {
-            if (pagerState.currentPage == onBoardingPages.lastIndex) {
-                 rootNavigator.navigate(Routes.CreateProfile.name)
+            if (pagerState.currentPage == indexesToShow.lastIndex) {
+                rootNavigator.navigate(Routes.CreateProfile.name)
             } else {
                 pagerState.animateScrollToPage(pagerState.currentPage + 1)
             }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
@@ -12,21 +12,21 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.composeModels.OnBoardingPage
+import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 val onBoardingPages = listOf(
-    OnBoardingPage(
+    PagerViewItem(
         title = "Introducing Bisq Easy",
         image = Res.drawable.img_bisq_Easy,
         desc = "Getting your first Bitcoin privately has never been easier"
     ),
-    OnBoardingPage(
+    PagerViewItem(
         title = "Learn & Discover",
         image = Res.drawable.img_learn_and_discover,
         desc = "Get a gentle introduction into Bitcoin through our guides and community chat"
     ),
-    OnBoardingPage(
+    PagerViewItem(
         title = "Coming soon",
         image = Res.drawable.img_fiat_btc,
         desc = "Choose how to trade: Bisq MuSig, Lightning, Submarine Swaps,..."
@@ -37,24 +37,12 @@ open class OnBoardingPresenter(
     mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), IOnboardingPresenter {
 
-    private val _pagerState = MutableStateFlow<PagerState?>(null)
-    override val pagerState: StateFlow<PagerState?> = _pagerState
-
-    override fun setPagerState(pagerState: PagerState) {
-        _pagerState.value = pagerState
-    }
-
-    override fun onNextButtonClick(coroutineScope: CoroutineScope) {
+    override fun onNextButtonClick(coroutineScope: CoroutineScope, pagerState: PagerState) {
         coroutineScope.launch {
-            val state = pagerState.value
-            if (state != null) {
-                if (state.currentPage == onBoardingPages.lastIndex) {
-                    rootNavigator.navigate(Routes.CreateProfile.name) {
-                        popUpTo(Routes.Onboarding.name) { inclusive = true }
-                    }
-                } else {
-                    state.animateScrollToPage(state.currentPage + 1)
-                }
+            if (pagerState.currentPage == onBoardingPages.lastIndex) {
+                 rootNavigator.navigate(Routes.CreateProfile.name)
+            } else {
+                pagerState.animateScrollToPage(pagerState.currentPage + 1)
             }
         }
     }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.components.organisms.startup.BisqPagerView
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -42,7 +43,7 @@ fun OnBoardingScreen() {
         presenter.onViewAttached()
     }
 
-    BisqScrollLayout() {
+    BisqScrollScaffold() {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
         BisqText.h1Light(

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -19,6 +19,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.components.organisms.startup.BisqPagerView
+import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.koin.compose.koinInject
@@ -26,6 +27,10 @@ import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
 interface IOnboardingPresenter: ViewPresenter {
+
+    val onBoardingData: List<PagerViewItem>
+
+    val indexesToShow: List<Number>
     fun onNextButtonClick(coroutineScope: CoroutineScope, pagerState: PagerState)
 }
 
@@ -37,10 +42,14 @@ fun OnBoardingScreen() {
     val presenter: IOnboardingPresenter = koinInject { parametersOf(navController) }
 
     val coroutineScope = rememberCoroutineScope()
-    val pagerState = rememberPagerState(pageCount = { onBoardingPages.size })
+    val pagerState = rememberPagerState(pageCount = { presenter.indexesToShow.size })
 
     LaunchedEffect(pagerState) {
         presenter.onViewAttached()
+    }
+
+    val finalPages = presenter.onBoardingData.filterIndexed { index, _ ->
+        presenter.indexesToShow.contains(index)
     }
 
     BisqScrollScaffold() {
@@ -51,11 +60,11 @@ fun OnBoardingScreen() {
             color = BisqTheme.colors.grey1,
             )
         Spacer(modifier = Modifier.height(56.dp))
-        BisqPagerView(pagerState, onBoardingPages)
+        BisqPagerView(pagerState, finalPages)
         Spacer(modifier = Modifier.height(56.dp))
 
         BisqButton(
-            text = if (pagerState.currentPage == onBoardingPages.lastIndex) strings.onboarding_button_create_profile else strings.buttons_next,
+            text = if (pagerState.currentPage == presenter.indexesToShow.lastIndex) strings.onboarding_button_create_profile else strings.buttons_next,
             onClick = { presenter.onNextButtonClick(coroutineScope, pagerState) }
         )
 

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -1,32 +1,13 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import bisqapps.shared.presentation.generated.resources.*
 import cafe.adriel.lyricist.LocalStrings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -36,19 +17,15 @@ import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
+import network.bisq.mobile.presentation.ui.components.organisms.startup.BisqPagerView
 import network.bisq.mobile.presentation.ui.theme.*
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
 interface IOnboardingPresenter: ViewPresenter {
-    val pagerState: StateFlow<PagerState?>
-
-    fun onNextButtonClick(coroutineScope: CoroutineScope)
-    fun setPagerState(pagerState: PagerState)
+    fun onNextButtonClick(coroutineScope: CoroutineScope, pagerState: PagerState)
 }
 
 @OptIn(ExperimentalResourceApi::class)
@@ -63,7 +40,6 @@ fun OnBoardingScreen() {
 
     LaunchedEffect(pagerState) {
         presenter.onViewAttached()
-        presenter.setPagerState(pagerState)
     }
 
     BisqScrollLayout() {
@@ -74,130 +50,14 @@ fun OnBoardingScreen() {
             color = BisqTheme.colors.grey1,
             )
         Spacer(modifier = Modifier.height(56.dp))
-        PagerView(presenter)
+        BisqPagerView(pagerState, onBoardingPages)
         Spacer(modifier = Modifier.height(56.dp))
 
         BisqButton(
             text = if (pagerState.currentPage == onBoardingPages.lastIndex) strings.onboarding_button_create_profile else strings.buttons_next,
-            onClick = { presenter.onNextButtonClick(coroutineScope) }
+            onClick = { presenter.onNextButtonClick(coroutineScope, pagerState) }
         )
 
     }
 
 }
-
-@Composable
-fun PagerView(presenter: IOnboardingPresenter) {
-
-    val pagerState = presenter.pagerState.collectAsState().value
-
-    pagerState?.let {
-        CompositionLocalProvider(values = arrayOf()) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(36.dp, Alignment.CenterVertically),
-                ) {
-                HorizontalPager(
-                    pageSpacing = 56.dp,
-                    contentPadding = PaddingValues(horizontal = 36.dp),
-                    pageSize = PageSize.Fill,
-                    verticalAlignment = Alignment.CenterVertically,
-                    state = it
-                ) { index ->
-                    onBoardingPages.getOrNull(
-                        index % (onBoardingPages.size)
-                    )?.let { item ->
-                        BannerItem(
-                            image = item.image,
-                            title = item.title,
-                            desc = item.desc,
-                            index = index,
-                            )
-                    }
-                }
-                    LineIndicator(pagerState = it)
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalResourceApi::class)
-@Composable
-fun BannerItem(
-    title: String,
-    image: DrawableResource,
-    desc: String,
-    index: Int
-) {
-    Box(
-        modifier = Modifier
-            .clip(RoundedCornerShape(18.dp)),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            verticalArrangement = Arrangement.SpaceBetween,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(color = BisqTheme.colors.dark3)
-                .padding(vertical = 56.dp)
-        ) {
-            Image(painterResource(image), title, modifier = Modifier.size(120.dp),)
-            Spacer(modifier = Modifier.height(if (index == 1) 48.dp else 70.dp))
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                BisqText.h4Regular(
-                    text = title,
-                    color = BisqTheme.colors.light1,
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                BisqText.largeRegular(
-                    text = desc,
-                    color = BisqTheme.colors.grey2,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    textAlign = TextAlign.Center,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun LineIndicator(pagerState: PagerState) {
-    Box(
-        contentAlignment = Alignment.CenterStart
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            repeat(pagerState.pageCount) {
-                Box(
-                    modifier = Modifier
-                        .size(width = 76.dp, height = 2.dp)
-                        .background(
-                            color = BisqTheme.colors.grey2,
-                        )
-                )
-            }
-        }
-        Box(
-            Modifier
-                .slidingLineTransition(
-                    pagerState,
-                    76f * LocalDensity.current.density
-                )
-                .size(width = 76.dp, height = 3.dp)
-                .background(
-                    color = BisqTheme.colors.primary,
-                    shape = RoundedCornerShape(4.dp),
-                )
-        )
-    }
-}
-
-fun Modifier.slidingLineTransition(pagerState: PagerState, distance: Float) =
-    graphicsLayer {
-        val scrollPosition = pagerState.currentPage + pagerState.currentPageOffsetFraction
-        translationX = scrollPosition * distance
-    }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -30,18 +30,11 @@ open class SplashPresenter(
     }
 
     private fun navigateToNextScreen() {
-        // TODO: Conditional nav
+        // TODO: Conditional nav - Will implement once we got persistant storage from nish to save flags
         // If firstTimeApp launch, goto Onboarding[clientMode] (androidNode / xClient)
         // If not, goto TabContainerScreen
-        /*  rootNavigator.navigate(Routes.Onboarding.name) {
-              popUpTo(Routes.Splash.name) { inclusive = true }
-          }*/
-
-        //TODO
-        /* rootNavigator.navigate(Routes.TabContainer.name) {
-             popUpTo(Routes.TrustedNodeSetup.name) { inclusive = true }
-         }*/
-        rootNavigator.navigate(Routes.CreateProfile.name) {
+        rootNavigator.navigate(Routes.Onboarding.name) {
+        // navController.navigate(Routes.TabContainer.name) {
             popUpTo(Routes.Splash.name) { inclusive = true }
         }
     }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
@@ -12,7 +12,7 @@ import cafe.adriel.lyricist.LocalStrings
 import network.bisq.mobile.presentation.ui.components.atoms.BisqProgressBar
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
-import network.bisq.mobile.presentation.ui.components.layout.BisqStaticLayout
+import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
@@ -30,7 +30,7 @@ fun SplashScreen(
         presenter.onViewAttached()
     }
 
-    BisqStaticLayout {
+    BisqStaticScaffold {
         BisqLogo()
 
         Column {

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -43,8 +43,6 @@ class TrustedNodeSetupPresenter(
     }
 
     override fun navigateToNextScreen() {
-        rootNavigator.navigate(Routes.TabContainer.name) {
-            popUpTo(Routes.TrustedNodeSetup.name) { inclusive = true }
-        }
+        rootNavigator.navigate(Routes.TabContainer.name)
     }
 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.icon_copy
+import bisqapps.shared.presentation.generated.resources.icon_qr
 import bisqapps.shared.presentation.generated.resources.icon_question_mark
 import network.bisq.mobile.components.MaterialTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
@@ -31,6 +33,9 @@ import cafe.adriel.lyricist.LocalStrings
 
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
+import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
+import network.bisq.mobile.presentation.ui.components.atoms.icons.CopyIcon
+import network.bisq.mobile.presentation.ui.components.atoms.icons.ScanIcon
 
 interface ITrustedNodeSetupPresenter: ViewPresenter {
     val bisqUrl: StateFlow<String>
@@ -65,19 +70,18 @@ fun TrustedNodeSetupScreen(
             verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxSize().padding(horizontal = 0.dp)
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                BisqText.baseRegular(
-                    text = "Bisq URL",
-                    color = BisqTheme.colors.light1,
-                )
-                Image(painterResource(Res.drawable.icon_question_mark), "Question mark")
-            }
+            BisqTextField(
+                label = "Bisq URL",
+                onValueChanged = { presenter.updateBisqUrl(it) },
+                value = bisqUrl,
+                placeholder = "",
+                labelRightSuffix = {
+                    // TODO: Should be a IconButton
+                    Image(painterResource(Res.drawable.icon_question_mark), "Question mark")
+                }
+            )
 
-            MaterialTextField(bisqUrl, onValueChanged = { presenter.updateBisqUrl(it) })
+            // MaterialTextField(bisqUrl, onValueChanged = { presenter.updateBisqUrl(it) })
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -88,13 +92,13 @@ fun TrustedNodeSetupScreen(
                     onClick = {},
                     backgroundColor = BisqTheme.colors.dark5,
                     color = BisqTheme.colors.light1,
-                    //leftIcon=Image(painterResource(Res.drawable.icon_copy), "Copy button")
+                    leftIcon= { CopyIcon() } // TODO: Should be IconButtons
                 )
 
                 BisqButton(
                     text = "Scan",
                     onClick = {},
-                    //leftIcon=Image(painterResource(Res.drawable.icon_qr), "Scan button")
+                    leftIcon= { ScanIcon() } // TODO: Should be IconButtons
                 )
             }
             Spacer(modifier = Modifier.height(36.dp))

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -14,15 +14,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.icon_copy
-import bisqapps.shared.presentation.generated.resources.icon_qr
-import bisqapps.shared.presentation.generated.resources.icon_question_mark
 import network.bisq.mobile.components.MaterialTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
+import network.bisq.mobile.presentation.ui.components.atoms.icons.QuestionIcon
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
@@ -63,7 +60,7 @@ fun TrustedNodeSetupScreen(
         presenter.onViewAttached()
     }
 
-    BisqScrollLayout {
+    BisqScrollScaffold {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
         Column(
@@ -76,12 +73,13 @@ fun TrustedNodeSetupScreen(
                 value = bisqUrl,
                 placeholder = "",
                 labelRightSuffix = {
-                    // TODO: Should be a IconButton
-                    Image(painterResource(Res.drawable.icon_question_mark), "Question mark")
+                    BisqButton(
+                        iconOnly = { QuestionIcon() },
+                        backgroundColor = BisqTheme.colors.backgroundColor,
+                        onClick = { presenter.navigateToNextScreen() }
+                    )
                 }
             )
-
-            // MaterialTextField(bisqUrl, onValueChanged = { presenter.updateBisqUrl(it) })
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -92,13 +90,13 @@ fun TrustedNodeSetupScreen(
                     onClick = {},
                     backgroundColor = BisqTheme.colors.dark5,
                     color = BisqTheme.colors.light1,
-                    leftIcon= { CopyIcon() } // TODO: Should be IconButtons
+                    leftIcon= { CopyIcon() }
                 )
 
                 BisqButton(
                     text = "Scan",
                     onClick = {},
-                    leftIcon= { ScanIcon() } // TODO: Should be IconButtons
+                    leftIcon= { ScanIcon() }
                 )
             }
             Spacer(modifier = Modifier.height(36.dp))

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/trades/MyTrades.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/trades/MyTrades.kt
@@ -1,16 +1,14 @@
 
 package network.bisq.mobile.presentation.ui.uicases.trades
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.koin.compose.koinInject
@@ -19,15 +17,16 @@ import org.koin.core.qualifier.named
 @OptIn(ExperimentalResourceApi::class)
 @Composable
 fun MyTradesScreen() {
-    val rootNavController: NavHostController = koinInject(named("RootNavController"))
-    Box(
-        modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center // Centers the content within the Box
-    ) {
-        BisqText.h2Regular(
-            text = "My Trades",
-            color = BisqTheme.colors.light1,
-        )
+    BisqScrollLayout(verticalArrangement = Arrangement.Center) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            BisqText.h2Regular(
+                text = "My Trades",
+                color = BisqTheme.colors.light1,
+            )
+        }
     }
 }


### PR DESCRIPTION
- Android full screen issue (https://github.com/bisq-network/bisq-mobile/issues/61) - Made the system bar transparent, so it takes up current screen's BG color

 - Improved docs (README.md) for /components and /navigation

 - Component improvements: Button, TextField, Icons, PagerView, Layout components

 - Code cleanup: Create profile, Onboarding, TrustedNodeSetup
 
 - Clean, separate RootNavGraph and TabNavGraph

 - TopBar for Tab pages - Moved to TabContainerHome (added comments on why?)

 - Different onboarding page content in androidNode and xClient (facing some other issue in androidNode)