### PR TITLE
WebSocketClient dynamic host/port

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -25,6 +25,7 @@ import network.bisq.mobile.client.service.trades.TradesApiGateway
 import network.bisq.mobile.client.service.user_profile.ClientUserProfileServiceFacade
 import network.bisq.mobile.client.service.user_profile.UserProfileApiGateway
 import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
 import network.bisq.mobile.client.websocket.messages.SubscriptionRequest
 import network.bisq.mobile.client.websocket.messages.SubscriptionResponse
@@ -60,6 +61,7 @@ import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
+import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -132,12 +134,21 @@ val clientModule = module {
     single(named("WebsocketApiHost")) { get<EnvironmentController>().getWebSocketHost() }
     single(named("WebsocketApiPort")) { get<EnvironmentController>().getWebSocketPort() }
 
-    single {
+    factory { (host: String, port: Int) ->
         WebSocketClient(
             get(),
             get(),
+            host,
+            port
+        )
+    }
+
+    single {
+        WebSocketClientProvider(
             get(named("WebsocketApiHost")),
-            get(named("WebsocketApiPort"))
+            get(named("WebsocketApiPort")),
+            get(),
+            clientFactory = { host, port -> get { parametersOf(host, port) } },
         )
     }
 
@@ -171,7 +182,7 @@ val clientModule = module {
     single { ExplorerApiGateway(get()) }
     single<ExplorerServiceFacade> { ClientExplorerServiceFacade(get()) }
 
-    single { MediationApiGateway(get(), get()) }
+    single { MediationApiGateway(get()) }
     single<MediationServiceFacade> { ClientMediationServiceFacade(get()) }
 
     single { SettingsApiGateway(get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/MarketPriceApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/MarketPriceApiGateway.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.client.service.market
 
 import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
 import network.bisq.mobile.client.websocket.subscription.Topic
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventObserver
@@ -8,7 +9,7 @@ import network.bisq.mobile.domain.utils.Logging
 
 class MarketPriceApiGateway(
     private val webSocketApiClient: WebSocketApiClient,
-    private val webSocketClient: WebSocketClient,
+    private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
     private val basePath = "market-price"
 
@@ -17,6 +18,6 @@ class MarketPriceApiGateway(
     }
 
     suspend fun subscribeMarketPrice(): WebSocketEventObserver {
-        return webSocketClient.subscribe(Topic.MARKET_PRICE)
+        return webSocketClientProvider.get().subscribe(Topic.MARKET_PRICE)
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/mediation/MediationApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/mediation/MediationApiGateway.kt
@@ -1,12 +1,11 @@
 package network.bisq.mobile.client.service.mediation
 
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
 import network.bisq.mobile.domain.utils.Logging
 
 class MediationApiGateway(
-    private val webSocketApiClient: WebSocketApiClient,
-    private val webSocketClient: WebSocketClient,
+    private val webSocketApiClient: WebSocketApiClient
 ) : Logging {
     private val basePath = "mediation"
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/OfferbookApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/OfferbookApiGateway.kt
@@ -1,6 +1,6 @@
 package network.bisq.mobile.client.service.offers
 
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
 import network.bisq.mobile.client.websocket.subscription.Topic
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventObserver
@@ -13,7 +13,7 @@ import network.bisq.mobile.domain.utils.Logging
 
 class OfferbookApiGateway(
     private val webSocketApiClient: WebSocketApiClient,
-    private val webSocketClient: WebSocketClient,
+    private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
     private val basePath = "offerbook"
 
@@ -58,7 +58,7 @@ class OfferbookApiGateway(
 
     // Subscriptions
     suspend fun subscribeNumOffers(): WebSocketEventObserver {
-        return webSocketClient.subscribe(Topic.NUM_OFFERS)
+        return webSocketClientProvider.get().subscribe(Topic.NUM_OFFERS)
     }
 
     /**
@@ -66,7 +66,7 @@ class OfferbookApiGateway(
      *              If null or empty string we receive for all markets the offer updates.
      */
     suspend fun subscribeOffers(code: String? = null): WebSocketEventObserver {
-        return webSocketClient.subscribe(Topic.OFFERS, code)
+        return webSocketClientProvider.get().subscribe(Topic.OFFERS, code)
     }
 }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.subscription.ModificationType
 import network.bisq.mobile.client.websocket.subscription.Subscription
 import network.bisq.mobile.client.websocket.subscription.Topic
@@ -19,7 +19,7 @@ import network.bisq.mobile.domain.utils.Logging
 
 class ClientTradesServiceFacade(
     private val apiGateway: TradesApiGateway,
-    webSocketClient: WebSocketClient,
+    webSocketClientProvider: WebSocketClientProvider,
     json: Json
 ) :
     TradesServiceFacade, Logging {
@@ -38,10 +38,10 @@ class ClientTradesServiceFacade(
     private val tradeId get() = selectedTrade.value?.tradeId
     private val coroutineScope = CoroutineScope(BackgroundDispatcher)
     private val openTradesSubscription: Subscription<TradeItemPresentationDto> =
-        Subscription(webSocketClient, json, Topic.TRADES, this::handleTradeItemPresentationChange)
+        Subscription(webSocketClientProvider, json, Topic.TRADES, this::handleTradeItemPresentationChange)
 
     private val tradePropertiesSubscription: Subscription<Map<String, TradePropertiesDto>> =
-        Subscription(webSocketClient, json, Topic.TRADE_PROPERTIES, this::handleTradePropertiesChange)
+        Subscription(webSocketClientProvider, json, Topic.TRADE_PROPERTIES, this::handleTradePropertiesChange)
 
     //private var openTradesSubscriptionJob: Job? = null
     // private var tradePropertiesSubscriptionJob: Job? = null

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/TradesApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/TradesApiGateway.kt
@@ -9,13 +9,13 @@ import network.bisq.mobile.client.service.trades.TradeEventTypeEnum.REJECT_TRADE
 import network.bisq.mobile.client.service.trades.TradeEventTypeEnum.SELLER_CONFIRM_BTC_SENT
 import network.bisq.mobile.client.service.trades.TradeEventTypeEnum.SELLER_CONFIRM_FIAT_RECEIPT
 import network.bisq.mobile.client.service.trades.TradeEventTypeEnum.SELLER_SENDS_PAYMENT_ACCOUNT
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
 import network.bisq.mobile.domain.utils.Logging
 
 class TradesApiGateway(
     private val webSocketApiClient: WebSocketApiClient,
-    private val webSocketClient: WebSocketClient,
+    private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
     private val basePath = "trades"
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -1,0 +1,66 @@
+package network.bisq.mobile.client.websocket
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.domain.utils.Logging
+import kotlin.concurrent.Volatile
+
+/**
+ * Provider to handle dynamic host/port changes
+ */
+class WebSocketClientProvider(
+    defaultHost: String,
+    defaultPort: Int,
+    private val settingsRepository: SettingsRepository,
+    private val clientFactory: (String, Int) -> WebSocketClient) : Logging {
+
+    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+
+    @Volatile
+    private var currentClient: WebSocketClient? = null
+
+    init {
+        // Listen to changes in WebSocket configuration and update the client
+        backgroundScope.launch {
+            try {
+                settingsRepository.data.collect { newSettings ->
+                    var host = defaultHost
+                    var port = defaultPort
+                    newSettings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                        log.d { "new bisq url $url "}
+                        url.split("//")[1].split(":").let {
+                            host = it[0]
+                            port = it[1].toInt()
+                        }
+                    }
+                    // only update if there was actually a change
+                    if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
+                        if (currentClient?.isConnected == true) {
+                            currentClient?.disconnect()
+                        }
+                        log.d { "Websocket client updated with url $host:$port" }
+                        currentClient = createClient(host, port)
+                    }
+                }
+            } catch (e: Exception) {
+                log.e(e) { "Error updating WebSocket client with new settings." }
+            }
+        }
+    }
+
+    private fun createClient(host: String, port: Int): WebSocketClient {
+        return clientFactory(host, port)
+    }
+
+    fun get(): WebSocketClient {
+        if (currentClient == null) {
+            runBlocking {
+                settingsRepository.fetch()
+            }
+        }
+        return currentClient!!
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -3,10 +3,14 @@ package network.bisq.mobile.client.websocket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import network.bisq.mobile.client.websocket.messages.WebSocketRestApiRequest
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.Logging
 import kotlin.concurrent.Volatile
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * Provider to handle dynamic host/port changes
@@ -17,6 +21,14 @@ class WebSocketClientProvider(
     private val settingsRepository: SettingsRepository,
     private val clientFactory: (String, Int) -> WebSocketClient) : Logging {
 
+    companion object {
+        fun parseUri(uri: String): Pair<String,Int> {
+            uri.split("//")[1].split(":").let {
+                return Pair(it[0], it[1].toInt())
+            }
+        }
+    }
+
     private val backgroundScope = CoroutineScope(BackgroundDispatcher)
 
     @Volatile
@@ -24,6 +36,7 @@ class WebSocketClientProvider(
 
     init {
         // Listen to changes in WebSocket configuration and update the client
+        // TODO we might need to replicate this for changes in settings to reconnect to channels
         backgroundScope.launch {
             try {
                 settingsRepository.data.collect { newSettings ->
@@ -31,9 +44,9 @@ class WebSocketClientProvider(
                     var port = defaultPort
                     newSettings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
                         log.d { "new bisq url $url "}
-                        url.split("//")[1].split(":").let {
-                            host = it[0]
-                            port = it[1].toInt()
+                        parseUri(url).apply {
+                            host = first
+                            port = second
                         }
                     }
                     // only update if there was actually a change
@@ -48,6 +61,22 @@ class WebSocketClientProvider(
             } catch (e: Exception) {
                 log.e(e) { "Error updating WebSocket client with new settings." }
             }
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun testClient(host: String, port: Int): Boolean {
+        val client = createClient(host, port)
+        val url = "ws://$host:$port"
+        return try {
+            // if connection is refused, catch will execute returning false
+            client.connect()
+            return client.isConnected
+        } catch (e: Exception) {
+            log.e("Error testing connection to $url: ${e.message}")
+            false
+        } finally {
+            client.disconnect() // Ensure the client is closed to free resources
         }
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
@@ -12,7 +12,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.messages.WebSocketRestApiRequest
 import network.bisq.mobile.client.websocket.messages.WebSocketRestApiResponse
 import network.bisq.mobile.domain.utils.Logging
@@ -21,7 +21,7 @@ import kotlin.uuid.Uuid
 
 class WebSocketApiClient(
     val httpClient: HttpClient,
-    val webSocketClient: WebSocketClient,
+    val webSocketClientProvider: WebSocketClientProvider,
     val json: Json,
     host: String,
     port: Int
@@ -108,7 +108,7 @@ class WebSocketApiClient(
             bodyAsJson
         )
         try {
-            val response = webSocketClient.sendRequestAndAwaitResponse(webSocketRestApiRequest)
+            val response = webSocketClientProvider.get().sendRequestAndAwaitResponse(webSocketRestApiRequest)
             require(response is WebSocketRestApiResponse) { "Response not of expected type. response=$response" }
             val body = response.body
             if (response.isSuccess()) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
@@ -5,12 +5,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.utils.Logging
 
 class Subscription<T>(
-    private val webSocketClient: WebSocketClient,
+    private val webSocketClientProvider: WebSocketClientProvider,
     private val json: Json,
     private val topic: Topic,
     private val resultHandler: (List<T>, ModificationType) -> Unit
@@ -25,7 +25,7 @@ class Subscription<T>(
         require(job == null)
         job = coroutineScope.launch {
             // subscribe blocks until we get a response
-            val observer = webSocketClient.subscribe(topic)
+            val observer = webSocketClientProvider.get().subscribe(topic)
             observer.webSocketEvent.collect { webSocketEvent ->
                 try {
                     if (webSocketEvent?.deferredPayload == null) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/BaseModel.kt
@@ -26,7 +26,7 @@ sealed class BaseModel {
             return false
         if (other is BaseModel) {
             if (other.id != UNDEFINED_ID && id != UNDEFINED_ID)
-                return other.id.equals(id)
+                return other.id == id
             return super.equals(other)
         }
         return false

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Settings.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 open class Settings : BaseModel() {
     open var bisqApiUrl: String = ""
-    open var isConnected: Boolean = false
-
     //todo better rely on the source data alone (has user profile, has bisqApiUrl set) as otherwise we can get out of sync
     open var firstLaunch: Boolean = true
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -1,7 +1,7 @@
 package network.bisq.mobile.domain.service
 
 import kotlinx.coroutines.CoroutineScope
-import network.bisq.mobile.client.websocket.WebSocketClient
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.utils.Logging
 
@@ -9,19 +9,19 @@ import network.bisq.mobile.domain.utils.Logging
  * This service allows to interact with the underlaying connectivity system
  * against the trusted node for the client.
  */
-class TrustedNodeService(private val websocketClient: WebSocketClient) : Logging {
+class TrustedNodeService(private val webSocketClientProvider: WebSocketClientProvider) : Logging {
     private val backgroundScope = CoroutineScope(BackgroundDispatcher)
 
     // TODO websocketClient.isConnected should be observable so that we emit
     // events when disconnected and UI can react
-    fun isConnected() = websocketClient.isConnected
+    fun isConnected() = webSocketClientProvider.get().isConnected
 
     /**
      * Connects to the trusted node, throws an exception if connection fails
      */
     suspend fun connect() {
         runCatching {
-            websocketClient.connect()
+            webSocketClientProvider.get().connect()
         }.onSuccess {
             log.d { "Connected to trusted node" }
         }.onFailure {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -78,7 +78,8 @@ val presentationModule = module {
     single {
         TrustedNodeSetupPresenter(
             get(),
-            settingsRepository = get()
+            settingsRepository = get(),
+            get()
         )
     } bind ITrustedNodeSetupPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
@@ -52,7 +52,8 @@ open class OnBoardingPresenter(
 
             if (pagerState.currentPage == indexesToShow.lastIndex) {
 
-                val updatedSettings = (settings ?: Settings()).apply {
+                val updatedSettings = Settings().apply {
+                    bisqApiUrl = settings?.bisqApiUrl ?: ""
                     firstLaunch = false
                 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -46,6 +46,7 @@ class TrustedNodeSetupPresenter(
     }
 
     override fun updateBisqApiUrl(newUrl: String) {
+        // TODO apply validation of the URL format ws://<IP>:<PORT> after Buddha's support for it
         _bisqApiUrl.value = newUrl
         _isConnected.value = false
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
 import network.bisq.mobile.presentation.ui.components.atoms.icons.QuestionIcon
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
@@ -22,15 +21,11 @@ import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.koin.compose.koinInject
-import org.koin.core.qualifier.named
-import org.koin.core.parameter.parametersOf
-import cafe.adriel.lyricist.LocalStrings
 
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.CopyIcon
-import network.bisq.mobile.presentation.ui.components.atoms.icons.ScanIcon
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 
 interface ITrustedNodeSetupPresenter: ViewPresenter {
@@ -39,7 +34,7 @@ interface ITrustedNodeSetupPresenter: ViewPresenter {
 
     fun updateBisqApiUrl(newUrl: String)
 
-    fun testConnection(isTested: Boolean)
+    fun testConnection()
 
     fun navigateToNextScreen()
 
@@ -49,9 +44,7 @@ interface ITrustedNodeSetupPresenter: ViewPresenter {
 @OptIn(ExperimentalResourceApi::class)
 @Composable
 fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
-    val strings = LocalStrings.current
     val presenter: ITrustedNodeSetupPresenter = koinInject()
-    val navController: NavHostController = presenter.getRootNavController()
 
     val bisqApiUrl = presenter.bisqApiUrl.collectAsState().value
     val isConnected = presenter.isConnected.collectAsState().value
@@ -64,15 +57,20 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
     ) {
         BisqLogo()
         Spacer(modifier = Modifier.height(24.dp))
+        BisqText.largeRegular(
+            text = "To use Bisq through your trusted node, please enter the URL to connect to. E.g. ws://10.0.0.1:8090",
+            color = BisqTheme.colors.light1,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxSize().padding(horizontal = 0.dp)
         ) {
             BisqTextField(
-                label = "Bisq URL",
+                label = "Trusted Bisq Node URL",
                 onValueChanged = { presenter.updateBisqApiUrl(it) },
                 value = bisqApiUrl,
-                placeholder = "",
+                placeholder = "ws://10.0.2.2:8090",
                 labelRightSuffix = {
                     BisqButton(
                         iconOnly = { QuestionIcon() },
@@ -90,19 +88,19 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     text = "Paste",
                     onClick = {
                         val annotatedString = clipboardManager.getText()
-                        if(annotatedString != null) {
+                        if (annotatedString != null) {
                             presenter.updateBisqApiUrl(annotatedString.text)
                         }                    },
                     backgroundColor = BisqTheme.colors.dark5,
                     color = BisqTheme.colors.light1,
                     leftIcon= { CopyIcon() }
                 )
-
-                BisqButton(
-                    text = "Scan",
-                    onClick = {},
-                    leftIcon= { ScanIcon() }
-                )
+//              TODO uncomment when feature gets implemented
+//                BisqButton(
+//                    text = "Scan",
+//                    onClick = {},
+//                    leftIcon= { ScanIcon() }
+//                )
             }
             Spacer(modifier = Modifier.height(36.dp))
             BisqText.baseRegular(
@@ -133,7 +131,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                 text = "Test Connection",
                 color = if (bisqApiUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
                 onClick = {
-                    presenter.testConnection(true)
+                    presenter.testConnection()
                           },
                 padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                 )
@@ -149,7 +147,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     BisqButton(
                         text = "Test Connection",
                         color = if (bisqApiUrl.isEmpty()) BisqTheme.colors.grey1 else BisqTheme.colors.light1,
-                        onClick = { presenter.testConnection(true) },
+                        onClick = { presenter.testConnection() },
                         padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                     )
                 }
@@ -162,7 +160,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     BisqButton(
                         text = if (isWorkflow) "Next" else "Save",
                         color = BisqTheme.colors.light1,
-                        onClick = { if (isWorkflow) presenter.navigateToNextScreen() else presenter.testConnection(true) },
+                        onClick = { if (isWorkflow) presenter.navigateToNextScreen() else presenter.testConnection() },
                         padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                     )
                 }


### PR DESCRIPTION
 - Implementation for https://github.com/bisq-network/bisq-mobile/issues/163
 - make dependants on webSocketclient use a provider
 - provider listens to settings repository changes and updates instance cached
 - implementation for test connection on trusted node setup