### PR TITLE
Logging runtime crash fix

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/utils/Logging.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/utils/Logging.kt
@@ -17,11 +17,7 @@ fun getLogger(anyObj: Any): Logger {
 }
 
 fun getLogger(tag: String): Logger {
-    return getLogger(tag)
-}
-
-fun getLogger(): Logger {
-    return doGetLogger(null)
+    return doGetLogger(tag)
 }
 
 private fun doGetLogger(tag: String?): Logger {


### PR DESCRIPTION
 - fix runtime crash grabbing logger from views (this will need a refactor, we do not want views logging stuff)