### PR TITLE
Feature/home redesign

### DIFF
--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.client.di
 
 import network.bisq.mobile.client.service.user_profile.ClientCatHashService
+import network.bisq.mobile.domain.AndroidUrlLauncher
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.service.AndroidClientCatHashService
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.bind
@@ -8,6 +10,7 @@ import org.koin.dsl.module
 
 
 val androidClientModule = module {
+    single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
     single {
         val context = androidContext()
         val filesDir = context.filesDir.absolutePath

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -13,6 +13,8 @@ import network.bisq.mobile.android.node.service.offer.NodeOfferServiceFacade
 import network.bisq.mobile.android.node.service.offerbook.NodeOfferbookServiceFacade
 import network.bisq.mobile.android.node.service.trade.NodeTradeServiceFacade
 import network.bisq.mobile.android.node.service.user_profile.NodeUserProfileServiceFacade
+import network.bisq.mobile.domain.AndroidUrlLauncher
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offer.OfferServiceFacade
@@ -53,9 +55,11 @@ val androidNodeModule = module {
 
     single<TradeServiceFacade> { NodeTradeServiceFacade(get()) }
 
+    single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
+
     // this line showcases both, the possibility to change behaviour of the app by changing one definition
     // and binding the same obj to 2 different abstractions
-    single<MainPresenter> { NodeMainPresenter(get(), get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
+    single<MainPresenter> { NodeMainPresenter(get(), get(), get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
 
     single<SplashPresenter> {
         NodeSplashPresenter(

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -1,10 +1,7 @@
 package network.bisq.mobile.android.node.di
 
 import network.bisq.mobile.android.node.AndroidApplicationService
-import network.bisq.mobile.android.node.presentation.NodeMainPresenter
-import network.bisq.mobile.android.node.presentation.NodeSettingsPresenter
-import network.bisq.mobile.android.node.presentation.NodeSplashPresenter
-import network.bisq.mobile.android.node.presentation.OnBoardingNodePresenter
+import network.bisq.mobile.android.node.presentation.*
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.android.node.service.AndroidNodeCatHashService
 import network.bisq.mobile.android.node.service.bootstrap.NodeApplicationBootstrapFacade
@@ -23,6 +20,7 @@ import network.bisq.mobile.domain.service.trade.TradeServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.uicases.GettingStartedPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.IOnboardingPresenter
@@ -69,6 +67,10 @@ val androidNodeModule = module {
             get(),
             get(),
         )
+    }
+
+    single<GettingStartedPresenter> {
+        NodeGettingStartedPresenter(get(), get(), get(), get())
     }
 
     single<SettingsPresenter> { NodeSettingsPresenter(get(), get()) } bind ISettingsPresenter::class

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -70,7 +70,7 @@ val androidNodeModule = module {
     }
 
     single<GettingStartedPresenter> {
-        NodeGettingStartedPresenter(get(), get(), get(), get())
+        NodeGettingStartedPresenter(get(), get(), get(), get(), get())
     }
 
     single<SettingsPresenter> { NodeSettingsPresenter(get(), get()) } bind ISettingsPresenter::class

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
@@ -1,0 +1,22 @@
+package network.bisq.mobile.android.node.presentation
+
+import network.bisq.mobile.domain.data.repository.BisqStatsRepository
+import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.uicases.GettingStartedPresenter
+import network.bisq.mobile.presentation.ui.uicases.offer.create_offer.CreateOfferPresenter
+
+class NodeGettingStartedPresenter(
+    mainPresenter: MainPresenter,
+    bisqStatsRepository: BisqStatsRepository,
+    marketPriceServiceFacade: MarketPriceServiceFacade,
+    createOfferPresenter: CreateOfferPresenter
+) : GettingStartedPresenter(mainPresenter, bisqStatsRepository, marketPriceServiceFacade, createOfferPresenter) {
+    override val title: String = "Bisq Easy Node"
+    override val bulletPoints: List<String> = listOf(
+        "Take control of your trading experience with the full power of Bisq, now on your mobile.",
+        "Your Node, Your Privacy: Operate a fully-featured P2P Bisq Node directly from your mobile. No compromises on privacy & security - just like running Bisq on your desktop.",
+        "Click on Start Trading button to browse available offers from other Bisq users or create your own. Request mediation if needed.",
+        "Bisq Easy protocol uses seller's reputation which is visible on each offer."
+    )
+}

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.android.node.presentation
 
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.uicases.GettingStartedPresenter
 import network.bisq.mobile.presentation.ui.uicases.offer.create_offer.CreateOfferPresenter
@@ -10,8 +11,9 @@ class NodeGettingStartedPresenter(
     mainPresenter: MainPresenter,
     bisqStatsRepository: BisqStatsRepository,
     marketPriceServiceFacade: MarketPriceServiceFacade,
-    createOfferPresenter: CreateOfferPresenter
-) : GettingStartedPresenter(mainPresenter, bisqStatsRepository, marketPriceServiceFacade, createOfferPresenter) {
+    createOfferPresenter: CreateOfferPresenter,
+    offerbookServiceFacade: OfferbookServiceFacade
+) : GettingStartedPresenter(mainPresenter, bisqStatsRepository, marketPriceServiceFacade, createOfferPresenter, offerbookServiceFacade) {
     override val title: String = "Bisq Easy Node"
     override val bulletPoints: List<String> = listOf(
         "Take control of your trading experience with the full power of Bisq, now on your mobile.",

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGettingStartedPresenter.kt
@@ -13,7 +13,7 @@ class NodeGettingStartedPresenter(
     marketPriceServiceFacade: MarketPriceServiceFacade,
     createOfferPresenter: CreateOfferPresenter,
     offerbookServiceFacade: OfferbookServiceFacade
-) : GettingStartedPresenter(mainPresenter, bisqStatsRepository, marketPriceServiceFacade, createOfferPresenter, offerbookServiceFacade) {
+) : GettingStartedPresenter(mainPresenter, bisqStatsRepository, marketPriceServiceFacade,   offerbookServiceFacade) {
     override val title: String = "Bisq Easy Node"
     override val bulletPoints: List<String> = listOf(
         "Take control of your trading experience with the full power of Bisq, now on your mobile.",

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.android.node.presentation
 import android.app.Activity
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
@@ -13,6 +14,7 @@ import network.bisq.mobile.presentation.MainPresenter
 
 class NodeMainPresenter(
     notificationServiceController: NotificationServiceController,
+    urlLauncher: UrlLauncher,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
@@ -20,7 +22,7 @@ class NodeMainPresenter(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val offerServiceFacade: OfferServiceFacade,
     private val tradeServiceFacade: TradeServiceFacade,
-) : MainPresenter(notificationServiceController) {
+) : MainPresenter(notificationServiceController, urlLauncher) {
 
     private var applicationServiceCreated = false
     override fun onViewAttached() {

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.android.kt
@@ -2,8 +2,11 @@
 
 package network.bisq.mobile.domain
 
+import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Build
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
@@ -20,6 +23,14 @@ actual fun getPlatformSettings(): Settings {
 
 actual fun getDeviceLanguageCode(): String {
     return Locale.getDefault().language
+}
+
+class AndroidUrlLauncher(private val context: Context) : UrlLauncher {
+    override fun openUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(intent)
+    }
 }
 
 class AndroidPlatformInfo : PlatformInfo {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.kt
@@ -19,6 +19,10 @@ interface PlatformInfo {
     val name: String
 }
 
+interface UrlLauncher {
+    fun openUrl(url: String)
+}
+
 expect fun getDeviceLanguageCode(): String
 
 expect fun getPlatformInfo(): PlatformInfo

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
@@ -14,14 +14,10 @@ import kotlinx.cinterop.usePinned
 import kotlinx.serialization.Serializable
 import platform.Foundation.NSData
 import platform.Foundation.*
-import platform.UIKit.UIDevice
-import platform.UIKit.UIImage
 import platform.Foundation.create
-import platform.UIKit.UIImagePNGRepresentation
 import platform.Foundation.NSString
-import platform.Foundation.create
 import platform.Foundation.stringWithFormat
-import platform.UIKit.UIImagePNGRepresentation
+import platform.UIKit.*
 import platform.posix.memcpy
 
 @OptIn(ExperimentalSettingsImplementation::class)
@@ -33,6 +29,15 @@ actual fun getPlatformSettings(): Settings {
 
 actual fun getDeviceLanguageCode(): String {
     return NSLocale.currentLocale.languageCode ?: "en"
+}
+
+class IOSUrlLauncher : UrlLauncher {
+    override fun openUrl(url: String) {
+        val nsUrl = NSURL.URLWithString(url)
+        if (nsUrl != null) {
+            UIApplication.sharedApplication.openURL(nsUrl)
+        }
+    }
 }
 
 class IOSPlatformInfo : PlatformInfo {

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
@@ -18,6 +18,8 @@ import platform.Foundation.create
 import platform.Foundation.NSString
 import platform.Foundation.stringWithFormat
 import platform.UIKit.*
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
 import platform.posix.memcpy
 
 @OptIn(ExperimentalSettingsImplementation::class)
@@ -35,7 +37,8 @@ class IOSUrlLauncher : UrlLauncher {
     override fun openUrl(url: String) {
         val nsUrl = NSURL.URLWithString(url)
         if (nsUrl != null) {
-            UIApplication.sharedApplication.openURL(nsUrl)
+            // fake secondary parameters are important so that iOS compiler knows which override to use
+            UIApplication.sharedApplication.openURL(nsUrl, options = mapOf<Any?,String>(), completionHandler = null)
         }
     }
 }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
@@ -1,11 +1,12 @@
 package network.bisq.mobile.domain.di
 
-import network.bisq.mobile.client.shared.BuildConfig
+import network.bisq.mobile.domain.IOSUrlLauncher
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val iosClientModule = module {
+    single<UrlLauncher> { IOSUrlLauncher() }
     single<NotificationServiceController> {
         NotificationServiceController().apply {
             this.registerBackgroundTask()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client
 
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.service.TrustedNodeService
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
@@ -12,8 +13,9 @@ class ClientMainPresenter(
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val trustedNodeService: TrustedNodeService,
     private val offerbookServiceFacade: OfferbookServiceFacade,
-    private val marketPriceServiceFacade: MarketPriceServiceFacade
-) : MainPresenter(notificationServiceController) {
+    private val marketPriceServiceFacade: MarketPriceServiceFacade,
+    urlLauncher: UrlLauncher
+) : MainPresenter(notificationServiceController, urlLauncher) {
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -232,7 +232,10 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
     }
 
     fun setStrings(localStrings: AppStrings) {
-        BasePresenter.strings = localStrings
+        strings = localStrings
     }
 
+    open fun navigateToUrl(url: String) {
+        rootPresenter?.navigateToUrl(url)
+    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -83,14 +83,12 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
     init {
         rootPresenter?.registerChild(child = this)
     }
-
+    
     protected fun enableInteractive(enable: Boolean) {
-        if (enable) {
-            presenterScope.launch {
+        uiScope.launch {
+            if (enable) {
                 delay(250L)
-                _isInteractive.value = enable
             }
-        } else {
             _isInteractive.value = enable
         }
     }
@@ -170,7 +168,9 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
         } catch (e: Exception) {
             log.e("Custom cleanup failed", e)
         } finally {
-            rootPresenter?.unregisterChild(this)
+//          we can't get read of the link here since link is done at construction only
+//            and we are using singletons
+//            rootPresenter?.unregisterChild(this)
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.getDeviceLanguageCode
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
@@ -18,7 +19,10 @@ import kotlin.random.Random
 /**
  * Main Presenter as an example of implementation for now.
  */
-open class MainPresenter(private val notificationServiceController: NotificationServiceController) :
+open class MainPresenter(
+    private val notificationServiceController: NotificationServiceController,
+    private val urlLauncher: UrlLauncher
+) :
     BasePresenter(null), AppPresenter {
     companion object {
         // FIXME this will be erased eventually, for now you can turn on to see the notifications working
@@ -33,15 +37,6 @@ open class MainPresenter(private val notificationServiceController: Notification
     // Observable state
     private val _isContentVisible = MutableStateFlow(false)
     override val isContentVisible: StateFlow<Boolean> = _isContentVisible
-
-
-    // passthrough example
-    //    private val _greetingText: StateFlow<String> = stateFlowFromRepository(
-    //        repositoryFlow = greetingRepository.data,
-    //        transform = { it?.greet() ?: "" },
-    //        initialValue = "Welcome!"
-    //    )
-    //    override val greetingText: StateFlow<String> = _greetingText
 
     init {
         val localeCode = getDeviceLanguageCode()
@@ -87,6 +82,10 @@ open class MainPresenter(private val notificationServiceController: Notification
 
     override fun getRootTabNavController(): NavHostController {
         return tabNavController
+    }
+
+    final override fun navigateToUrl(url: String) {
+        urlLauncher.openUrl(url)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.di
 
 import network.bisq.mobile.client.ClientMainPresenter
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.presentation.ui.components.molecules.ITopBarPresenter
@@ -39,7 +40,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val presentationModule = module {
-    single<MainPresenter> { ClientMainPresenter(get(), get(), get(), get(), get()) } bind AppPresenter::class
+    single<MainPresenter> { ClientMainPresenter(get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
 
     single<TopBarPresenter> { TopBarPresenter(get(), get()) } bind ITopBarPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -62,7 +62,7 @@ val presentationModule = module {
 
     single<UserProfileSettingsPresenter> { UserProfileSettingsPresenter(get(), get(), get()) } bind IUserProfileSettingsPresenter::class
 
-    single<GettingStartedPresenter> { GettingStartedPresenter(get(), get(), get(), get(), get()) }
+    single<GettingStartedPresenter> { GettingStartedPresenter(get(), get(), get(), get()) }
 
     single {
         CreateProfilePresenter(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -62,7 +62,7 @@ val presentationModule = module {
 
     single<UserProfileSettingsPresenter> { UserProfileSettingsPresenter(get(), get(), get()) } bind IUserProfileSettingsPresenter::class
 
-    single<GettingStartedPresenter> { GettingStartedPresenter(get(), get(), get(), get()) }
+    single<GettingStartedPresenter> { GettingStartedPresenter(get(), get(), get(), get(), get()) }
 
     single {
         CreateProfilePresenter(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.draw.alpha
 import androidx.navigation.compose.currentBackStackEntryAsState
 import network.bisq.mobile.presentation.ui.components.atoms.animations.ShineOverlay
@@ -29,6 +30,8 @@ import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
 interface ITopBarPresenter: ViewPresenter {
+    fun onAvatarClicked()
+
     val uniqueAvatar: StateFlow<PlatformImage?>
 }
 
@@ -44,6 +47,8 @@ fun TopBar(
     val presenter: ITopBarPresenter = koinInject()
     val navController: NavHostController = presenter.getRootNavController()
     val tabNavController: NavHostController = presenter.getRootTabNavController()
+
+    val interactionEnabled = presenter.isInteractive.collectAsState().value
 
     val currentTab = tabNavController.currentBackStackEntryAsState().value?.destination?.route
 
@@ -113,8 +118,8 @@ fun TopBar(
 //                                 .fillMaxSize()
                                  .alpha(if (currentTab == Routes.TabSettings.name) 0.5f else 1.0f)
                                  .clickable {
-                                     if (currentTab != Routes.TabSettings.name) {
-                                         navController.navigate(Routes.UserProfileSettings.name)
+                                     if (currentTab != Routes.TabSettings.name && interactionEnabled) {
+                                         presenter.onAvatarClicked()
                                      }
                                  })
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
@@ -7,6 +7,7 @@ import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
 
 open class TopBarPresenter(
     private val userRepository: UserRepository,
@@ -27,6 +28,12 @@ open class TopBarPresenter(
     override fun onViewAttached() {
         super.onViewAttached()
         refresh()
+    }
+
+    override fun onAvatarClicked() {
+        enableInteractive(false)
+        getRootNavController().navigate(Routes.UserProfileSettings.name)
+        enableInteractive(true)
     }
 
     private fun refresh() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -12,13 +12,13 @@ import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.offer.create_offer.CreateOfferPresenter
 
-class GettingStartedPresenter(
+open class GettingStartedPresenter(
     mainPresenter: MainPresenter,
     private val bisqStatsRepository: BisqStatsRepository,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val createOfferPresenter: CreateOfferPresenter
 ) : BasePresenter(mainPresenter), IGettingStarted {
-    override val title: String = "Bisq Easy - Trusted node edition"
+    override val title: String = "Bisq Easy Client"
 
     override val bulletPoints: List<String> = listOf(
         "Experience Bisq with the guidance of a trusted friend or connect remotely to your own full node.",
@@ -37,13 +37,16 @@ class GettingStartedPresenter(
     private var job: Job? = null
 
     override fun navigateToCreateOffer() {
-        //rootNavigator.popBackStack(Routes.TabContainer.name, inclusive = false, saveState = false)
+        enableInteractive(false)
         createOfferPresenter.onStartCreateOffer()
         rootNavigator.navigate(Routes.CreateOfferDirection.name)
+        enableInteractive(true)
     }
 
     override fun navigateLearnMore() {
+        enableInteractive(false)
         navigateToUrl("https://bisq.wiki/Bisq_Easy")
+        enableInteractive(true)
     }
 
     private fun refresh() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -17,6 +18,13 @@ class GettingStartedPresenter(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val createOfferPresenter: CreateOfferPresenter
 ) : BasePresenter(mainPresenter), IGettingStarted {
+    override val title: String = "Bisq Easy - Trusted node edition"
+
+    override val bulletPoints: List<String> = listOf(
+        "Experience Bisq with the guidance of a trusted friend or connect remotely to your own full node.",
+        "Connect to Trusted Nodes: Start trading with confidence by connecting to a trusted Bisq node hosted by someone you trust.",
+        "Remote Management for Experts: Manage your trades on the go by connecting securely to your own desktop-based Bisq node, no matter where you are."
+    )
 
     private val _offersOnline = MutableStateFlow(145)
     override val offersOnline: StateFlow<Int> = _offersOnline
@@ -32,6 +40,10 @@ class GettingStartedPresenter(
         //rootNavigator.popBackStack(Routes.TabContainer.name, inclusive = false, saveState = false)
         createOfferPresenter.onStartCreateOffer()
         rootNavigator.navigate(Routes.CreateOfferDirection.name)
+    }
+
+    override fun navigateLearnMore() {
+        navigateToUrl("https://bisq.wiki/Bisq_Easy")
     }
 
     private fun refresh() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -36,11 +36,22 @@ open class GettingStartedPresenter(
 
     private var job: Job? = null
 
-    override fun navigateToCreateOffer() {
+    override fun onStartTrading() {
         enableInteractive(false)
-        createOfferPresenter.onStartCreateOffer()
-        rootNavigator.navigate(Routes.CreateOfferDirection.name)
+        navigateToTradingTab()
         enableInteractive(true)
+    }
+
+    private fun navigateToTradingTab() {
+        getRootTabNavController().navigate(Routes.TabCurrencies.name) {
+            getRootTabNavController().graph.startDestinationRoute?.let { route ->
+                popUpTo(route) {
+                    saveState = true
+                }
+            }
+            launchSingleTop = true
+            restoreState = true
+        }
     }
 
     override fun navigateLearnMore() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -1,11 +1,11 @@
 package network.bisq.mobile.presentation.ui.uicases
 
-import androidx.compose.runtime.collectAsState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.UrlLauncher
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
@@ -18,7 +18,6 @@ open class GettingStartedPresenter(
     mainPresenter: MainPresenter,
     private val bisqStatsRepository: BisqStatsRepository,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
-    private val createOfferPresenter: CreateOfferPresenter,
     private val offerbookServiceFacade: OfferbookServiceFacade
 ) : BasePresenter(mainPresenter), IGettingStarted {
     override val title: String = "Bisq Easy Client"
@@ -66,6 +65,7 @@ open class GettingStartedPresenter(
     private fun refresh() {
         job = backgroundScope.launch {
             try {
+                enableInteractive(false)
                 // TODO get published profiles data from service
                 val bisqStats = bisqStatsRepository.fetch()
                 _publishedProfiles.value = bisqStats?.publishedProfiles ?: 0
@@ -76,7 +76,14 @@ open class GettingStartedPresenter(
                 // Handle errors
                 println("Error: ${e.message}")
             }
+        }.also {
+            enableInteractive(true)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refresh()
     }
 
     override fun onViewAttached() {
@@ -88,10 +95,5 @@ open class GettingStartedPresenter(
         super.onViewUnattaching()
         job?.cancel()
         job = null
-    }
-
-    override fun onResume() {
-        super.onResume()
-        refresh()
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases
 
+import androidx.compose.runtime.collectAsState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -7,6 +8,7 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.service.offerbook.OfferbookServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -16,7 +18,8 @@ open class GettingStartedPresenter(
     mainPresenter: MainPresenter,
     private val bisqStatsRepository: BisqStatsRepository,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
-    private val createOfferPresenter: CreateOfferPresenter
+    private val createOfferPresenter: CreateOfferPresenter,
+    private val offerbookServiceFacade: OfferbookServiceFacade
 ) : BasePresenter(mainPresenter), IGettingStarted {
     override val title: String = "Bisq Easy Client"
 
@@ -63,9 +66,12 @@ open class GettingStartedPresenter(
     private fun refresh() {
         job = backgroundScope.launch {
             try {
+                // TODO get published profiles data from service
                 val bisqStats = bisqStatsRepository.fetch()
-                _offersOnline.value = bisqStats?.offersOnline ?: 0
                 _publishedProfiles.value = bisqStats?.publishedProfiles ?: 0
+                offerbookServiceFacade.offerListItems.collect {
+                    _offersOnline.value = it.size
+                }
             } catch (e: Exception) {
                 // Handle errors
                 println("Error: ${e.message}")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +13,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -23,29 +25,22 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.icon_chat_outlined
-import bisqapps.shared.presentation.generated.resources.icon_star_outlined
-import bisqapps.shared.presentation.generated.resources.icon_tag_outlined
-import bisqapps.shared.presentation.generated.resources.img_fiat_btc
-import bisqapps.shared.presentation.generated.resources.img_learn_and_discover
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
-import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
-import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
 interface IGettingStarted : ViewPresenter {
+    val title: String
+    val bulletPoints: List<String>
     val offersOnline: StateFlow<Number>
     val publishedProfiles: StateFlow<Number>
 
     fun navigateToCreateOffer()
+    fun navigateLearnMore()
 }
 
 @Composable
@@ -53,15 +48,6 @@ fun GettingStartedScreen() {
     val presenter: GettingStartedPresenter = koinInject()
     val offersOnline: Number = presenter.offersOnline.collectAsState().value
     val publishedProfiles: Number = presenter.publishedProfiles.collectAsState().value
-
-    // TODO attach view should happen here to let the presenter know?
-    // buddha: So here we have 2 screens actually.
-    //  - TabContainerScreen that has Scaffold, Topbar, Bottom bar (with 4 tabs)
-    //  - Indidivual tab screens like current GettingStartedScreen, which is technically
-    //  - not an indpendent screen. Since it doesn't have scaffold, topbar on it's own.
-
-    //  - So I guess, TabContainerScreen will have it's own TabContainerPresenter
-    //  - GettingStartedScreen (and other 3 tabs) will have it's own IGettingStarted
 
     RememberPresenterLifecycle(presenter)
 
@@ -92,73 +78,80 @@ fun GettingStartedScreen() {
                 }
             }
         }
-        BisqButton("Create offer", onClick={ presenter.navigateToCreateOffer() })
         WelcomeCard(
-            title = "Get your first BTC",
-            buttonText = "Enter Bisq Easy"
+            presenter = presenter,
+            title = presenter.title,
+            bulletPoints = presenter.bulletPoints,
+            primaryButtonText = "Start Trading",
+            footerLink = "Learn more"
         )
-        Column {
-            InstructionCard(
-                image = Res.drawable.img_fiat_btc,
-                title = "Multiple trade protocols",
-                description = "Checkout the roadmap for upcoming trade protocols. Get an overview about the features of the different protocols.",
-                buttonText = "Explore trade protocols"
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            InstructionCard(
-                image = Res.drawable.img_learn_and_discover,
-                title = "Learn & discover",
-                description = "Learn about Bitcoin and checkout upcoming events. Meet other Bisq users in the discussion chat.",
-                buttonText = "Learn more"
-            )
-        }
     }
 }
 
 @Composable
-fun WelcomeCard(title: String, buttonText: String) {
+fun WelcomeCard(
+    presenter: GettingStartedPresenter,
+    title: String,
+    bulletPoints: List<String>,
+    primaryButtonText: String,
+    footerLink: String
+) {
     NeumorphicCard {
         Column(
-            modifier = Modifier.shadow(
-                ambientColor = Color.Blue, spotColor = BisqTheme.colors.primary,
-                elevation = 2.dp,
-                shape = RoundedCornerShape(5.dp),
-
-                ).clip(shape = RoundedCornerShape(5.dp)).background(color = BisqTheme.colors.dark2)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(32.dp)
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .background(BisqTheme.colors.dark2)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            // Title
             BisqText.h4Regular(
                 text = title,
-                color = BisqTheme.colors.light1,
+                color = BisqTheme.colors.light1
             )
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                FeatureCard(
-                    image = Res.drawable.icon_tag_outlined,
-                    title = "Start trading or browser open offers in the offerbook"
-                )
-                FeatureCard(
-                    image = Res.drawable.icon_chat_outlined,
-                    title = "Chat based and guided user interface for trading"
-                )
-                FeatureCard(
-                    image = Res.drawable.icon_star_outlined,
-                    title = "Security is based on seller’s reputation"
+
+            // Bullet Points
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                bulletPoints.forEach { point ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Canvas(modifier = Modifier.size(6.dp)) {
+                            drawCircle(color = Color.White)
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        BisqText.baseMedium(
+                            text = point,
+                            color = BisqTheme.colors.light2
+                        )
+                    }
+                }
+            }
+
+            // Primary Button
+            Button(
+                onClick={ presenter.navigateToCreateOffer() },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = BisqTheme.colors.primary),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                BisqText.baseBold(
+                    text = primaryButtonText,
+                    color = Color.White,
                 )
             }
-            BisqText.baseMedium(
-                text = buttonText,
-                color = BisqTheme.colors.light1,
-                textAlign = TextAlign.Center,
+
+//            BisqButton("Create offer", onClick={ presenter.navigateToCreateOffer() })
+
+            // Footer Link
+            Text(
+                text = footerLink,
+//                style = BisqTheme.type.caption,
+                color = BisqTheme.colors.primary,
                 modifier = Modifier
-                    .clip(shape = RoundedCornerShape(4.dp))
-                    .background(color = BisqTheme.colors.primary)
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp),
+                    .align(Alignment.Start)
+                    .clickable { presenter.navigateLearnMore() }
             )
         }
     }
-
 }
 
 @Composable
@@ -182,50 +175,6 @@ fun PriceProfileCard(price: String, priceText: String) {
             text = priceText,
             color = BisqTheme.colors.grey1,
             textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@OptIn(ExperimentalResourceApi::class)
-@Composable
-fun FeatureCard(image: DrawableResource, title: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Image(painterResource(image), null, Modifier.size(20.dp))
-        Spacer(modifier = Modifier.width(9.dp))
-        BisqText.smallRegular(
-            text = title,
-            color = BisqTheme.colors.light1,
-        )
-
-    }
-}
-
-@OptIn(ExperimentalResourceApi::class)
-@Composable
-fun InstructionCard(image: DrawableResource, title: String, description: String, buttonText: String) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clip(shape = RoundedCornerShape(8.dp)).background(color = BisqTheme.colors.dark3)
-            .padding(vertical = 18.dp, horizontal = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp)
-    ) {
-        Image(painterResource(image), "")
-        BisqText.baseRegular(
-            text = title,
-            color = BisqTheme.colors.light1,
-        )
-        BisqText.baseRegular(
-            text = description,
-            color = BisqTheme.colors.grey3,
-            textAlign = TextAlign.Center,
-        )
-        BisqText.smallRegular(
-            text = buttonText,
-            color = BisqTheme.colors.light1,
-            modifier = Modifier
-                .clip(shape = RoundedCornerShape(4.dp))
-                .background(color = BisqTheme.colors.dark5)
-                .padding(horizontal = 18.dp, vertical = 6.dp),
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
@@ -129,6 +129,7 @@ fun WelcomeCard(
             // Primary Button
             Button(
                 onClick={ presenter.navigateToCreateOffer() },
+                enabled = presenter.isInteractive.collectAsState().value,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = BisqTheme.colors.primary),
                 shape = RoundedCornerShape(8.dp)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedScreen.kt
@@ -39,7 +39,7 @@ interface IGettingStarted : ViewPresenter {
     val offersOnline: StateFlow<Number>
     val publishedProfiles: StateFlow<Number>
 
-    fun navigateToCreateOffer()
+    fun onStartTrading()
     fun navigateLearnMore()
 }
 
@@ -128,7 +128,7 @@ fun WelcomeCard(
 
             // Primary Button
             Button(
-                onClick={ presenter.navigateToCreateOffer() },
+                onClick={ presenter.onStartTrading() },
                 enabled = presenter.isInteractive.collectAsState().value,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = BisqTheme.colors.primary),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -37,10 +37,15 @@ fun SettingsScreen(isTabSelected: Boolean) {
     // Column is used leaving the possibility to the leaf views to set the scrolling as they please
     Column {
         BreadcrumbNavigation(path = menuPath) { index ->
-            currentMenu.value = menuPath[index]
-            // TODO might need complex index logic?
-            selectedLeaf.value = null
-            menuPath.removeRange(index + 1, menuPath.size)
+            if (index == menuPath.size - 1) {
+//                TODO Default: Do nth, otherwise we can choose the below
+//                currentMenu.value = menuPath[index - 1]
+//                menuPath.removeRange(index, menuPath.size)
+            } else {
+                currentMenu.value = menuPath[index]
+                menuPath.removeRange(index + 1, menuPath.size)
+                selectedLeaf.value = null
+            }
         }
 
         if (selectedLeaf.value == null) {


### PR DESCRIPTION
 - Implementation for #97 
 - provided generic way of navigating to URL using default browser and applied to home navigations
 - Same for blocking UI, with examples on avatar and this home screen. This fixes double-tap UI issues
 - Start Trading takes the user to the Buy/Sell trading screen
 - Applied new desing to home screen
 - fix breadcrum navigation bug on leaf click