### PR TITLE
bugfix/double_tap_navigation_launching_screens_twice

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -210,10 +210,15 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
     protected fun navigateTo(destination: Routes, customSetup: (NavOptionsBuilder) -> Unit = {}) {
         enableInteractive(false)
         uiScope.launch(Dispatchers.Main) {
-            rootNavigator.navigate(destination.name) {
-                customSetup(this)
+            try {
+                rootNavigator.navigate(destination.name) {
+                    customSetup(this)
+                }
+            } catch (e: Exception) {
+                log.e(e) { "Failed to navigate to ${destination.name}" }
+            } finally {
+                enableInteractive()
             }
-            enableInteractive()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -208,10 +208,12 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
      * Navigate to given destination
      */
     protected fun navigateTo(destination: Routes, customSetup: (NavOptionsBuilder) -> Unit = {}) {
+        enableInteractive(false)
         uiScope.launch(Dispatchers.Main) {
             rootNavigator.navigate(destination.name) {
                 customSetup(this)
             }
+            enableInteractive()
         }
     }
 


### PR DESCRIPTION
 - fix double launch on navigation. E.g. tapping on avatar fast was launching profile screen twice at least

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the navigation experience by temporarily managing user interactions during screen transitions, reducing unintended actions and providing a smoother, more reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->