### PR TITLE
Feature/multiplatform settings persistence

### DIFF
--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/market_price/NodeMarketPriceServiceFacade.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/market_price/NodeMarketPriceServiceFacade.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.domain.offerbook.NodeOfferbookServiceFacade.Companion.toLibraryMarket
 import network.bisq.mobile.android.node.domain.offerbook.NodeOfferbookServiceFacade.Companion.toReplicatedMarket
-import network.bisq.mobile.domain.data.model.market_price.MarketPriceItem
+import network.bisq.mobile.domain.data.model.MarketPriceItem
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.utils.Logging
 
 class NodeMarketPriceServiceFacade(private val applicationService: AndroidApplicationService.Provider) :

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/NodeOfferbookServiceFacade.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/NodeOfferbookServiceFacade.kt
@@ -7,10 +7,10 @@ import network.bisq.mobile.android.node.domain.offerbook.market.NodeMarketListIt
 import network.bisq.mobile.android.node.domain.offerbook.market.NodeSelectedOfferbookMarketService
 import network.bisq.mobile.android.node.domain.offerbook.offer.NodeOfferbookListItemService
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.OfferbookMarket
+import network.bisq.mobile.domain.data.model.MarketListItem
+import network.bisq.mobile.domain.data.model.OfferbookMarket
 import network.bisq.mobile.utils.Logging
 
 class NodeOfferbookServiceFacade(

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeMarketListItemService.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeMarketListItemService.kt
@@ -9,7 +9,7 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.domain.offerbook.NodeOfferbookServiceFacade.Companion.toLibraryMarket
 import network.bisq.mobile.client.replicated_model.common.currency.Market
 import network.bisq.mobile.domain.LifeCycleAware
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.utils.Logging
 
 class NodeMarketListItemService(private val applicationService: AndroidApplicationService.Provider) :

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeSelectedOfferbookMarketService.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeSelectedOfferbookMarketService.kt
@@ -12,7 +12,7 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.domain.offerbook.NodeOfferbookServiceFacade.Companion.toReplicatedMarket
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.market.OfferbookMarket
+import network.bisq.mobile.domain.data.model.OfferbookMarket
 import network.bisq.mobile.utils.Logging
 
 

--- a/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/offer/NodeOfferbookListItemService.kt
+++ b/bisqapps/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/offer/NodeOfferbookListItemService.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.client.replicated_model.user.reputation.ReputationScore
 import network.bisq.mobile.domain.LifeCycleAware
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.utils.Logging
 import java.text.DateFormat
 import java.util.Date

--- a/bisqapps/gradle/libs.versions.toml
+++ b/bisqapps/gradle/libs.versions.toml
@@ -64,11 +64,14 @@ koin = "4.0.0"
 lombok-lib = { strictly = '1.18.34' }
 typesafe-config-lib = { strictly = '1.4.3' }
 
+multiplatform-settings = "1.2.0"
+
 [libraries]
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit-v180 = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlinTestJunit" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktorClientCio" }
@@ -171,6 +174,12 @@ google-guava = { module = 'com.google.guava:guava', version.ref = 'google-guava-
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+
+
+# mp-settings
+multiplatform-settings = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
+multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatform-settings" }
 
 [bundles]
 #glassfish-jersey = ['glassfish-jersey-jdk-http', 'glassfish-jersey-json-jackson', 'glassfish-jersey-inject-hk2', 'glassfish-jaxb-runtime']

--- a/bisqapps/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/bisqapps/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
 				3281115E126FA938007845C3 /* [CP] Embed Pods Frameworks */,
-				C4A62A78957219C45FAA848E /* [CP] Copy Pods Resources */,
+				1A6DDAE88360C0C271494A24 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -180,6 +180,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1A6DDAE88360C0C271494A24 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		2F2A98D842CF884E9E4EADA4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -217,23 +234,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C4A62A78957219C45FAA848E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosClient/Pods-iosClient-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */ = {

--- a/bisqapps/shared/domain/build.gradle.kts
+++ b/bisqapps/shared/domain/build.gradle.kts
@@ -49,12 +49,30 @@ kotlin {
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.jetbrains.serialization.gradle.plugin)
 
+            implementation(libs.multiplatform.settings)
+
             configurations.all {
                 exclude(group = "org.slf4j", module = "slf4j-api")
             }
         }
+
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.multiplatform.settings.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.koin.test)
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.multiplatform.settings.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.koin.test)
+//            implementation("com.russhwolf:multiplatform-settings-datastore:1.2.0")
+//
+//            implementation("androidx.test:core:1.5.0")
+//            implementation("androidx.test.ext:junit:1.1.5")
+//            implementation("androidx.test.espresso:espresso-core:3.5.1")
+//            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
         }
 
         iosMain.dependencies {

--- a/bisqapps/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
+++ b/bisqapps/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
@@ -1,0 +1,7 @@
+package network.bisq.mobile.domain.di
+
+import com.russhwolf.settings.Settings
+
+actual fun provideSettings(): Settings {
+     return Settings()
+}

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/market/ClientMarketPriceServiceFacade.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/market/ClientMarketPriceServiceFacade.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.client.replicated_model.common.currency.Market
 import network.bisq.mobile.client.service.Polling
 import network.bisq.mobile.domain.data.BackgroundDispatcher
-import network.bisq.mobile.domain.data.model.market_price.MarketPriceItem
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketPriceItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.utils.Logging
 

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookServiceFacade.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookServiceFacade.kt
@@ -6,10 +6,10 @@ import network.bisq.mobile.client.offerbook.market.ClientSelectedOfferbookMarket
 import network.bisq.mobile.client.offerbook.offer.ClientOfferbookListItemService
 import network.bisq.mobile.client.offerbook.offer.OfferbookApiGateway
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.OfferbookMarket
+import network.bisq.mobile.domain.data.model.MarketListItem
+import network.bisq.mobile.domain.data.model.OfferbookMarket
 import network.bisq.mobile.utils.Logging
 
 class ClientOfferbookServiceFacade(

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientMarketListItemService.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientMarketListItemService.kt
@@ -10,7 +10,7 @@ import network.bisq.mobile.client.replicated_model.common.currency.Market
 import network.bisq.mobile.client.service.Polling
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.BackgroundDispatcher
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.utils.Logging
 
 

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientSelectedOfferbookMarketService.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientSelectedOfferbookMarketService.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.OfferbookMarket
+import network.bisq.mobile.domain.data.model.MarketListItem
+import network.bisq.mobile.domain.data.model.OfferbookMarket
 import network.bisq.mobile.utils.Logging
 
 class ClientSelectedOfferbookMarketService(

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/ClientOfferbookListItemService.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/ClientOfferbookListItemService.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.client.service.Polling
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.BackgroundDispatcher
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.utils.Logging
 
 

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/OfferbookApiGateway.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/OfferbookApiGateway.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.offerbook.offer
 
 import network.bisq.mobile.client.replicated_model.common.currency.Market
 import network.bisq.mobile.client.service.ApiRequestService
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.utils.Logging
 
 class OfferbookApiGateway(private val apiRequestService: ApiRequestService) : Logging {

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
@@ -1,9 +1,30 @@
 package network.bisq.mobile.domain.data.model
 
+import kotlinx.serialization.Serializable
+
 /**
  * BisqApps Base Domain Model definition
  */
-abstract class BaseModel {
+@Serializable
+sealed class BaseModel {
+    companion object {
+        const val UNDEFINED_ID = ""
+    }
     // Add here any common properties of models (id?, timestamps?)
-//    abstract val id: String
+    open var id: String = UNDEFINED_ID
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null)
+            return false
+        if (other is BaseModel) {
+            if (other.id != UNDEFINED_ID && id != UNDEFINED_ID)
+                return other.id.equals(id)
+            return super.equals(other)
+        }
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return if (id == UNDEFINED_ID) super.hashCode() else id.hashCode()
+    }
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
@@ -13,6 +13,13 @@ sealed class BaseModel {
     // Add here any common properties of models (id?, timestamps?)
     open var id: String = UNDEFINED_ID
 
+    override fun toString(): String {
+        if (id != UNDEFINED_ID) {
+            return "${this::class.simpleName}(id=$id)"
+        }
+        return super.toString()
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other == null)
             return false

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 sealed class BaseModel {
     companion object {
         const val UNDEFINED_ID = ""
+        inline fun <reified T : BaseModel> typeName(): String = T::class.simpleName ?: "BaseModel"
     }
     // Add here any common properties of models (id?, timestamps?)
     open var id: String = UNDEFINED_ID

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/MarketListItem.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/MarketListItem.kt
@@ -14,13 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
-package network.bisq.mobile.domain.data.model.offerbook.market
+package network.bisq.mobile.domain.data.model
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.client.replicated_model.common.currency.Market
-import network.bisq.mobile.domain.data.model.BaseModel
 
 /**
  * Provides data for offerbook market list items

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/MarketPriceItem.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/MarketPriceItem.kt
@@ -1,9 +1,8 @@
-package network.bisq.mobile.domain.data.model.market_price
+package network.bisq.mobile.domain.data.model
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.client.replicated_model.common.currency.Market
-import network.bisq.mobile.domain.data.model.BaseModel
 
 /**
  * Provides market price data

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/OfferListItem.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/OfferListItem.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.domain.data.model.offerbook
+package network.bisq.mobile.domain.data.model
 
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.client.replicated_model.offer.Direction

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/OfferbookMarket.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/OfferbookMarket.kt
@@ -1,10 +1,9 @@
-package network.bisq.mobile.domain.data.model.offerbook.market
+package network.bisq.mobile.domain.data.model
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.client.replicated_model.common.currency.Market
-import network.bisq.mobile.domain.data.model.BaseModel
 
 /**
  * Provides data for the offerbook header showing the selected market data

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
@@ -7,11 +7,3 @@ open class Settings : BaseModel() {
     open var bisqUrl: String = ""
     open var isConnected: Boolean = false
 }
-
-interface SettingsFactory {
-    fun createSettings(): Settings
-}
-
-class DefaultSettingsFactory : SettingsFactory {
-    override fun createSettings() = Settings()
-}

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
@@ -1,5 +1,8 @@
 package network.bisq.mobile.domain.data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 open class Settings : BaseModel() {
     open var bisqUrl: String = ""
     open var isConnected: Boolean = false

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 open class Settings : BaseModel() {
-    open var bisqUrl: String = ""
+    open var bisqApiUrl: String = ""
     open var isConnected: Boolean = false
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
@@ -1,0 +1,54 @@
+package network.bisq.mobile.domain.data.persistance
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.set
+import network.bisq.mobile.domain.data.model.BaseModel
+
+/**
+ * Multi platform key-value storage ("settings")
+ */
+class KeyValueStorage<T : BaseModel>(
+    private val settings: Settings,
+    private val keyPrefix: String,
+    private val serializer: (t: T) -> String,
+    private val deserializer: (String) -> T
+) : PersistenceSource<T> {
+
+    override suspend fun save(item: T) {
+        settings[keyPrefix + item.id] = serializer(item)
+    }
+
+    override suspend fun saveAll(items: List<T>) {
+        items.forEach { save(it) }
+    }
+
+    override suspend fun get(id: String?): T? {
+        // Assume a single item by some predefined ID (or modify logic for specific use cases)
+        try {
+            val key = settings.keys.firstOrNull { it.startsWith(keyPrefix + (id ?: "")) }
+            return key?.let { deserializer(settings.getStringOrNull(it)!!) }
+        } catch (e: Exception) {
+            throw IllegalArgumentException("No saved object with id $id")
+        }
+    }
+
+    override suspend fun getAll(): List<T> {
+        return settings.keys
+            .filter { it.startsWith(keyPrefix) }
+            .mapNotNull { settings.getStringOrNull(it)?.let(deserializer) }
+    }
+
+    override suspend fun delete(item: T) {
+        settings.remove(keyPrefix + item.id)
+    }
+
+    override suspend fun deleteAll() {
+        settings.keys
+            .filter { it.startsWith(keyPrefix) }
+            .forEach { settings.remove(it) }
+    }
+
+    override suspend fun clear() {
+        settings.clear()
+    }
+}

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
@@ -5,7 +5,11 @@ import com.russhwolf.settings.set
 import network.bisq.mobile.domain.data.model.BaseModel
 
 /**
- * Multi platform key-value storage ("settings")
+ * Multi platform key-value storage ("settings") linked to the usage of our BaseModels.
+ * The key for the key-value is exctracted from the model based on its final runtime class and an id if available
+ * Hence why some methods will require a prototype of the model being used.
+ * This allows us to reuse a single instance of this storage in different repositories without having data collision
+ * If you are going to persist only one obj of T, you can just leave the id with default BaseModel#UNDEFINED_ID value.
  */
 class KeyValueStorage<T : BaseModel>(
     private val settings: Settings,

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorage.kt
@@ -9,46 +9,54 @@ import network.bisq.mobile.domain.data.model.BaseModel
  */
 class KeyValueStorage<T : BaseModel>(
     private val settings: Settings,
-    private val keyPrefix: String,
     private val serializer: (t: T) -> String,
     private val deserializer: (String) -> T
 ) : PersistenceSource<T> {
 
     override suspend fun save(item: T) {
-        settings[keyPrefix + item.id] = serializer(item)
+        settings[generateKey(item)] = serializer(item)
     }
 
     override suspend fun saveAll(items: List<T>) {
         items.forEach { save(it) }
     }
 
-    override suspend fun get(id: String?): T? {
+    /**
+     * @param prototype the prototype of the object you want to retrieve, which the id you are looking
+     * for or BaseModel.UNDEFINED_ID to get the generic settings associated with the class key
+     * @throws IllegalArgumentException if no object found with that key
+     */
+    override suspend fun get(prototype: T): T? {
         // Assume a single item by some predefined ID (or modify logic for specific use cases)
+        val searchKey = generateKey(prototype)
         try {
-            val key = settings.keys.firstOrNull { it.startsWith(keyPrefix + (id ?: "")) }
+            val key = settings.keys.firstOrNull { it == searchKey }
             return key?.let { deserializer(settings.getStringOrNull(it)!!) }
         } catch (e: Exception) {
-            throw IllegalArgumentException("No saved object with id $id")
+            throw IllegalArgumentException("No saved object with id $searchKey")
         }
     }
 
-    override suspend fun getAll(): List<T> {
+    override suspend fun getAll(prototype: T): List<T> {
         return settings.keys
-            .filter { it.startsWith(keyPrefix) }
+            .filter { it.startsWith(generatePrefix(prototype)) }
             .mapNotNull { settings.getStringOrNull(it)?.let(deserializer) }
     }
 
     override suspend fun delete(item: T) {
-        settings.remove(keyPrefix + item.id)
+        settings.remove(generateKey(item))
     }
 
-    override suspend fun deleteAll() {
+    override suspend fun deleteAll(prototype: T) {
         settings.keys
-            .filter { it.startsWith(keyPrefix) }
+            .filter { it.startsWith(generatePrefix(prototype)) }
             .forEach { settings.remove(it) }
     }
 
     override suspend fun clear() {
         settings.clear()
     }
+
+    private fun generatePrefix(t: T) = t::class.simpleName ?: "BaseModel"
+    private fun generateKey(t: T) = "${generatePrefix(t)}_${t.id}"
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
@@ -2,6 +2,10 @@ package network.bisq.mobile.domain.data.persistance
 
 import network.bisq.mobile.domain.data.model.BaseModel
 
+/**
+ * BaseModel related persistance source.
+ * Information for kets is derived from the involved runtime base model instance.
+ */
 interface PersistenceSource<T: BaseModel> {
     suspend fun save(item: T)
     suspend fun saveAll(items: List<T>)

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
@@ -5,7 +5,11 @@ import network.bisq.mobile.domain.data.model.BaseModel
 interface PersistenceSource<T: BaseModel> {
     suspend fun save(item: T)
     suspend fun saveAll(items: List<T>)
-    suspend fun get(): T?
+
+    /**
+     * @param id: pass null if this source handles a unique saved obj.
+     */
+    suspend fun get(id: String?): T?
     suspend fun getAll(): List<T>
     suspend fun delete(item: T)
     suspend fun deleteAll()

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/persistance/PersistanceSource.kt
@@ -7,11 +7,11 @@ interface PersistenceSource<T: BaseModel> {
     suspend fun saveAll(items: List<T>)
 
     /**
-     * @param id: pass null if this source handles a unique saved obj.
+     * @param prototype: of the object to search for. The prototype class and BaseModel#id is used to find the right obj data.
      */
-    suspend fun get(id: String?): T?
-    suspend fun getAll(): List<T>
+    suspend fun get(prototype: T): T?
+    suspend fun getAll(prototype: T): List<T>
     suspend fun delete(item: T)
-    suspend fun deleteAll()
+    suspend fun deleteAll(prototype: T)
     suspend fun clear()
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
@@ -38,4 +38,4 @@ open class MyTradesRepository : SingleObjectRepository<MyTrades>() {
         }
     }
 }
-open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>): SingleObjectRepository<Settings>(keyValueStorage)
+open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>): SingleObjectRepository<Settings>(keyValueStorage, Settings())

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
@@ -2,13 +2,17 @@ package network.bisq.mobile.domain.data.repository
 
 import kotlinx.coroutines.runBlocking
 import network.bisq.mobile.domain.data.model.*
+import network.bisq.mobile.domain.data.model.BisqStats
+import network.bisq.mobile.domain.data.model.BtcPrice
+import network.bisq.mobile.domain.data.model.Greeting
+import network.bisq.mobile.domain.data.model.Settings
+import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 
 // this way of defining supports both platforms
 // add your repositories here and then in your DI module call this classes for instanciation
 open class GreetingRepository<T: Greeting>: SingleObjectRepository<T>()
 open class BisqStatsRepository: SingleObjectRepository<BisqStats>()
 open class BtcPriceRepository: SingleObjectRepository<BtcPrice>()
-open class SettingsRepository: SingleObjectRepository<Settings>()
 
 open class MyTradesRepository : SingleObjectRepository<MyTrades>() {
     init {
@@ -34,3 +38,4 @@ open class MyTradesRepository : SingleObjectRepository<MyTrades>() {
         }
     }
 }
+open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>): SingleObjectRepository<Settings>(keyValueStorage)

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -31,7 +31,7 @@ abstract class SingleObjectRepository<out T : BaseModel>(
         // Load from persistence on initialization if available
         persistenceSource?.let {
             scope.launch {
-                _data.value = it.get()
+                _data.value = it.get(null)
             }
         }
     }
@@ -52,7 +52,7 @@ abstract class SingleObjectRepository<out T : BaseModel>(
     }
 
     override suspend fun fetch(): T? {
-        return _data.value ?: persistenceSource?.get().also { _data.value = it }
+        return _data.value ?: persistenceSource?.get(null).also { _data.value = it }
     }
 
     override suspend fun clear() {

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -19,7 +19,7 @@ import network.bisq.mobile.utils.Logging
  */
 abstract class SingleObjectRepository<out T : BaseModel>(
     private val persistenceSource: PersistenceSource<T>? = null
-) : Repository<T>,Logging {
+) : Repository<T>, Logging {
 
     private val _data = MutableStateFlow<T?>(null)
     override val data: StateFlow<T?> = _data

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.data.persistance.PersistenceSource
@@ -15,10 +14,15 @@ import network.bisq.mobile.utils.Logging
 /**
  * Repository implementation for a single object. Allows for persistance if the persistance source if provided, otherwise is mem-only.
  *
+ * @param T a domain model
+ * @param persistenceSource <optional> persistance mechanism to use to save/load data for this repository. Otherwise its mem-only.
+ * @param prototype <optional> an instance of T to use as prototype, can be null if no persistance source will be used
+ *
  * TODO: create a map-based multi object repository when needed (might need to leverage some kind of id generation on the base model)
  */
 abstract class SingleObjectRepository<out T : BaseModel>(
-    private val persistenceSource: PersistenceSource<T>? = null
+    private val persistenceSource: PersistenceSource<T>? = null,
+    private val prototype: T? = null,
 ) : Repository<T>, Logging {
 
     private val _data = MutableStateFlow<T?>(null)
@@ -26,15 +30,6 @@ abstract class SingleObjectRepository<out T : BaseModel>(
 
     private val job = Job()
     private val scope = CoroutineScope(job + BackgroundDispatcher)
-
-    init {
-        // Load from persistence on initialization if available
-        persistenceSource?.let {
-            scope.launch {
-                _data.value = it.get(null)
-            }
-        }
-    }
 
     override suspend fun create(data: @UnsafeVariance T) {
         _data.value = data
@@ -52,7 +47,7 @@ abstract class SingleObjectRepository<out T : BaseModel>(
     }
 
     override suspend fun fetch(): T? {
-        return _data.value ?: persistenceSource?.get(null).also { _data.value = it }
+        return _data.value ?: persistenceSource?.get(prototype!!).also { _data.value = it }
     }
 
     override suspend fun clear() {

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.json.Json
 import network.bisq.mobile.domain.data.model.Greeting
 import network.bisq.mobile.domain.data.repository.*
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
-import network.bisq.mobile.domain.data.persistance.PersistenceSource
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.BtcPriceRepository
 import network.bisq.mobile.domain.data.repository.GreetingRepository
@@ -20,7 +19,7 @@ val domainModule = module {
     single<Settings> { provideSettings() }
 
     // Provide PersistenceSource
-    single<PersistenceSource<*>> {
+    single<KeyValueStorage<*>> {
         KeyValueStorage(
             settings = get(),
             keyPrefix = "domain_",
@@ -33,6 +32,7 @@ val domainModule = module {
     single<GreetingRepository<Greeting>> { GreetingRepository() }
     single<BisqStatsRepository> { BisqStatsRepository() }
     single<BtcPriceRepository> { BtcPriceRepository() }
-    single<SettingsRepository> { SettingsRepository() }
     single<MyTradesRepository> { MyTradesRepository() }
+    single<CurrenciesRepository> { CurrenciesRepository() }
+    single<SettingsRepository> { SettingsRepository(get()) }
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -32,6 +32,5 @@ val domainModule = module {
     single<BisqStatsRepository> { BisqStatsRepository() }
     single<BtcPriceRepository> { BtcPriceRepository() }
     single<MyTradesRepository> { MyTradesRepository() }
-    single<CurrenciesRepository> { CurrenciesRepository() }
     single<SettingsRepository> { SettingsRepository(get()) }
 }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -1,10 +1,35 @@
 package network.bisq.mobile.domain.di
 
+import com.russhwolf.settings.Settings
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import network.bisq.mobile.domain.data.model.Greeting
 import network.bisq.mobile.domain.data.repository.*
+import network.bisq.mobile.domain.data.persistance.KeyValueStorage
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import network.bisq.mobile.domain.data.repository.BisqStatsRepository
+import network.bisq.mobile.domain.data.repository.BtcPriceRepository
+import network.bisq.mobile.domain.data.repository.GreetingRepository
+import network.bisq.mobile.domain.data.repository.SettingsRepository
 import org.koin.dsl.module
 
+expect fun provideSettings(): Settings
+
 val domainModule = module {
+    // Data
+    single<Settings> { provideSettings() }
+
+    // Provide PersistenceSource
+    single<PersistenceSource<*>> {
+        KeyValueStorage(
+            settings = get(),
+            keyPrefix = "domain_",
+            serializer = { Json.encodeToString(it) },
+            deserializer = { Json.decodeFromString(it) }
+        )
+    }
+
+    // Repositories
     single<GreetingRepository<Greeting>> { GreetingRepository() }
     single<BisqStatsRepository> { BisqStatsRepository() }
     single<BtcPriceRepository> { BtcPriceRepository() }

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -22,7 +22,6 @@ val domainModule = module {
     single<KeyValueStorage<*>> {
         KeyValueStorage(
             settings = get(),
-            keyPrefix = "domain_",
             serializer = { Json.encodeToString(it) },
             deserializer = { Json.decodeFromString(it) }
         )

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/market_price/MarketPriceServiceFacade.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/market_price/MarketPriceServiceFacade.kt
@@ -2,8 +2,8 @@ package network.bisq.mobile.domain.service.market_price
 
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
-import network.bisq.mobile.domain.data.model.market_price.MarketPriceItem
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketPriceItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 
 interface MarketPriceServiceFacade : LifeCycleAware {
     val marketPriceItem: StateFlow<MarketPriceItem>

--- a/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/offerbook/OfferbookServiceFacade.kt
+++ b/bisqapps/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/offerbook/OfferbookServiceFacade.kt
@@ -2,9 +2,9 @@ package network.bisq.mobile.domain.service.offerbook
 
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
-import network.bisq.mobile.domain.data.model.offerbook.market.OfferbookMarket
+import network.bisq.mobile.domain.data.model.OfferListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
+import network.bisq.mobile.domain.data.model.OfferbookMarket
 
 interface OfferbookServiceFacade: LifeCycleAware {
     val offerbookMarketItems: List<MarketListItem>

--- a/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorageTest.kt
+++ b/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorageTest.kt
@@ -1,0 +1,113 @@
+import kotlinx.coroutines.runBlocking
+import network.bisq.mobile.domain.data.model.BaseModel
+import network.bisq.mobile.domain.data.model.Settings
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import network.bisq.mobile.domain.di.testModule
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KeyValueStorageTest : KoinTest {
+
+    private val persistenceSource: PersistenceSource<BaseModel> by inject()
+
+    @BeforeTest
+    fun setup() {
+        startKoin {
+            modules(testModule)
+        }
+    }
+
+    @AfterTest
+    fun teardown() {
+        stopKoin()
+    }
+
+    @Test
+    fun testSaveAndGet() = runBlocking {
+        val item = Settings().apply { id = "1" }
+        persistenceSource.save(item)
+
+        val retrievedItem = persistenceSource.get("1")
+        assertEquals(item, retrievedItem)
+    }
+
+    @Test
+    fun testSaveAllAndGetAll() = runBlocking {
+        val items = listOf(Settings().apply { id = "1" }, Settings().apply { id = "2" })
+        persistenceSource.saveAll(items)
+
+        val retrievedItems = persistenceSource.getAll()
+        assertEquals(items, retrievedItems)
+    }
+
+    @Test
+    fun testDelete() = runBlocking {
+        val item = Settings().apply { id = "1" }
+        persistenceSource.save(item)
+
+        persistenceSource.delete(item)
+        val retrievedItem = persistenceSource.get("1")
+        assertEquals(null, retrievedItem)
+    }
+
+    @Test
+    fun testClear() = runBlocking {
+        val items = listOf(Settings().apply { id = "1" }, Settings().apply { id = "2" })
+        persistenceSource.saveAll(items)
+
+        persistenceSource.clear()
+        val retrievedItems = persistenceSource.getAll()
+        assertEquals(emptyList<BaseModel>(), retrievedItems)
+    }
+
+    @Test
+    fun testDuplicateIds() = runBlocking {
+        val item1 = Settings().apply { id = "1" }
+        val item2 = Settings().apply { id = "1" }
+
+        persistenceSource.save(item1)
+        persistenceSource.save(item2)
+
+        val retrievedItem = persistenceSource.get("1")
+        assertEquals(item2, retrievedItem)
+    }
+
+    @Test
+    fun testNonExistentId() = runBlocking {
+        val retrievedItem = persistenceSource.get("999")
+        assertEquals(null, retrievedItem)
+    }
+
+    @Test
+    fun testKeyOverlap() = runBlocking {
+        val item1 = Settings().apply { id = "1" }
+        val item2 = Settings().apply { id = "10" }
+
+        persistenceSource.save(item1)
+        persistenceSource.save(item2)
+
+        val retrievedItem1 = persistenceSource.get("1")
+        val retrievedItem2 = persistenceSource.get("10")
+
+        assertEquals(item1, retrievedItem1)
+        assertEquals(item2, retrievedItem2)
+    }
+
+    @Test
+    fun testClearSpecificKey() = runBlocking {
+        val item1 = Settings().apply { id = "1" }
+        val item2 = Settings().apply { id = "2" }
+
+        persistenceSource.saveAll(listOf(item1, item2))
+        persistenceSource.delete(item1)
+
+        val allItems = persistenceSource.getAll()
+        assertEquals(listOf(item2), allItems)
+    }
+}

--- a/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorageTest.kt
+++ b/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/persistance/KeyValueStorageTest.kt
@@ -33,7 +33,8 @@ class KeyValueStorageTest : KoinTest {
         val item = Settings().apply { id = "1" }
         persistenceSource.save(item)
 
-        val retrievedItem = persistenceSource.get("1")
+        val testModel = Settings().apply { id = "1" }
+        val retrievedItem = persistenceSource.get(testModel)
         assertEquals(item, retrievedItem)
     }
 
@@ -42,7 +43,8 @@ class KeyValueStorageTest : KoinTest {
         val items = listOf(Settings().apply { id = "1" }, Settings().apply { id = "2" })
         persistenceSource.saveAll(items)
 
-        val retrievedItems = persistenceSource.getAll()
+        val testModel = Settings()
+        val retrievedItems = persistenceSource.getAll(testModel)
         assertEquals(items, retrievedItems)
     }
 
@@ -51,8 +53,9 @@ class KeyValueStorageTest : KoinTest {
         val item = Settings().apply { id = "1" }
         persistenceSource.save(item)
 
+        val testModel = Settings().apply { id = "1" }
         persistenceSource.delete(item)
-        val retrievedItem = persistenceSource.get("1")
+        val retrievedItem = persistenceSource.get(testModel)
         assertEquals(null, retrievedItem)
     }
 
@@ -61,8 +64,9 @@ class KeyValueStorageTest : KoinTest {
         val items = listOf(Settings().apply { id = "1" }, Settings().apply { id = "2" })
         persistenceSource.saveAll(items)
 
+        val testModel = Settings()
         persistenceSource.clear()
-        val retrievedItems = persistenceSource.getAll()
+        val retrievedItems = persistenceSource.getAll(testModel)
         assertEquals(emptyList<BaseModel>(), retrievedItems)
     }
 
@@ -74,13 +78,15 @@ class KeyValueStorageTest : KoinTest {
         persistenceSource.save(item1)
         persistenceSource.save(item2)
 
-        val retrievedItem = persistenceSource.get("1")
+        val testModel = Settings().apply { id = "1" }
+        val retrievedItem = persistenceSource.get(testModel)
         assertEquals(item2, retrievedItem)
     }
 
     @Test
     fun testNonExistentId() = runBlocking {
-        val retrievedItem = persistenceSource.get("999")
+        val testModel = Settings().apply { id = "999" }
+        val retrievedItem = persistenceSource.get(testModel)
         assertEquals(null, retrievedItem)
     }
 
@@ -92,8 +98,9 @@ class KeyValueStorageTest : KoinTest {
         persistenceSource.save(item1)
         persistenceSource.save(item2)
 
-        val retrievedItem1 = persistenceSource.get("1")
-        val retrievedItem2 = persistenceSource.get("10")
+        val testModel = Settings().apply { id = "1" }
+        val retrievedItem1 = persistenceSource.get(testModel)
+        val retrievedItem2 = persistenceSource.get(testModel.apply { id = "10" })
 
         assertEquals(item1, retrievedItem1)
         assertEquals(item2, retrievedItem2)
@@ -107,7 +114,8 @@ class KeyValueStorageTest : KoinTest {
         persistenceSource.saveAll(listOf(item1, item2))
         persistenceSource.delete(item1)
 
-        val allItems = persistenceSource.getAll()
+        val testModel = Settings()
+        val allItems = persistenceSource.getAll(testModel)
         assertEquals(listOf(item2), allItems)
     }
 }

--- a/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
+++ b/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.domain.di
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.Settings
+import kotlinx.serialization.encodeToString
+import network.bisq.mobile.domain.data.persistance.KeyValueStorage
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import org.koin.dsl.module
+
+val testModule = module {
+    single<Settings> { MapSettings() }
+
+    single<PersistenceSource<*>> {
+        KeyValueStorage(
+            settings = get(),
+            keyPrefix = "testBaseModel_",
+            serializer = { kotlinx.serialization.json.Json.encodeToString(it) },
+            deserializer = { kotlinx.serialization.json.Json.decodeFromString(it) }
+        )
+    }
+}

--- a/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
+++ b/bisqapps/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
@@ -13,7 +13,6 @@ val testModule = module {
     single<PersistenceSource<*>> {
         KeyValueStorage(
             settings = get(),
-            keyPrefix = "testBaseModel_",
             serializer = { kotlinx.serialization.json.Json.encodeToString(it) },
             deserializer = { kotlinx.serialization.json.Json.decodeFromString(it) }
         )

--- a/bisqapps/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
+++ b/bisqapps/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
@@ -6,5 +6,7 @@ import com.russhwolf.settings.Settings
 
 @OptIn(ExperimentalSettingsImplementation::class)
 actual fun provideSettings(): Settings {
+    // TODO we might get away just using normal Settings() KMP agnostic implementation,
+    // leaving this here to be able to choose the specific one for iOS - defaulting to KeyChain
     return KeychainSettings("Settings")
 }

--- a/bisqapps/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
+++ b/bisqapps/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.domain.di
+
+import com.russhwolf.settings.ExperimentalSettingsImplementation
+import com.russhwolf.settings.KeychainSettings
+import com.russhwolf.settings.Settings
+
+@OptIn(ExperimentalSettingsImplementation::class)
+actual fun provideSettings(): Settings {
+    return KeychainSettings("Settings")
+}

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.ui.theme.BisqTheme

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/PaymentMethods.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/PaymentMethods.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 
 // TODO: Get params and render apt
 @Composable

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ProfileRating.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ProfileRating.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.icon_star
 import bisqapps.shared.presentation.generated.resources.img_bot_image
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import org.jetbrains.compose.resources.painterResource
 
 // TODO: Get params and render apt

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/OfferCard.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/OfferCard.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.icon_chat_outlined
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.PaymentMethods
 import network.bisq.mobile.presentation.ui.components.atoms.ProfileRating

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.model.BisqStats
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.BtcPriceRepository
 import network.bisq.mobile.presentation.BasePresenter

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/MarketListPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/MarketListPresenter.kt
@@ -1,6 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.offers
 
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/OffersListPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/OffersListPresenter.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.offers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.client.replicated_model.offer.Direction
-import network.bisq.mobile.domain.data.model.offerbook.OfferListItem
+import network.bisq.mobile.domain.data.model.OfferListItem
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -41,7 +41,11 @@ open class SplashPresenter(
 
     private fun navigateToNextScreen() {
         CoroutineScope(Dispatchers.Main).launch {
+            // TODO: Conditional nav - Will implement once we got persistant storage from nish to save flags
+            // If firstTimeApp launch, goto Onboarding[clientMode] (androidNode / xClient)
+            // If not, goto TabContainerScreen
             if (userProfileService.hasUserProfile()) {
+                //                rootNavigator.navigate(Routes.TrustedNodeSetup.name) {
                 rootNavigator.navigate(Routes.TabContainer.name) {
                     popUpTo(Routes.Splash.name) { inclusive = true }
                 }

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -16,8 +16,8 @@ class TrustedNodeSetupPresenter(
     private val settingsRepository: SettingsRepository
 ) : BasePresenter(mainPresenter), ITrustedNodeSetupPresenter {
 
-    private val _bisqUrl = MutableStateFlow("")
-    override val bisqUrl: StateFlow<String> = _bisqUrl
+    private val _bisqApiUrl = MutableStateFlow("")
+    override val bisqApiUrl: StateFlow<String> = _bisqApiUrl
 
     private val _isConnected = MutableStateFlow(false)
     override val isConnected: StateFlow<Boolean> = _isConnected
@@ -33,8 +33,8 @@ class TrustedNodeSetupPresenter(
                 settingsRepository.fetch()
                 settingsRepository.data.value.let {
                     it?.let {
-                        log.d { "Settings connected:${it.isConnected} url:${it.bisqUrl}" }
-                        _bisqUrl.value = it.bisqUrl
+                        log.d { "Settings connected:${it.isConnected} url:${it.bisqApiUrl}" }
+                        _bisqApiUrl.value = it.bisqApiUrl
                         _isConnected.value = it.isConnected
                     }
                 }
@@ -44,8 +44,8 @@ class TrustedNodeSetupPresenter(
         }
     }
 
-    override fun updateBisqUrl(newUrl: String) {
-        _bisqUrl.value = newUrl
+    override fun updateBisqApiUrl(newUrl: String) {
+        _bisqApiUrl.value = newUrl
     }
 
     override fun testConnection(isTested: Boolean) {
@@ -54,7 +54,7 @@ class TrustedNodeSetupPresenter(
         CoroutineScope(BackgroundDispatcher).launch {
             // TODO only update repository if the test connection succeds. (will need a service for this)
             val updatedSettings = (settingsRepository.data.value ?: Settings()).apply {
-                bisqUrl = _bisqUrl.value
+                bisqApiUrl = _bisqApiUrl.value
                 isConnected = _isConnected.value
             }
 

--- a/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/bisqapps/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -33,10 +33,10 @@ import network.bisq.mobile.presentation.ui.components.atoms.icons.ScanIcon
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 
 interface ITrustedNodeSetupPresenter: ViewPresenter {
-    val bisqUrl: StateFlow<String>
+    val bisqApiUrl: StateFlow<String>
     val isConnected: StateFlow<Boolean>
 
-    fun updateBisqUrl(newUrl: String)
+    fun updateBisqApiUrl(newUrl: String)
 
     fun testConnection(isTested: Boolean)
 
@@ -51,7 +51,7 @@ fun TrustedNodeSetupScreen(
     val navController: NavHostController = koinInject(named("RootNavController"))
     val presenter: ITrustedNodeSetupPresenter = koinInject { parametersOf(navController) }
 
-    val bisqUrl = presenter.bisqUrl.collectAsState().value
+    val bisqApiUrl = presenter.bisqApiUrl.collectAsState().value
     val isConnected = presenter.isConnected.collectAsState().value
 
     RememberPresenterLifecycle(presenter)
@@ -65,8 +65,8 @@ fun TrustedNodeSetupScreen(
         ) {
             BisqTextField(
                 label = "Bisq URL",
-                onValueChanged = { presenter.updateBisqUrl(it) },
-                value = bisqUrl,
+                onValueChanged = { presenter.updateBisqApiUrl(it) },
+                value = bisqApiUrl,
                 placeholder = "",
                 labelRightSuffix = {
                     BisqButton(
@@ -122,7 +122,7 @@ fun TrustedNodeSetupScreen(
         if (!isConnected) {
             BisqButton(
                 text = "Test Connection",
-                color = if (bisqUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
+                color = if (bisqApiUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
                 onClick = {
                     presenter.testConnection(true)
                           },
@@ -139,7 +139,7 @@ fun TrustedNodeSetupScreen(
                 ) {
                     BisqButton(
                         text = "Test Connection",
-                        color = if (bisqUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
+                        color = if (bisqApiUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
                         onClick = { presenter.testConnection(true) },
                         padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                     )


### PR DESCRIPTION
 - Implementation of https://github.com/bisq-network/bisq-mobile/issues/39
 - key value store common implementation based on most used KMP lib
 - provided common tests with mocked implementation
 - using SettingsRepository for an example of real usage: url and connected flag gets saved now and loaded every time the app starts (xClients)
 - tested on the 3 apps, using keychain for iOS