### PR TITLE
Feature/demo mode (connect)

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -36,7 +36,9 @@ class ClientApplicationBootstrapFacade(
             setState("Connecting to Trusted Node..")
             if (!trustedNodeService.isConnected) {
                 try {
-                    trustedNodeService.connect()
+                    if (!trustedNodeService.isDemo()) {
+                        trustedNodeService.connect()
+                    }
                     setState("bootstrap.connectedToTrustedNode".i18n())
                     setProgress(1.0f)
                 } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -32,6 +32,9 @@ class ClientApplicationBootstrapFacade(
 //                setState("Trusted node not configured")
 //                setProgress(0f)
 //            } else {
+            if (trustedNodeService.isDemo()) {
+                isDemo = true
+            }
             setProgress(0.5f)
             setState("Connecting to Trusted Node..")
             if (!trustedNodeService.isConnected) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -42,6 +42,8 @@ import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.BaseSideFixedAmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.domain.data.replicated.offer.payment_method.BitcoinPaymentMethodSpecVO
+import network.bisq.mobile.domain.data.replicated.offer.payment_method.FiatPaymentMethodSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.FixPriceSpecVO
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationDto
 import network.bisq.mobile.domain.data.replicated.security.keys.PubKeyVO
@@ -309,11 +311,11 @@ class WebSocketClient(
                         ),
                         pubKey = PubKeyVO(
                             publicKey = PublicKeyVO(
-                                encoded = ""
+                                encoded = "makerpub"
                             ),
-                            keyId = "",
-                            hash = "",
-                            id = ""
+                            keyId = "makerkey",
+                            hash = "makerhash",
+                            id = "maker"
                         )
                     ),
                     direction = DirectionEnum.SELL,
@@ -321,9 +323,6 @@ class WebSocketClient(
                     amountSpec = QuoteSideFixedAmountSpecVO(
                         amount = 100
                     ),
-//                    BaseSideFixedAmountSpecVO(
-//                        amount = 100
-//                    ),
                     priceSpec = FixPriceSpecVO(
                         priceQuote = PriceQuoteVO(
                             value = 100L,
@@ -334,10 +333,16 @@ class WebSocketClient(
                         )
                     ),
                     protocolTypes = listOf(),
-                    baseSidePaymentMethodSpecs = listOf(),
-                    quoteSidePaymentMethodSpecs = listOf(),
+                    baseSidePaymentMethodSpecs = listOf(BitcoinPaymentMethodSpecVO(
+                        paymentMethod = "onchain",
+                        saltedMakerAccountId = "onchain"
+                    )),
+                    quoteSidePaymentMethodSpecs = listOf(FiatPaymentMethodSpecVO(
+                        paymentMethod = "payid",
+                        saltedMakerAccountId = "payid"
+                    )),
                     offerOptions = listOf(),
-                    supportedLanguageCodes = listOf()
+                    supportedLanguageCodes = listOf("EN")
                 ),
                 isMyOffer = false,
                 userProfile = UserProfileVO(
@@ -355,7 +360,7 @@ class WebSocketClient(
                         addressByTransportTypeMap = AddressByTransportTypeMapVO(map = mapOf()),
                         pubKey = PubKeyVO(
                             publicKey = PublicKeyVO("encoded"),
-                            keyId = "keid",
+                            keyId = "keyid",
                             hash = "hash",
                             id = "id"
                         )
@@ -372,8 +377,92 @@ class WebSocketClient(
                 formattedBaseAmount = "",
                 formattedPrice = "",
                 formattedPriceSpec = "",
-                quoteSidePaymentMethods = listOf(),
-                baseSidePaymentMethods = listOf(),
+                quoteSidePaymentMethods = listOf("onchain"),
+                baseSidePaymentMethods = listOf("payid"),
+                reputationScore = ReputationScoreVO(
+                    totalScore = 12,
+                    fiveSystemScore = 22.0,
+                    ranking = 4
+                ),
+            ),
+            OfferItemPresentationDto(
+                bisqEasyOffer = BisqEasyOfferVO(
+                    id = "2",
+                    date = 1741922747L,
+                    makerNetworkId = NetworkIdVO(
+                        addressByTransportTypeMap = AddressByTransportTypeMapVO(
+                            map = mapOf()
+                        ),
+                        pubKey = PubKeyVO(
+                            publicKey = PublicKeyVO(
+                                encoded = "makerpub"
+                            ),
+                            keyId = "makerkey",
+                            hash = "makerhash",
+                            id = "maker"
+                        )
+                    ),
+                    direction = DirectionEnum.BUY,
+                    market = MarketVO("Bitcoin", "USD"),
+                    amountSpec = QuoteSideFixedAmountSpecVO(
+                        amount = 102
+                    ),
+                    priceSpec = FixPriceSpecVO(
+                        priceQuote = PriceQuoteVO(
+                            value = 102L,
+                            market = MarketVO(
+                                baseCurrencyCode = "Bitcoin",
+                                quoteCurrencyCode = "USD",
+                            )
+                        )
+                    ),
+                    protocolTypes = listOf(),
+                    baseSidePaymentMethodSpecs = listOf(BitcoinPaymentMethodSpecVO(
+                        paymentMethod = "onchain",
+                        saltedMakerAccountId = "onchain"
+                    )),
+                    quoteSidePaymentMethodSpecs = listOf(FiatPaymentMethodSpecVO(
+                        paymentMethod = "payid",
+                        saltedMakerAccountId = "payid"
+                    )),
+                    offerOptions = listOf(),
+                    supportedLanguageCodes = listOf("EN")
+                ),
+                isMyOffer = true,
+                userProfile = UserProfileVO(
+                    1, "pepe",
+                    ProofOfWorkVO(
+                        payloadEncoded = "payme",
+                        counter = 1L,
+                        challengeEncoded = "challenge",
+                        difficulty = 2.0,
+                        solutionEncoded = "solution",
+                        duration = 2000L
+                    ),
+                    avatarVersion = 1,
+                    networkId = NetworkIdVO(
+                        addressByTransportTypeMap = AddressByTransportTypeMapVO(map = mapOf()),
+                        pubKey = PubKeyVO(
+                            publicKey = PublicKeyVO("encoded"),
+                            keyId = "keyid",
+                            hash = "hash",
+                            id = "id"
+                        )
+                    ),
+                    terms = "",
+                    statement = "",
+                    applicationVersion = "",
+                    nym = "mynym",
+                    userName = "myoffer",
+                    publishDate = 1741212747L,
+                ),
+                formattedDate = "",
+                formattedQuoteAmount = "",
+                formattedBaseAmount = "",
+                formattedPrice = "",
+                formattedPriceSpec = "",
+                quoteSidePaymentMethods = listOf("onchain"),
+                baseSidePaymentMethods = listOf("payid"),
                 reputationScore = ReputationScoreVO(
                     totalScore = 12,
                     fiveSystemScore = 22.0,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -34,8 +34,22 @@ import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.domain.data.replicated.common.currency.marketListDemoObj
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVO
+import network.bisq.mobile.domain.data.replicated.common.network.AddressByTransportTypeMapVO
 import network.bisq.mobile.domain.data.replicated.identity.identitiesDemoObj
+import network.bisq.mobile.domain.data.replicated.network.identity.NetworkIdVO
+import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
+import network.bisq.mobile.domain.data.replicated.offer.amount.spec.BaseSideFixedAmountSpecVO
+import network.bisq.mobile.domain.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
+import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.domain.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationDto
+import network.bisq.mobile.domain.data.replicated.security.keys.PubKeyVO
+import network.bisq.mobile.domain.data.replicated.security.keys.PublicKeyVO
+import network.bisq.mobile.domain.data.replicated.security.pow.ProofOfWorkVO
 import network.bisq.mobile.domain.data.replicated.settings.settingsVODemoObj
+import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.domain.utils.createUuid
 
@@ -268,28 +282,105 @@ class WebSocketClient(
     private fun getFakePayloadForTopic(topic: Topic): String? {
         return when (topic) {
             Topic.MARKET_PRICE -> Json.encodeToString(FakeSubscriptionData.marketPrice)
+            Topic.NUM_OFFERS -> Json.encodeToString(FakeSubscriptionData.numOffers)
+            Topic.OFFERS -> Json.encodeToString(FakeSubscriptionData.offers)
 //            Topic.TRADES -> Json.encodeToString(FakeData.trades)
 //            Topic.TRADE_PROPERTIES -> Json.encodeToString(FakeData.tradeProps)
             else -> null // Default empty response
         }
     }
 
+    // TODO refactor our of websocket client
     // Example fake data
     object FakeSubscriptionData {
-        val marketPrice = mapOf("id" to PriceQuoteVO(1000, MarketVO("sdf", "SFS")))
-        val trades = mapOf("BTC" to "0.5", "USD" to "10000")
-        val tradeProps = listOf(
-            mapOf("id" to "order1", "amount" to "0.1 BTC", "price" to "5000 USD"),
-            mapOf("id" to "order2", "amount" to "0.05 BTC", "price" to "5100 USD")
+        val marketPrice = mapOf(
+            "USD" to PriceQuoteVO(80000, MarketVO("Bitcoin", "USD")),
+            "EUR" to PriceQuoteVO(75000, MarketVO("Bitcoin", "EUR")),
         )
+        val trades = mapOf("BTC" to "0.5", "USD" to "10000")
+        val offers = listOf(
+            OfferItemPresentationDto(
+                bisqEasyOffer = BisqEasyOfferVO(
+                    id = "1",
+                    date = 1741912747L,
+                    makerNetworkId = NetworkIdVO(
+                        addressByTransportTypeMap = AddressByTransportTypeMapVO(
+                            map = mapOf()
+                        ),
+                        pubKey = PubKeyVO(
+                            publicKey = PublicKeyVO(
+                                encoded = ""
+                            ),
+                            keyId = "",
+                            hash = "",
+                            id = ""
+                        )
+                    ),
+                    direction = DirectionEnum.SELL,
+                    market = MarketVO("Bitcoin", "USD"),
+                    amountSpec = QuoteSideFixedAmountSpecVO(
+                        amount = 100
+                    ),
+//                    BaseSideFixedAmountSpecVO(
+//                        amount = 100
+//                    ),
+                    priceSpec = FixPriceSpecVO(
+                        priceQuote = PriceQuoteVO(
+                            value = 100L,
+                            market = MarketVO(
+                                baseCurrencyCode = "Bitcoin",
+                                quoteCurrencyCode = "USD",
+                            )
+                        )
+                    ),
+                    protocolTypes = listOf(),
+                    baseSidePaymentMethodSpecs = listOf(),
+                    quoteSidePaymentMethodSpecs = listOf(),
+                    offerOptions = listOf(),
+                    supportedLanguageCodes = listOf()
+                ),
+                isMyOffer = false,
+                userProfile = UserProfileVO(
+                    1, "pepe",
+                    ProofOfWorkVO(
+                        payloadEncoded = "payme",
+                        counter = 1L,
+                        challengeEncoded = "challenge",
+                        difficulty = 2.0,
+                        solutionEncoded = "solution",
+                        duration = 2000L
+                    ),
+                    avatarVersion = 1,
+                    networkId = NetworkIdVO(
+                        addressByTransportTypeMap = AddressByTransportTypeMapVO(map = mapOf()),
+                        pubKey = PubKeyVO(
+                            publicKey = PublicKeyVO("encoded"),
+                            keyId = "keid",
+                            hash = "hash",
+                            id = "id"
+                        )
+                    ),
+                    terms = "",
+                    statement = "",
+                    applicationVersion = "",
+                    nym = "mynym",
+                    userName = "pepito",
+                    publishDate = 1741212747L,
+                ),
+                formattedDate = "",
+                formattedQuoteAmount = "",
+                formattedBaseAmount = "",
+                formattedPrice = "",
+                formattedPriceSpec = "",
+                quoteSidePaymentMethods = listOf(),
+                baseSidePaymentMethods = listOf(),
+                reputationScore = ReputationScoreVO(
+                    totalScore = 12,
+                    fiveSystemScore = 22.0,
+                    ranking = 4
+                ),
+            )
+        )
+        val numOffers = mapOf("USD" to offers.size)
     }
-
-    /* object ServerEventSerializer :
-         JsonTransformingSerializer<WebSocketMessage>(WebSocketMessage.serializer()) {
-         override fun transformDeserialize(element: JsonElement): JsonElement {
-             // Ignore deferredPayload at deserialization as we do not know that type at that
-             // moment
-             return JsonObject(element.jsonObject.filterKeys { it != "deferredPayload" })
-         }
-     }*/
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -3,14 +3,10 @@ package network.bisq.mobile.client.websocket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
-import network.bisq.mobile.client.websocket.messages.WebSocketRestApiRequest
 import network.bisq.mobile.domain.data.BackgroundDispatcher
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.Logging
 import kotlin.concurrent.Volatile
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 /**
  * Provider to handle dynamic host/port changes
@@ -64,12 +60,14 @@ class WebSocketClientProvider(
         }
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     suspend fun testClient(host: String, port: Int): Boolean {
         val client = createClient(host, port)
         val url = "ws://$host:$port"
         return try {
             // if connection is refused, catch will execute returning false
+            if (client.isDemo()) {
+                return true
+            }
             client.connect(true)
             return client.isConnected()
         } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -64,10 +64,10 @@ class WebSocketClientProvider(
         val client = createClient(host, port)
         val url = "ws://$host:$port"
         return try {
-            // if connection is refused, catch will execute returning false
             if (client.isDemo()) {
                 return true
             }
+            // if connection is refused, catch will execute returning false
             client.connect(true)
             return client.isConnected()
         } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
@@ -133,6 +133,7 @@ class WebSocketApiClient(
                 }
             }
         } catch (e: Exception) {
+            log.e(e) { "Failed to get WS request result" }
             return Result.failure(e)
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/common/currency/MarketVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/common/currency/MarketVO.kt
@@ -25,3 +25,13 @@ data class MarketVO(
     val baseCurrencyName: String = baseCurrencyCode,
     val quoteCurrencyName: String = quoteCurrencyCode
 )
+
+val marketListDemoObj = listOf(MarketVO("BTC", "USD"),
+    MarketVO("BTC", "EUR"),
+    MarketVO("BTC", "ARS"),
+    MarketVO("BTC", "PYG"),
+    MarketVO("BTC", "LBP"),
+    MarketVO("BTC", "CZK"),
+    MarketVO("BTC", "AUD"),
+    MarketVO("BTC", "CAD"),
+    MarketVO("BTC", "IDR"))

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/identity/IdentityVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/identity/IdentityVO.kt
@@ -6,3 +6,5 @@ import network.bisq.mobile.domain.data.replicated.security.keys.KeyBundleVO
 
 @Serializable
 data class IdentityVO(val tag: String, val networkId: NetworkIdVO, val keyBundle: KeyBundleVO)
+
+val identitiesDemoObj = listOf("id1", "id2")

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/AmountSpecVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/AmountSpecVO.kt
@@ -16,4 +16,7 @@
  */
 package network.bisq.mobile.domain.data.replicated.offer.amount.spec
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed interface AmountSpecVO

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/FixedAmountSpecVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/FixedAmountSpecVO.kt
@@ -16,6 +16,9 @@
  */
 package network.bisq.mobile.domain.data.replicated.offer.amount.spec
 
-interface FixedAmountSpecVO : AmountSpecVO {
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface FixedAmountSpecVO : AmountSpecVO {
     val amount: Long
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/RangeAmountSpecVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/amount/spec/RangeAmountSpecVO.kt
@@ -16,7 +16,10 @@
  */
 package network.bisq.mobile.domain.data.replicated.offer.amount.spec
 
-interface RangeAmountSpecVO : AmountSpecVO {
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RangeAmountSpecVO : AmountSpecVO {
     val minAmount: Long
     val maxAmount: Long
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/price/spec/PriceSpecVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/price/spec/PriceSpecVO.kt
@@ -16,4 +16,7 @@
  */
 package network.bisq.mobile.domain.data.replicated.offer.price.spec
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed interface PriceSpecVO

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/settings/SettingsVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/settings/SettingsVO.kt
@@ -31,3 +31,13 @@ data class SettingsVO(
     val selectedMarket: MarketVO,
     val numDaysAfterRedactingTradeData: Int
 )
+
+val settingsVODemoObj = SettingsVO(true,
+    true,
+    true,
+    "EN",
+    setOf("EN", "SP"),
+    1.0,
+    true,
+    MarketVO("AUD", "AUD"),
+    1)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -25,8 +25,12 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
         }
         runCatching {
             // first test connect and proceed to establish it if test passes
-            webSocketClientProvider.get().connect(true)
-            webSocketClientProvider.get().connect()
+            webSocketClientProvider.get().let {
+                if (!it.isDemo()) {
+                    it.connect(true)
+                    it.connect()
+                }
+            }
         }.onSuccess {
             log.d { "Connected to trusted node" }
         }.onFailure {
@@ -48,4 +52,6 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
         }
         observingConnectivity = true
     }
+
+    fun isDemo() = webSocketClientProvider.get().isDemo()
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.utils.Logging
 
 abstract class ApplicationBootstrapFacade : LifeCycleAware, Logging {
+    var isDemo = false
     private val _state = MutableStateFlow("")
     val state: StateFlow<String> = _state
     fun setState(value: String) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -6,7 +6,10 @@ import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.utils.Logging
 
 abstract class ApplicationBootstrapFacade : LifeCycleAware, Logging {
-    var isDemo = false
+    companion object {
+        var isDemo = false
+    }
+
     private val _state = MutableStateFlow("")
     val state: StateFlow<String> = _state
     fun setState(value: String) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -85,5 +85,5 @@ open class ClientMainPresenter(
         super.onViewUnattaching()
     }
 
-    override fun isDemo(): Boolean = applicationBootstrapFacade.isDemo
+    override fun isDemo(): Boolean = ApplicationBootstrapFacade.isDemo
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -84,4 +84,6 @@ open class ClientMainPresenter(
         languageServiceFacade.deactivate()
         super.onViewUnattaching()
     }
+
+    override fun isDemo(): Boolean = applicationBootstrapFacade.isDemo
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -99,6 +99,10 @@ interface ViewPresenter {
  * if root present is passed, this present attach itself to the root to get updates (consequently its dependants will be always empty
  */
 abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPresenter, Logging {
+    companion object {
+        var isDemo = false
+    }
+
     protected var view: Any? = null
     // Coroutine scope for the presenter
     protected val presenterScope = CoroutineScope(Dispatchers.Main + Job())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -429,4 +429,6 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
         navigateToUrl("https://github.com/bisq-network/bisq-mobile/issues")
         enableInteractive(true)
     }
+
+    open fun isDemo(): Boolean = rootPresenter?.isDemo() ?: false
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -97,4 +97,5 @@ open class MainPresenter(
         urlLauncher.openUrl(url)
     }
 
+    override fun isDemo(): Boolean = false
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -11,8 +11,15 @@ class TabContainerPresenter(
 ) : BasePresenter(mainPresenter), ITabContainerPresenter {
 
     override fun createOffer() {
-        createOfferPresenter.onStartCreateOffer()
-        navigateTo(Routes.CreateOfferDirection)
+        try {
+            createOfferPresenter.onStartCreateOffer()
+            navigateTo(Routes.CreateOfferDirection)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to create offer" }
+            showSnackbar(
+                if (isDemo()) "Create offer is disabled in demo mode" else "Cannot create offer at this time, please try again later"
+            )
+        }
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -83,9 +83,16 @@ class OfferbookPresenter(
     }
 
     fun createOffer() {
-        val market =offersServiceFacade.selectedOfferbookMarket.value.market
-        createOfferPresenter.onStartCreateOffer()
-        createOfferPresenter.commitMarket(market)
-        navigateTo(Routes.CreateOfferDirection)
+        try {
+            val market =offersServiceFacade.selectedOfferbookMarket.value.market
+            createOfferPresenter.onStartCreateOffer()
+            createOfferPresenter.commitMarket(market)
+            navigateTo(Routes.CreateOfferDirection)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to create offer" }
+            showSnackbar(
+                if (isDemo()) "Create offer is disabled in demo mode" else "Cannot create offer at this time, please try again later"
+            )
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsPresenter.kt
@@ -35,9 +35,10 @@ open class SettingsPresenter(
     }
 
     override fun versioning(): Triple<String, String, String> {
-        val version = if (isIOS()) BuildConfig.IOS_APP_VERSION else BuildConfig.ANDROID_APP_VERSION
+        val demo = if (isDemo()) "-demo-" else ""
+        val version = demo + if (isIOS()) BuildConfig.IOS_APP_VERSION else BuildConfig.ANDROID_APP_VERSION
         val wsApiVersion = BuildConfig.BISQ_API_VERSION
-        return Triple(version, "node", wsApiVersion)
+        return Triple(version, "node-api", wsApiVersion)
     }
 
     protected open fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -78,6 +78,14 @@ open class CreateProfilePresenter(
         }
     }
 
+    fun validateNickname(nickname: String): String? {
+        return when {
+            nickname.length < 3 -> "Min length: 3 characters"
+            nickname.length > 256 -> "Max length: 256 characters"
+            else -> null
+        }
+    }
+
     // UI handlers
     fun onGenerateKeyPair() {
         generateKeyPair()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -49,15 +49,7 @@ fun CreateProfileScreen(
             onValueChange = { name, isValid -> presenter.setNickname(name) },
             placeholder = "onboarding.createProfile.nickName.prompt".i18n(),
             validation = {
-
-                if (it.length < 3) {
-                    return@BisqTextField "Min length: 3 characters"
-                }
-                if (it.length > 256) {
-                    return@BisqTextField "Max length: 256 characters"
-                }
-
-                return@BisqTextField null
+                return@BisqTextField presenter.validateNickname(it)
             }
         )
         Spacer(modifier = Modifier.height(36.dp))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -21,7 +21,7 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 
 open class SplashPresenter(
     mainPresenter: MainPresenter,
-    applicationBootstrapFacade: ApplicationBootstrapFacade,
+    private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val userProfileService: UserProfileServiceFacade,
     private val userRepository: UserRepository,
     private val settingsRepository: SettingsRepository,
@@ -72,6 +72,7 @@ open class SplashPresenter(
 
     private fun navigateToNextScreen() {
         uiScope.launch {
+            ApplicationBootstrapFacade.isDemo = webSocketClientProvider?.get()?.isDemo() ?: false
             if (!hasConnectivity()) {
                 navigateToTrustedNodeSetup()
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -57,6 +57,18 @@ class TrustedNodeSetupPresenter(
         _isConnected.value = false
     }
 
+    override fun validateWsUrl(url: String): String? {
+        val wsUrlPattern =
+            """^(ws|wss):\/\/(([a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|localhost)|(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:\d{1,5})$""".toRegex()
+        if (url.isEmpty()) {
+            return "URL cannot be empty" //TODO:i18n
+        }
+        if (!wsUrlPattern.matches(url)) {
+            return "Invalid WebSocket URL. Must be ws:// or wss:// followed by a domain/IP and port" //TODO:i18n
+        }
+        return null
+    }
+
     override fun testConnection() {
         backgroundScope.launch {
             _isLoading.value = true

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -47,6 +47,11 @@ interface ITrustedNodeSetupPresenter : ViewPresenter {
 
     fun updateBisqApiUrl(newUrl: String, isValid: Boolean)
 
+    /**
+     * @return the error message if url is invalid, null otherwise
+     */
+    fun validateWsUrl(url: String): String?
+
     fun testConnection()
 
     fun navigateToNextScreen()
@@ -94,17 +99,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     )
                 },
                 validation = {
-                    val wsUrlPattern =
-                        """^(ws|wss):\/\/(([a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|localhost)|(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:\d{1,5})$""".toRegex()
-
-                    if (it.isEmpty()) {
-                        return@BisqTextField "URL cannot be empty" //TODO:i18n
-                    }
-                    if (!wsUrlPattern.matches(it)) {
-                        return@BisqTextField "Invalid WebSocket URL. Must be ws:// or wss:// followed by a domain/IP and port" //TODO:i18n
-                    }
-
-                    return@BisqTextField null
+                    return@BisqTextField presenter.validateWsUrl(it)
                 }
             )
 


### PR DESCRIPTION
 - connect apps implementation for #233 
 - demo url is `ws://demo.bisq:21`
 - bootstrap of app determines demo mode based on trusted node WS url
 - webclient provides fake demo data whilst in demo mode (enough to generically browse the app)
 - moved some validations to presenter (dumb views)