### PR TITLE
UI Fixes #79, #81: Back button, Small screen layouts

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
+import network.bisq.mobile.domain.getPlatform
 import network.bisq.mobile.presentation.ui.AppPresenter
 
 
@@ -48,5 +49,10 @@ open class MainPresenter() :
         _isContentVisible.value = !_isContentVisible.value
     }
 
+    override fun isIOS(): Boolean {
+        val platform = getPlatform()
+        val isIOS = platform.name.lowercase().contains("ios")
+        return isIOS
+    }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -9,6 +9,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
+import network.bisq.mobile.presentation.ui.components.SwipeBackIOSNavigationHandler
 import org.koin.compose.koinInject
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
@@ -57,7 +58,9 @@ fun App() {
     BisqTheme(darkTheme = true) {
         ProvideStrings(lyricist) {
             if (isNavControllerSet) {
-                RootNavGraph()
+                SwipeBackIOSNavigationHandler(rootNavController) {
+                    RootNavGraph()
+                }
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -17,13 +17,16 @@ import network.bisq.mobile.presentation.ui.navigation.graph.RootNavGraph
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.koin.mp.KoinPlatform.getKoin
 
-interface AppPresenter: ViewPresenter {
+interface AppPresenter : ViewPresenter {
     fun setNavController(controller: NavHostController)
-        // Observables for state
+
+    // Observables for state
     val isContentVisible: StateFlow<Boolean>
 
     // Actions
     fun toggleContentVisibility()
+
+    fun isIOS(): Boolean
 }
 
 /**

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
+import network.bisq.mobile.domain.data.model.MarketListItem
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.ui.theme.BisqTheme

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyProfileCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.domain.data.model.MarketListItem
+import network.bisq.mobile.domain.data.model.offerbook.market.MarketListItem
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
@@ -35,7 +35,7 @@ fun CurrencyProfileCard(
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 4.dp)
+            .padding(vertical = 4.dp)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/SwipeBackIOSNavigationHandler.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/SwipeBackIOSNavigationHandler.kt
@@ -1,0 +1,66 @@
+package network.bisq.mobile.presentation.ui.components
+
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import network.bisq.mobile.domain.getPlatform
+
+// TODO:
+// Patch work to handle horizontal swipe in iOS and pop back
+// Will remove this once compose officially has this support for iOS
+// Ref links:
+// - https://github.com/adrielcafe/voyager/issues/144
+// - https://trycatchdebug.net/news/1426361/native-ios-swipe-back-gesture-in-compose
+@Composable
+fun SwipeBackIOSNavigationHandler(
+    navController: NavController,
+    content: @Composable () -> Unit
+) {
+
+    val platform = getPlatform()
+    val isIOS = platform.name.lowercase().contains("ios")
+
+    // TODO: Find the right way to get screenWidth in KMP way.
+    // This is not right.
+    val screenWidthDp = remember { 360.dp }
+    val density = LocalDensity.current
+
+    val screenWidthPx = with(density) { screenWidthDp.toPx() }
+    val threshold = screenWidthPx / 3
+
+    var cumulativeDrag by remember { mutableStateOf(0f) }
+
+    Box(
+        modifier = if (isIOS) {
+            Modifier.pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragStart = {
+                        cumulativeDrag = 0f
+                    },
+                    onDragEnd = {
+                        cumulativeDrag = 0f
+                    },
+                    onDragCancel = {
+                    },
+                    onHorizontalDrag = { change, dragAmount ->
+                        cumulativeDrag += dragAmount.takeIf { it > 0 } ?: 0f
+
+                        if (cumulativeDrag >= threshold) {
+                            if (navController.currentBackStackEntry != null) navController.popBackStack()
+                            cumulativeDrag = 0f
+                        }
+                    }
+                )
+            }
+        } else {
+            Modifier
+        }
+    ) {
+        content()
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/SwipeBackIOSNavigationHandler.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/SwipeBackIOSNavigationHandler.kt
@@ -8,7 +8,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import network.bisq.mobile.domain.getPlatform
+import network.bisq.mobile.presentation.ui.AppPresenter
+import org.koin.compose.koinInject
 
 // TODO:
 // Patch work to handle horizontal swipe in iOS and pop back
@@ -21,9 +22,7 @@ fun SwipeBackIOSNavigationHandler(
     navController: NavController,
     content: @Composable () -> Unit
 ) {
-
-    val platform = getPlatform()
-    val isIOS = platform.name.lowercase().contains("ios")
+    val presenter: AppPresenter = koinInject()
 
     // TODO: Find the right way to get screenWidth in KMP way.
     // This is not right.
@@ -36,7 +35,7 @@ fun SwipeBackIOSNavigationHandler(
     var cumulativeDrag by remember { mutableStateOf(0f) }
 
     Box(
-        modifier = if (isIOS) {
+        modifier = if (presenter.isIOS()) {
             Modifier.pointerInput(Unit) {
                 detectHorizontalDragGestures(
                     onDragStart = {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -1,10 +1,24 @@
 package network.bisq.mobile.presentation.ui.components.atoms
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import network.bisq.mobile.components.MaterialTextField
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
@@ -15,24 +29,66 @@ fun BisqTextField(
     placeholder: String?,
     labelRightSuffix: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
-) {
+    ) {
+    var isFocused by remember { mutableStateOf(false) }
     Column(modifier = modifier) {
-        Row (
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            BisqText.baseRegular(
-                text = label,
-                color = BisqTheme.colors.light2,
-                )
-            if (labelRightSuffix != null) {
-                labelRightSuffix()
+        if (label.isNotEmpty()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BisqText.baseRegular(
+                    text = label,
+                    color = BisqTheme.colors.light2,
+                    )
+                if (labelRightSuffix != null) {
+                    labelRightSuffix()
+                }
             }
         }
-        MaterialTextField(
-            text = value,
-            placeholder = placeholder ?: "",
-            onValueChanged = { onValueChanged(it) })
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(shape = RoundedCornerShape(6.dp))
+                .background(color = BisqTheme.colors.secondary)
+        ) {
+            TextField(
+                value = value,
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().clickable { isFocused = true }
+                    .onFocusChanged { focusState ->
+                        isFocused = focusState.isFocused
+                                    },
+                textStyle = TextStyle(fontSize = 22.sp),
+                onValueChange = onValueChanged,
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = BisqTheme.colors.light3,
+                    unfocusedTextColor = BisqTheme.colors.secondaryHover,
+                    unfocusedIndicatorColor = BisqTheme.colors.secondary,
+                    focusedIndicatorColor = Color.Transparent,
+                    focusedContainerColor = BisqTheme.colors.secondary,
+                    cursorColor = Color.Blue,
+                    unfocusedContainerColor = BisqTheme.colors.secondary
+                ),
+                placeholder = {
+                    if (placeholder != null) {
+                        BisqText.h5Regular(
+                            text = placeholder,
+                            color = BisqTheme.colors.secondaryHover,
+                            )
+                    }
+                }
+            )
+            if (isFocused) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .align(Alignment.BottomCenter)
+                        .background(BisqTheme.colors.primary)
+                )
+            }
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
@@ -10,10 +10,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqScrollLayout(
-    innerPadding: PaddingValues = PaddingValues(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
+    padding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     content: @Composable ColumnScope.() -> Unit
 ) {
@@ -23,7 +24,7 @@ fun BisqScrollLayout(
         modifier = Modifier
             .fillMaxSize()
             .background(color = BisqTheme.colors.backgroundColor)
-            .padding(innerPadding)
+            .padding(padding)
             .verticalScroll(rememberScrollState())
     ) {
         content()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
@@ -5,22 +5,26 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqScrollScaffold(
-    innerPadding: PaddingValues = PaddingValues(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
-    topBar: @Composable () -> Unit = {},
-    bottomBar: @Composable () -> Unit = {},
+    padding: PaddingValues = PaddingValues(
+        top = BisqUIConstants.ScrollTopPadding,
+        bottom = BisqUIConstants.ScreenPadding,
+        start = BisqUIConstants.ScreenPadding,
+        end = BisqUIConstants.ScreenPadding
+    ),
+    topBar: @Composable (() -> Unit)? = null,
+    bottomBar: @Composable (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Scaffold(
         containerColor = BisqTheme.colors.backgroundColor,
-        topBar = topBar,
-        bottomBar = bottomBar,
+        topBar = topBar ?: {},
+        bottomBar = bottomBar ?: {},
         content = {
-            BisqScrollLayout {
-                content()
-            }
+            BisqScrollLayout(padding = if (topBar != null) it else padding) { content() }
         },
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticLayout.kt
@@ -8,10 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqStaticLayout(
-    innerPadding: PaddingValues = PaddingValues(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
+    padding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
     verticalArrangement: Arrangement.Vertical = Arrangement.SpaceBetween,
     content: @Composable ColumnScope.() -> Unit
 ) {
@@ -21,7 +22,7 @@ fun BisqStaticLayout(
         modifier = Modifier
             .fillMaxSize()
             .background(color = BisqTheme.colors.backgroundColor)
-            .padding(innerPadding)
+            .padding(padding)
     ) {
         content()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
@@ -2,23 +2,29 @@ package network.bisq.mobile.presentation.ui.components.layout
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqStaticScaffold(
-    innerPadding: PaddingValues = PaddingValues(top = 96.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
-    topBar: @Composable () -> Unit = {},
-    bottomBar: @Composable () -> Unit = {},
+    padding: PaddingValues = PaddingValues(
+        top = BisqUIConstants.StaticTopPadding,
+        bottom = BisqUIConstants.ScreenPadding,
+        start = BisqUIConstants.ScreenPadding,
+        end = BisqUIConstants.ScreenPadding
+    ),
+    topBar: @Composable (() -> Unit)? = null,
+    bottomBar: @Composable (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Scaffold(
         containerColor = BisqTheme.colors.backgroundColor,
-        topBar = topBar,
-        bottomBar = bottomBar,
+        topBar = topBar ?: {},
+        bottomBar = bottomBar ?: {},
         content = {
-            BisqStaticLayout(innerPadding = innerPadding) { content() }
+            BisqStaticLayout(padding = if (topBar != null) it else padding) { content() }
         }
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -54,7 +54,7 @@ fun TopBar(
             }
         },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = Color.DarkGray, // BisqTheme.colors.backgroundColor,
+            containerColor = BisqTheme.colors.backgroundColor, //Color.DarkGray,
         ),
         title = {
             if (isHome) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -36,7 +36,11 @@ fun TopBar(
     val showBackButton = customBackButton == null && navController.previousBackStackEntry != null
 
     val defaultBackButton: @Composable () -> Unit = {
-        IconButton(onClick = { navController.popBackStack() }) {
+        IconButton(onClick = {
+            if (navController.previousBackStackEntry != null) {
+                navController.popBackStack()
+            }
+        }) {
             Icon(
                 Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -1,36 +1,60 @@
 package network.bisq.mobile.presentation.ui.components.molecules
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BellIcon
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogoSmall
 import network.bisq.mobile.presentation.ui.components.atoms.icons.UserIcon
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopBar(
     title: String = "",
     isHome: Boolean = false,
-    navigationIcon: @Composable () -> Unit = {}
+    customBackButton: @Composable (() -> Unit)? = null
 ) {
+    val navController: NavHostController = koinInject(named("RootNavController"))
+
+    val showBackButton = customBackButton == null && navController.previousBackStackEntry != null
+
+    val defaultBackButton: @Composable () -> Unit = {
+        IconButton(onClick = { navController.popBackStack() }) {
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = BisqTheme.colors.primary
+            )
+        }
+    }
+
     TopAppBar(
-        modifier = Modifier.padding(horizontal = 16.dp).padding(end = 16.dp),
-        navigationIcon = navigationIcon,
+        navigationIcon = {
+            if (showBackButton) {
+                defaultBackButton()
+            } else {
+                customBackButton?.invoke()
+            }
+        },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = BisqTheme.colors.backgroundColor,
+            containerColor = Color.DarkGray, // BisqTheme.colors.backgroundColor,
         ),
         title = {
             if (isHome) {
@@ -43,7 +67,7 @@ fun TopBar(
             }
         },
         actions = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(modifier = Modifier.padding(end = 16.dp), verticalAlignment = Alignment.CenterVertically) {
                 BellIcon(modifier = Modifier.size(30.dp))
                 Spacer(modifier = Modifier.width(12.dp))
                 UserIcon(modifier = Modifier.size(30.dp))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
@@ -11,7 +11,7 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.navigation.Graph
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.uicases.GettingStartedScreen
-import network.bisq.mobile.presentation.ui.uicases.offers.CurrencyListScreen
+import network.bisq.mobile.presentation.ui.uicases.offers.MarketListScreen
 import network.bisq.mobile.presentation.ui.uicases.settings.SettingsScreen
 import network.bisq.mobile.presentation.ui.uicases.trades.MyTradesScreen
 import org.koin.compose.koinInject
@@ -35,7 +35,7 @@ fun TabNavGraph() {
                 GettingStartedScreen()
             }
             composable(route = Routes.TabCurrencies.name) {
-                CurrencyListScreen()
+                MarketListScreen()
             }
             composable(route = Routes.TabMyTrades.name) {
                 MyTradesScreen()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object BisqUIConstants {
+    val ScreenPadding = 12.dp
+    val StaticTopPadding = 36.dp
+    val ScrollTopPadding = 24.dp
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -35,7 +35,6 @@ fun TabContainerScreen() {
     }
 
     BisqStaticScaffold(
-        innerPadding = PaddingValues(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
         topBar = {
             // TODO: Since Topbar should go inside Scaffold
             // the TopBar is written here commonly for all 4 tabs.
@@ -69,7 +68,8 @@ fun TabContainerScreen() {
                         restoreState = true
                     }
                 })
-        }
+        },
+        content = { TabNavGraph() }
 
-    ) { TabNavGraph() }
+    )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/MarketListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/MarketListScreen.kt
@@ -1,42 +1,32 @@
 package network.bisq.mobile.presentation.ui.uicases.offers
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import cafe.adriel.lyricist.LocalStrings
-import network.bisq.mobile.components.MaterialTextField
 import network.bisq.mobile.presentation.ui.components.CurrencyProfileCard
+import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.SortIcon
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticLayout
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
 @Composable
-fun CurrencyListScreen() {
+fun MarketListScreen() {
     val strings = LocalStrings.current
     val presenter: MarketListPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 
-    BisqStaticLayout(verticalArrangement = Arrangement.Top) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+    BisqStaticLayout(
+        verticalArrangement = Arrangement.Top,
         ) {
-            MaterialTextField(text = strings.common_search, onValueChanged = {})
-            SortIcon(modifier = Modifier.size(24.dp))
-        }
-        Spacer(modifier = Modifier.height(12.dp))
+        BisqTextField(label = "", placeholder = strings.common_search, value ="", onValueChanged = {})
+
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding))
 
         LazyColumn {
             items(presenter.marketListItemWithNumOffers) { item ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/OffersListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offers/OffersListScreen.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.presentation.ui.components.molecules.OfferCard
 import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
@@ -57,21 +58,10 @@ fun OffersListScreen() {
 
     BisqStaticScaffold(
         topBar = {
-            TopBar(
-                title = strings.common_offers,
-                false,
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                            tint = BisqTheme.colors.primary
-                        )
-                    }
-                },
-            )
+            TopBar(title = strings.common_offers)
         },
     ) {
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding))
         Box(modifier = Modifier.fillMaxSize()) {
             Column {
                 Column(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -35,7 +35,7 @@ fun CreateProfileScreen(
 
     RememberPresenterLifecycle(presenter)
 
-    BisqScrollScaffold() {
+    BisqScrollScaffold {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
         BisqText.h1Light(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -45,7 +45,7 @@ fun OnBoardingScreen() {
         presenter.indexesToShow.contains(index)
     }
 
-    BisqScrollScaffold() {
+    BisqScrollScaffold {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
         BisqText.h1Light(


### PR DESCRIPTION
This PR has fixes for https://github.com/bisq-network/bisq-mobile/issues/81 (temporary patch) and https://github.com/bisq-network/bisq-mobile/issues/79

Summarizing here. Added more in those specific issues:
 * Back button logic generalized to TopBar.
 * Back swipe gesture implemented for iOS. But it's not as good as back gesture in SwiftUI. Details in the issue page.
 * Tested in Pixel 6a and Pixel 2. Made changes to Scaffold, Layout components so now they all look good. (@rodvar Please check and confirm me from your side)