### PR TITLE
Feature/ios client ongoing trades notifications

### DIFF
--- a/iosClient/iosClient/ContentView.swift
+++ b/iosClient/iosClient/ContentView.swift
@@ -5,19 +5,34 @@ import presentation
 import domain
 
 struct ComposeView: UIViewControllerRepresentable {
-
+    
+    @EnvironmentObject var notificationServiceWrapper: NotificationServiceWrapper
     private let presenter: MainPresenter = get()
 
     func makeUIViewController(context: Context) -> UIViewController {
-        return LifecycleAwareComposeViewController(presenter: presenter)
+        return LifecycleAwareComposeViewController(presenter: presenter, notificationServiceWrapper: notificationServiceWrapper)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }
 
 struct ContentView: View {
+    @EnvironmentObject var notificationServiceWrapper: NotificationServiceWrapper
+
     var body: some View {
         ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            .environmentObject(notificationServiceWrapper)
+//            .onAppear {
+//                notificationServiceWrapper.notificationServiceController.stopService()
+//                NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: .main) { _ in
+//                    notificationServiceWrapper.notificationServiceController.startService()
+//                }
+//                NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main) { _ in
+//                    notificationServiceWrapper.notificationServiceController.stopService()
+//                }
+//            }.onDisappear {
+//                NotificationCenter.default.removeObserver(self)
+//            }
     }
 }

--- a/iosClient/iosClient/ContentView.swift
+++ b/iosClient/iosClient/ContentView.swift
@@ -23,16 +23,5 @@ struct ContentView: View {
         ComposeView()
             .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
             .environmentObject(notificationServiceWrapper)
-//            .onAppear {
-//                notificationServiceWrapper.notificationServiceController.stopService()
-//                NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: .main) { _ in
-//                    notificationServiceWrapper.notificationServiceController.startService()
-//                }
-//                NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main) { _ in
-//                    notificationServiceWrapper.notificationServiceController.stopService()
-//                }
-//            }.onDisappear {
-//                NotificationCenter.default.removeObserver(self)
-//            }
     }
 }

--- a/iosClient/iosClient/LifecycleAwareComposeViewController.swift
+++ b/iosClient/iosClient/LifecycleAwareComposeViewController.swift
@@ -37,12 +37,6 @@ class LifecycleAwareComposeViewController: UIViewController {
             notificationServiceWrapper.notificationServiceController.stopService()
             presenter.onResume()
         }
-//        presenter.onResume()
-//        NotificationCenter.default.addObserver(
-//            self,
-//            selector: #selector(handleDidBecomeActive),
-//            name: UIApplication.didBecomeActiveNotification,
-//            object: nil)
     }
 
     @objc private func handleDidBecomeActive() {

--- a/iosClient/iosClient/LifecycleAwareComposeViewController.swift
+++ b/iosClient/iosClient/LifecycleAwareComposeViewController.swift
@@ -6,9 +6,11 @@ import domain
 
 class LifecycleAwareComposeViewController: UIViewController {
     private let presenter: MainPresenter
+    private let notificationServiceWrapper: NotificationServiceWrapper
 
-    init(presenter: MainPresenter) {
+    init(presenter: MainPresenter, notificationServiceWrapper: NotificationServiceWrapper) {
         self.presenter = presenter
+        self.notificationServiceWrapper = notificationServiceWrapper
         MainPresenter.companion.doInit()
         super.init(nibName: nil, bundle: nil)
     }
@@ -26,11 +28,21 @@ class LifecycleAwareComposeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         presenter.onResume()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleDidBecomeActive),
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil)
+        notificationServiceWrapper.notificationServiceController.stopService()
+        NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: .main) { [self] _ in
+            notificationServiceWrapper.notificationServiceController.startService()
+            presenter.onPause()
+        }
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main) { [self] _ in
+            notificationServiceWrapper.notificationServiceController.stopService()
+            presenter.onResume()
+        }
+//        presenter.onResume()
+//        NotificationCenter.default.addObserver(
+//            self,
+//            selector: #selector(handleDidBecomeActive),
+//            name: UIApplication.didBecomeActiveNotification,
+//            object: nil)
     }
 
     @objc private func handleDidBecomeActive() {

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -1,8 +1,17 @@
 import SwiftUI
 import presentation
 
+class NotificationServiceWrapper: ObservableObject {
+    @Published var notificationServiceController: DomainNotificationServiceController
+
+    init() {
+        self.notificationServiceController = get()
+    }
+}
+
 @main
 struct iosClient: App {
+    @StateObject var notificationServiceWrapper = NotificationServiceWrapper()
 
     init() {
         DependenciesProviderHelper().doInitKoin()
@@ -11,7 +20,7 @@ struct iosClient: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(notificationServiceWrapper)
         }
     }
-
 }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
@@ -135,8 +135,12 @@ actual class NotificationServiceController (private val appForegroundController:
 
     private fun deleteNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            manager.deleteNotificationChannel(BisqForegroundService.CHANNEL_ID)
+            try {
+                val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                manager.deleteNotificationChannel(BisqForegroundService.CHANNEL_ID)
+            } catch (e: Exception) {
+                log.e(e) { "Failed to delete bisq notification channel" }
+            }
         }
     }
 

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.ios.kt
@@ -9,8 +9,6 @@ import platform.BackgroundTasks.*
 import platform.Foundation.NSDate
 import platform.Foundation.NSUUID
 import platform.Foundation.setValue
-import platform.UIKit.UIApplication
-import platform.UIKit.UIApplicationState
 import platform.UserNotifications.*
 import platform.darwin.NSObject
 import platform.darwin.dispatch_get_main_queue
@@ -66,6 +64,7 @@ actual class NotificationServiceController(private val appForegroundController: 
             logDebug("Notification Service already started, skipping launch")
             return
         }
+        stopService() // needed in iOS to clear the id registration and avoid duplicates
         logDebug("Starting background service")
         UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
             UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge
@@ -188,23 +187,25 @@ actual class NotificationServiceController(private val appForegroundController: 
             return
         }
 
-        // Register for background task handler
-        BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(
-            identifier = BACKGROUND_TASK_ID,
-            usingQueue = null
-        ) { task ->
-            handleBackgroundTask(task as BGProcessingTask)
-        }
+        runCatching {
+            // Register for background task handler
+            BGTaskScheduler.sharedScheduler.registerForTaskWithIdentifier(
+                identifier = BACKGROUND_TASK_ID,
+                usingQueue = null
+            ) { task ->
+                handleBackgroundTask(task as BGProcessingTask)
+            }
 
-        isBackgroundTaskRegistered = true
-        logDebug("Background task handler registered")
+            isBackgroundTaskRegistered = true
+            logDebug("Background task handler registered")
+        }.onFailure {
+            log.e(it) { "Failed to register background task - notifications won't work" }
+            isBackgroundTaskRegistered = false
+        }
     }
 
     actual fun isAppInForeground(): Boolean {
-        var isForeground = false
-        dispatch_sync(dispatch_get_main_queue()) {
-            isForeground = (appForegroundController.isForeground.value)
-        }
-        return isForeground
+        // for iOS we handle this externally
+        return false
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -53,7 +53,16 @@ open class MainPresenter(
     @CallSuper
     override fun onViewAttached() {
         super.onViewAttached()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        openTradesNotificationService.stopNotificationService()
+    }
+
+    override fun onPause() {
         openTradesNotificationService.launchNotificationService()
+        super.onPause()
     }
 
     // Toggle action


### PR DESCRIPTION
 - iOS implementation for #126 
 - background task that handles notifications only turned on whilst app is in the background
 - fix lifecycleaware not notifying onPause() correctly
 - ios notificationService implementation always return "in background" since the service only starts in background