### PR TITLE
Refactor/node connectivity service

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
@@ -32,6 +32,8 @@ import bisq.contract.ContractService
 import bisq.identity.IdentityService
 import bisq.network.NetworkService
 import bisq.network.NetworkServiceConfig
+import bisq.network.p2p.ServiceNode
+import bisq.network.p2p.node.Node
 import bisq.offer.OfferService
 import bisq.presentation.notifications.SystemNotificationService
 import bisq.security.SecurityService
@@ -69,6 +71,15 @@ class AndroidApplicationService(
 
     @Getter
     class Provider {
+        fun findAllServiceNodes(): List<ServiceNode> {
+            val serviceNodes = mutableListOf<ServiceNode>()
+            val networkService = applicationService.networkService
+            networkService.supportedTransportTypes.forEach { transportType ->
+                serviceNodes.add(networkService.findServiceNode(transportType).get())
+            }
+            return serviceNodes.toList()
+        }
+
         @Setter
         lateinit var applicationService: AndroidApplicationService
         var state: Supplier<Observable<State>> =

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
@@ -34,8 +34,11 @@ class NodeConnectivityService(private val applicationService: AndroidApplication
 
     override fun onStart() {
         try {
-            val serviceNode = applicationService.networkService.get().findServiceNode(TransportType.CLEAR).get()
-            serviceNode.nodesById.addNodeListener(nodeListener)
+            val networkService = applicationService.networkService.get()
+            networkService.supportedTransportTypes.forEach { transportType ->
+                val serviceNode = networkService.findServiceNode(transportType).get()
+                serviceNode.nodesById.addNodeListener(nodeListener)
+            }
         } catch (e: Exception) {
             log.w(e) { "failed to start node monitoring for connectivity service" }
         }
@@ -43,8 +46,11 @@ class NodeConnectivityService(private val applicationService: AndroidApplication
 
     override fun onStop() {
         try {
-            val serviceNode = applicationService.networkService.get().findServiceNode(TransportType.CLEAR).get()
-            serviceNode.nodesById.removeNodeListener(nodeListener)
+            val networkService = applicationService.networkService.get()
+            networkService.supportedTransportTypes.forEach { transportType ->
+                val serviceNode = networkService.findServiceNode(transportType).get()
+                serviceNode.nodesById.removeNodeListener(nodeListener)
+            }
         } catch (e: Exception) {
             log.w(e) { "failed to start node monitoring for connectivity service" }
         }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.android.node.service.network
 
-import bisq.common.network.TransportType
 import bisq.network.identity.NetworkId
 import bisq.network.p2p.message.EnvelopePayloadMessage
 import bisq.network.p2p.node.CloseReason
@@ -10,7 +9,10 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.domain.service.network.ConnectivityService
 
 class NodeConnectivityService(private val applicationService: AndroidApplicationService.Provider): ConnectivityService() {
-    // TODO ConnectivityService#newRequestRoundTripTime() call needs to be applied when a P2P roundtrip call is done for the parent isSlow impl to work
+
+    companion object {
+        const val SLOW_PEER_QUANTITY_THRESHOLD = 2
+    }
 
     private var connections = 0
     private val nodeListener : Node.Listener = object: Node.Listener {
@@ -59,5 +61,11 @@ class NodeConnectivityService(private val applicationService: AndroidApplication
     override fun isConnected(): Boolean {
         log.d { "Connected peers = $connections"}
         return connections > 0
+    }
+
+    override suspend fun isSlow(): Boolean {
+        // TODO improve impl using ConnectivityService#newRequestRoundTripTime() call needs to be applied when a P2P roundtrip call is done for the
+        // parent isSlow impl to work
+        return connections < SLOW_PEER_QUANTITY_THRESHOLD
     }
 }


### PR DESCRIPTION
 - last PR for #130 for completeness
 - addressed latest pr review comments
 - simplified implementation avoiding storing the connections in the service
 - simple implementation for isSlow on node provided
 - easy to test (turn on/off your seed node, the http_api_server , even your desktop to see the avatar indicator change from disconnected (red dot) to slow (yellow dot, avatar animation kicks in) to green :)