### PR TITLE
Feature/clients ongoing trades notifications (android)

### DIFF
--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/AndroidClientMainPresenter.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/AndroidClientMainPresenter.kt
@@ -1,0 +1,29 @@
+package network.bisq.mobile.client
+
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
+import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
+import network.bisq.mobile.domain.service.offers.OffersServiceFacade
+import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
+import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+
+/**
+ * Redefinition to be able to access activity for trading notifications click handling
+ */
+class AndroidClientMainPresenter(openTradesNotificationService: OpenTradesNotificationService,
+                                 tradesServiceFacade: TradesServiceFacade,
+                                 webSocketClientProvider: WebSocketClientProvider,
+                                 applicationBootstrapFacade: ApplicationBootstrapFacade,
+                                 offersServiceFacade: OffersServiceFacade,
+                                 marketPriceServiceFacade: MarketPriceServiceFacade,
+                                 settingsServiceFacade: SettingsServiceFacade, urlLauncher: UrlLauncher
+) : ClientMainPresenter(
+    openTradesNotificationService, tradesServiceFacade, webSocketClientProvider, applicationBootstrapFacade,
+    offersServiceFacade, marketPriceServiceFacade, settingsServiceFacade, urlLauncher
+) {
+    init {
+        openTradesNotificationService.notificationServiceController.activityClassForIntents = MainActivity::class.java
+    }
+}

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client
 
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
@@ -17,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.App
+import network.bisq.mobile.presentation.ui.navigation.Routes
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
@@ -27,6 +29,14 @@ class MainActivity : ComponentActivity() {
 
     init {
         MainPresenter.init()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+
+        intent?.getStringExtra("destination")?.let { destination ->
+            Routes.fromString(destination)?.let { presenter.navigateToTab(it) }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
@@ -4,6 +4,8 @@ import network.bisq.mobile.client.AndroidClientMainPresenter
 import network.bisq.mobile.client.service.user_profile.ClientCatHashService
 import network.bisq.mobile.domain.AndroidUrlLauncher
 import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.service.AppForegroundController
+import network.bisq.mobile.domain.service.ForegroundDetector
 import network.bisq.mobile.domain.service.notifications.controller.NotificationServiceController
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
@@ -21,8 +23,9 @@ val androidClientModule = module {
         AndroidClientCatHashService(context, filesDir)
     } bind ClientCatHashService::class
 
+    single<AppForegroundController> { AppForegroundController(androidContext()) } bind ForegroundDetector::class
     single<NotificationServiceController> {
-        NotificationServiceController(androidContext())
+        NotificationServiceController(get())
     }
 
     single<MainPresenter> { AndroidClientMainPresenter(get(), get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
@@ -1,8 +1,12 @@
 package network.bisq.mobile.client.di
 
+import network.bisq.mobile.client.AndroidClientMainPresenter
 import network.bisq.mobile.client.service.user_profile.ClientCatHashService
 import network.bisq.mobile.domain.AndroidUrlLauncher
 import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.service.notifications.controller.NotificationServiceController
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.service.AndroidClientCatHashService
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.bind
@@ -16,4 +20,10 @@ val androidClientModule = module {
         val filesDir = context.filesDir.absolutePath
         AndroidClientCatHashService(context, filesDir)
     } bind ClientCatHashService::class
+
+    single<NotificationServiceController> {
+        NotificationServiceController(androidContext())
+    }
+
+    single<MainPresenter> { AndroidClientMainPresenter(get(), get(), get(), get(), get(), get(), get(), get()) } bind AppPresenter::class
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -13,10 +13,13 @@ import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 
+/**
+ * Node main presenter has a very different setup than the rest of the apps (bisq2 core dependencies)
+ */
 class NodeMainPresenter(
     urlLauncher: UrlLauncher,
+    openTradesNotificationService: OpenTradesNotificationService,
     private val tradesServiceFacade: TradesServiceFacade,
-    private val openTradesNotificationService: OpenTradesNotificationService,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/di/DomainModule.android.kt
@@ -1,9 +1,13 @@
 package network.bisq.mobile.domain.di
 
+import network.bisq.mobile.domain.service.AppForegroundController
+import network.bisq.mobile.domain.service.ForegroundDetector
 import network.bisq.mobile.domain.service.notifications.controller.NotificationServiceController
 import org.koin.dsl.module
 import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.bind
 
 val serviceModule = module {
-    single<NotificationServiceController> { NotificationServiceController(androidContext()) }
+    single<AppForegroundController> { AppForegroundController(androidContext()) } bind ForegroundDetector::class
+    single<NotificationServiceController> { NotificationServiceController(get()) }
 }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.android.kt
@@ -1,0 +1,46 @@
+package network.bisq.mobile.domain.service
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.utils.Logging
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class AppForegroundController(val context: Context) : ForegroundDetector, Logging {
+    private val _isForeground = MutableStateFlow(false)
+    override val isForeground: StateFlow<Boolean> = _isForeground
+
+    init {
+        (context.applicationContext as Application).registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                onAppWillEnterForeground()
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+                onAppDidEnterBackground()
+            }
+
+            // Other lifecycle methods can be left empty
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityStarted(activity: Activity) {}
+            override fun onActivityStopped(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
+    }
+
+
+    private fun onAppDidEnterBackground() {
+        log.d("App is in foreground -> false")
+        _isForeground.value = false
+    }
+
+    private fun onAppWillEnterForeground() {
+        log.d("App is in foreground -> true")
+        _isForeground.value = true
+    }
+
+}

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
@@ -34,8 +34,10 @@ actual class NotificationServiceController (private val context: Context): Servi
     private var isRunning = false
 
     var activityClassForIntents = context::class.java
+    var defaultDestination = "tab_my_trades" // TODO minor refactor move this hardcode out of here and into client leaf code
 
     init {
+        // TODO move to a separate component for reusal injectable through Koin
         (context.applicationContext as Application).registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
             override fun onActivityResumed(activity: Activity) {
                 isForeground = true
@@ -116,7 +118,7 @@ actual class NotificationServiceController (private val context: Context): Servi
         val intent = Intent(context, activityClassForIntents).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
 //            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra("destination", "tab_my_trades") // Add extras to navigate to a specific screen
+            putExtra("destination", defaultDestination) // Add extras to navigate to a specific screen
         }
 
         // Create a PendingIntent to handle the notification click
@@ -159,7 +161,7 @@ actual class NotificationServiceController (private val context: Context): Servi
     }
 
     actual fun isAppInForeground(): Boolean {
-        TODO("Not yet implemented")
+        return isForeground
     }
 
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -192,7 +192,7 @@ class WebSocketClient(
             } catch (e: Exception) {
                 log.e(e) { "Exception ocurred whilst listening for WS messages - triggering reconnect" }
             } finally {
-                log.d { "Not listining for WS messages anymore" }
+                log.d { "Not listening for WS messages anymore - launching reconnect" }
                 reconnect()
             }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.domain.service
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface ForegroundDetector {
+    val isForeground: StateFlow<Boolean>
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+expect class AppForegroundController

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
@@ -2,13 +2,17 @@ package network.bisq.mobile.domain.di
 
 import network.bisq.mobile.domain.IOSUrlLauncher
 import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.service.AppForegroundController
+import network.bisq.mobile.domain.service.ForegroundDetector
 import network.bisq.mobile.domain.service.notifications.controller.NotificationServiceController
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val iosClientModule = module {
     single<UrlLauncher> { IOSUrlLauncher() }
+    single<AppForegroundController> { AppForegroundController() } bind ForegroundDetector::class
     single<NotificationServiceController> {
-        NotificationServiceController().apply {
+        NotificationServiceController(get()).apply {
             this.registerBackgroundTask()
         }
     }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
@@ -8,7 +8,7 @@ import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-actual class AppForegroundController() : ForegroundDetector, Logging {
+actual class AppForegroundController : ForegroundDetector, Logging {
     private val _isForeground = MutableStateFlow(true)
     override val isForeground: StateFlow<Boolean> = _isForeground
 
@@ -31,13 +31,13 @@ actual class AppForegroundController() : ForegroundDetector, Logging {
     }
 
     private fun onAppDidEnterBackground() {
-        log.d("App is in foreground -> false")
+        log.d {"App is in foreground -> false" }
         _isForeground.value = false
 
     }
 
     private fun onAppWillEnterForeground() {
-        log.d("App is in foreground -> true")
+        log.d {"App is in foreground -> true" }
         _isForeground.value = true
     }
 }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
@@ -1,0 +1,43 @@
+package network.bisq.mobile.domain.service
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.utils.Logging
+import platform.Foundation.NSNotificationCenter
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationWillEnterForegroundNotification
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class AppForegroundController() : ForegroundDetector, Logging {
+    private val _isForeground = MutableStateFlow(true)
+    override val isForeground: StateFlow<Boolean> = _isForeground
+
+    init {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+        notificationCenter.addObserverForName(
+            name = UIApplicationDidEnterBackgroundNotification,
+            `object` = null,
+            queue = null
+        ) { notification ->
+            onAppDidEnterBackground()
+        }
+        notificationCenter.addObserverForName(
+            name = UIApplicationWillEnterForegroundNotification,
+            `object` = null,
+            queue = null
+        ) { notification ->
+            onAppWillEnterForeground()
+        }
+    }
+
+    private fun onAppDidEnterBackground() {
+        log.d("App is in foreground -> false")
+        _isForeground.value = false
+
+    }
+
+    private fun onAppWillEnterForeground() {
+        log.d("App is in foreground -> true")
+        _isForeground.value = true
+    }
+}

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.ios.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.domain.service.notifications.controller
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.service.AppForegroundController
 import network.bisq.mobile.domain.utils.Logging
 import platform.BackgroundTasks.*
 import platform.Foundation.NSDate
@@ -15,7 +16,7 @@ import platform.darwin.NSObject
 
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-actual class NotificationServiceController: ServiceController, Logging {
+actual class NotificationServiceController(private val appForegroundController: AppForegroundController): ServiceController, Logging {
 
     companion object {
         const val BACKGROUND_TASK_ID = "network.bisq.mobile.iosUC4273Y485"
@@ -106,6 +107,11 @@ actual class NotificationServiceController: ServiceController, Logging {
     }
 
     actual fun pushNotification(title: String, message: String) {
+        if (isAppInForeground()) {
+            log.w { "Skipping notification since app is in the foreground" }
+            return
+        }
+        
         val content = UNMutableNotificationContent().apply {
             setValue(title, forKey = "title")
             setValue(message, forKey = "body")
@@ -191,6 +197,6 @@ actual class NotificationServiceController: ServiceController, Logging {
     }
 
     actual fun isAppInForeground(): Boolean {
-        return UIApplication.sharedApplication.applicationState == UIApplicationState.UIApplicationStateActive
+        return appForegroundController.isForeground.value
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -11,7 +11,10 @@ import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 
-class ClientMainPresenter(
+/**
+ * Contains all the share code for each client. Each specific app might extend this class if needed.
+ */
+open class ClientMainPresenter(
     openTradesNotificationService: OpenTradesNotificationService,
     private val tradesServiceFacade: TradesServiceFacade,
     private val webSocketClientProvider: WebSocketClientProvider,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -134,6 +134,7 @@ fun TopBar(
                             .alpha(if (currentTab == Routes.TabSettings.name) 0.5f else 1.0f)
                             .clickable {
                                 if (currentTab != Routes.TabSettings.name) {
+                                    // TODO this should be presenter code, with the proper main thread coroutine used (causes random crashes as is)
                                     navController.navigate(Routes.UserProfileSettings.name)
                                 }
                             })

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -66,6 +66,7 @@ fun TabContainerScreen() {
                 },
                 backBehavior = {
                     if (currentRoute != Routes.TabHome.name) {
+                        // TODO this should be presenter code, with the proper main thread coroutine used (causes random crashes as is)
                         navController.navigate(Routes.TabHome.name) {
                             navController.graph.startDestinationRoute?.let { route ->
                                 popUpTo(route) { saveState = false }
@@ -86,6 +87,7 @@ fun TabContainerScreen() {
                 items = navigationListItem,
                 currentRoute = currentRoute.orEmpty(),
                 onItemClick = { currentNavigationItem ->
+                    // TODO this should be presenter code, with the proper main thread coroutine used (causes random crashes as is)
                     navController.navigate(currentNavigationItem.route) {
                         navController.graph.startDestinationRoute?.let { route ->
                             popUpTo(route) {


### PR DESCRIPTION
 - PR # 2 for #126 
 - android client working as node (except "kill app" case which is still under discussion)
 - refactor to have a platform-based controller to know if the app goes into background/foreground
 - improved logs