### PR TITLE
Add user profile icon support for android node

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
@@ -16,6 +16,7 @@
  */
 package network.bisq.mobile.android.node
 
+import android.content.Context
 import androidx.core.util.Supplier
 import bisq.account.AccountService
 import bisq.application.ApplicationService
@@ -42,6 +43,7 @@ import bisq.user.UserService
 import lombok.Getter
 import lombok.Setter
 import lombok.extern.slf4j.Slf4j
+import network.bisq.mobile.android.node.service.AndroidCatHashService
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.utils.Logging
 import java.nio.file.Path
@@ -59,6 +61,7 @@ import java.util.concurrent.TimeUnit
 @Getter
 class AndroidApplicationService(
     androidMemoryReportService: AndroidMemoryReportService,
+    context: Context,
     userDataDir: Path?
 ) :
     ApplicationService("android", arrayOf<String>(), userDataDir), Logging {
@@ -69,6 +72,8 @@ class AndroidApplicationService(
         lateinit var applicationService: AndroidApplicationService
         var state: Supplier<Observable<State>> =
             Supplier { applicationService.state }
+        var androidCatHashService: Supplier<AndroidCatHashService> =
+            Supplier { applicationService.androidCatHashService }
         var securityService: Supplier<SecurityService> =
             Supplier { applicationService.securityService }
         var networkService: Supplier<NetworkService> =
@@ -112,6 +117,8 @@ class AndroidApplicationService(
 
     private val shutDownErrorMessage = Observable<String>()
     private val startupErrorMessage = Observable<String>()
+
+    val androidCatHashService = AndroidCatHashService(context, config.baseDir)
 
     val securityService =
         SecurityService(persistenceService, SecurityService.Config.from(getConfig("security")))

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -25,6 +25,11 @@ val androidNodeModule = module {
         AndroidMemoryReportService(androidContext())
     }
 
+    single<AndroidCatHashService> {
+        val context = androidContext()
+        AndroidCatHashService(context, context.filesDir.toPath())
+    }
+
     single { AndroidApplicationService.Provider() }
 
     single<ApplicationBootstrapFacade> { NodeApplicationBootstrapFacade(get()) }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -25,11 +25,6 @@ val androidNodeModule = module {
         AndroidMemoryReportService(androidContext())
     }
 
-    single<AndroidCatHashService> {
-        val context = androidContext()
-        AndroidCatHashService(context, context.filesDir.toPath())
-    }
-
     single { AndroidApplicationService.Provider() }
 
     single<ApplicationBootstrapFacade> { NodeApplicationBootstrapFacade(get()) }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -22,8 +22,13 @@ class NodeMainPresenter(
         if (!applicationServiceCreated) {
             applicationServiceCreated = true
             val filesDirsPath = (view as Activity).filesDir.toPath()
+            val applicationContext = (view as Activity).applicationContext
             val applicationService =
-                AndroidApplicationService(androidMemoryReportService, filesDirsPath)
+                AndroidApplicationService(
+                    androidMemoryReportService,
+                    applicationContext,
+                    filesDirsPath
+                )
             provider.applicationService = applicationService
 
             applicationBootstrapFacade.activate()

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/AndroidCatHashService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/AndroidCatHashService.kt
@@ -26,9 +26,16 @@ import java.nio.file.Path
 /**
  * Cat Hash implementation for Android
  */
-class AndroidCatHashService(private val context: Context, baseDir: Path?) : CatHashService<Bitmap>(baseDir) {
+class AndroidCatHashService(private val context: Context, baseDir: Path?) :
+    CatHashService<Bitmap>(baseDir) {
     override fun composeImage(paths: Array<String>, size: Double): Bitmap {
-        return ImageUtil.composeImage(context, paths, size.toInt(), size.toInt())
+        return ImageUtil.composeImage(
+            context,
+            ImageUtil.BASE_PATH,
+            paths,
+            size.toInt(),
+            size.toInt()
+        )
     }
 
     override fun writeRawImage(image: Bitmap, file: File) {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/utils/ImageUtils.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/utils/ImageUtils.kt
@@ -13,17 +13,23 @@ import java.io.FileOutputStream
 import java.io.IOException
 
 /**
- * Android images utilitary functions
+ * Android images utility functions
  */
 object ImageUtil : Logging {
-
-    fun composeImage(context: Context, paths: Array<String>, width: Int, height: Int): Bitmap {
+    const val BASE_PATH = "cathash/"
+    fun composeImage(
+        context: Context,
+        basePath: String,
+        paths: Array<String>,
+        width: Int,
+        height: Int
+    ): Bitmap {
         val resultBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(resultBitmap)
         val paint = Paint()
 
         paths.forEach { path ->
-            val bitmap = getImageByPath(context, path)
+            val bitmap = getImageByPath(context, basePath, path)
             if (bitmap != null) {
                 val scaledBitmap = Bitmap.createScaledBitmap(bitmap, width, height, true)
                 canvas.drawBitmap(scaledBitmap, 0f, 0f, paint)
@@ -52,9 +58,9 @@ object ImageUtil : Logging {
         }
     }
 
-    internal fun getImageByPath(context: Context, path: String): Bitmap? {
+    internal fun getImageByPath(context: Context, basePath: String, path: String): Bitmap? {
         return try {
-            val fullPath = "cathash/$path"
+            val fullPath = basePath + path
             val inputStream = context.assets.open(fullPath)
             BitmapFactory.decodeStream(inputStream)
         } catch (e: Exception) {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/utils/ImageUtils.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/utils/ImageUtils.kt
@@ -15,7 +15,7 @@ import java.io.IOException
 /**
  * Android images utilitary functions
  */
-object ImageUtil: Logging {
+object ImageUtil : Logging {
 
     fun composeImage(context: Context, paths: Array<String>, width: Int, height: Int): Bitmap {
         val resultBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
@@ -25,7 +25,8 @@ object ImageUtil: Logging {
         paths.forEach { path ->
             val bitmap = getImageByPath(context, path)
             if (bitmap != null) {
-                canvas.drawBitmap(bitmap, 0f, 0f, paint)
+                val scaledBitmap = Bitmap.createScaledBitmap(bitmap, width, height, true)
+                canvas.drawBitmap(scaledBitmap, 0f, 0f, paint)
             }
         }
 
@@ -53,8 +54,8 @@ object ImageUtil: Logging {
 
     internal fun getImageByPath(context: Context, path: String): Bitmap? {
         return try {
-            log.d { "opening file in path $path"}
-            val inputStream = context.assets.open(path)
+            val fullPath = "cathash/$path"
+            val inputStream = context.assets.open(fullPath)
             BitmapFactory.decodeStream(inputStream)
         } catch (e: Exception) {
             e.printStackTrace()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -12,9 +12,9 @@ import network.bisq.mobile.client.market.ClientMarketPriceServiceFacade
 import network.bisq.mobile.client.market.MarketPriceApiGateway
 import network.bisq.mobile.client.offerbook.ClientOfferbookServiceFacade
 import network.bisq.mobile.client.service.ApiRequestService
-import network.bisq.mobile.domain.client.main.user_profile.ClientUserProfileServiceFacade
+import network.bisq.mobile.client.user_profile.ClientUserProfileServiceFacade
 import network.bisq.mobile.client.offerbook.offer.OfferbookApiGateway
-import network.bisq.mobile.domain.client.main.user_profile.UserProfileApiGateway
+import network.bisq.mobile.client.user_profile.UserProfileApiGateway
 import network.bisq.mobile.domain.data.repository.main.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/ClientUserProfileServiceFacade.kt
@@ -1,10 +1,9 @@
-package network.bisq.mobile.domain.client.main.user_profile
+package network.bisq.mobile.client.user_profile
 
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import network.bisq.mobile.client.replicated_model.user.identity.PreparedData
 import network.bisq.mobile.client.replicated_model.user.profile.UserProfile
-import network.bisq.mobile.client.user_profile.UserProfileResponse
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.utils.Logging
 import kotlin.math.max
@@ -22,12 +21,13 @@ class ClientUserProfileServiceFacade(private val apiGateway: UserProfileApiGatew
         return getUserIdentityIds().isNotEmpty()
     }
 
-    override suspend fun generateKeyPair(result: (String, String) -> Unit) {
+    override suspend fun generateKeyPair(result: (String, String, Any?) -> Unit) {
         try {
             val ts = Clock.System.now().toEpochMilliseconds()
             val preparedData = apiGateway.requestPreparedData()
             createSimulatedDelay(Clock.System.now().toEpochMilliseconds() - ts)
-            result(preparedData.id, preparedData.nym)
+            //todo not impl yet
+            result(preparedData.id, preparedData.nym, null)
             this.preparedData = preparedData
         } catch (e: Exception) {
             log.e { e.toString() }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/CreateUserIdentityRequest.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/CreateUserIdentityRequest.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.domain.client.main.user_profile
+package network.bisq.mobile.client.user_profile
 
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.client.replicated_model.user.identity.PreparedData

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/UserProfileApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/user_profile/UserProfileApiGateway.kt
@@ -1,9 +1,8 @@
-package network.bisq.mobile.domain.client.main.user_profile
+package network.bisq.mobile.client.user_profile
 
 import network.bisq.mobile.client.replicated_model.user.identity.PreparedData
 import network.bisq.mobile.client.replicated_model.user.profile.UserProfile
 import network.bisq.mobile.client.service.ApiRequestService
-import network.bisq.mobile.client.user_profile.UserProfileResponse
 
 class UserProfileApiGateway(
     private val apiRequestService: ApiRequestService

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
@@ -21,7 +21,7 @@ interface UserProfileServiceFacade {
      * the proof of work solution.
      * The CatHash image is also created based on that hash and the proof of work solution.
      */
-    suspend fun generateKeyPair(result: (String, String) -> Unit)
+    suspend fun generateKeyPair(result: (String, String, Any?) -> Unit)
 
     /**
      * Once the user clicks the `create` button we create a user identity and publish the

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -30,6 +30,12 @@ open class CreateProfilePresenter(
         _nym.value = value
     }
 
+    private val _profileIcon = MutableStateFlow<Any?>(null)
+    val profileIcon: StateFlow<Any?> get() = _profileIcon
+    private fun setProfileIcon(value: Any?) {
+        _profileIcon.value = value
+    }
+
     private val _nickName = MutableStateFlow("")
     val nickName: StateFlow<String> get() = _nickName
     fun setNickname(value: String) {
@@ -99,10 +105,10 @@ open class CreateProfilePresenter(
             setGenerateKeyPairInProgress(true)
             log.i { "Show busy animation for generateKeyPair" }
             // takes 200 -1000 ms
-            userProfileService.generateKeyPair { id, nym ->
+            userProfileService.generateKeyPair { id, nym, profileIcon ->
                 setId(id)
                 setNym(nym)
-                //todo show new profile image
+                setProfileIcon(profileIcon)
             }
             setGenerateKeyPairInProgress(false)
             log.i { "Hide busy animation for generateKeyPair" }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -3,16 +3,17 @@ package network.bisq.mobile.presentation.ui.uicases.startup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.img_bot_image
 import cafe.adriel.lyricist.LocalStrings
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -21,10 +22,10 @@ import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
+import kotlin.math.log
 
 @Composable
 fun CreateProfileScreen(
@@ -57,10 +58,19 @@ fun CreateProfileScreen(
             placeholder = strings.onboarding_createProfile_nickName_prompt
         )
         Spacer(modifier = Modifier.height(36.dp))
-        Image(
-            painterResource(Res.drawable.img_bot_image),
-            "User profile icon generated from the hash of the public key"
-        ) // TODO: Translation
+
+        presenter.profileIcon.collectAsState().value?.let { profileIcon ->
+            // how can i convert a coil3.Bitmap to androidx.compose.ui.graphics.ImageBitmap in KMP
+            val imageBitmap: ImageBitmap? = profileIcon as ImageBitmap
+            if (imageBitmap != null) {
+                Image(
+                    bitmap = imageBitmap,
+                    contentDescription = "User profile icon generated from the hash of the public key",
+                    modifier = Modifier.height(60.dp).width(60.dp)
+                )
+            }
+        }
+
         Spacer(modifier = Modifier.height(32.dp))
         BisqText.baseRegular(
             text = presenter.nym.collectAsState().value,


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq-mobile/pull/85

Preliminary solution. Follow up PR will come with client and iOS support.

For testing it one need to either delete the data directory in simulator or edit SplashPresenter to not skip user profile creation page.
Only here the (on node) it is applied, not at offers yet. 