### PR TITLE
Feature/account settings

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
+import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.SplashPresenter
 import org.koin.android.ext.koin.androidContext
@@ -56,7 +57,7 @@ val androidNodeModule = module {
         )
     }
 
-    single { NodeSettingsPresenter(get(), get()) } bind ISettingsPresenter::class
+    single<SettingsPresenter> { NodeSettingsPresenter(get(), get()) } bind ISettingsPresenter::class
 
     single<IOnboardingPresenter> { OnBoardingNodePresenter(get(), get()) } bind IOnboardingPresenter::class
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.android.node.domain.market_price.NodeMarketPriceServi
 import network.bisq.mobile.android.node.domain.offerbook.NodeOfferbookServiceFacade
 import network.bisq.mobile.android.node.domain.user_profile.NodeUserProfileServiceFacade
 import network.bisq.mobile.android.node.presentation.NodeMainPresenter
+import network.bisq.mobile.android.node.presentation.NodeSettingsPresenter
 import network.bisq.mobile.android.node.presentation.NodeSplashPresenter
 import network.bisq.mobile.android.node.presentation.OnBoardingNodePresenter
 import network.bisq.mobile.android.node.service.AndroidNodeCatHashService
@@ -16,6 +17,7 @@ import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.SplashPresenter
 import org.koin.android.ext.koin.androidContext
@@ -53,6 +55,8 @@ val androidNodeModule = module {
             get(),
         )
     }
+
+    single { NodeSettingsPresenter(get(), get()) } bind ISettingsPresenter::class
 
     single<IOnboardingPresenter> { OnBoardingNodePresenter(get(), get()) } bind IOnboardingPresenter::class
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSettingsPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSettingsPresenter.kt
@@ -1,14 +1,16 @@
 package network.bisq.mobile.android.node.presentation
 
 import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.MenuItem
 import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
 
 class NodeSettingsPresenter(
     settingsRepository: SettingsRepository,
-    mainPresenter: NodeMainPresenter): SettingsPresenter(settingsRepository, mainPresenter) {
+    mainPresenter: MainPresenter): SettingsPresenter(settingsRepository, mainPresenter), ISettingsPresenter {
 
     override fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
-        return menuItems
+        return menuItems.toList()
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSettingsPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSettingsPresenter.kt
@@ -1,0 +1,14 @@
+package network.bisq.mobile.android.node.presentation
+
+import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.presentation.ui.uicases.settings.MenuItem
+import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
+
+class NodeSettingsPresenter(
+    settingsRepository: SettingsRepository,
+    mainPresenter: NodeMainPresenter): SettingsPresenter(settingsRepository, mainPresenter) {
+
+    override fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
+        return menuItems
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -20,6 +20,8 @@ import network.bisq.mobile.presentation.ui.uicases.offers.takeOffer.TradeAmountP
 import network.bisq.mobile.presentation.ui.uicases.offers.createOffer.CreateOfferPresenter
 import network.bisq.mobile.presentation.ui.uicases.offers.createOffer.ICreateOfferPresenter
 import network.bisq.mobile.presentation.ui.uicases.offers.takeOffer.*
+import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
+import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.CreateProfilePresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.ITrustedNodeSetupPresenter
@@ -52,6 +54,8 @@ val presentationModule = module {
     }
 
     single { OnBoardingPresenter(get(), get()) } bind IOnboardingPresenter::class
+
+    single { SettingsPresenter(get(), get()) } bind ISettingsPresenter::class
 
     single<GettingStartedPresenter> {
         GettingStartedPresenter(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -55,7 +55,7 @@ val presentationModule = module {
 
     single { OnBoardingPresenter(get(), get()) } bind IOnboardingPresenter::class
 
-    single { SettingsPresenter(get(), get()) } bind ISettingsPresenter::class
+    single<SettingsPresenter> { SettingsPresenter(get(), get()) } bind ISettingsPresenter::class
 
     single<GettingStartedPresenter> {
         GettingStartedPresenter(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/TabNavGraph.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -21,6 +23,7 @@ import org.koin.core.qualifier.named
 fun TabNavGraph() {
 
     val navController: NavHostController = koinInject(named("TabNavController"))
+    val selectedTab = remember { mutableStateOf(Routes.TabHome.name) }
 
     NavHost(
         modifier = Modifier.background(color = BisqTheme.colors.backgroundColor),
@@ -32,16 +35,22 @@ fun TabNavGraph() {
             route = Graph.MAIN_SCREEN_GRAPH_KEY
         ) {
             composable(route = Routes.TabHome.name) {
+                selectedTab.value = Routes.TabHome.name
                 GettingStartedScreen()
             }
             composable(route = Routes.TabCurrencies.name) {
+                selectedTab.value = Routes.TabCurrencies.name
                 MarketListScreen()
             }
             composable(route = Routes.TabMyTrades.name) {
+                selectedTab.value = Routes.TabMyTrades.name
                 MyTradesScreen()
             }
             composable(route = Routes.TabSettings.name) {
-                SettingsScreen()
+                selectedTab.value = Routes.TabSettings.name
+                SettingsScreen(
+                    isTabSelected = selectedTab.value == Routes.TabSettings.name
+                )
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
@@ -1,0 +1,24 @@
+package network.bisq.mobile.presentation.ui.uicases.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+
+@Composable
+fun PaymentAccountSettingsScreen() {
+
+//    RememberPresenterLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "PaymentAccountSettingsScreen",
+            style = MaterialTheme.typography.bodyLarge.copy(color = BisqTheme.colors.light1 , fontSize = 16.sp),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
@@ -16,8 +16,8 @@ open class SettingsPresenter(
             MenuItem.Parent(
                 label = "Account",
                 children = listOf(
-                    MenuItem.Leaf(label = "User Profile", onClick = ::navigateToUserProfileSettings),
-                    MenuItem.Leaf(label = "Payment Methods", onClick = ::navigateToPaymentMethodsSettings)
+                    MenuItem.Leaf(label = "User Profile", content = { UserProfileSettingsScreen() }),
+                    MenuItem.Leaf(label = "Payment Accounts", content = { PaymentAccountSettingsScreen() })
                 )
             )
         )
@@ -28,19 +28,7 @@ open class SettingsPresenter(
     }
 
     protected open fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
-        menuItems.add(MenuItem.Leaf("Trusted Node", onClick = ::navigateToTrustedNodeSettings))
+        menuItems.add(MenuItem.Leaf("Trusted Node", content = { TrustedNodeSettingsScreen() }))
         return menuItems.toList()
-    }
-
-    private fun navigateToUserProfileSettings() {
-        log.d { "TODO: Userprofile" }
-    }
-
-    private fun navigateToPaymentMethodsSettings() {
-        log.d { "TODO: Payment methods" }
-    }
-
-    private fun navigateToTrustedNodeSettings() {
-        log.d { "TODO: Trusted node settings" }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
@@ -1,0 +1,46 @@
+package network.bisq.mobile.presentation.ui.uicases.settings
+
+import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+
+/**
+ * SettingsPresenter with default implementation
+ */
+open class SettingsPresenter(
+    private val settingsRepository: SettingsRepository,
+    mainPresenter: MainPresenter): BasePresenter(mainPresenter), ISettingsPresenter {
+
+    final override fun menuTree(): MenuItem {
+        val defaultList: MutableList<MenuItem> = mutableListOf(
+            MenuItem.Parent(
+                label = "Account",
+                children = listOf(
+                    MenuItem.Leaf(label = "User Profile", onClick = ::navigateToUserProfileSettings),
+                    MenuItem.Leaf(label = "Payment Methods", onClick = ::navigateToPaymentMethodsSettings)
+                )
+            )
+        )
+        return MenuItem.Parent(
+            label = "Application",
+            children = addCustomSettings(defaultList)
+            )
+    }
+
+    protected open fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
+        menuItems.add(MenuItem.Leaf("Trusted Node", onClick = ::navigateToTrustedNodeSettings))
+        return menuItems.toList()
+    }
+
+    private fun navigateToUserProfileSettings() {
+        log.d { "TODO: Userprofile" }
+    }
+
+    private fun navigateToPaymentMethodsSettings() {
+        log.d { "TODO: Payment methods" }
+    }
+
+    private fun navigateToTrustedNodeSettings() {
+        log.d { "TODO: Trusted node settings" }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -1,27 +1,105 @@
 
 package network.bisq.mobile.presentation.ui.uicases.settings
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
+// UI model/s
+sealed class MenuItem(val label: String, val onClick: (() -> Unit)? = null) {
+    class Leaf(label: String, onClick: () -> Unit) : MenuItem(label, onClick)
+    class Parent(label: String, val children: List<MenuItem>) : MenuItem(label)
+}
+
 @Composable
-fun SettingsScreen(
-) {
-    BisqScrollLayout(verticalArrangement = Arrangement.Center) {
-        Box(
+fun SettingsMenu(menuItem: MenuItem, onNavigate: (MenuItem) -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
             modifier = Modifier
-                .fillMaxSize(),
-            contentAlignment = Alignment.Center // Centers the content within the Box
+                .fillMaxSize()
+                .background(BisqTheme.colors.backgroundColor)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.Start
         ) {
-            BisqText.h2Regular(
-                text = "Settings",
-                color = BisqTheme.colors.light1,
+            when (menuItem) {
+                is MenuItem.Parent -> menuItem.children.forEach { child ->
+                    SettingsButton(label = child.label, onClick = { onNavigate(child) })
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                else -> {
+                    SettingsButton(label = menuItem.label, onClick = { onNavigate(menuItem) })
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsButton(label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BisqTheme.colors.backgroundColor)
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge.copy(color = BisqTheme.colors.primary, fontSize = 16.sp),
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = ">",
+            textAlign = TextAlign.End,
+            style = MaterialTheme.typography.bodyLarge.copy(color = BisqTheme.colors.secondary, fontSize = 16.sp),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+// TODO refactor to get the menu structure from presenter and let presenter decide what to do
+// on click (in this way each presenter can customize the settings , useful for node vs xclients
+@Composable
+fun SettingsScreen() {
+//    val currentMenu = remember { mutableStateOf(menuTree) }
+    // TODO get menu tree from presenter
+    val exampleMenuTree = MenuItem.Parent(
+        label = "Settings",
+        children = listOf(
+            MenuItem.Parent(
+                label = "Account",
+                children = listOf(
+                    MenuItem.Leaf(label = "User Profile", onClick = { println("Userprofile") }),
+                    MenuItem.Leaf(label = "Payment Methods", onClick = { println("Payment methods") })
+                )
             )
+        )
+    )
+    val currentMenu = remember { mutableStateOf(exampleMenuTree) }
+
+    SettingsMenu(menuItem = currentMenu.value) { selectedItem ->
+        if (selectedItem is MenuItem.Parent) {
+            currentMenu.value = selectedItem
+        } else {
+            selectedItem.onClick?.invoke()
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -24,8 +24,8 @@ interface ISettingsPresenter: ViewPresenter {
 }
 
 // UI model/s
-sealed class MenuItem(val label: String, val onClick: (() -> Unit)? = null) {
-    class Leaf(label: String, onClick: () -> Unit) : MenuItem(label, onClick)
+sealed class MenuItem(val label: String) {
+    class Leaf(label: String, val content: @Composable () -> Unit) : MenuItem(label)
     class Parent(label: String, val children: List<MenuItem>) : MenuItem(label)
 }
 
@@ -139,13 +139,11 @@ fun SettingsScreen(isTabSelected: Boolean) {
                     currentMenu.value = selectedItem
                     menuPath.add(selectedItem)
                 } else {
-                    println("Item selected ${selectedItem}")
                     selectedLeaf.value = selectedItem as MenuItem.Leaf
-                    selectedItem.onClick?.invoke()
                 }
             }
         } else {
-            Text("fuck")
+            selectedLeaf.value!!.content.invoke()
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -113,27 +113,39 @@ fun SettingsScreen(isTabSelected: Boolean) {
     val menuTree: MenuItem = settingsPresenter.menuTree()
     val currentMenu = remember { mutableStateOf(menuTree) }
     val menuPath = remember { mutableStateListOf(menuTree) }
+    val selectedLeaf = remember { mutableStateOf<MenuItem.Leaf?>(null) }
 
     RememberPresenterLifecycle(settingsPresenter)
     // Reset to root menu when the tab is selected
     LaunchedEffect(isTabSelected) {
         if (isTabSelected) {
             currentMenu.value = menuTree
+            selectedLeaf.value = null
         }
     }
 
-    Column {
+    Column(modifier = Modifier.fillMaxSize()) {
         BreadcrumbNavigation(path = menuPath) { index ->
             currentMenu.value = menuPath[index]
+            // TODO might need complex index logic?
+            selectedLeaf.value = null
             menuPath.removeRange(index + 1, menuPath.size)
         }
-        SettingsMenu(menuItem = currentMenu.value) { selectedItem ->
-            if (selectedItem is MenuItem.Parent) {
-                currentMenu.value = selectedItem
-                menuPath.add(selectedItem)
-            } else {
-                selectedItem.onClick?.invoke()
+
+        if (selectedLeaf.value == null) {
+            SettingsMenu(menuItem = currentMenu.value) { selectedItem ->
+                if (selectedItem is MenuItem.Parent) {
+                    selectedLeaf.value = null
+                    currentMenu.value = selectedItem
+                    menuPath.add(selectedItem)
+                } else {
+                    println("Item selected ${selectedItem}")
+                    selectedLeaf.value = selectedItem as MenuItem.Leaf
+                    selectedItem.onClick?.invoke()
+                }
             }
+        } else {
+            Text("fuck")
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/TrustedSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/TrustedSettingsScreen.kt
@@ -1,0 +1,24 @@
+package network.bisq.mobile.presentation.ui.uicases.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+
+@Composable
+fun TrustedNodeSettingsScreen() {
+
+//    RememberPresenterLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "TrustedNodeSettingsScreen",
+            style = MaterialTheme.typography.bodyLarge.copy(color = BisqTheme.colors.light1 , fontSize = 16.sp),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -1,0 +1,24 @@
+package network.bisq.mobile.presentation.ui.uicases.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+
+@Composable
+fun UserProfileSettingsScreen() {
+
+//    RememberPresenterLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "UserProfileSettingsScreen",
+            style = MaterialTheme.typography.bodyLarge.copy(color = BisqTheme.colors.light1 , fontSize = 16.sp),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}


### PR DESCRIPTION
 - 1/2 PRs pf implementation for #51 10a,10b
 - Settings implementation with configurable menu per presenter (allows to configure per app type)
 - Basic implementation with mockup screens
 - navigation of settings fully implemented
 - tested on the 3 apps