### PR TITLE
 - Trusted node - UI for API version mismatch

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/settings/ClientSettingsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/settings/ClientSettingsServiceFacade.kt
@@ -125,7 +125,14 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
         val appApiRequiredVersion = BuildConfig.BISQ_API_VERSION
         val trustedNodeApiVersion = apiGateway.getApiVersion().getOrThrow().version
         log.d { "required trusted node api version is $appApiRequiredVersion and current is $trustedNodeApiVersion" }
+        // return false // (for debug)
         return trustedNodeApiVersion >= appApiRequiredVersion
+    }
+
+    override suspend fun getTrustedNodeVersion(): String {
+        val trustedNodeApiVersion = apiGateway.getApiVersion().getOrThrow().version
+        // return "0.1.1.1" // (for debug)
+        return trustedNodeApiVersion
     }
 
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/settings/SettingsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/settings/SettingsServiceFacade.kt
@@ -43,4 +43,6 @@ interface SettingsServiceFacade : LifeCycleAware {
     suspend fun setNumDaysAfterRedactingTradeData(days: Int)
 
     suspend fun isApiCompatible() = true
+
+    suspend fun getTrustedNodeVersion() = ""
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_af_ZA {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_cs {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_de {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
@@ -1556,6 +1556,7 @@ object GeneratedResourceBundles_en {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_es {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_it {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
@@ -1525,6 +1525,7 @@ object GeneratedResourceBundles_pcm {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_pt_BR {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
@@ -1540,6 +1540,7 @@ object GeneratedResourceBundles_ru {
         "mobile" to mapOf(
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
             "error.exception" to "Exception",
+            "error.warning" to "Warning",
             "confirmation.areYouSure" to "Are you sure?",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -1,6 +1,7 @@
 
 bootstrap.connectedToTrustedNode=Connected to trusted node
 error.exception=Exception
+error.warning=Warning
 mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo=Use the trade ID {0} for the ''Reason for payment'' field
 confirmation.areYouSure=Are you sure?
 mobile.openTrades.inMediation.banner=A mediator has joined the trade chat.\n\

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.BackgroundDispatcher
@@ -66,8 +67,8 @@ open class ClientMainPresenter(
                 log.d { "trusted node is compatible, continue" }
             } else {
                 log.w { "configured trusted node doesn't have a compatible api version" }
-                // TODO flow and make UI react blocking usage of the app
-//                throw IllegalStateException("API version is not compatible")
+                val trustedNodeVersion = settingsServiceFacade.getTrustedNodeVersion()
+                MainPresenter._genericErrorMessage.value = "This app requires API Version: ${BuildConfig.BISQ_API_VERSION}.\nTrusted node API version: $trustedNodeVersion"
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -68,7 +68,7 @@ open class ClientMainPresenter(
             } else {
                 log.w { "configured trusted node doesn't have a compatible api version" }
                 val trustedNodeVersion = settingsServiceFacade.getTrustedNodeVersion()
-                MainPresenter._genericErrorMessage.value = "This app requires API Version: ${BuildConfig.BISQ_API_VERSION}.\nTrusted node API version: $trustedNodeVersion"
+                MainPresenter._genericErrorMessage.value = "Your configured trusted node is running Bisq version $trustedNodeVersion.\nBisq Connect requires version ${BuildConfig.BISQ_API_VERSION} to run properly.\n"
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationSe
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.setupUncaughtExceptionHandler
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
 import kotlin.jvm.JvmStatic
 
 
@@ -82,6 +83,11 @@ open class MainPresenter(
     // Toggle action
     override fun toggleContentVisibility() {
         _isContentVisible.value = !_isContentVisible.value
+    }
+
+    override fun navigateToTrustedNode() {
+        tabNavController.navigate(Routes.TabSettings.name)
+        navController.navigate(Routes.TrustedNodeSettings.name)
     }
 
     override fun getRootNavController(): NavHostController {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -108,6 +108,7 @@ val presentationModule = module {
         TrustedNodeSetupPresenter(
             get(),
             settingsRepository = get(),
+            get(),
             get()
         )
     } bind ITrustedNodeSetupPresenter::class

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -31,6 +31,8 @@ interface AppPresenter : ViewPresenter {
 
     // Actions
     fun toggleContentVisibility()
+
+    fun navigateToTrustedNode()
 }
 
 /**
@@ -46,7 +48,6 @@ fun App() {
     val presenter: AppPresenter = koinInject()
     val errorMessage = MainPresenter._genericErrorMessage.collectAsState().value
     val systemCrashed = MainPresenter._systemCrashed.collectAsState().value
-
 
     RememberPresenterLifecycle(presenter, {
         presenter.navController = rootNavController

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ErrorOverlay.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ErrorOverlay.kt
@@ -2,13 +2,23 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.presentation.ui.components.organisms.GenericErrorPanel
 import network.bisq.mobile.presentation.ui.components.organisms.ReportBugPanel
+import network.bisq.mobile.presentation.ui.components.organisms.TrustedNodeAPIIncompatiblePopup
+import org.koin.compose.koinInject
 
 @Composable
-fun ErrorOverlay(errorMessage: String?, systemCrashed: Boolean, onClose: () -> Unit) {
+fun ErrorOverlay(
+    errorMessage: String?,
+    systemCrashed: Boolean,
+    onClose: () -> Unit
+) {
+    val presenter: AppPresenter = koinInject()
 
     if (errorMessage != null) {
         Box(
@@ -16,11 +26,23 @@ fun ErrorOverlay(errorMessage: String?, systemCrashed: Boolean, onClose: () -> U
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = 0.5f)) // Dim the background
         ) {
-            ReportBugPanel(
-                errorMessage = errorMessage,
-                systemCrashed = systemCrashed,
-                onClose = { onClose() }
-            )
+            // TODO: Should define exception types.
+            // For this specific issue, have a type like TRUST_NODE_VERSION_INCOMPATIBLE
+            if (errorMessage.startsWith("This app requires API Version:")) {
+                TrustedNodeAPIIncompatiblePopup(
+                    errorMessage = errorMessage,
+                    onFix = {
+                        presenter.navigateToTrustedNode()
+                        MainPresenter._genericErrorMessage.value = null
+                    }
+                )
+            } else {
+                ReportBugPanel(
+                    errorMessage = errorMessage,
+                    systemCrashed = systemCrashed,
+                    onClose = { onClose() }
+                )
+            }
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ErrorOverlay.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/ErrorOverlay.kt
@@ -28,7 +28,7 @@ fun ErrorOverlay(
         ) {
             // TODO: Should define exception types.
             // For this specific issue, have a type like TRUST_NODE_VERSION_INCOMPATIBLE
-            if (errorMessage.startsWith("This app requires API Version:")) {
+            if (errorMessage.startsWith("Your configured trusted ")) {
                 TrustedNodeAPIIncompatiblePopup(
                     errorMessage = errorMessage,
                     onFix = {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
@@ -2,12 +2,7 @@ package network.bisq.mobile.presentation.ui.components.molecules.dialog
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
@@ -27,7 +27,7 @@ fun TrustedNodeAPIIncompatiblePopup(
         Row(horizontalArrangement = Arrangement.Start) {
             ExclamationRedIcon()
             BisqGap.HQuarter()
-            BisqText.baseRegular("error.exception".i18n())
+            BisqText.baseRegular("error.warning".i18n())
         }
 
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
@@ -1,0 +1,51 @@
+package network.bisq.mobile.presentation.ui.components.organisms
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
+import network.bisq.mobile.presentation.ui.components.atoms.icons.ExclamationRedIcon
+import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.ui.components.molecules.dialog.BisqDialog
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.koin.compose.koinInject
+
+@Composable
+fun TrustedNodeAPIIncompatiblePopup(
+    errorMessage: String,
+    onFix: () -> Unit,
+) {
+    BisqDialog {
+
+        Row(horizontalArrangement = Arrangement.Start) {
+            ExclamationRedIcon()
+            BisqGap.HQuarter()
+            BisqText.baseRegular("error.exception".i18n())
+        }
+
+        BisqGap.V1()
+
+        BisqTextField(
+            value = errorMessage,
+            indicatorColor = BisqTheme.colors.backgroundColor,
+            isTextArea = true,
+        )
+
+        BisqGap.V1()
+
+        BisqButton(
+            text = "Fix trusted node", // TODO:i18n
+            onClick = onFix,
+            type = BisqButtonType.Grey,
+            fullWidth = true,
+            padding = PaddingValues(BisqUIConstants.ScreenPaddingHalf)
+        )
+    }
+}


### PR DESCRIPTION
 - UI for https://github.com/bisq-network/bisq-mobile/issues/136
 - On app start, popup is shown on APi version mismatch. Offers 'Fix' button, that navigates to 'Trusted node config' screen.
 - Trusted node config screen, now also checks for API version compatibility.
 - If connection happens, but API version is incompatible, respective error is shown and `next / save` button is hidden.

Question:
 - Right now, user can navigate to other screens, when API version mismatch. Should lock the user to Trusted node config screen, till connecting with a API compatible node?