### PR TITLE
Feature/resilient background service

### DIFF
--- a/androidClient/src/androidMain/AndroidManifest.xml
+++ b/androidClient/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />  
 
     <application
         android:name=".MainApplication"

--- a/androidClient/src/androidMain/AndroidManifest.xml
+++ b/androidClient/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />  
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
 
     <application
         android:name=".MainApplication"
@@ -22,6 +24,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- OS services -->
+        <service
+            android:name="network.bisq.mobile.domain.service.BisqForegroundService"
+            android:exported="false"
+            android:permission="android.permission.FOREGROUND_SERVICE"
+            android:foregroundServiceType="remoteMessaging">
+        </service>
     </application>
 
 </manifest>

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
@@ -1,19 +1,29 @@
 package network.bisq.mobile.client
 
+import android.content.pm.PackageManager
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.App
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
     private val presenter: MainPresenter by inject()
+    
+    // TODO probably better to handle from presenter once the user reach home
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +33,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             App()
         }
+
+        handleDynamicPermissions()
     }
 
     override fun onStart() {
@@ -49,6 +61,38 @@ class MainActivity : ComponentActivity() {
         presenter.detachView()
         presenter.onDestroy()
         super.onDestroy()
+    }
+
+    private fun handleDynamicPermissions() {
+        requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { isGranted: Boolean ->
+            if (isGranted) {
+                // Permission granted, proceed with posting notifications
+            } else {
+                // Permission denied, show a message to the user
+                Toast.makeText(this, "Permission denied. Notifications won't be sent.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        // Call the method to check and request permission in APIs where its mandatory
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            checkAndRequestNotificationPermission()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun checkAndRequestNotificationPermission() {
+        // Check if the permission is granted
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED) {
+            // Permission already granted, proceed with posting notifications
+        } else {
+            // Request permission if not granted
+            requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 }
 

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainApplication.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import network.bisq.mobile.client.di.androidClientModule
 import network.bisq.mobile.client.di.clientModule
 import network.bisq.mobile.domain.di.domainModule
+import network.bisq.mobile.domain.di.serviceModule
 import network.bisq.mobile.presentation.di.presentationModule
 import org.koin.android.ext.koin.androidContext
 
@@ -15,7 +16,7 @@ class MainApplication: Application() {
 
         startKoin {
             androidContext(this@MainApplication)
-            modules(listOf(domainModule, presentationModule, clientModule, androidClientModule))
+            modules(listOf(domainModule, serviceModule, presentationModule, clientModule, androidClientModule))
         }
     }
 }

--- a/androidNode/src/androidMain/AndroidManifest.xml
+++ b/androidNode/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
 
     <application
         android:name="network.bisq.mobile.android.node.MainApplication"
@@ -21,6 +23,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- OS services -->
+        <service
+            android:name="network.bisq.mobile.domain.service.BisqForegroundService"
+            android:exported="false"
+            android:permission="android.permission.FOREGROUND_SERVICE"
+            android:foregroundServiceType="remoteMessaging">
+        </service>
     </application>
 
 </manifest>

--- a/androidNode/src/androidMain/AndroidManifest.xml
+++ b/androidNode/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="network.bisq.mobile.android.node.MainApplication"

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainActivity.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainActivity.kt
@@ -1,16 +1,26 @@
 package network.bisq.mobile.android.node
 
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.App
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
     private val presenter : MainPresenter by inject()
+
+    // TODO probably better to handle from presenter once the user reach home
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,8 +29,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             App()
         }
-    }
 
+        handleDynamicPermissions()
+    }
     override fun onStart() {
         super.onStart()
         presenter.onStart()
@@ -46,6 +57,39 @@ class MainActivity : ComponentActivity() {
         presenter.onDestroy()
         super.onDestroy()
     }
+
+    private fun handleDynamicPermissions() {
+        requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { isGranted: Boolean ->
+            if (isGranted) {
+                // Permission granted, proceed with posting notifications
+            } else {
+                // Permission denied, show a message to the user
+                Toast.makeText(this, "Permission denied. Notifications won't be sent.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        // Call the method to check and request permission in APIs where its mandatory
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            checkAndRequestNotificationPermission()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun checkAndRequestNotificationPermission() {
+        // Check if the permission is granted
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED) {
+            // Permission already granted, proceed with posting notifications
+        } else {
+            // Request permission if not granted
+            requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
 }
 
 @Preview

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainApplication.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainApplication.kt
@@ -8,6 +8,7 @@ import bisq.common.facades.android.AndroidJdkFacade
 import bisq.common.network.AndroidEmulatorLocalhostFacade
 import network.bisq.mobile.android.node.di.androidNodeModule
 import network.bisq.mobile.domain.di.domainModule
+import network.bisq.mobile.domain.di.serviceModule
 import network.bisq.mobile.presentation.di.presentationModule
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.koin.android.ext.koin.androidContext
@@ -40,7 +41,7 @@ class MainApplication : Application() {
             startKoin {
                 androidContext(this@MainApplication)
                 // order is important, last one is picked for each interface/class key
-                modules(listOf(domainModule, presentationModule, androidNodeModule))
+                modules(listOf(domainModule, serviceModule, presentationModule, androidNodeModule))
             }
         }
     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -41,7 +41,7 @@ val androidNodeModule = module {
     single<OfferbookServiceFacade> { NodeOfferbookServiceFacade(get(), get()) }
     // this line showcases both, the possibility to change behaviour of the app by changing one definition
     // and binding the same obj to 2 different abstractions
-    single<MainPresenter> { NodeMainPresenter(get(), get(),  get(), get(), get()) } bind AppPresenter::class
+    single<MainPresenter> { NodeMainPresenter(get(), get(), get(),  get(), get(), get()) } bind AppPresenter::class
 
     single<IOnboardingPresenter> { OnBoardingNodePresenter(get()) } bind IOnboardingPresenter::class
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/market_price/NodeMarketPriceServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/market_price/NodeMarketPriceServiceFacade.kt
@@ -55,8 +55,12 @@ class NodeMarketPriceServiceFacade(private val applicationService: AndroidApplic
     private fun observeSelectedMarket() {
         selectedMarketPin?.unbind()
         selectedMarketPin = marketPriceService.selectedMarket.addObserver { market ->
-            _marketPriceItem.value = MarketPriceItem(toReplicatedMarket(market))
-            updatePrice()
+           try {
+                _marketPriceItem.value = MarketPriceItem(toReplicatedMarket(market))
+                updatePrice()
+           } catch (e: Exception) {
+               log.e("Failed to update market item", e)
+           }
         }
     }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeSelectedOfferbookMarketService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/domain/offerbook/market/NodeSelectedOfferbookMarketService.kt
@@ -73,8 +73,8 @@ class NodeSelectedOfferbookMarketService(
     private fun observeSelectedChannel() {
         selectedChannelPin =
             bisqEasyOfferbookChannelSelectionService.selectedChannel.addObserver { selectedChannel ->
-                this.selectedChannel = selectedChannel as BisqEasyOfferbookChannel
-                marketPriceService.setSelectedMarket(selectedChannel.market)
+                this.selectedChannel = selectedChannel as BisqEasyOfferbookChannel?
+                marketPriceService.setSelectedMarket(selectedChannel?.market)
                 applySelectedOfferbookMarket()
             }
     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -4,17 +4,19 @@ import android.app.Activity
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.domain.data.repository.main.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 
 class NodeMainPresenter(
+    notificationServiceController: NotificationServiceController,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val offerbookServiceFacade: OfferbookServiceFacade,
     private val marketPriceServiceFacade: MarketPriceServiceFacade
-) : MainPresenter() {
+) : MainPresenter(notificationServiceController) {
 
     private var applicationServiceCreated = false
     override fun onViewAttached() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-activityCompose = "1.9.2"
 
 androidx-appcompat = "1.7.0"
 androidx-constraintlayout = "2.1.4"
+androidx-core = "1.13.1"
 androidx-core-ktx = "1.13.1"
 androidx-espresso-core = "3.6.1"
 androidx-material = "1.12.0"
@@ -92,6 +93,7 @@ androidx-test-compose = { group = "androidx.compose.ui", name = "ui-test-junit4-
 androidx-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "androidx-test-compose-ver" }
 
 #kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+androidx-core = { group = "androidx.core", name = "core", version.ref = "androidx-core" }
 #androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
 roboelectric = { group = "org.robolectric", name = "robolectric", version.ref = "roboelectric" }
 androidx-test = { group = "androidx.test", name = "core", version.ref = "androidx-test" }

--- a/iosClient/iosClient/Info.plist
+++ b/iosClient/iosClient/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>network.bisq.mobile.ios.backgroundtask</string>
+		<string>network.bisq.mobile.iosUC4273Y485.backgroundTask</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>

--- a/iosClient/iosClient/Info.plist
+++ b/iosClient/iosClient/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>network.bisq.mobile.ios.backgroundtask</string>
+	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -20,13 +26,16 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/iosClient/iosClient/Info.plist
+++ b/iosClient/iosClient/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>network.bisq.mobile.iosUC4273Y485.backgroundTask</string>
+		<string>network.bisq.mobile.iosUC4273Y485</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>

--- a/iosClient/iosClient/LifecycleAwareComposeViewController.swift
+++ b/iosClient/iosClient/LifecycleAwareComposeViewController.swift
@@ -10,7 +10,6 @@ class LifecycleAwareComposeViewController: UIViewController {
     init(presenter: MainPresenter) {
         self.presenter = presenter
         super.init(nibName: nil, bundle: nil)
-        presenter.attachView(view: self)
     }
 
     required init?(coder: NSCoder) {
@@ -64,6 +63,7 @@ class LifecycleAwareComposeViewController: UIViewController {
 
         // Notify the child view controller that it was moved to a parent
         mainViewController.didMove(toParent: self)
+        presenter.attachView(view: self)
     }
 
     // Equivalent to `onDestroy` in Android for final cleanup

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -1,15 +1,82 @@
 import SwiftUI
+import domain
 import presentation
 
 @main
 struct iosClient: App {
+
+//    private let notificationServiceController: NotificationServiceController?
+    private let notificationHandler = NotificationHandler()
+
     init() {
         DependenciesProviderHelper().doInitKoin()
+//        TODO not working
+//        notificationServiceController = get()
+//        if (notificationServiceController != nil) {
+//            notificationHandler.setNotificationHandlerImpl(notificationServiceController!)
+//        }
+//        // Request notification permissions and set the delegate
+//        configureNotifications()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+    }
+
+    private func configureNotifications() {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = notificationHandler  // Custom delegate
+
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("Error requesting notifications permission: \(error)")
+            }
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+        }
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            print("Notification settings: \(settings)")
+            if settings.authorizationStatus == .authorized {
+                print("Notifications are authorized.")
+            } else {
+                print("Notifications are not authorized.")
+            }
+        }
+
+        // simulation
+        let content = UNMutableNotificationContent()
+        content.title = "Test Notification"
+        content.body = "This is a test notification."
+        content.sound = .default
+
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("Failed to add notification: \(error)")
+            } else {
+                print("Notification added successfully")
+            }
+        }
+    }
+}
+
+// Custom notification handler that conforms to `UNUserNotificationCenterDelegate`
+class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
+    private var impl: NotificationServiceController?
+
+    func setNotificationHandlerImpl(_ controller: NotificationServiceController) {
+        self.impl = controller
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // Show the notification while in foreground
+        print("Foreground notification received")
+        completionHandler([.banner, .sound, .badge])
+        impl?.pushNotification(title: "pepe", message: "parada")
     }
 }

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -5,18 +5,8 @@ import presentation
 @main
 struct iosClient: App {
 
-//    private let notificationServiceController: NotificationServiceController?
-    private let notificationHandler = NotificationHandler()
-
     init() {
         DependenciesProviderHelper().doInitKoin()
-//        TODO not working
-//        notificationServiceController = get()
-//        if (notificationServiceController != nil) {
-//            notificationHandler.setNotificationHandlerImpl(notificationServiceController!)
-//        }
-//        // Request notification permissions and set the delegate
-//        configureNotifications()
     }
 
     var body: some Scene {
@@ -25,58 +15,4 @@ struct iosClient: App {
         }
     }
 
-    private func configureNotifications() {
-        let center = UNUserNotificationCenter.current()
-        center.delegate = notificationHandler  // Custom delegate
-
-        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if let error = error {
-                print("Error requesting notifications permission: \(error)")
-            }
-            if granted {
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
-            }
-        }
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            print("Notification settings: \(settings)")
-            if settings.authorizationStatus == .authorized {
-                print("Notifications are authorized.")
-            } else {
-                print("Notifications are not authorized.")
-            }
-        }
-
-        // simulation
-        let content = UNMutableNotificationContent()
-        content.title = "Test Notification"
-        content.body = "This is a test notification."
-        content.sound = .default
-
-        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                print("Failed to add notification: \(error)")
-            } else {
-                print("Notification added successfully")
-            }
-        }
-    }
-}
-
-// Custom notification handler that conforms to `UNUserNotificationCenterDelegate`
-class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
-    private var impl: NotificationServiceController?
-
-    func setNotificationHandlerImpl(_ controller: NotificationServiceController) {
-        self.impl = controller
-    }
-
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // Show the notification while in foreground
-        print("Foreground notification received")
-        completionHandler([.banner, .sound, .badge])
-        impl?.pushNotification(title: "pepe", message: "parada")
-    }
 }

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import domain
 import presentation
 
 @main

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -67,6 +67,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.androidx.core)
+            
+            implementation(libs.koin.core)
+            implementation(libs.koin.android)
         }
         androidUnitTest.dependencies {
             implementation(libs.mock.io)

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -65,6 +65,9 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.koin.test)
         }
+        androidMain.dependencies {
+            implementation(libs.androidx.core)
+        }
         androidUnitTest.dependencies {
             implementation(libs.mock.io)
             implementation(libs.kotlin.test.junit.v180)

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.domain.di
+
+import network.bisq.mobile.domain.service.controller.NotificationServiceController
+import org.koin.dsl.module
+import org.koin.android.ext.koin.androidContext
+
+val serviceModule = module {
+    single<NotificationServiceController> { NotificationServiceController(androidContext()) }
+}

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/BisqForegroundService.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/BisqForegroundService.kt
@@ -1,12 +1,24 @@
 package network.bisq.mobile.domain.service
 
 import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import network.bisq.mobile.utils.Logging
 
 /**
  * Implements foreground service (api >= 26) or background service accordingly
@@ -15,22 +27,64 @@ import androidx.core.content.ContextCompat
  *
  * android docs: https://developer.android.com/develop/background-work/services/foreground-services
  */
-open class BisqForegroundService : Service() {
+open class BisqForegroundService : Service(), Logging {
     companion object {
         const val CHANNEL_ID = "BISQ_SERVICE_CHANNEL"
         const val SERVICE_ID = 21000000
+        const val PUSH_NOTIFICATION_ID = 1
         const val SERVICE_NAME = "Bisq Foreground Service"
         const val PUSH_NOTIFICATION_ACTION_KEY = "network.bisq.bisqapps.ACTION_REQUEST_PERMISSION"
     }
 
+    private lateinit var silentNotification: Notification
+
+    private lateinit var defaultNotification: Notification
+
     override fun onCreate() {
         super.onCreate()
-        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle(SERVICE_NAME)
-            .setSmallIcon(android.R.drawable.ic_notification_overlay)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT) // For android previous to O
-            .build()
-        startForeground(SERVICE_ID, notification)
+        initDefaultNotifications()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceCompat.startForeground(this, SERVICE_ID, silentNotification, ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING)
+            log.i { "Started as foreground service compat"}
+        } else {
+            startForeground(SERVICE_ID, silentNotification)
+            log.i { "Started foreground"}
+        }
+        log.i { "Service ready" }
+
+        CoroutineScope(Dispatchers.Main).launch {
+            delay(10000)  // Wait for 10 seconds
+            // Create an Intent to open the MainActivity when the notification is tapped
+            val pendingIntent = null
+//            val intent = Intent(this, MainActivity::class.java).apply {
+//                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK // Clears any existing task and starts a new one
+//            }
+//
+//            // Create a PendingIntent to wrap the Intent
+//            val pendingIntent: PendingIntent = PendingIntent.getActivity(
+//                this@BisqForegroundService,
+//                0,
+//                intent,
+//                PendingIntent.FLAG_UPDATE_CURRENT // This flag updates the existing PendingIntent if it's already created
+//            )
+            val updatedNotification: Notification = NotificationCompat.Builder(this@BisqForegroundService, CHANNEL_ID)
+                .setContentTitle("New Update!")
+                .setContentText("Tap to open the app")
+                .setSmallIcon(android.R.drawable.ic_notification_overlay)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setOngoing(true)  // Keeps the notification active
+                .setContentIntent(pendingIntent)  // Set the pending intent to launch the app
+                .build()
+
+            // Update the notification
+//            NotificationManagerCompat.from(this@BisqForegroundService).notify(SERVICE_ID, updatedNotification)
+
+            val notificationManager = this@BisqForegroundService.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.notify(PUSH_NOTIFICATION_ID, updatedNotification)
+
+            // Log the update
+            log.i { "Notification updated after 10 seconds" }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -43,13 +97,30 @@ open class BisqForegroundService : Service() {
             val broadcastIntent = Intent(PUSH_NOTIFICATION_ACTION_KEY)
             sendBroadcast(broadcastIntent)
         }
+        log.i { "Service starting sticky" }
         return START_STICKY
     }
 
     override fun onDestroy() {
+        log.i { "Service is being destroyed" }
         super.onDestroy()
         // Cleanup tasks
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun initDefaultNotifications() {
+        silentNotification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("") // No title
+            .setContentText("")  // No content
+            .setSmallIcon(android.R.drawable.ic_notification_overlay)
+            .setPriority(NotificationCompat.PRIORITY_MIN)  // Silent notification
+            .setOngoing(true)  // Keeps the notification active
+            .build()
+        defaultNotification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(SERVICE_NAME)
+            .setSmallIcon(android.R.drawable.ic_notification_overlay)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT) // For android previous to O
+            .build()
+    }
 }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/BisqForegroundService.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/BisqForegroundService.kt
@@ -1,0 +1,55 @@
+package network.bisq.mobile.domain.service
+
+import android.app.Notification
+import android.app.Service
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+/**
+ * Implements foreground service (api >= 26) or background service accordingly
+ *
+ * This class is open for extension (for example, for the androidNode)
+ *
+ * android docs: https://developer.android.com/develop/background-work/services/foreground-services
+ */
+open class BisqForegroundService : Service() {
+    companion object {
+        const val CHANNEL_ID = "BISQ_SERVICE_CHANNEL"
+        const val SERVICE_ID = 21000000
+        const val SERVICE_NAME = "Bisq Foreground Service"
+        const val PUSH_NOTIFICATION_ACTION_KEY = "network.bisq.bisqapps.ACTION_REQUEST_PERMISSION"
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(SERVICE_NAME)
+            .setSmallIcon(android.R.drawable.ic_notification_overlay)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT) // For android previous to O
+            .build()
+        startForeground(SERVICE_ID, notification)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Check if notification permission is granted
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED) {
+            // Send a broadcast to the activity to request permission
+            val broadcastIntent = Intent(PUSH_NOTIFICATION_ACTION_KEY)
+            sendBroadcast(broadcastIntent)
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Cleanup tasks
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.android.kt
@@ -1,0 +1,73 @@
+package network.bisq.mobile.domain.service.controller
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import network.bisq.mobile.domain.service.BisqForegroundService
+
+/**
+ * Controller interacting with the bisq service
+ */
+actual class NotificationServiceController (private val context: Context): ServiceController {
+
+    companion object {
+        const val SERVICE_NAME = "Bisq Service"
+    }
+    private var isRunning = false
+
+    /**
+     * Starts the service in the appropiate mode based on the current device running Android API
+     */
+    actual override fun startService() {
+        if (!isRunning) {
+            createNotificationChannel()
+            val intent = Intent(context, BisqForegroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                // if the phone does not support foreground service
+                context.startService(intent)
+            }
+            isRunning = true
+        }
+    }
+
+    actual override fun stopService() {
+        // TODO we need to leave the service running if the user is ok with it
+        deleteNotificationChannel()
+        val intent = Intent(context, BisqForegroundService::class.java)
+        context.stopService(intent)
+        isRunning = false
+    }
+
+    actual fun pushNotification(title: String, message: String) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notification = NotificationCompat.Builder(context, BisqForegroundService.CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setSmallIcon(android.R.drawable.ic_notification_overlay)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT) // For android previous to O
+            .build()
+        notificationManager.notify(1, notification)
+    }
+
+    actual override fun isServiceRunning() = isRunning
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(BisqForegroundService.CHANNEL_ID, SERVICE_NAME, NotificationManager.IMPORTANCE_LOW)
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun deleteNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.deleteNotificationChannel(BisqForegroundService.CHANNEL_ID)
+        }
+    }
+}

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.android.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.utils.Logging
 /**
  * Controller interacting with the bisq service
  */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class NotificationServiceController (private val context: Context): ServiceController, Logging {
 
     companion object {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/market/ClientMarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/market/ClientMarketPriceServiceFacade.kt
@@ -58,7 +58,7 @@ class ClientMarketPriceServiceFacade(
 
                     applyQuote()
                 } catch (e: Exception) {
-                    log.e("Error at API request", e)
+                    log.e("Error at getQuotes API request", e)
                 }
             }
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientMarketListItemService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/market/ClientMarketListItemService.kt
@@ -24,7 +24,7 @@ class ClientMarketListItemService(private val apiGateway: OfferbookApiGateway) :
     // Misc
     private val coroutineScope = CoroutineScope(BackgroundDispatcher)
     private var job: Job? = null
-    private var polling = Polling(1000) { updateNumOffers() }
+    private var polling = Polling(10000) { updateNumOffers() }
     private var marketListItemsRequested = false
 
     // Life cycle
@@ -45,7 +45,7 @@ class ClientMarketListItemService(private val apiGateway: OfferbookApiGateway) :
                     requestAndApplyNumOffers()
                     marketListItemsRequested = true
                 } catch (e: Exception) {
-                    log.e("Error at API request", e)
+                    log.e("Error at Fill Market List Items API request", e)
                 }
             }
         }
@@ -87,7 +87,7 @@ class ClientMarketListItemService(private val apiGateway: OfferbookApiGateway) :
                 marketListItem
             }
         } catch (e: Exception) {
-            log.e("Error at API request", e)
+            log.e("Error at apply num offers for markets API request", e)
         }
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/ClientOfferbookListItemService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/offer/ClientOfferbookListItemService.kt
@@ -24,7 +24,7 @@ class ClientOfferbookListItemService(private val apiGateway: OfferbookApiGateway
 
     // Misc
     private var job: Job? = null
-    private var polling = Polling(1000) { updateOffers() }
+    private var polling = Polling(10000) { updateOffers() }
     private var selectedMarket: MarketListItem? = null
     private val coroutineScope = CoroutineScope(BackgroundDispatcher)
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -7,6 +7,10 @@ import network.bisq.mobile.domain.data.model.Greeting
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.repository.*
 import network.bisq.mobile.domain.getPlatformSettings
+import network.bisq.mobile.domain.data.repository.BisqStatsRepository
+import network.bisq.mobile.domain.data.repository.BtcPriceRepository
+import network.bisq.mobile.domain.data.repository.GreetingRepository
+import network.bisq.mobile.domain.data.repository.SettingsRepository
 import org.koin.dsl.module
 
 val domainModule = module {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.domain.service.controller
 /**
  * And interface for a controller of a notification service
  */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect class NotificationServiceController: ServiceController {
     fun pushNotification(title: String, message: String)
     override fun startService()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.kt
@@ -1,0 +1,11 @@
+package network.bisq.mobile.domain.service.controller
+
+/**
+ * And interface for a controller of a notification service
+ */
+expect class NotificationServiceController: ServiceController {
+    fun pushNotification(title: String, message: String)
+    override fun startService()
+    override fun stopService()
+    override fun isServiceRunning(): Boolean
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/ServiceController.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/controller/ServiceController.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.domain.service.controller
+
+/**
+ * Service controller behaviour definitions
+ */
+interface ServiceController {
+    fun startService()
+    fun stopService()
+    fun isServiceRunning(): Boolean
+}

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/DomainModule.ios.kt
@@ -1,10 +1,12 @@
 package network.bisq.mobile.domain.di
 
+import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val iosDomainModule = module {
     single<String>(named("ApiBaseUrl")) { provideApiBaseUrl() }
+    single<NotificationServiceController> { NotificationServiceController() }
 }
 
 fun provideApiBaseUrl(): String {

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -14,6 +14,10 @@
     @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
     actual class NotificationServiceController: ServiceController, Logging {
 
+        companion object {
+            const val BACKGROUND_TASK_ID = "network.bisq.mobile.ios.backgroundtask"
+        }
+
         private var isRunning = false
 
         private val logScope = CoroutineScope(Dispatchers.Main)
@@ -41,7 +45,7 @@
                     logDebug("Notification permission granted.")
 
 //                  TODO need to move to iOS callback ->  didFinishLaunchingWithOptions
-                    BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = "network.bisq.mobile.ios.backgroundtask", usingQueue = null) { task ->
+                    BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = BACKGROUND_TASK_ID, usingQueue = null) { task ->
                         handleBackgroundTask(task as BGProcessingTask)
                     }
                     scheduleBackgroundTask()
@@ -92,7 +96,7 @@
 
         @OptIn(ExperimentalForeignApi::class)
         private fun scheduleBackgroundTask() {
-            val request = BGProcessingTaskRequest("com.yourapp.backgroundtask").apply {
+            val request = BGProcessingTaskRequest(BACKGROUND_TASK_ID).apply {
                 requiresNetworkConnectivity = true
             }
             BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -1,0 +1,50 @@
+package network.bisq.mobile.domain.service.controller
+
+import platform.Foundation.*
+import platform.UIKit.*
+import platform.UserNotifications.*
+import platform.BackgroundTasks.*
+
+actual class NotificationServiceController: ServiceController {
+
+    actual override fun startService() {
+        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier("com.yourapp.backgroundtask") { task ->
+            handleBackgroundTask(task as BGProcessingTask)
+        }
+        scheduleBackgroundTask()
+    }
+
+    actual override fun stopService() {
+        BGTaskScheduler.sharedScheduler.cancelAllTaskRequests()
+    }
+
+    actual override fun pushNotification(title: String, message: String) {
+        val content = UNMutableNotificationContent().apply {
+            this.title = title
+            this.body = message
+        }
+        val request = UNNotificationRequest.requestWithIdentifier(
+            NSUUID().UUIDString,
+            content,
+            null
+        )
+        UNUserNotificationCenter.currentNotificationCenter.addNotificationRequest(request, null)
+    }
+
+    actual override fun isServiceRunning(): Boolean {
+        // iOS doesn't allow querying background task state directly
+        return false
+    }
+
+    private fun handleBackgroundTask(task: BGProcessingTask) {
+        task.setTaskCompletedWithSuccess(true)
+        scheduleBackgroundTask() // Reschedule if needed
+    }
+
+    private fun scheduleBackgroundTask() {
+        val request = BGProcessingTaskRequest("com.yourapp.backgroundtask").apply {
+            requiresNetworkConnectivity = true
+        }
+        BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
+    }
+}

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -1,34 +1,43 @@
 package network.bisq.mobile.domain.service.controller
 
-import platform.Foundation.*
-import platform.UIKit.*
-import platform.UserNotifications.*
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import network.bisq.mobile.utils.Logging
 import platform.BackgroundTasks.*
 
-actual class NotificationServiceController: ServiceController {
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class NotificationServiceController: ServiceController, Logging {
+
+    private val logScope = CoroutineScope(Dispatchers.Main)
 
     actual override fun startService() {
-        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier("com.yourapp.backgroundtask") { task ->
+        logDebug("Starting background service")
+        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = "network.bisq.mobile.ios.backgroundtask", usingQueue = null) { task ->
             handleBackgroundTask(task as BGProcessingTask)
         }
         scheduleBackgroundTask()
+        logDebug("Background service started")
     }
 
     actual override fun stopService() {
         BGTaskScheduler.sharedScheduler.cancelAllTaskRequests()
+        logDebug("Background service stopped")
     }
 
-    actual override fun pushNotification(title: String, message: String) {
-        val content = UNMutableNotificationContent().apply {
-            this.title = title
-            this.body = message
-        }
-        val request = UNNotificationRequest.requestWithIdentifier(
-            NSUUID().UUIDString,
-            content,
-            null
-        )
-        UNUserNotificationCenter.currentNotificationCenter.addNotificationRequest(request, null)
+    actual fun pushNotification(title: String, message: String) {
+//        TODO
+//        val content = UNMutableNotificationContent().apply {
+//            this.title = title
+//            this.body = message
+//        }
+//        val request = UNNotificationRequest.requestWithIdentifier(
+//            NSUUID().UUIDString,
+//            content,
+//            null
+//        )
+//        UNUserNotificationCenter.currentNotificationCenter().addNotificationRequest(request, null)
     }
 
     actual override fun isServiceRunning(): Boolean {
@@ -37,14 +46,23 @@ actual class NotificationServiceController: ServiceController {
     }
 
     private fun handleBackgroundTask(task: BGProcessingTask) {
+        logDebug("Executing background task")
         task.setTaskCompletedWithSuccess(true)
         scheduleBackgroundTask() // Reschedule if needed
     }
 
+    @OptIn(ExperimentalForeignApi::class)
     private fun scheduleBackgroundTask() {
         val request = BGProcessingTaskRequest("com.yourapp.backgroundtask").apply {
             requiresNetworkConnectivity = true
         }
         BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
+        logDebug("Background task scheduled")
+    }
+
+    private fun logDebug(message: String) {
+        logScope.launch {
+            log.d { message }
+        }
     }
 }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.domain.service.controller
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import network.bisq.mobile.utils.Logging
 import platform.BackgroundTasks.*
@@ -18,13 +19,14 @@ actual class NotificationServiceController: ServiceController, Logging {
 
     companion object {
         const val BACKGROUND_TASK_ID = "network.bisq.mobile.iosUC4273Y485"
+        const val CHECK_NOTIFICATIONS_DELAY = 15 * 10000L
     }
 
     private var isRunning = false
     private var isBackgroundTaskRegistered = false
     private val logScope = CoroutineScope(Dispatchers.Main)
 
-    init {
+    private fun setupDelegate() {
         val delegate = object : NSObject(), UNUserNotificationCenterDelegateProtocol {
             override fun userNotificationCenter(
                 center: UNUserNotificationCenter,
@@ -46,10 +48,10 @@ actual class NotificationServiceController: ServiceController, Logging {
                 // Handle the response when the user taps the notification
                 withCompletionHandler()
             }
-
         }
 
         UNUserNotificationCenter.currentNotificationCenter().delegate = delegate
+        logDebug("Notification center delegate applied")
     }
 
 
@@ -57,26 +59,27 @@ actual class NotificationServiceController: ServiceController, Logging {
         if (isRunning) {
             return
         }
-        registerBackgroundTask()
         logDebug("Starting background service")
         UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
             UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
         ) { granted, error ->
             if (granted) {
-                println("Notification permission granted.")
+                logDebug("Notification permission granted.")
+                setupDelegate()
+                registerBackgroundTask()
                 // Once permission is granted, you can start scheduling background tasks
-                scheduleBackgroundTask()
-                println("Background service started")
+                startBackgroundTaskLoop()
+                logDebug("Background service started")
                 isRunning = true
             } else {
-                println("Notification permission denied: ${error?.localizedDescription}")
+                logDebug("Notification permission denied: ${error?.localizedDescription}")
             }
         }
     }
 
     actual override fun stopService() {
         BGTaskScheduler.sharedScheduler.cancelAllTaskRequests()
-        println("Background service stopped")
+        logDebug("Background service stopped")
         isRunning = false
     }
 
@@ -89,17 +92,17 @@ actual class NotificationServiceController: ServiceController, Logging {
 
         val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(5.0, repeats = false)
 
+        val requestId = NSUUID().UUIDString
         val request = UNNotificationRequest.requestWithIdentifier(
-            NSUUID().UUIDString,  // Generates a unique identifier
+            requestId,
             content,
-            trigger  // Trigger can be set to null for immediate delivery
+            trigger
         )
-        println("getting called every 10 sec")
         UNUserNotificationCenter.currentNotificationCenter().addNotificationRequest(request) { error ->
             if (error != null) {
-                println("Error adding notification request: ${error.localizedDescription}")
+                logDebug("Error adding notification request: ${error.localizedDescription}")
             } else {
-                println("Notification added successfully")
+                logDebug("Notification $requestId added successfully")
             }
         }
     }
@@ -110,11 +113,18 @@ actual class NotificationServiceController: ServiceController, Logging {
     }
 
     private fun handleBackgroundTask(task: BGProcessingTask) {
-        logDebug("Executing background task")
-        pushNotification("Background Notification", "This notification was triggered in the background")
+        task.setTaskCompletedWithSuccess(true)  // Mark the task as completed
+        logDebug("Background task completed successfully")
+        scheduleBackgroundTask()    // Re-schedule the next task
+    }
 
-        task.setTaskCompletedWithSuccess(true)
-//        scheduleBackgroundTask() // Reschedule if needed
+    private fun startBackgroundTaskLoop() {
+        CoroutineScope(Dispatchers.Default).launch {
+            while (isRunning) {
+                scheduleBackgroundTask()
+                delay(CHECK_NOTIFICATIONS_DELAY) // Check notifications every min
+            }
+        }
     }
 
     @OptIn(ExperimentalForeignApi::class)
@@ -124,20 +134,24 @@ actual class NotificationServiceController: ServiceController, Logging {
             earliestBeginDate = NSDate(timeIntervalSinceReferenceDate = 10.0)
         }
         BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
-        println("Background task scheduled")
+        logDebug("Background task scheduled")
     }
+
+//    fun setupTaskHandlers() {
+//        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(BACKGROUND_TASK_ID, BGProcessingTask.class, ::handleBackgroundTask)
+//    }
 
 
     private fun logDebug(message: String) {
         logScope.launch {
-            log.d(message)
+            log.d { message }
         }
     }
 
 
     private fun registerBackgroundTask() {
         if (isBackgroundTaskRegistered) {
-            println("Background task is already registered.")
+            logDebug("Background task is already registered.")
             return
         }
 
@@ -150,7 +164,6 @@ actual class NotificationServiceController: ServiceController, Logging {
         }
 
         isBackgroundTaskRegistered = true
-        // TODO logger is not working
-        println("Background task handler registered.")
+        logDebug("Background task handler registered.")
     }
 }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -57,25 +57,8 @@ actual class NotificationServiceController: ServiceController, Logging {
         if (isRunning) {
             return
         }
+        registerBackgroundTask()
         logDebug("Starting background service")
-//            UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
-//                UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
-//            ) { granted, error ->
-//                if (granted) {
-//                    logDebug("Notification permission granted.")
-//
-////                  TODO need to move to iOS callback ->  didFinishLaunchingWithOptions
-//                    BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = BACKGROUND_TASK_ID, usingQueue = null) { task ->
-//                        handleBackgroundTask(task as BGProcessingTask)
-//                    }
-//                    scheduleBackgroundTask()
-//                    logDebug("Background service started")
-//                    isRunning = true
-//                } else {
-//                    logDebug("Notification permission denied: ${error?.localizedDescription}")
-//                }
-//            }
-
         UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
             UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
         ) { granted, error ->
@@ -131,7 +114,7 @@ actual class NotificationServiceController: ServiceController, Logging {
         pushNotification("Background Notification", "This notification was triggered in the background")
 
         task.setTaskCompletedWithSuccess(true)
-        scheduleBackgroundTask() // Reschedule if needed
+//        scheduleBackgroundTask() // Reschedule if needed
     }
 
     @OptIn(ExperimentalForeignApi::class)

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/controller/NotificationServiceController.ios.kt
@@ -1,111 +1,163 @@
-    package network.bisq.mobile.domain.service.controller
+package network.bisq.mobile.domain.service.controller
 
-    import kotlinx.cinterop.ExperimentalForeignApi
-    import kotlinx.coroutines.CoroutineScope
-    import kotlinx.coroutines.Dispatchers
-    import kotlinx.coroutines.launch
-    import network.bisq.mobile.utils.Logging
-    import platform.BackgroundTasks.*
-    import platform.Foundation.NSUUID
-    import platform.Foundation.setValue
-    import platform.UserNotifications.*
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import network.bisq.mobile.utils.Logging
+import platform.BackgroundTasks.*
+import platform.Foundation.NSUUID
+import platform.Foundation.setValue
+import platform.UserNotifications.*
+import platform.darwin.NSObject
 
 
-    @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-    actual class NotificationServiceController: ServiceController, Logging {
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class NotificationServiceController: ServiceController, Logging {
 
-        companion object {
-            const val BACKGROUND_TASK_ID = "network.bisq.mobile.ios.backgroundtask"
+    companion object {
+        const val BACKGROUND_TASK_ID = "network.bisq.mobile.ios.backgroundtask"
+    }
+
+    private var isRunning = false
+    private var isBackgroundTaskRegistered = false
+    private val logScope = CoroutineScope(Dispatchers.Main)
+
+    init {
+        val delegate = object : NSObject(), UNUserNotificationCenterDelegateProtocol {
+            override fun userNotificationCenter(
+                center: UNUserNotificationCenter,
+                willPresentNotification: UNNotification,
+                withCompletionHandler: (UNNotificationPresentationOptions) -> Unit
+            ) {
+                // Display alert, sound, or badge when the app is in the foreground
+                withCompletionHandler(
+                    UNNotificationPresentationOptionAlert or UNNotificationPresentationOptionSound or UNNotificationPresentationOptionBadge
+                )
+            }
+
+            // Handle user actions on the notification
+            override fun userNotificationCenter(
+                center: UNUserNotificationCenter,
+                didReceiveNotificationResponse: UNNotificationResponse,
+                withCompletionHandler: () -> Unit
+            ) {
+                // Handle the response when the user taps the notification
+                withCompletionHandler()
+            }
+
         }
 
-        private var isRunning = false
+        UNUserNotificationCenter.currentNotificationCenter().delegate = delegate
+    }
 
-        private val logScope = CoroutineScope(Dispatchers.Main)
 
-//      TODO foreground notifications?
-//        UNUserNotificationCenter.currentNotificationCenter().delegate = object : UNUserNotificationCenterDelegateProtocol {
-//            override fun userNotificationCenter(
-//                center: UNUserNotificationCenter,
-//                willPresentNotification: UNNotification,
-//                withCompletionHandler: (UNNotificationPresentationOptions) -> Unit
-//            ) {
-//                withCompletionHandler(UNNotificationPresentationOptionsAlert or UNNotificationPresentationOptionsSound)
+    actual override fun startService() {
+        if (isRunning) {
+            return
+        }
+        logDebug("Starting background service")
+//            UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
+//                UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
+//            ) { granted, error ->
+//                if (granted) {
+//                    logDebug("Notification permission granted.")
+//
+////                  TODO need to move to iOS callback ->  didFinishLaunchingWithOptions
+//                    BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = BACKGROUND_TASK_ID, usingQueue = null) { task ->
+//                        handleBackgroundTask(task as BGProcessingTask)
+//                    }
+//                    scheduleBackgroundTask()
+//                    logDebug("Background service started")
+//                    isRunning = true
+//                } else {
+//                    logDebug("Notification permission denied: ${error?.localizedDescription}")
+//                }
 //            }
-//        }
 
-        actual override fun startService() {
-            if (isRunning) {
-                return
-            }
-            logDebug("Starting background service")
-            UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
-                UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
-            ) { granted, error ->
-                if (granted) {
-                    logDebug("Notification permission granted.")
-
-//                  TODO need to move to iOS callback ->  didFinishLaunchingWithOptions
-                    BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = BACKGROUND_TASK_ID, usingQueue = null) { task ->
-                        handleBackgroundTask(task as BGProcessingTask)
-                    }
-                    scheduleBackgroundTask()
-                    logDebug("Background service started")
-                    isRunning = true
-                } else {
-                    logDebug("Notification permission denied: ${error?.localizedDescription}")
-                }
-            }
-        }
-
-        actual override fun stopService() {
-            BGTaskScheduler.sharedScheduler.cancelAllTaskRequests()
-            logDebug("Background service stopped")
-            isRunning = false
-        }
-
-        actual fun pushNotification(title: String, message: String) {
-            val content = UNMutableNotificationContent().apply {
-                setValue(title, forKey = "title")
-                setValue(message, forKey = "body")
-            }
-
-            val request = UNNotificationRequest.requestWithIdentifier(
-                NSUUID().UUIDString,  // Generates a unique identifier
-                content,
-                null  // Trigger can be set to null for immediate delivery
-            )
-            UNUserNotificationCenter.currentNotificationCenter().addNotificationRequest(request) { error ->
-                if (error != null) {
-                    println("Error adding notification request: ${error.localizedDescription}")
-                } else {
-                    println("Notification added successfully")
-                }
-            }
-        }
-
-        actual override fun isServiceRunning(): Boolean {
-            // iOS doesn't allow querying background task state directly
-            return isRunning
-        }
-
-        private fun handleBackgroundTask(task: BGProcessingTask) {
-            logDebug("Executing background task")
-            task.setTaskCompletedWithSuccess(true)
-            scheduleBackgroundTask() // Reschedule if needed
-        }
-
-        @OptIn(ExperimentalForeignApi::class)
-        private fun scheduleBackgroundTask() {
-            val request = BGProcessingTaskRequest(BACKGROUND_TASK_ID).apply {
-                requiresNetworkConnectivity = true
-            }
-            BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
-            logDebug("Background task scheduled")
-        }
-
-        private fun logDebug(message: String) {
-            logScope.launch {
-                log.d(message)
+        UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
+            UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
+        ) { granted, error ->
+            if (granted) {
+                logDebug("Notification permission granted.")
+                // Once permission is granted, you can start scheduling background tasks
+                scheduleBackgroundTask()
+                logDebug("Background service started")
+                isRunning = true
+            } else {
+                logDebug("Notification permission denied: ${error?.localizedDescription}")
             }
         }
     }
+
+    actual override fun stopService() {
+        BGTaskScheduler.sharedScheduler.cancelAllTaskRequests()
+        println("Background service stopped")
+        isRunning = false
+    }
+
+    actual fun pushNotification(title: String, message: String) {
+        val content = UNMutableNotificationContent().apply {
+            setValue(title, forKey = "title")
+            setValue(message, forKey = "body")
+            setSound(UNNotificationSound.defaultSound())
+        }
+
+        val request = UNNotificationRequest.requestWithIdentifier(
+            NSUUID().UUIDString,  // Generates a unique identifier
+            content,
+            null  // Trigger can be set to null for immediate delivery
+        )
+        UNUserNotificationCenter.currentNotificationCenter().addNotificationRequest(request) { error ->
+            if (error != null) {
+                println("Error adding notification request: ${error.localizedDescription}")
+            } else {
+                println("Notification added successfully")
+            }
+        }
+    }
+
+    actual override fun isServiceRunning(): Boolean {
+        // iOS doesn't allow querying background task state directly
+        return isRunning
+    }
+
+    private fun handleBackgroundTask(task: BGProcessingTask) {
+        logDebug("Executing background task")
+        task.setTaskCompletedWithSuccess(true)
+        scheduleBackgroundTask() // Reschedule if needed
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun scheduleBackgroundTask() {
+        val request = BGProcessingTaskRequest(BACKGROUND_TASK_ID).apply {
+            requiresNetworkConnectivity = true
+        }
+        BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
+        logDebug("Background task scheduled")
+    }
+
+
+    private fun logDebug(message: String) {
+        logScope.launch {
+            log.d(message)
+        }
+    }
+
+
+    private fun registerBackgroundTask() {
+        if (isBackgroundTaskRegistered) {
+            logDebug("Background task is already registered.")
+            return
+        }
+
+        // Register for background task handler
+        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(identifier = BACKGROUND_TASK_ID, usingQueue = null) { task ->
+            handleBackgroundTask(task as BGProcessingTask)
+        }
+
+        isBackgroundTaskRegistered = true
+        logDebug("Background task handler registered.")
+
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -1,15 +1,17 @@
 package network.bisq.mobile.client
 
 import network.bisq.mobile.domain.data.repository.main.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 
 class ClientMainPresenter(
+    notificationServiceController: NotificationServiceController,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val offerbookServiceFacade: OfferbookServiceFacade,
     private val  marketPriceServiceFacade: MarketPriceServiceFacade
-) : MainPresenter() {
+) : MainPresenter(notificationServiceController) {
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
+import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.presentation.ui.AppPresenter

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -22,6 +22,9 @@ import kotlin.random.Random
 open class MainPresenter(private val notificationServiceController: NotificationServiceController) :
     BasePresenter(null), AppPresenter {
     companion object {
+        // FIXME this will be erased eventually, for now you can turn on to see the notifications working
+        // it will push a notification every 60 sec
+        const val testNotifications = false
         const val PUSH_DELAY = 60000L
     }
 
@@ -57,13 +60,15 @@ open class MainPresenter(private val notificationServiceController: Notification
         super.onViewAttached()
         notificationServiceController.startService()
         // sample code for push notifications sends a random message every 10 secs
-        CoroutineScope(BackgroundDispatcher).launch {
-            while (notificationServiceController.isServiceRunning()) {
-                val randomTitle = "Title ${Random.nextInt(1, 100)}"
-                val randomMessage = "Message ${Random.nextInt(1, 100)}"
-                notificationServiceController.pushNotification(randomTitle, randomMessage)
-                log.d {"Pushed: $randomTitle - $randomMessage" }
-                delay(PUSH_DELAY) // 1 min
+        if (testNotifications) {
+            backgroundScope.launch {
+                while (notificationServiceController.isServiceRunning()) {
+                    val randomTitle = "Title ${Random.nextInt(1, 100)}"
+                    val randomMessage = "Message ${Random.nextInt(1, 100)}"
+                    notificationServiceController.pushNotification(randomTitle, randomMessage)
+                    log.d {"Pushed: $randomTitle - $randomMessage" }
+                    delay(PUSH_DELAY) // 1 min
+                }
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -1,6 +1,9 @@
 package network.bisq.mobile.presentation
 
+import androidx.annotation.CallSuper
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.BuildNodeConfig
@@ -8,6 +11,7 @@ import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.presentation.ui.AppPresenter
+import kotlin.random.Random
 
 
 /**
@@ -40,9 +44,22 @@ open class MainPresenter(private val notificationServiceController: Notification
         log.i { "iOS Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Node Version: ${BuildNodeConfig.APP_VERSION}" }
+    }
+
+    @CallSuper
+    override fun onViewAttached() {
+        super.onViewAttached()
         notificationServiceController.startService()
-//        CoroutineScope(BackgroundDispatcher).launch {
-//        }
+        // sample code for push notifications sends a random message every 10 secs
+        CoroutineScope(BackgroundDispatcher).launch {
+            while (notificationServiceController.isServiceRunning()) {
+                val randomTitle = "Title ${Random.nextInt(1, 100)}"
+                val randomMessage = "Message ${Random.nextInt(1, 100)}"
+                notificationServiceController.pushNotification(randomTitle, randomMessage)
+                println("Pushed: $randomTitle - $randomMessage")
+                delay(10000) // 10 seconds
+            }
+        }
     }
 
     // Toggle action

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -41,9 +41,8 @@ open class MainPresenter(private val notificationServiceController: Notification
         log.i { "Android Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Node Version: ${BuildNodeConfig.APP_VERSION}" }
         notificationServiceController.startService()
-        //        CoroutineScope(BackgroundDispatcher).launch {
-        //            greetingRepository.create(Greeting())
-        //        }
+//        CoroutineScope(BackgroundDispatcher).launch {
+//        }
     }
 
     // Toggle action

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -6,13 +6,14 @@ import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.getPlatformInfo
+import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.presentation.ui.AppPresenter
 
 
 /**
  * Main Presenter as an example of implementation for now.
  */
-open class MainPresenter() :
+open class MainPresenter(private val notificationServiceController: NotificationServiceController) :
     BasePresenter(null), AppPresenter {
     lateinit var navController: NavHostController
         private set
@@ -39,6 +40,7 @@ open class MainPresenter() :
         log.i { "iOS Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Client Version: ${BuildConfig.IOS_APP_VERSION}" }
         log.i { "Android Node Version: ${BuildNodeConfig.APP_VERSION}" }
+        notificationServiceController.startService()
         //        CoroutineScope(BackgroundDispatcher).launch {
         //            greetingRepository.create(Greeting())
         //        }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -21,6 +21,10 @@ import kotlin.random.Random
  */
 open class MainPresenter(private val notificationServiceController: NotificationServiceController) :
     BasePresenter(null), AppPresenter {
+    companion object {
+        const val PUSH_DELAY = 60000L
+    }
+
     lateinit var navController: NavHostController
         private set
 
@@ -58,8 +62,8 @@ open class MainPresenter(private val notificationServiceController: Notification
                 val randomTitle = "Title ${Random.nextInt(1, 100)}"
                 val randomMessage = "Message ${Random.nextInt(1, 100)}"
                 notificationServiceController.pushNotification(randomTitle, randomMessage)
-                println("Pushed: $randomTitle - $randomMessage")
-                delay(10000) // 10 seconds
+                log.d {"Pushed: $randomTitle - $randomMessage" }
+                delay(PUSH_DELAY) // 1 min
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -31,7 +31,7 @@ val presentationModule = module {
     single(named("RootNavController")) { getKoin().getProperty<NavHostController>("RootNavController") }
     single(named("TabNavController")) { getKoin().getProperty<NavHostController>("TabNavController") }
 
-    single<MainPresenter> { ClientMainPresenter(get(), get(), get()) } bind AppPresenter::class
+    single<MainPresenter> { ClientMainPresenter(get(), get(), get(), get()) } bind AppPresenter::class
 
     single<TopBarPresenter> { TopBarPresenter(get(), get()) } bind ITopBarPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -10,6 +10,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.SwipeBackIOSNavigationHandler
+import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
@@ -41,20 +42,12 @@ fun App() {
     var isNavControllerSet by remember { mutableStateOf(false) }
     val presenter: AppPresenter = koinInject()
 
-    DisposableEffect(Unit) {
-//        For the main presenter use case we leave this for the moment the activity/viewcontroller respectively gets attached
-//        presenter.onViewAttached()
+    RememberPresenterLifecycle(presenter, {
         getKoin().setProperty("RootNavController", rootNavController)
         getKoin().setProperty("TabNavController", tabNavController)
         presenter.setNavController(rootNavController)
         isNavControllerSet = true
-
-        onDispose {
-            // Optional cleanup logic
-//            getKoin().setProperty("RootNavController", null)
-//            getKoin().setProperty("TabNavController", null)
-        }
-    }
+    })
 
     val lyricist = rememberStrings()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/LifecycleHelper.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/LifecycleHelper.kt
@@ -4,13 +4,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import network.bisq.mobile.presentation.ViewPresenter
 
+/**
+ * @param presenter
+ * @param onExecute <optional> callback after view attached
+ * @param onDispose <optional> callback before on view unnattaching
+ */
 @Composable
-fun RememberPresenterLifecycle(presenter: ViewPresenter) {
+fun RememberPresenterLifecycle(presenter: ViewPresenter, onExecute: (() -> Unit)? = null, onDispose: (() -> Unit)? = null) {
     DisposableEffect(presenter) {
         presenter.onViewAttached() // Called when the view is attached
+        onExecute?.let {
+            onExecute()
+        }
 
         onDispose {
             presenter.onViewUnattaching() // Called when the view is detached
+            onDispose?.let {
+                onDispose()
+            }
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -12,7 +12,6 @@ import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.BtcPriceRepository
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class GettingStartedPresenter(
     mainPresenter: MainPresenter,

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/DependenciesProviderHelper.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/DependenciesProviderHelper.kt
@@ -11,6 +11,9 @@ import org.koin.core.context.startKoin
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.Qualifier
 
+/**
+ * Helper for iOS koin injection
+ */
 class DependenciesProviderHelper {
 
     fun initKoin() {


### PR DESCRIPTION
**Implementation on both platforms with some limitations described below**

**note** this is a WIP, first PR of a series (even more so for iOS side)

 - Implementation for https://github.com/bisq-network/bisq-mobile/issues/53
 - Registers service into OS enabling comms with the user even if the app is backgrounded/killed
 - Tapping on a notification opens the app, even if the app was killed by the OS
 - Notification permissions requests using latest practices
 - added a sample coroutine that pushes new messages every 10 sec for sample dev purposes
 - notification controller allows the rest of the software components to easily send notifications through the service (just need to inject the controller in your presenter/ service)

** Limitations **

 - on iOS, logs are triggered properly but couldn't actually see any notifications neither in a simulator nor on a real device
 