### PR TITLE
 - Fix for offer/market mismatch in xClients (#227)

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
@@ -78,15 +78,14 @@ class ClientOffersServiceFacade(
 
     // API
     override fun selectOfferbookMarket(marketListItem: MarketListItem) {
+        marketPriceServiceFacade.selectMarket(marketListItem)
+        _selectedOfferbookMarket.value = OfferbookMarket(marketListItem.market)
+
         if (subscribeOffersJob == null) {
             subscribeOffers()
         } else {
             applyOffersToSelectedMarket()
         }
-
-        marketPriceServiceFacade.selectMarket(marketListItem)
-
-        _selectedOfferbookMarket.value = OfferbookMarket(marketListItem.market)
 
         cancelObserveMarketPriceJob()
         observeMarketPriceJob = observeMarketPrice()


### PR DESCRIPTION
- Fix for https://github.com/bisq-network/bisq-mobile/issues/227
- `selectedMarket` was updated after offerlist is assigned in `applyOffersToSelectedMarket()` using the previously selectedMarket.