### PR TITLE
Feature/auto reconnect ws

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -34,7 +34,7 @@ class ClientApplicationBootstrapFacade(
 //            } else {
             setProgress(0.5f)
             setState("Connecting to Trusted Node..")
-            if (!trustedNodeService.isConnected()) {
+            if (!trustedNodeService.isConnected) {
                 try {
                     trustedNodeService.connect()
                     setState("bootstrap.connectedToTrustedNode".i18n())

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -51,7 +51,7 @@ class WebSocketClientProvider(
                     }
                     // only update if there was actually a change
                     if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
-                        if (currentClient?.isConnected == true) {
+                        if (currentClient?.isConnected() == true) {
                             currentClient?.disconnect()
                         }
                         log.d { "Websocket client updated with url $host:$port" }
@@ -70,13 +70,13 @@ class WebSocketClientProvider(
         val url = "ws://$host:$port"
         return try {
             // if connection is refused, catch will execute returning false
-            client.connect()
-            return client.isConnected
+            client.connect(true)
+            return client.isConnected()
         } catch (e: Exception) {
             log.e("Error testing connection to $url: ${e.message}")
             false
         } finally {
-            client.disconnect() // Ensure the client is closed to free resources
+            client.disconnect(true) // Ensure the client is closed to free resources
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
@@ -41,11 +42,15 @@ class ClientMainPresenter(
             webSocketClientProvider.get().connected.collect {
                 if (webSocketClientProvider.get().isConnected()) {
                     log.d { "connectivity status changed to $it - reconnecting services" }
-                    deactivateServices()
-                    activateServices()
+                    reactiveServices()
                 }
             }
         }
+    }
+
+    private fun reactiveServices() {
+        deactivateServices()
+        activateServices()
     }
 
     private fun activateServices() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.client
 
+import kotlinx.coroutines.launch
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.controller.NotificationServiceController
@@ -11,6 +13,7 @@ import network.bisq.mobile.presentation.MainPresenter
 
 class ClientMainPresenter(
     notificationServiceController: NotificationServiceController,
+    private val webSocketClientProvider: WebSocketClientProvider,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val offersServiceFacade: OffersServiceFacade,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
@@ -21,7 +24,31 @@ class ClientMainPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
+        activateServices()
+        listenForConnectivity()
+    }
 
+    override fun onViewUnattaching() {
+        // For Tor we might want to leave it running while in background to avoid delay of re-connect
+        // when going into foreground again.
+        // coroutineScope.launch {  webSocketClient.disconnect() }
+        deactivateServices()
+        super.onViewUnattaching()
+    }
+
+    private fun listenForConnectivity() {
+        backgroundScope.launch {
+            webSocketClientProvider.get().connected.collect {
+                if (webSocketClientProvider.get().isConnected()) {
+                    log.d { "connectivity status changed to $it - reconnecting services" }
+                    deactivateServices()
+                    activateServices()
+                }
+            }
+        }
+    }
+
+    private fun activateServices() {
         runCatching {
             applicationBootstrapFacade.activate()
             offersServiceFacade.activate()
@@ -35,16 +62,11 @@ class ClientMainPresenter(
         }
     }
 
-    override fun onViewUnattaching() {
-        // For Tor we might want to leave it running while in background to avoid delay of re-connect
-        // when going into foreground again.
-        // coroutineScope.launch {  webSocketClient.disconnect() }
-
+    private fun deactivateServices() {
         applicationBootstrapFacade.deactivate()
         offersServiceFacade.deactivate()
         marketPriceServiceFacade.deactivate()
         tradesServiceFacade.deactivate()
         settingsServiceFacade.deactivate()
-        super.onViewUnattaching()
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -43,7 +43,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val presentationModule = module {
-    single<MainPresenter> { ClientMainPresenter(get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
+    single<MainPresenter> { ClientMainPresenter(get(), get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
 
     single<TopBarPresenter> { TopBarPresenter(get(), get()) } bind ITopBarPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
@@ -35,6 +35,7 @@ class InterruptedTradePresenter(
     var reportToMediatorButtonVisible: Boolean = false
 
     override fun onViewAttached() {
+        super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
         presenterScope.launch {
@@ -46,6 +47,7 @@ class InterruptedTradePresenter(
 
     override fun onViewUnattaching() {
         reset()
+        super.onViewUnattaching()
     }
 
     private fun tradeStateChanged(state: BisqEasyTradeStateEnum?) {
@@ -138,9 +140,10 @@ class InterruptedTradePresenter(
 
     fun onCloseTrade() {
         backgroundScope.launch {
-            require(selectedTrade.value != null)
-            tradesServiceFacade.closeTrade()
-            navigateToTab(Routes.TabOpenTradeList)
+            if (selectedTrade.value != null) {
+                tradesServiceFacade.closeTrade()
+            }
+            navigateBack()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -171,9 +171,9 @@ class TradeDetailsHeaderPresenter(
         }
     }
 
-    fun closeWorkflow() {
-        // doing a shark navigateBack causes white broken UI screen
-        navigateToTab(Routes.TabOpenTradeList)
+    private fun closeWorkflow() {
+//        Do not navigate, close button on the same screen does it
+//        navigateBack()
     }
 
     private fun reset() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
@@ -148,6 +148,7 @@ class TradeFlowPresenter(
         _tradePhaseState.value = TradePhaseState.INIT
         isSeller = false
         isMainChain = false
+        super.onViewUnattaching()
     }
 
     private fun tradeStateChanged(state: BisqEasyTradeStateEnum?) {


### PR DESCRIPTION
 - Implementation for #157 
 - when a disconnection occurs, a recursive reconnect mechanism gets triggers that retries every 3 secs.
 - DISCONNECTED - CONNECTING - CONNECTED stateflows paving the way for the semaphore UI
 - on connecting services get also reactivated on the client main presenter providing a resilient experience
 - fixed crash on closing old non-active trades
 - refactor could occur based on this PR when doing #130 to provide a solution for both node and clients