### PR TITLE
Refactor background scope

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
@@ -2,12 +2,10 @@ package network.bisq.mobile.android.node.service.accounts
 
 import bisq.account.AccountService
 import bisq.account.accounts.UserDefinedFiatAccount
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.UserDefinedFiatAccountMapping
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.utils.Logging
@@ -20,8 +18,6 @@ class NodeAccountsServiceFacade(applicationService: AndroidApplicationService.Pr
 
     private val _selectedAccount = MutableStateFlow<UserDefinedFiatAccountVO?>(null)
     override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount
-
-    private val backgroundScope = CoroutineScope(IODispatcher)
 
     override suspend fun getAccounts(): List<UserDefinedFiatAccountVO> {
         log.e { "NodeAccountServiceFacade :: getAccounts()" }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
@@ -5,14 +5,12 @@ import bisq.account.accounts.UserDefinedFiatAccount
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.UserDefinedFiatAccountMapping
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.utils.Logging
-import org.koin.core.component.getScopeName
 
 class NodeAccountsServiceFacade(applicationService: AndroidApplicationService.Provider) : AccountsServiceFacade, Logging {
     private val accountService: AccountService by lazy { applicationService.accountService.get() }
@@ -23,7 +21,7 @@ class NodeAccountsServiceFacade(applicationService: AndroidApplicationService.Pr
     private val _selectedAccount = MutableStateFlow<UserDefinedFiatAccountVO?>(null)
     override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount
 
-    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    private val backgroundScope = CoroutineScope(IODispatcher)
 
     override suspend fun getAccounts(): List<UserDefinedFiatAccountVO> {
         log.e { "NodeAccountServiceFacade :: getAccounts()" }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -57,7 +57,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     private var pubKeyHash: ByteArray? = null
@@ -71,7 +71,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
             deactivate()
         }
 
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             _selectedUserProfile.value = getSelectedUserProfile()
         }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -15,7 +15,7 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
 import network.bisq.mobile.android.node.service.AndroidNodeCatHashService
 import network.bisq.mobile.domain.PlatformImage
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.user.identity.UserIdentityVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
@@ -57,7 +57,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     private var pubKeyHash: ByteArray? = null

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/data/BackgroundDispatcher.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/data/BackgroundDispatcher.android.kt
@@ -3,4 +3,4 @@ package network.bisq.mobile.domain.data
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-actual val BackgroundDispatcher: CoroutineDispatcher = Dispatchers.IO
+actual val IODispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.service.bootstrap
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.service.TrustedNodeService
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
@@ -13,7 +13,7 @@ class ClientApplicationBootstrapFacade(
     private val trustedNodeService: TrustedNodeService
 ) : ApplicationBootstrapFacade() {
 
-    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    private val backgroundScope = CoroutineScope(IODispatcher)
     override fun activate() {
         if (isActive) {
             return

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -13,7 +13,7 @@ class ClientApplicationBootstrapFacade(
     private val trustedNodeService: TrustedNodeService
 ) : ApplicationBootstrapFacade() {
 
-    private val backgroundScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     override fun activate() {
         if (isActive) {
             return
@@ -24,7 +24,7 @@ class ClientApplicationBootstrapFacade(
         setProgress(0f)
 
         // just dummy loading simulation, might be that there is no loading delay at the end...
-        backgroundScope.launch {
+        ioScope.launch {
             settingsRepository.fetch()
             val url = settingsRepository.data.value?.bisqApiUrl
             log.d { "Settings url $url" }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -41,7 +41,7 @@ class ClientTradeChatMessagesServiceFacade(
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     override fun activate() {
@@ -50,23 +50,23 @@ class ClientTradeChatMessagesServiceFacade(
             deactivate()
         }
 
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             selectedTrade.collect { _ -> updateChatMessages() }
         }
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             selectedUserProfileId.collect { _ -> updateChatMessages() }
         }
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             allBisqEasyOpenTradeMessages.collect { _ -> updateChatMessages() }
         }
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             allChatReactions.collect { _ -> updateChatMessages() }
         }
 
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             subscribeTradeChats()
         }
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             subscribeChatReactions()
         }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
@@ -41,7 +41,7 @@ class ClientTradeChatMessagesServiceFacade(
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     override fun activate() {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventObserver
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
 import network.bisq.mobile.domain.utils.Logging
 
@@ -31,7 +31,7 @@ class ClientLanguageServiceFacade(
     }
 
     // Misc
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
 
     // Life cycle

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
@@ -31,12 +31,12 @@ class ClientLanguageServiceFacade(
     }
 
     // Misc
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
 
     // Life cycle
     override fun activate() {
-        job = coroutineScope.launch {
+        job = ioScope.launch {
 
             _i18nPairs.value = listOf(
                 "en" to "English (English)",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.MarketPriceItem
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
@@ -31,7 +31,7 @@ class ClientMarketPriceServiceFacade(
     override val selectedFormattedMarketPrice: StateFlow<String> = _selectedFormattedMarketPrice
 
     // Misc
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private var selectedMarket: MarketVO = MarketVOFactory.USD// todo use persisted or user default
     private val quotes = ConcurrentMap<String, PriceQuoteVO>()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
@@ -31,14 +31,14 @@ class ClientMarketPriceServiceFacade(
     override val selectedFormattedMarketPrice: StateFlow<String> = _selectedFormattedMarketPrice
 
     // Misc
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private var selectedMarket: MarketVO = MarketVOFactory.USD// todo use persisted or user default
     private val quotes = ConcurrentMap<String, PriceQuoteVO>()
 
     // Life cycle
     override fun activate() {
-        job = coroutineScope.launch {
+        job = ioScope.launch {
             val observer = apiGateway.subscribeMarketPrice()
             observer.webSocketEvent.collect { webSocketEvent ->
                 try {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
@@ -43,7 +43,7 @@ class ClientOffersServiceFacade(
     // Misc
     private var offerbookListItemsByMarket: MutableMap<String, MutableMap<String, OfferItemPresentationModel>> = mutableMapOf()
 
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var offersSequenceNumber = atomic(-1)
     private var subscribeOffersJob: Job? = null
     private var observeMarketPriceJob: Job? = null
@@ -55,7 +55,7 @@ class ClientOffersServiceFacade(
         observeMarketPriceJob = observeMarketPrice()
 
         cancelGetMarketsJob()
-        getMarketsJob = coroutineScope.launch {
+        getMarketsJob = ioScope.launch {
             val result = apiGateway.getMarkets()
             if (result.isFailure) {
                 result.exceptionOrNull()?.let { log.e { "GetMarkets request failed with exception $it" } }
@@ -127,7 +127,7 @@ class ClientOffersServiceFacade(
 
     // Private
     private fun observeMarketPrice(): Job {
-        return coroutineScope.launch {
+        return ioScope.launch {
             marketPriceServiceFacade.selectedMarketPriceItem.collectLatest { marketPriceItem ->
                 if (marketPriceItem != null) {
                     _selectedOfferbookMarket.value.setFormattedPrice(marketPriceItem.formattedPrice)
@@ -157,7 +157,7 @@ class ClientOffersServiceFacade(
 
     private fun subscribeOffers() {
         if (subscribeOffersJob == null) {
-            subscribeOffersJob = coroutineScope.launch {
+            subscribeOffersJob = ioScope.launch {
                 offersSequenceNumber = atomic(-1)
                 // We subscribe for all markets
                 val observer = apiGateway.subscribeOffers()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.subscription.ModificationType
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
 import network.bisq.mobile.domain.data.model.offerbook.OfferbookMarket
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
@@ -43,7 +43,7 @@ class ClientOffersServiceFacade(
     // Misc
     private var offerbookListItemsByMarket: MutableMap<String, MutableMap<String, OfferItemPresentationModel>> = mutableMapOf()
 
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var offersSequenceNumber = atomic(-1)
     private var subscribeOffersJob: Job? = null
     private var observeMarketPriceJob: Job? = null

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -9,7 +9,7 @@ import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.subscription.ModificationType
 import network.bisq.mobile.client.websocket.subscription.Subscription
 import network.bisq.mobile.client.websocket.subscription.Topic
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationDto
@@ -34,7 +34,7 @@ class ClientTradesServiceFacade(
 
     // Misc
     private val tradeId get() = selectedTrade.value?.tradeId
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private val openTradesSubscription: Subscription<TradeItemPresentationDto> =
         Subscription(webSocketClientProvider, json, Topic.TRADES, this::handleTradeItemPresentationChange)
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.client.service.trades
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -9,7 +8,6 @@ import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.client.websocket.subscription.ModificationType
 import network.bisq.mobile.client.websocket.subscription.Subscription
 import network.bisq.mobile.client.websocket.subscription.Topic
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationDto
@@ -34,7 +32,6 @@ class ClientTradesServiceFacade(
 
     // Misc
     private val tradeId get() = selectedTrade.value?.tradeId
-    private val coroutineScope = CoroutineScope(IODispatcher)
     private val openTradesSubscription: Subscription<TradeItemPresentationDto> =
         Subscription(webSocketClientProvider, json, Topic.TRADES, this::handleTradeItemPresentationChange)
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import network.bisq.mobile.domain.PlatformImage
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.user.identity.UserIdentityVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
@@ -34,7 +34,7 @@ class ClientUserProfileServiceFacade(
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -34,7 +34,7 @@ class ClientUserProfileServiceFacade(
 
     // Misc
     private var active = false
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var jobs: MutableSet<Job> = mutableSetOf()
 
 
@@ -44,7 +44,7 @@ class ClientUserProfileServiceFacade(
             deactivate()
         }
 
-        jobs += coroutineScope.launch {
+        jobs += ioScope.launch {
             _selectedUserProfile.value = getSelectedUserProfile()
         }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -78,27 +78,27 @@ class WebSocketClient(
 
     private val backgroundScope = CoroutineScope(IODispatcher)
 
-    enum class WebSockectClientStatus {
+    enum class WebSocketClientStatus {
         DISCONNECTED,
         CONNECTING,
         CONNECTED
     }
 
-    val _connected = MutableStateFlow(WebSockectClientStatus.DISCONNECTED)
-    val connected: StateFlow<WebSockectClientStatus> = _connected
+    val _connected = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
+    val connected: StateFlow<WebSocketClientStatus> = _connected
 
-    fun isConnected(): Boolean = connected.value == WebSockectClientStatus.CONNECTED || isDemo()
+    fun isConnected(): Boolean = connected.value == WebSocketClientStatus.CONNECTED || isDemo()
 
     fun isDemo(): Boolean = webSocketUrl.startsWith(DEMO_URL)
 
     suspend fun connect(isTest: Boolean = false) {
         log.i("Connecting to websocket at: $webSocketUrl")
-        if (connected.value != WebSockectClientStatus.CONNECTED) {
+        if (connected.value != WebSocketClientStatus.CONNECTED) {
             try {
-                _connected.value = WebSockectClientStatus.CONNECTING
+                _connected.value = WebSocketClientStatus.CONNECTING
                 session = httpClient.webSocketSession { url(webSocketUrl) }
                 if (session?.isActive == true) {
-                    _connected.value = WebSockectClientStatus.CONNECTED
+                    _connected.value = WebSocketClientStatus.CONNECTED
                     CoroutineScope(IODispatcher).launch { startListening() }
                     connectionReady.complete(true)
                     if (!isTest) {
@@ -107,7 +107,7 @@ class WebSocketClient(
                 }
             } catch (e: Exception) {
                 log.e("Connecting websocket failed", e)
-                _connected.value = WebSockectClientStatus.DISCONNECTED
+                _connected.value = WebSocketClientStatus.DISCONNECTED
                 if (isTest) {
                     throw e
                 } else {
@@ -125,7 +125,7 @@ class WebSocketClient(
 
         session?.close()
         session = null
-        _connected.value = WebSockectClientStatus.DISCONNECTED
+        _connected.value = WebSocketClientStatus.DISCONNECTED
         if (!isTest) {
             log.d { "WS disconnected" }
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -30,7 +30,7 @@ import network.bisq.mobile.client.websocket.messages.WebSocketRestApiResponse
 import network.bisq.mobile.client.websocket.subscription.ModificationType
 import network.bisq.mobile.client.websocket.subscription.Topic
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventObserver
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.domain.data.replicated.common.currency.marketListDemoObj
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVO
@@ -76,7 +76,7 @@ class WebSocketClient(
     private var connectionReady = CompletableDeferred<Boolean>()
     private val requestResponseHandlersMutex = Mutex()
 
-    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    private val backgroundScope = CoroutineScope(IODispatcher)
 
     enum class WebSockectClientStatus {
         DISCONNECTED,
@@ -99,7 +99,7 @@ class WebSocketClient(
                 session = httpClient.webSocketSession { url(webSocketUrl) }
                 if (session?.isActive == true) {
                     _connected.value = WebSockectClientStatus.CONNECTED
-                    CoroutineScope(BackgroundDispatcher).launch { startListening() }
+                    CoroutineScope(IODispatcher).launch { startListening() }
                     connectionReady.complete(true)
                     if (!isTest) {
                         log.d { "Websocket connected" }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -84,21 +84,21 @@ class WebSocketClient(
         CONNECTED
     }
 
-    val _connected = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
-    val connected: StateFlow<WebSocketClientStatus> = _connected
+    val _webSocketClientStatus = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
+    val webSocketClientStatus: StateFlow<WebSocketClientStatus> = _webSocketClientStatus
 
-    fun isConnected(): Boolean = connected.value == WebSocketClientStatus.CONNECTED || isDemo()
+    fun isConnected(): Boolean = webSocketClientStatus.value == WebSocketClientStatus.CONNECTED || isDemo()
 
     fun isDemo(): Boolean = webSocketUrl.startsWith(DEMO_URL)
 
     suspend fun connect(isTest: Boolean = false) {
         log.i("Connecting to websocket at: $webSocketUrl")
-        if (connected.value != WebSocketClientStatus.CONNECTED) {
+        if (webSocketClientStatus.value != WebSocketClientStatus.CONNECTED) {
             try {
-                _connected.value = WebSocketClientStatus.CONNECTING
+                _webSocketClientStatus.value = WebSocketClientStatus.CONNECTING
                 session = httpClient.webSocketSession { url(webSocketUrl) }
                 if (session?.isActive == true) {
-                    _connected.value = WebSocketClientStatus.CONNECTED
+                    _webSocketClientStatus.value = WebSocketClientStatus.CONNECTED
                     CoroutineScope(IODispatcher).launch { startListening() }
                     connectionReady.complete(true)
                     if (!isTest) {
@@ -107,7 +107,7 @@ class WebSocketClient(
                 }
             } catch (e: Exception) {
                 log.e("Connecting websocket failed", e)
-                _connected.value = WebSocketClientStatus.DISCONNECTED
+                _webSocketClientStatus.value = WebSocketClientStatus.DISCONNECTED
                 if (isTest) {
                     throw e
                 } else {
@@ -125,7 +125,7 @@ class WebSocketClient(
 
         session?.close()
         session = null
-        _connected.value = WebSocketClientStatus.DISCONNECTED
+        _webSocketClientStatus.value = WebSocketClientStatus.DISCONNECTED
         if (!isTest) {
             log.d { "WS disconnected" }
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -76,7 +76,7 @@ class WebSocketClient(
     private var connectionReady = CompletableDeferred<Boolean>()
     private val requestResponseHandlersMutex = Mutex()
 
-    private val backgroundScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
 
     enum class WebSocketClientStatus {
         DISCONNECTED,
@@ -132,7 +132,7 @@ class WebSocketClient(
     }
 
     private fun reconnect() {
-        backgroundScope.launch {
+        ioScope.launch {
             log.d { "Launching reconnect" }
             disconnect()
             delay(DELAY_TO_RECONNECT) // Delay before reconnecting

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -26,7 +26,7 @@ class WebSocketClientProvider(
         }
     }
 
-    private val backgroundScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
 
     @Volatile
     private var currentClient: WebSocketClient? = null
@@ -34,7 +34,7 @@ class WebSocketClientProvider(
     init {
         // Listen to changes in WebSocket configuration and update the client
         // TODO we might need to replicate this for changes in settings to reconnect to channels
-        backgroundScope.launch {
+        ioScope.launch {
             try {
                 settingsRepository.data.collect { newSettings ->
                     var host = defaultHost

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.websocket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.utils.Logging
@@ -26,7 +26,7 @@ class WebSocketClientProvider(
         }
     }
 
-    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    private val backgroundScope = CoroutineScope(IODispatcher)
 
     @Volatile
     private var currentClient: WebSocketClient? = null

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
@@ -17,13 +17,13 @@ class Subscription<T>(
 ) : Logging {
 
     // Misc
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private var sequenceNumber = atomic(-1)
 
     fun subscribe() {
         require(job == null)
-        job = coroutineScope.launch {
+        job = ioScope.launch {
             // subscribe blocks until we get a response
             val observer = webSocketClientProvider.get().subscribe(topic)
             observer.webSocketEvent.collect { webSocketEvent ->

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Subscription.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.utils.Logging
 
 class Subscription<T>(
@@ -17,7 +17,7 @@ class Subscription<T>(
 ) : Logging {
 
     // Misc
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private var sequenceNumber = atomic(-1)
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/IODispatcher.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/IODispatcher.kt
@@ -5,4 +5,4 @@ import kotlinx.coroutines.CoroutineDispatcher
 /**
  * To use for I/O access and any expensive operation, selects the right dispatcher platform-based
  */
-expect val BackgroundDispatcher: CoroutineDispatcher
+expect val IODispatcher: CoroutineDispatcher

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/IODispatcher.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/IODispatcher.kt
@@ -3,6 +3,15 @@ package network.bisq.mobile.domain.data
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
- * To use for I/O access and any expensive operation, selects the right dispatcher platform-based
+ * Provides the best suited dispatcher for IO operations.
+ *
+ * For Android Dispatchers.IO dispatcher is used for offloading blocking I/O tasks to a shared pool of threads.
+ * For iOS there is no dedicated IO dispatch, thus Dispatchers.Default is used.
+ *
+ * Typical use cases:
+ * - Reading/writing files
+ * - Network requests using blocking clients
+ * - Accessing databases
+ * - Interacting with legacy APIs that block the thread
  */
 expect val IODispatcher: CoroutineDispatcher

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.data.persistance.PersistenceSource
 import network.bisq.mobile.domain.utils.Logging
@@ -29,7 +29,7 @@ abstract class SingleObjectRepository<out T : BaseModel>(
     override val data: StateFlow<T?> = _data
 
     private val job = Job()
-    private val scope = CoroutineScope(job + BackgroundDispatcher)
+    private val scope = CoroutineScope(job + IODispatcher)
 
     override suspend fun create(data: @UnsafeVariance T) {
         _data.value = data

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.domain.service
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.utils.Logging
 
 /**
@@ -11,7 +11,7 @@ import network.bisq.mobile.domain.utils.Logging
  * against the trusted node for the client.
  */
 class TrustedNodeService(private val webSocketClientProvider: WebSocketClientProvider) : Logging {
-    private val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    private val backgroundScope = CoroutineScope(IODispatcher)
 
     var isConnected: Boolean = false
     private var observingConnectivity = false

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -45,7 +45,7 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
 
     private fun observeConnectivity() {
         backgroundScope.launch {
-            webSocketClientProvider.get().connected.collect {
+            webSocketClientProvider.get().webSocketClientStatus.collect {
                 log.d { "connectivity status changed - connected = $it" }
                 isConnected = webSocketClientProvider.get().isConnected()
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -11,7 +11,7 @@ import network.bisq.mobile.domain.utils.Logging
  * against the trusted node for the client.
  */
 class TrustedNodeService(private val webSocketClientProvider: WebSocketClientProvider) : Logging {
-    private val backgroundScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
 
     var isConnected: Boolean = false
     private var observingConnectivity = false
@@ -44,7 +44,7 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
     }
 
     private fun observeConnectivity() {
-        backgroundScope.launch {
+        ioScope.launch {
             webSocketClientProvider.get().webSocketClientStatus.collect {
                 log.d { "connectivity status changed - connected = $it" }
                 isConnected = webSocketClientProvider.get().isConnected()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
@@ -45,7 +45,7 @@ abstract class ConnectivityService: Logging {
         CONNECTED
     }
 
-    private val coroutineScope = CoroutineScope(IODispatcher)
+    private val ioScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private val _status = MutableStateFlow(ConnectivityStatus.DISCONNECTED)
     val status: StateFlow<ConnectivityStatus> = _status
@@ -56,7 +56,7 @@ abstract class ConnectivityService: Logging {
     fun startMonitoring(period: Long = PERIOD) {
         onStart()
         job?.cancel()
-        job = coroutineScope.launch(IODispatcher) {
+        job = ioScope.launch(IODispatcher) {
             while (true) {
                 try {
                     withTimeout(TIMEOUT) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
@@ -1,15 +1,14 @@
 package network.bisq.mobile.domain.service.network
 
 import kotlinx.coroutines.CoroutineScope
-import network.bisq.mobile.domain.data.BackgroundDispatcher
-
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.TimeoutCancellationException
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.utils.Logging
 
 /**
@@ -46,7 +45,7 @@ abstract class ConnectivityService: Logging {
         CONNECTED
     }
 
-    private val coroutineScope = CoroutineScope(BackgroundDispatcher)
+    private val coroutineScope = CoroutineScope(IODispatcher)
     private var job: Job? = null
     private val _status = MutableStateFlow(ConnectivityStatus.DISCONNECTED)
     val status: StateFlow<ConnectivityStatus> = _status
@@ -57,7 +56,7 @@ abstract class ConnectivityService: Logging {
     fun startMonitoring(period: Long = PERIOD) {
         onStart()
         job?.cancel()
-        job = coroutineScope.launch(BackgroundDispatcher) {
+        job = coroutineScope.launch(IODispatcher) {
             while (true) {
                 try {
                     withTimeout(TIMEOUT) {

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/data/BackgroundDispatcher.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/data/BackgroundDispatcher.ios.kt
@@ -3,4 +3,4 @@ package network.bisq.mobile.domain.data
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-actual val BackgroundDispatcher: CoroutineDispatcher = Dispatchers.Default
+actual val IODispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -110,7 +110,6 @@ open class ClientMainPresenter(
         tradeChatMessagesServiceFacade.deactivate()
         settingsServiceFacade.deactivate()
         languageServiceFacade.deactivate()
-        super.onViewUnattaching()
     }
 
     override fun isDemo(): Boolean = ApplicationBootstrapFacade.isDemo

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -55,7 +55,7 @@ open class ClientMainPresenter(
     private fun listenForConnectivity() {
         ioScope.launch {
             connectivityService.startMonitoring()
-            webSocketClientProvider.get().connected.collect {
+            webSocketClientProvider.get().webSocketClientStatus.collect {
                 if (webSocketClientProvider.get().isConnected()) {
                     log.d { "connectivity status changed to $it - reconnecting services" }
                     reactiveServices()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -53,7 +53,7 @@ open class ClientMainPresenter(
     }
 
     private fun listenForConnectivity() {
-        backgroundScope.launch {
+        ioScope.launch {
             connectivityService.startMonitoring()
             webSocketClientProvider.get().connected.collect {
                 if (webSocketClientProvider.get().isConnected()) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -47,7 +47,7 @@ open class ClientMainPresenter(
     override fun onViewUnattaching() {
         // For Tor we might want to leave it running while in background to avoid delay of re-connect
         // when going into foreground again.
-        // coroutineScope.launch {  webSocketClient.disconnect() }
+        // presenterScope.launch {  webSocketClient.disconnect() }
         deactivateServices()
         super.onViewUnattaching()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -53,8 +53,8 @@ open class ClientMainPresenter(
     }
 
     private fun listenForConnectivity() {
-        ioScope.launch {
-            connectivityService.startMonitoring()
+        connectivityService.startMonitoring()
+        presenterScope.launch {
             webSocketClientProvider.get().webSocketClientStatus.collect {
                 if (webSocketClientProvider.get().isConnected()) {
                     log.d { "connectivity status changed to $it - reconnecting services" }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
@@ -65,7 +65,7 @@ open class ClientMainPresenter(
     }
 
     private fun validateVersion() {
-        CoroutineScope(BackgroundDispatcher).launch {
+        CoroutineScope(IODispatcher).launch {
             if (settingsServiceFacade.isApiCompatible()) {
                 log.d { "trusted node is compatible, continue" }
             } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -432,6 +432,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     private fun cleanup() {
         try {
             this.presenterScope.cancel()
+            this.ioScope.cancel()
             // copy to avoid concurrency exception - no problem with multiple on destroy calls
             dependants?.toList()?.forEach { it.onDestroy() }
         } catch (e: Exception) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -118,7 +118,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     protected val presenterScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     // For network access, persistence or file IO
-    protected val ioScope = CoroutineScope(IODispatcher)
+    protected val ioScope = CoroutineScope(IODispatcher + SupervisorJob())
 
     private val dependants = if (isRoot()) mutableListOf<BasePresenter>() else null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -108,7 +108,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
     // Coroutine scope for the presenter
     protected val presenterScope = CoroutineScope(Dispatchers.Main + Job())
     protected val uiScope = CoroutineScope(Dispatchers.Main)
-    protected val backgroundScope = CoroutineScope(IODispatcher)
+    protected val ioScope = CoroutineScope(IODispatcher)
 
     private val dependants = if (isRoot()) mutableListOf<BasePresenter>() else null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -159,12 +159,14 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
         rootPresenter?.registerChild(child = this)
     }
 
-    protected fun enableInteractive(enable: Boolean = true) {
-        this.presenterScope.launch {
-            if (enable) {
-                delay(250L)
-            }
-            _isInteractive.value = enable
+    protected fun disableInteractive() {
+        _isInteractive.value = false
+    }
+
+    protected fun enableInteractive() {
+        presenterScope.launch {
+            delay(250L)
+            _isInteractive.value = true
         }
     }
 
@@ -218,7 +220,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
      * Navigate to given destination
      */
     protected fun navigateTo(destination: Routes, customSetup: (NavOptionsBuilder) -> Unit = {}) {
-        enableInteractive(false)
+        disableInteractive()
         this.presenterScope.launch(Dispatchers.Main) {
             try {
                 rootNavigator.navigate(destination.name) {
@@ -291,7 +293,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 //        UIApplication.sharedApplication.performSelector(NSSelectorFromString("suspend"))
 //    }
     override fun goBack(): Boolean {
-        enableInteractive(false)
+        disableInteractive()
         var wentBack = false
         this.presenterScope.launch(Dispatchers.Main) {
             try {
@@ -448,9 +450,9 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     }
 
     override fun navigateToReportError() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://github.com/bisq-network/bisq-mobile/issues")
-        enableInteractive(true)
+        enableInteractive()
     }
 
     override fun isDemo(): Boolean = rootPresenter?.isDemo() ?: false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.Logging
@@ -108,7 +108,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?): ViewPre
     // Coroutine scope for the presenter
     protected val presenterScope = CoroutineScope(Dispatchers.Main + Job())
     protected val uiScope = CoroutineScope(Dispatchers.Main)
-    protected val backgroundScope = CoroutineScope(BackgroundDispatcher)
+    protected val backgroundScope = CoroutineScope(IODispatcher)
 
     private val dependants = if (isRoot()) mutableListOf<BasePresenter>() else null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
@@ -39,7 +39,7 @@ open class TopBarPresenter(
     }
 
     private fun refresh() {
-        backgroundScope.launch {
+        ioScope.launch {
             val uniqueAvatar = userRepository.fetch()?.uniqueAvatar
 //            log.d("Unique avatar fetched: $uniqueAvatar")
             setUniqueAvatar(uniqueAvatar)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
@@ -3,7 +3,9 @@ package network.bisq.mobile.presentation.ui.components.molecules
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.PlatformImage
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
@@ -16,7 +18,7 @@ open class TopBarPresenter(
     private val settingsServiceFacade: SettingsServiceFacade,
     connectivityService: ConnectivityService,
     mainPresenter: MainPresenter
-): BasePresenter(mainPresenter), ITopBarPresenter {
+) : BasePresenter(mainPresenter), ITopBarPresenter {
 
     private val _uniqueAvatar = MutableStateFlow(userRepository.data.value?.uniqueAvatar)
     override val uniqueAvatar: StateFlow<PlatformImage?> get() = _uniqueAvatar
@@ -39,9 +41,10 @@ open class TopBarPresenter(
     }
 
     private fun refresh() {
-        ioScope.launch {
-            val uniqueAvatar = userRepository.fetch()?.uniqueAvatar
-//            log.d("Unique avatar fetched: $uniqueAvatar")
+        presenterScope.launch {
+            val uniqueAvatar = withContext(IODispatcher) {
+                userRepository.fetch()?.uniqueAvatar
+            }
             setUniqueAvatar(uniqueAvatar)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/error/GenericErrorHandler.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/error/GenericErrorHandler.kt
@@ -32,7 +32,7 @@ class GenericErrorHandler : Logging {
             getLogger("GenericErrorHandler").e(errorMessage, exception)
             _genericErrorMessage.value = errorMessage + "\nException: " + exception.message
         }
-        
+
         @JvmStatic
         fun init() {
             setupUncaughtExceptionHandler {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -38,9 +38,9 @@ open class GettingStartedPresenter(
     private var job: Job? = null
 
     override fun onStartTrading() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToTradingTab()
-        enableInteractive(true)
+        enableInteractive()
     }
 
     private fun navigateToTradingTab() {
@@ -48,9 +48,9 @@ open class GettingStartedPresenter(
     }
 
     override fun navigateLearnMore() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://bisq.wiki/Bisq_Easy")
-        enableInteractive(true)
+        enableInteractive()
     }
 
     fun navigateToGuide() {
@@ -58,7 +58,7 @@ open class GettingStartedPresenter(
     }
 
     private fun refresh() {
-        enableInteractive(false)
+        disableInteractive()
         job = presenterScope.launch {
             val bisqStats = withContext(IODispatcher) {
                 bisqStatsRepository.fetch()
@@ -70,7 +70,7 @@ open class GettingStartedPresenter(
                     _offersOnline.value = it.size
                 }
             }
-            enableInteractive(true)
+            enableInteractive()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/GettingStartedPresenter.kt
@@ -56,7 +56,7 @@ open class GettingStartedPresenter(
     }
 
     private fun refresh() {
-        job = backgroundScope.launch {
+        job = ioScope.launch {
             try {
                 enableInteractive(false)
                 // TODO get published profiles data from service

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -181,7 +181,7 @@ class CreateOfferAmountPresenter(
                 value
             ) ?: 0L
         _reputation.value = requiredReputation
-        backgroundScope.launch {
+        ioScope.launch {
             _takersCount.value = findPotentialTakers(requiredReputation)
             val numSellersString = "bisqEasy.tradeWizard.amount.buyer.numSellers".i18nPlural(takersCount.value)
             _hintText.value = "bisqEasy.tradeWizard.amount.buyer.limitInfo".i18n(numSellersString)
@@ -189,7 +189,7 @@ class CreateOfferAmountPresenter(
     }
 
     private fun updateSellerHintText() {
-        backgroundScope.launch {
+        ioScope.launch {
             val profile = userProfileServiceFacade.getSelectedUserProfile() ?: return@launch
 
             _reputation.value = reputationServiceFacade.getReputation(profile.id).getOrNull()?.totalScore ?: 0L

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -236,15 +236,15 @@ class CreateOfferAmountPresenter(
     }
 
     fun navigateToReputation() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://bisq.wiki/Reputation")
-        enableInteractive(true)
+        enableInteractive()
     }
 
     fun navigateToBuildReputation() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://bisq.wiki/Reputation#How_to_build_reputation")
-        enableInteractive(true)
+        enableInteractive()
     }
 
     private suspend fun findPotentialTakers(requiredReputationScore: Long): Int {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -78,9 +78,9 @@ class CreateOfferDirectionPresenter(
     }
 
     fun showLearnReputation() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://bisq.wiki/Reputation#How_to_build_reputation")
-        enableInteractive(true)
+        enableInteractive()
     }
 
     private fun navigateNext() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -1,8 +1,10 @@
 package network.bisq.mobile.presentation.ui.uicases.create_offer
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
@@ -34,10 +36,14 @@ class CreateOfferDirectionPresenter(
         super.onViewAttached()
         direction = createOfferPresenter.createOfferModel.direction
         headline = "bisqEasy.tradeWizard.directionAndMarket.headline".i18n() //TODO:i18n check
+
         ioScope.launch {
             val profile = userProfileServiceFacade.getSelectedUserProfile() ?: return@launch
             val reputation = reputationServiceFacade.getReputation(profile.id).getOrNull()
-            _reputation.value = reputation
+
+            withContext(Dispatchers.Main) {
+                _reputation.value = reputation
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -34,7 +34,7 @@ class CreateOfferDirectionPresenter(
         super.onViewAttached()
         direction = createOfferPresenter.createOfferModel.direction
         headline = "bisqEasy.tradeWizard.directionAndMarket.headline".i18n() //TODO:i18n check
-        backgroundScope.launch {
+        ioScope.launch {
             val profile = userProfileServiceFacade.getSelectedUserProfile() ?: return@launch
             val reputation = reputationServiceFacade.getReputation(profile.id).getOrNull()
             _reputation.value = reputation

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -7,10 +7,10 @@ import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.
 import network.bisq.mobile.domain.formatters.AmountFormatter
 import network.bisq.mobile.domain.formatters.PercentageFormatter
 import network.bisq.mobile.domain.formatters.PriceQuoteFormatter
-import network.bisq.mobile.presentation.ui.helpers.i18NPaymentMethod
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.helpers.i18NPaymentMethod
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class CreateOfferReviewPresenter(
@@ -121,7 +121,7 @@ class CreateOfferReviewPresenter(
     }
 
     private fun onGoToOfferList() {
-        presenterScope.launch {
+        this.presenterScope.launch {
             // FIXME without clearing the backstack it does not work
             val rootNavController = getRootNavController()
             var currentBackStack = rootNavController.currentBackStack.value

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -110,7 +110,7 @@ class CreateOfferReviewPresenter(
     }
 
     fun onCreateOffer() {
-        backgroundScope.launch {
+        ioScope.launch {
             enableInteractive(false)
             // TODO deactivate buttons, show waiting state
             createOfferPresenter.createOffer()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -37,6 +37,7 @@ class CreateOfferReviewPresenter(
 
 
     override fun onViewAttached() {
+        super.onViewAttached()
         createOfferModel = createOfferPresenter.createOfferModel
         direction = createOfferModel.direction
 
@@ -110,7 +111,6 @@ class CreateOfferReviewPresenter(
     }
 
     fun onCreateOffer() {
-        // TODO deactivate buttons, show waiting state
         disableInteractive()
 
         presenterScope.launch {
@@ -119,7 +119,6 @@ class CreateOfferReviewPresenter(
             // After createOffer is completed  we are back on presenterScope
             onGoToOfferList()
             enableInteractive()
-            // TODO hide waiting state, show successfully published state, show button to open offer book, clear navigation backstack
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -111,7 +111,7 @@ class CreateOfferReviewPresenter(
 
     fun onCreateOffer() {
         // TODO deactivate buttons, show waiting state
-        enableInteractive(false)
+        disableInteractive()
 
         presenterScope.launch {
             // We use withContext(IODispatcher) for the service call, thus we switch context and block

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -110,13 +110,16 @@ class CreateOfferReviewPresenter(
     }
 
     fun onCreateOffer() {
-        ioScope.launch {
-            enableInteractive(false)
-            // TODO deactivate buttons, show waiting state
+        // TODO deactivate buttons, show waiting state
+        enableInteractive(false)
+
+        presenterScope.launch {
+            // We use withContext(IODispatcher) for the service call, thus we switch context and block
             createOfferPresenter.createOffer()
-            // TODO hide waiting state, show successfully published state, show button to open offer book, clear navigation backstack
+            // After createOffer is completed  we are back on presenterScope
             onGoToOfferList()
             enableInteractive()
+            // TODO hide waiting state, show successfully published state, show button to open offer book, clear navigation backstack
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
@@ -45,9 +45,9 @@ class TradeGuidePresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl("https://bisq.wiki/Bisq_Easy")
-        enableInteractive(true)
+        enableInteractive()
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
@@ -34,7 +34,7 @@ class TradeGuidePresenter(
     }
 
     fun tradeRulesNextClick() {
-        presenterScope.launch {
+        this.presenterScope.launch {
             val isConfirmed = tradeRulesConfirmed.first()
             if (!isConfirmed) {
                 settingsServiceFacade.confirmTradeRules(true)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuidePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuidePresenter.kt
@@ -34,21 +34,21 @@ class WalletGuidePresenter(
     }
 
     fun navigateToBlueWallet() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl(blueWalletLink)
-        enableInteractive(true)
+        enableInteractive()
     }
 
     fun navigateToBlueWalletTutorial1() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl(tutorial1Link)
-        enableInteractive(true)
+        enableInteractive()
     }
 
     fun navigateToBlueWalletTutorial2() {
-        enableInteractive(false)
+        disableInteractive()
         navigateToUrl(tutorial2Link)
-        enableInteractive(true)
+        enableInteractive()
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
@@ -122,6 +122,7 @@ class OfferbookMarketPresenter(
 
     override fun onViewUnattaching() {
         stopUpdatingMarketPrices()
+        super.onViewUnattaching()
     }
 
     private fun startUpdatingMarketPrices() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -47,7 +47,7 @@ class OfferbookPresenter(
         runCatching {
             selectedOffer?.let { item ->
                 if (item.isMyOffer) {
-                    backgroundScope.launch {
+                    ioScope.launch {
                         offersServiceFacade.deleteOffer(item.offerId)
                         deselectOffer()
                     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -3,6 +3,8 @@ package network.bisq.mobile.presentation.ui.uicases.offerbook
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
@@ -27,7 +29,7 @@ class OfferbookPresenter(
 
     private val _showDeleteConfirmation = MutableStateFlow(false)
     val showDeleteConfirmation: StateFlow<Boolean> = _showDeleteConfirmation
-    var selectedOffer: OfferItemPresentationModel? = null
+    private var selectedOffer: OfferItemPresentationModel? = null
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -47,8 +49,10 @@ class OfferbookPresenter(
         runCatching {
             selectedOffer?.let { item ->
                 if (item.isMyOffer) {
-                    ioScope.launch {
-                        offersServiceFacade.deleteOffer(item.offerId)
+                    presenterScope.launch {
+                        withContext(IODispatcher) {
+                            offersServiceFacade.deleteOffer(item.offerId)
+                        }
                         deselectOffer()
                     }
                 } else {
@@ -64,7 +68,10 @@ class OfferbookPresenter(
             }
         }.onFailure {
             log.e(it) { "Failed to ${if (selectedOffer?.isMyOffer == true) "delete" else "take"} offer" }
-            showSnackbar("Unable to ${if (selectedOffer?.isMyOffer == true) "delete" else "take"} offer ${selectedOffer?.offerId}, please try again", true)
+            showSnackbar(
+                "Unable to ${if (selectedOffer?.isMyOffer == true) "delete" else "take"} offer ${selectedOffer?.offerId}, please try again",
+                true
+            )
             deselectOffer()
         }
     }
@@ -84,7 +91,7 @@ class OfferbookPresenter(
 
     fun createOffer() {
         try {
-            val market =offersServiceFacade.selectedOfferbookMarket.value.market
+            val market = offersServiceFacade.selectedOfferbookMarket.value.market
             createOfferPresenter.onStartCreateOffer()
             createOfferPresenter.commitMarket(market)
             navigateTo(Routes.CreateOfferDirection)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -39,7 +39,7 @@ class OpenTradeListPresenter(
 
     fun onConfirmTradeRules(value: Boolean) {
         _tradeGuideVisible.value = false
-        presenterScope.launch {
+        this.presenterScope.launch {
             settingsServiceFacade.confirmTradeRules(value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -46,10 +46,8 @@ class OpenTradeListPresenter(
 
     fun onSelect(openTradeItem: TradeItemPresentationModel) {
         if (tradeRulesConfirmed.value) {
-            ioScope.launch {
-                tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
-                navigateTo(Routes.OpenTrade)
-            }
+            tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
+            navigateTo(Routes.OpenTrade)
         } else {
             log.w { "User hasn't accepted trade rules yet, showing dialog" }
             // TODO show dialogue to open trade guide

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -25,9 +25,6 @@ class OpenTradeListPresenter(
     override fun onViewAttached() {
     }
 
-    override fun onViewUnattaching() {
-    }
-
     fun onOpenTradeGuide() {
         // _tradeGuideVisible.value = true
         navigateTo(Routes.TradeGuideOverview)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -46,7 +46,7 @@ class OpenTradeListPresenter(
 
     fun onSelect(openTradeItem: TradeItemPresentationModel) {
         if (tradeRulesConfirmed.value) {
-            backgroundScope.launch {
+            ioScope.launch {
                 tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
                 navigateTo(Routes.OpenTrade)
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
@@ -40,12 +40,12 @@ class InterruptedTradePresenter(
         super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
                 tradeStateChanged(tradeState)
             }
         }
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation.collect { isInMediation ->
                 _isInMediation.value = isInMediation
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
@@ -146,7 +146,7 @@ class InterruptedTradePresenter(
     }
 
     fun onCloseTrade() {
-        backgroundScope.launch {
+        ioScope.launch {
             if (selectedTrade.value != null) {
                 tradesServiceFacade.closeTrade()
             }
@@ -155,7 +155,7 @@ class InterruptedTradePresenter(
     }
 
     fun onReportToMediator() {
-        backgroundScope.launch {
+        ioScope.launch {
             mediationServiceFacade.reportToMediator(selectedTrade.value!!)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
@@ -3,6 +3,8 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.contract.RoleEnum
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
@@ -146,11 +148,13 @@ class InterruptedTradePresenter(
     }
 
     fun onCloseTrade() {
-        ioScope.launch {
-            if (selectedTrade.value != null) {
-                tradesServiceFacade.closeTrade()
+        if (selectedTrade.value != null) {
+            presenterScope.launch {
+                withContext(IODispatcher) {
+                    tradesServiceFacade.closeTrade()
+                }
+                navigateBack()
             }
-            navigateBack()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -61,6 +61,7 @@ class OpenTradePresenter(
         _tradeAbortedBoxVisible.value = false
         _tradeProcessBoxVisible.value = false
         _isInMediation.value = false
+        super.onViewUnattaching()
     }
 
     fun onOpenChat() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -44,13 +44,13 @@ class OpenTradePresenter(
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
                 tradeStateChanged(tradeState)
             }
         }
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation.collect { isInMediation ->
                 _isInMediation.value = isInMediation
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -250,9 +250,6 @@ class TradeDetailsHeaderPresenter(
                 }
             }
         }
-
-        ioScope.launch {
-        }
     }
 
     fun onOpenMediationConfirmationDialog() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -56,6 +56,7 @@ class TradeDetailsHeaderPresenter(
     val isInMediation: StateFlow<Boolean> = this._isInMediation
 
     override fun onViewAttached() {
+        super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
 
@@ -94,6 +95,7 @@ class TradeDetailsHeaderPresenter(
 
     override fun onViewUnattaching() {
         reset()
+        super.onViewUnattaching()
     }
 
     private fun tradeStateChanged(state: BisqEasyTradeStateEnum?) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -222,7 +222,7 @@ class TradeDetailsHeaderPresenter(
     }
 
     fun onInterruptTrade() {
-        backgroundScope.launch {
+        ioScope.launch {
             require(selectedTrade.value != null)
 
             var result: Result<Unit>? = null
@@ -250,7 +250,7 @@ class TradeDetailsHeaderPresenter(
 
     fun onOpenMediation() {
         _showMediationConfirmationDialog.value = false
-        backgroundScope.launch {
+        ioScope.launch {
             mediationServiceFacade.reportToMediator(selectedTrade.value!!)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -77,13 +77,13 @@ class TradeDetailsHeaderPresenter(
             rightCode = openTradeItemModel.baseCurrencyCode
         }
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
                 tradeStateChanged(tradeState)
             }
         }
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation.collect { isInMediation ->
                 this@TradeDetailsHeaderPresenter._isInMediation.value = isInMediation
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
@@ -63,7 +63,7 @@ import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.TradeFlo
 import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.TradeFlowPresenter.TradePhaseState.SELLER_STATE4
 import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.TradeFlowPresenter.TradePhaseState.SELLER_STATE_LIGHTNING3B
 import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.TradeFlowPresenter.TradePhaseState.SELLER_STATE_MAIN_CHAIN3B
-import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states.*
+import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states.TradeStatesProvider
 
 
 class TradeFlowPresenter(
@@ -97,7 +97,7 @@ class TradeFlowPresenter(
         val paymentMethod = openTradeItemModel.bisqEasyTradeModel.contract.baseSidePaymentMethodSpec.paymentMethod
         isMainChain = paymentMethod == "MAIN_CHAIN"
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
                 log.d { "Trade State Changed to: $tradeState" }
                 tradeStateChanged(tradeState)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -1,11 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
@@ -77,7 +75,7 @@ class BuyerState1aPresenter(
     fun onSend() {
         require(bitcoinPaymentData.value.isNotEmpty())
 
-        job = CoroutineScope(IODispatcher).launch {
+        job = ioScope.launch {
             tradesServiceFacade.buyerSendBitcoinPaymentData(bitcoinPaymentData.value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -75,8 +75,10 @@ class BuyerState1aPresenter(
     fun onSend() {
         require(bitcoinPaymentData.value.isNotEmpty())
 
-        job = ioScope.launch {
-            tradesServiceFacade.buyerSendBitcoinPaymentData(bitcoinPaymentData.value)
+        job = presenterScope.launch {
+            withContext(IODispatcher) {
+                tradesServiceFacade.buyerSendBitcoinPaymentData(bitcoinPaymentData.value)
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
@@ -41,6 +43,7 @@ class BuyerState1aPresenter(
     private var job: Job? = null
 
     override fun onViewAttached() {
+        super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
         val paymentMethod = openTradeItemModel.bisqEasyTradeModel.contract.baseSidePaymentMethodSpec.paymentMethod
@@ -57,6 +60,7 @@ class BuyerState1aPresenter(
         job = null
         _bitcoinPaymentData.value = ""
         _bitcoinPaymentDataValid.value = false
+        super.onViewUnattaching()
     }
 
     fun onBitcoinPaymentDataInput(value: String, isValid: Boolean) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
@@ -77,7 +77,7 @@ class BuyerState1aPresenter(
     fun onSend() {
         require(bitcoinPaymentData.value.isNotEmpty())
 
-        job = CoroutineScope(BackgroundDispatcher).launch {
+        job = CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.buyerSendBitcoinPaymentData(bitcoinPaymentData.value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -29,7 +29,7 @@ class BuyerState2aPresenter(
     }
 
     fun onConfirmFiatSent() {
-        job = CoroutineScope(BackgroundDispatcher).launch {
+        job = CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.buyerConfirmFiatSent()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
@@ -1,10 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -29,7 +27,7 @@ class BuyerState2aPresenter(
     }
 
     fun onConfirmFiatSent() {
-        job = CoroutineScope(IODispatcher).launch {
+        job = ioScope.launch {
             tradesServiceFacade.buyerConfirmFiatSent()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -27,7 +27,7 @@ class BuyerStateLightning3bPresenter(
     }
 
     fun onCompleteTrade() {
-        job = CoroutineScope(BackgroundDispatcher).launch {
+        job = CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.btcConfirmed()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
@@ -1,10 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -27,7 +25,7 @@ class BuyerStateLightning3bPresenter(
     }
 
     fun onCompleteTrade() {
-        job = CoroutineScope(IODispatcher).launch {
+        job = ioScope.launch {
             tradesServiceFacade.btcConfirmed()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
@@ -122,7 +122,7 @@ class BuyerStateMainChain3bPresenter(
 
                     // We request again after 20 seconds.
                     // As its presenterScope it will get canceled when presenter is deactivated.
-                    presenterScope.launch {
+                    this@BuyerStateMainChain3bPresenter.presenterScope.launch {
                         delay(20_000)
                         requestTx()
                     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory.from
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
@@ -74,7 +74,7 @@ class BuyerStateMainChain3bPresenter(
     }
 
     fun onCompleteTrade() {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.btcConfirmed()
         })
     }
@@ -90,7 +90,7 @@ class BuyerStateMainChain3bPresenter(
         if (txId == null || address == null) {
             return
         }
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             _blockExplorer.value = ""
             val result = explorerServiceFacade.getSelectedBlockExplorer()
             if (result.isSuccess) {
@@ -108,7 +108,7 @@ class BuyerStateMainChain3bPresenter(
         address: String,
         openTradeItemModel: TradeItemPresentationModel
     ) {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             _txConfirmationState.value = REQUEST_STARTED
             _errorMessage.value = null
             _balanceFromTx.value = ""

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
@@ -76,8 +76,10 @@ class BuyerStateMainChain3bPresenter(
     }
 
     fun onCompleteTrade() {
-        jobs.add(ioScope.launch {
-            tradesServiceFacade.btcConfirmed()
+        jobs.add(presenterScope.launch {
+            withContext(IODispatcher) {
+                tradesServiceFacade.btcConfirmed()
+            }
         })
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
@@ -50,6 +50,7 @@ class BuyerStateMainChain3bPresenter(
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     override fun onViewAttached() {
+        super.onViewAttached()
         if (txConfirmationState.value == CONFIRMED) {
             _buttonText.value = "bisqEasy.tradeState.info.phase3b.button.next".i18n()
         } else {
@@ -71,6 +72,7 @@ class BuyerStateMainChain3bPresenter(
         _blockExplorer.value = ""
         _balanceFromTx.value = ""
         _errorMessage.value = null
+        super.onViewUnattaching()
     }
 
     fun onCompleteTrade() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -64,7 +63,7 @@ class SellerState1Presenter(
 
     fun onSendPaymentData() {
         require(paymentAccountData.value.isNotEmpty())
-        job = CoroutineScope(IODispatcher).launch {
+        job = ioScope.launch {
             tradesServiceFacade.sellerSendsPaymentAccount(paymentAccountData.value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -59,7 +59,7 @@ class SellerState1Presenter(
 
     fun onSendPaymentData() {
         require(paymentAccountData.value.isNotEmpty())
-        job = CoroutineScope(BackgroundDispatcher).launch {
+        job = CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.sellerSendsPaymentAccount(paymentAccountData.value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -50,6 +50,7 @@ class SellerState1Presenter(
         job?.cancel()
         job = null
         _paymentAccountData.value = ""
+        super.onViewUnattaching()
     }
 
     fun onPaymentDataInput(value: String, isValid: Boolean) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -33,7 +33,7 @@ class SellerState1Presenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-        backgroundScope.launch {
+        ioScope.launch {
             val _accounts = accountsServiceFacade.getAccounts()
             if (_accounts.size > 0) {
                 onPaymentDataInput(_accounts[0].accountPayload.accountData, true)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
@@ -33,8 +34,12 @@ class SellerState1Presenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-        ioScope.launch {
-            val _accounts = accountsServiceFacade.getAccounts()
+
+        presenterScope.launch {
+            val _accounts = withContext(IODispatcher) {
+                accountsServiceFacade.getAccounts()
+            }
+
             if (_accounts.size > 0) {
                 onPaymentDataInput(_accounts[0].accountPayload.accountData, true)
                 _paymentAccountName.value = _accounts[0].accountName

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
@@ -22,6 +22,7 @@ class SellerState2bPresenter(
     override fun onViewUnattaching() {
         job?.cancel()
         job = null
+        super.onViewUnattaching()
     }
 
     fun onConfirmFiatReceipt() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
@@ -25,7 +25,7 @@ class SellerState2bPresenter(
     }
 
     fun onConfirmFiatReceipt() {
-        job = backgroundScope.launch {
+        job = ioScope.launch {
             tradesServiceFacade.sellerConfirmFiatReceipt()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
@@ -76,8 +76,10 @@ class SellerState3aPresenter(
         if (!isLightning.value) {
             require(paymentProof.value != null)
         }
-        job = ioScope.launch {
-            tradesServiceFacade.sellerConfirmBtcSent(paymentProof.value)
+        job = presenterScope.launch {
+            withContext(IODispatcher) {
+                tradesServiceFacade.sellerConfirmBtcSent(paymentProof.value)
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
@@ -76,7 +76,7 @@ class SellerState3aPresenter(
         if (!isLightning.value) {
             require(paymentProof.value != null)
         }
-        job = backgroundScope.launch {
+        job = ioScope.launch {
             tradesServiceFacade.sellerConfirmBtcSent(paymentProof.value)
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -23,7 +23,7 @@ class SellerStateLightning3bPresenter(
     }
 
     fun onCompleteTrade() {
-        job = CoroutineScope(BackgroundDispatcher).launch {
+        job = CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.btcConfirmed()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
@@ -1,9 +1,7 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -23,7 +21,7 @@ class SellerStateLightning3bPresenter(
     }
 
     fun onCompleteTrade() {
-        job = CoroutineScope(IODispatcher).launch {
+        job = ioScope.launch {
             tradesServiceFacade.btcConfirmed()
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
@@ -72,6 +72,7 @@ class SellerStateMainChain3bPresenter(
         _blockExplorer.value = ""
         _balanceFromTx.value = ""
         _errorMessage.value = null
+        super.onViewUnattaching()
     }
 
     fun onCompleteTrade() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory.from
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
@@ -75,7 +75,7 @@ class SellerStateMainChain3bPresenter(
     }
 
     fun onCompleteTrade() {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.btcConfirmed()
         })
     }
@@ -91,7 +91,7 @@ class SellerStateMainChain3bPresenter(
         if (txId == null || address == null) {
             return
         }
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             _blockExplorer.value = ""
             val result = explorerServiceFacade.getSelectedBlockExplorer()
             if (result.isSuccess) {
@@ -109,7 +109,7 @@ class SellerStateMainChain3bPresenter(
         address: String,
         openTradeItemModel: TradeItemPresentationModel
     ) {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             _txConfirmationState.value = REQUEST_STARTED
             _errorMessage.value = null
             _balanceFromTx.value = ""

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
@@ -123,7 +123,7 @@ class SellerStateMainChain3bPresenter(
 
                     // We request again after 20 seconds.
                     // As its presenterScope it will get canceled when presenter is deactivated.
-                    presenterScope.launch {
+                    this@SellerStateMainChain3bPresenter.presenterScope.launch {
                         delay(20_000)
                         requestTx()
                     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -45,7 +45,7 @@ abstract class State4Presenter(
             val result = tradesServiceFacade.closeTrade()
             when {
                 result.isFailure -> {
-                    presenterScope.launch {
+                    this@State4Presenter.presenterScope.launch {
                         _showCloseTradeDialog.value = false
                         result.exceptionOrNull()?.let { exception -> GenericErrorHandler.handleGenericError(exception.message) }
                             ?: GenericErrorHandler.handleGenericError("No Exception is set in result failure")
@@ -53,7 +53,7 @@ abstract class State4Presenter(
                 }
 
                 result.isSuccess -> {
-                    presenterScope.launch {
+                    this@State4Presenter.presenterScope.launch {
                         _showCloseTradeDialog.value = false
                         navigateBack()
                     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.BackgroundDispatcher
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
@@ -41,7 +41,7 @@ abstract class State4Presenter(
     }
 
     fun onConfirmCloseTrade() {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             val result = tradesServiceFacade.closeTrade()
             when {
                 result.isFailure -> {
@@ -63,7 +63,7 @@ abstract class State4Presenter(
     }
 
     fun onExportTradeDate() {
-        jobs.add(CoroutineScope(BackgroundDispatcher).launch {
+        jobs.add(CoroutineScope(IODispatcher).launch {
             tradesServiceFacade.exportTradeDate()
         })
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -30,6 +30,7 @@ abstract class State4Presenter(
         _showCloseTradeDialog.value = false
         jobs.forEach { it.cancel() }
         jobs.clear()
+        super.onViewUnattaching()
     }
 
     fun onCloseTrade() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -40,7 +40,7 @@ class TradeChatPresenter(
         require(tradesServiceFacade.selectedTrade.value != null)
         val selectedTrade = tradesServiceFacade.selectedTrade.value!!
 
-        presenterScope.launch {
+        this.presenterScope.launch {
             val settings = settingsRepository.fetch()!!
             _showChatRulesWarnBox.value = settings.showChatRulesWarnBox
             val bisqEasyOpenTradeChannelModel = selectedTrade.bisqEasyOpenTradeChannelModel

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -54,9 +54,9 @@ class TradeChatPresenter(
     }
 
     override fun onViewUnattaching() {
-        super.onViewUnattaching()
         jobs.forEach { it.cancel() }
         jobs.clear()
+        super.onViewUnattaching()
     }
 
     fun sendChatMessage(text: String) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -43,9 +43,10 @@ class TradeChatPresenter(
         val selectedTrade = tradesServiceFacade.selectedTrade.value!!
 
         this.presenterScope.launch {
-            val settings = settingsRepository.fetch()!!
-            _showChatRulesWarnBox.value = settings.showChatRulesWarnBox
+            val settings = withContext(IODispatcher) { settingsRepository.fetch() }
+            settings?.let { _showChatRulesWarnBox.value = it.showChatRulesWarnBox }
             val bisqEasyOpenTradeChannelModel = selectedTrade.bisqEasyOpenTradeChannelModel
+
             bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
                 _chatMessages.value = messages.toList()
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
@@ -95,11 +97,17 @@ class TradeChatPresenter(
     }
 
     fun onDontShowAgainChatRulesWarningBox() {
-        jobs.add(ioScope.launch {
-            _showChatRulesWarnBox.value = false
-            val settings = settingsRepository.fetch()!!
-            settings.showChatRulesWarnBox = false
-            settingsRepository.update(settings)
+        _showChatRulesWarnBox.value = false
+
+        jobs.add(presenterScope.launch {
+            val settings = withContext(IODispatcher) {
+                settingsRepository.fetch()
+            }
+
+            settings?.let {
+                it.showChatRulesWarnBox = false
+                settingsRepository.update(it)
+            }
         })
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -57,7 +57,7 @@ class TradeChatPresenter(
     }
 
     fun sendChatMessage(text: String) {
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             val citation = quotedMessage.value?.let { quotedMessage ->
                 quotedMessage.text?.let { text ->
                     CitationVO(
@@ -73,13 +73,13 @@ class TradeChatPresenter(
     }
 
     fun onAddReaction(message: BisqEasyOpenTradeMessageModel, reaction: ReactionEnum) {
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             tradeChatMessagesServiceFacade.addChatMessageReaction(message.id, reaction)
         })
     }
 
     fun onRemoveReaction(message: BisqEasyOpenTradeMessageModel, reaction: BisqEasyOpenTradeMessageReactionVO) {
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             tradeChatMessagesServiceFacade.removeChatMessageReaction(message.id, reaction)
         })
     }
@@ -95,7 +95,7 @@ class TradeChatPresenter(
     }
 
     fun onDontShowAgainChatRulesWarningBox() {
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             _showChatRulesWarnBox.value = false
             val settings = settingsRepository.fetch()!!
             settings.showChatRulesWarnBox = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -59,17 +59,19 @@ class TradeChatPresenter(
     }
 
     fun sendChatMessage(text: String) {
-        jobs.add(ioScope.launch {
-            val citation = quotedMessage.value?.let { quotedMessage ->
-                quotedMessage.text?.let { text ->
-                    CitationVO(
-                        quotedMessage.senderUserProfileId,
-                        text,
-                        quotedMessage.id
-                    )
-                }
+        val citation = quotedMessage.value?.let { quotedMessage ->
+            quotedMessage.text?.let { text ->
+                CitationVO(
+                    quotedMessage.senderUserProfileId,
+                    text,
+                    quotedMessage.id
+                )
             }
-            tradeChatMessagesServiceFacade.sendChatMessage(text, citation)
+        }
+        jobs.add(presenterScope.launch {
+            withContext(IODispatcher) {
+                tradeChatMessagesServiceFacade.sendChatMessage(text, citation)
+            }
             _quotedMessage.value = null
         })
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
@@ -153,6 +153,7 @@ open class GeneralSettingsPresenter(
     override fun onViewUnattaching() {
         jobs.forEach { it.cancel() }
         jobs.clear()
+        super.onViewUnattaching()
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
@@ -26,7 +26,7 @@ open class GeneralSettingsPresenter(
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("en")
     override val languageCode: MutableStateFlow<String> = _languageCode
     override fun setLanguageCode(langCode: String) {
-        backgroundScope.launch {
+        ioScope.launch {
             settingsServiceFacade.setLanguageCode(langCode)
             // TODO: Is this right?
             // Doing this to reload all bundles of the newly selected language,
@@ -43,7 +43,7 @@ open class GeneralSettingsPresenter(
     private val _supportedLanguageCodes: MutableStateFlow<Set<String>> = MutableStateFlow(setOf("en"))
     override val supportedLanguageCodes: MutableStateFlow<Set<String>> = _supportedLanguageCodes
     override fun setSupportedLanguageCodes(langCodes: Set<String>) {
-        backgroundScope.launch {
+        ioScope.launch {
             _supportedLanguageCodes.value = langCodes
             settingsServiceFacade.setSupportedLanguageCodes(langCodes)
         }
@@ -54,7 +54,7 @@ open class GeneralSettingsPresenter(
     override val chatNotification: StateFlow<String> = _chatNotification
 
     override fun setChatNotification(value: String) {
-        backgroundScope.launch {
+        ioScope.launch {
             _chatNotification.value = value
             // settingsServiceFacade.setChatNotificationType(value)
         }
@@ -63,7 +63,7 @@ open class GeneralSettingsPresenter(
     private val _closeOfferWhenTradeTaken: MutableStateFlow<Boolean> = MutableStateFlow(true)
     override val closeOfferWhenTradeTaken: StateFlow<Boolean> = _closeOfferWhenTradeTaken
     override fun setCloseOfferWhenTradeTaken(value: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _closeOfferWhenTradeTaken.value = value
             settingsServiceFacade.setCloseMyOfferWhenTaken(value)
         }
@@ -74,7 +74,7 @@ open class GeneralSettingsPresenter(
     private val _tradePriceTolerance: MutableStateFlow<String> = MutableStateFlow("5")
     override val tradePriceTolerance: StateFlow<String> = _tradePriceTolerance
     override fun setTradePriceTolerance(value: String, isValid: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _tradePriceTolerance.value = value
             if (isValid) {
                 val _value = value.toDoubleOrNull()
@@ -86,7 +86,7 @@ open class GeneralSettingsPresenter(
     private val _numDaysAfterRedactingTradeData = MutableStateFlow("90")
     override val numDaysAfterRedactingTradeData: StateFlow<String> = _numDaysAfterRedactingTradeData
     override fun setNumDaysAfterRedactingTradeData(value: String, isValid: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _numDaysAfterRedactingTradeData.value = value
             if (isValid) {
                 val _value = value.toIntOrNull()
@@ -100,7 +100,7 @@ open class GeneralSettingsPresenter(
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
     override val useAnimations: StateFlow<Boolean> = _useAnimations
     override fun setUseAnimations(value: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _useAnimations.value = value
             settingsServiceFacade.setUseAnimations(value)
         }
@@ -109,7 +109,7 @@ open class GeneralSettingsPresenter(
     private val _powFactor: MutableStateFlow<String> = MutableStateFlow("1")
     override val powFactor: StateFlow<String> = _powFactor
     override fun setPowFactor(value: String, isValid: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _powFactor.value = value
             if (isValid) {
                 val _value = value.toDoubleOrNull()
@@ -121,7 +121,7 @@ open class GeneralSettingsPresenter(
     private val _ignorePow: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val ignorePow: StateFlow<Boolean> = _ignorePow
     override fun setIgnorePow(value: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _ignorePow.value = value
             settingsServiceFacade.setIgnoreDiffAdjustmentFromSecManager(value)
         }
@@ -132,7 +132,7 @@ open class GeneralSettingsPresenter(
     private var jobs: MutableSet<Job> = mutableSetOf()
 
     override fun onViewAttached() {
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             val settings: SettingsVO = settingsServiceFacade.getSettings().getOrThrow()
             _languageCode.value = settings.languageCode
             _supportedLanguageCodes.value = if (settings.supportedLanguageCodes.isNotEmpty())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
@@ -21,7 +21,7 @@ open class PaymentAccountPresenter(
 
 
     override fun selectAccount(account: UserDefinedFiatAccountVO) {
-        backgroundScope.launch {
+        ioScope.launch {
             accountsServiceFacade.setSelectedAccount(account)
         }
     }
@@ -33,7 +33,7 @@ open class PaymentAccountPresenter(
             return
         }
 
-        backgroundScope.launch {
+        ioScope.launch {
             val newAccount = UserDefinedFiatAccountVO(
                 accountName = newName,
                 UserDefinedFiatAccountPayloadVO(
@@ -54,7 +54,7 @@ open class PaymentAccountPresenter(
         }
 
         if (selectedAccount.value != null) {
-            backgroundScope.launch {
+            ioScope.launch {
                 val newAccount = UserDefinedFiatAccountVO(
                     accountName = newName,
                     UserDefinedFiatAccountPayloadVO(
@@ -69,7 +69,7 @@ open class PaymentAccountPresenter(
 
     override fun deleteCurrentAccount() {
         if (selectedAccount.value != null) {
-            backgroundScope.launch {
+            ioScope.launch {
                 runCatching {
                     accountsServiceFacade.removeAccount(selectedAccount.value!!)
                     showSnackbar("Account deleted") // TODO:i18n
@@ -83,7 +83,7 @@ open class PaymentAccountPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-        backgroundScope.launch {
+        ioScope.launch {
             accountsServiceFacade.getAccounts()
             accountsServiceFacade.getSelectedAccount()
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.presentation.ui.uicases.settings
 
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountPayloadVO
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.data.repository.SettingsRepository
@@ -21,8 +23,10 @@ open class PaymentAccountPresenter(
 
 
     override fun selectAccount(account: UserDefinedFiatAccountVO) {
-        ioScope.launch {
-            accountsServiceFacade.setSelectedAccount(account)
+        presenterScope.launch {
+            withContext(IODispatcher) {
+                accountsServiceFacade.setSelectedAccount(account)
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -60,7 +60,7 @@ class UserProfileSettingsPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-        backgroundScope.launch {
+        ioScope.launch {
             userProfileServiceFacade.getSelectedUserProfile()?.let {
                 // _reputation.value = it.reputation // TODO reputation?
                 setProfileAge(it)
@@ -122,7 +122,7 @@ class UserProfileSettingsPresenter(
     }
 
     override fun onSave() {
-        backgroundScope.launch {
+        ioScope.launch {
             enableInteractive(false)
             setShowLoading(true)
             try {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -151,7 +151,7 @@ class UserProfileSettingsPresenter(
     }
 
     private fun setShowLoading(show: Boolean = true) {
-        uiScope.launch {
+        presenterScope.launch {
             _showLoading.value = show
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -137,10 +137,10 @@ class UserProfileSettingsPresenter(
         presenterScope.launch {
             try {
                 withContext(IODispatcher) {
-                    userRepository.fetch()!!.let {
-                        it.statement = statement.value
-                        it.tradeTerms = tradeTerms.value
-                        userRepository.update(it)
+                    userRepository.fetch()?.let { user ->
+                        user.statement = statement.value
+                        user.tradeTerms = tradeTerms.value
+                        userRepository.update(user)
 
                         // avoid flicker
                         delay(500L)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -132,7 +132,7 @@ class UserProfileSettingsPresenter(
     }
 
     override fun onSave() {
-        enableInteractive(false)
+        disableInteractive()
         setShowLoading(true)
         presenterScope.launch {
             try {
@@ -150,7 +150,7 @@ class UserProfileSettingsPresenter(
                 log.e(e) { "Failed to save user profile settings" }
             } finally {
                 setShowLoading(false)
-                enableInteractive(true)
+                enableInteractive()
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -3,10 +3,10 @@ package network.bisq.mobile.presentation.ui.uicases.startup
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.model.User
@@ -127,7 +127,7 @@ open class CreateProfilePresenter(
 
         runCatching {
             job = presenterScope.launch {
-                val deferred = CoroutineScope(Dispatchers.Default).async {
+                withContext(Dispatchers.Default) {
                     // takes 200 -1000 ms
                     userProfileService.generateKeyPair { id, nym, profileIcon ->
                         setId(id)
@@ -135,7 +135,6 @@ open class CreateProfilePresenter(
                         setProfileIcon(profileIcon)
                     }
                 }
-                deferred.await()
                 ioScope.launch {
                     userRepository.update(User().apply {
                         uniqueAvatar = profileIcon.value

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -93,7 +93,7 @@ open class CreateProfilePresenter(
             // We would never call generateKeyPair while generateKeyPair is not
             // completed, thus we can assign to same job reference
             job = coroutineScope.launch {
-                enableInteractive(false)
+                disableInteractive()
                 log.i { "Show busy animation for createAndPublishInProgress" }
                 _createAndPublishInProgress.value = true
                 runCatching {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -126,7 +126,7 @@ open class CreateProfilePresenter(
         log.i { "Show busy animation for generateKeyPair" }
 
         runCatching {
-            job = presenterScope.launch {
+            job = this.presenterScope.launch {
                 withContext(Dispatchers.Default) {
                     // takes 200 -1000 ms
                     userProfileService.generateKeyPair { id, nym, profileIcon ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -112,6 +112,7 @@ open class CreateProfilePresenter(
                     enableInteractive()
                 }.onFailure { e ->
                     GenericErrorHandler.handleGenericError("Creating and publishing new user profile failed.", e)
+                    _createAndPublishInProgress.value = false
                     enableInteractive()
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -64,6 +64,7 @@ open class CreateProfilePresenter(
 
     override fun onViewUnattaching() {
         cancelJob()
+        super.onViewUnattaching()
     }
 
     init {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,7 +55,6 @@ open class CreateProfilePresenter(
     val createAndPublishInProgress: StateFlow<Boolean> get() = _createAndPublishInProgress
 
     // Misc
-    private val coroutineScope = CoroutineScope(Dispatchers.Main) // rootNavigator.navigate requires Dispatchers.Main
     private var job: Job? = null
 
     // Lifecycle
@@ -92,7 +90,7 @@ open class CreateProfilePresenter(
         if (nickName.value.isNotEmpty()) {
             // We would never call generateKeyPair while generateKeyPair is not
             // completed, thus we can assign to same job reference
-            job = coroutineScope.launch {
+            job = presenterScope.launch {
                 disableInteractive()
                 log.i { "Show busy animation for createAndPublishInProgress" }
                 _createAndPublishInProgress.value = true

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -69,7 +69,7 @@ open class CreateProfilePresenter(
 
     init {
         // if this presenter gets to work, it means there is no profile saved
-        backgroundScope.launch {
+        ioScope.launch {
             userRepository.create(User())
         }
     }
@@ -136,7 +136,7 @@ open class CreateProfilePresenter(
                     }
                 }
                 deferred.await()
-                backgroundScope.launch {
+                ioScope.launch {
                     userRepository.update(User().apply {
                         uniqueAvatar = profileIcon.value
                         lastActivity = Clock.System.now().toEpochMilliseconds()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -72,8 +72,6 @@ open class SplashPresenter(
         // todo this should happen after connection to backend is configured if client mode
         // and it must not be cancelled at onViewUnattaching in case the presenter is just quickly activated
         // best its not called from a presenter but a service which checks if the url to backend is set...
-        ioScope.launch { settingsServiceFacade.getSettings() }
-        log.d { "SplashPresenter running finished.." }
     }
 
     override fun onViewUnattaching() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -102,7 +102,7 @@ open class SplashPresenter(
 
                     // Scenario 1: All good and setup for both androidNode and xClients
                     if (user != null && hasProfile) {
-                        // TOOD:
+                        // TODO:
                         // 1) Is this the right condition?
                         // 2a) androidNode being able to connect with other peers and
                         // 2b) xClients being able to connect with remote instance happening successfuly as part of services init?

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -61,6 +61,7 @@ open class SplashPresenter(
                     userRepository.update(it)
                 }
             }
+            super.onViewUnattaching()
 
             progress.collect { value ->
                 when {
@@ -77,6 +78,7 @@ open class SplashPresenter(
     override fun onViewUnattaching() {
         jobs.forEach { it.cancel() }
         jobs.clear()
+        super.onViewUnattaching()
     }
 
     private fun navigateToNextScreen() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -37,7 +37,7 @@ open class SplashPresenter(
 
     override fun onViewAttached() {
         log.d { "SplashPresenter running" }
-        jobs.add(backgroundScope.launch {
+        jobs.add(ioScope.launch {
             val settingsMobile: Settings = settingsRepository.fetch() ?: Settings()
             if (settingsMobile.firstLaunch) {
                 val deviceLanguageCode = getDeviceLanguageCode()
@@ -63,7 +63,7 @@ open class SplashPresenter(
         // todo this should happen after connection to backend is configured if client mode
         // and it must not be cancelled at onViewUnattaching in case the presenter is just quickly activated
         // best its not called from a presenter but a service which checks if the url to backend is set...
-        backgroundScope.launch { settingsServiceFacade.getSettings() }
+        ioScope.launch { settingsServiceFacade.getSettings() }
         log.d { "SplashPresenter running finished.." }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -73,7 +73,7 @@ open class SplashPresenter(
     }
 
     private fun navigateToNextScreen() {
-        uiScope.launch {
+        presenterScope.launch {
             if (!hasConnectivity()) {
                 navigateToTrustedNodeSetup()
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -43,7 +43,7 @@ class TrustedNodeSetupPresenter(
 
     private fun initialize() {
         log.i { "View attached to Trusted node presenter" }
-        backgroundScope.launch {
+        ioScope.launch {
             try {
                 settingsRepository.fetch()
                 settingsRepository.data.value.let {
@@ -79,7 +79,7 @@ class TrustedNodeSetupPresenter(
     }
 
     override fun testConnection(isWorkflow: Boolean) {
-        backgroundScope.launch {
+        ioScope.launch {
             _isLoading.value = true
             log.w { "Test: " + _bisqApiUrl.value }
             WebSocketClientProvider.parseUri(_bisqApiUrl.value).let { connectionSettings ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -3,7 +3,9 @@ package network.bisq.mobile.presentation.ui.uicases.startup
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.Settings
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
@@ -43,15 +45,15 @@ class TrustedNodeSetupPresenter(
 
     private fun initialize() {
         log.i { "View attached to Trusted node presenter" }
-        ioScope.launch {
+
+        presenterScope.launch {
             try {
-                settingsRepository.fetch()
-                settingsRepository.data.value.let {
-                    it?.let {
-                        log.d { "Settings url:${it.bisqApiUrl}" }
-                        updateBisqApiUrl(it.bisqApiUrl, true)
-                        validateVersion()
-                    }
+                val data = withContext(IODispatcher) {
+                    settingsRepository.fetch()
+                }
+                data?.let {
+                    updateBisqApiUrl(it.bisqApiUrl, true)
+                    validateVersion()
                 }
             } catch (e: Exception) {
                 log.e("Failed to load from repository", e)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferFlowResult.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferFlowResult.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.ui.uicases.take_offer
+
+import kotlinx.coroutines.flow.Flow
+import network.bisq.mobile.domain.service.trades.TakeOfferStatus
+
+data class TakeOfferFlowResult(
+    val statusFlow: Flow<TakeOfferStatus?>,
+    val errorMessageFlow: Flow<String?>
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPresenter.kt
@@ -113,12 +113,10 @@ class TakeOfferPresenter(
         takeOfferModel.baseSidePaymentMethod = baseSidePaymentMethod
     }
 
-    suspend fun takeOffer(
-        takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
-        takeOfferErrorMessage: MutableStateFlow<String?>
-    ) {
-        // todo add CompletableDeferred or callback to know when we have succeeded or failed
-        // and get errors back
+    suspend fun takeOffer(): TakeOfferFlowResult {
+        val takeOfferStatus = MutableStateFlow<TakeOfferStatus?>(null)
+        val takeOfferErrorMessage = MutableStateFlow<String?>(null)
+
         withContext(IODispatcher) {
             val result = tradesServiceFacade.takeOffer(
                 takeOfferModel.offerItemPresentationVO.bisqEasyOffer,
@@ -136,6 +134,7 @@ class TakeOfferPresenter(
                 log.w { "Take offer failed ${result.exceptionOrNull()}" }
             }
         }
+        return TakeOfferFlowResult(takeOfferStatus, takeOfferErrorMessage)
     }
 
     fun getMostRecentPriceQuote(): PriceQuoteVO {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPresenter.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.take_offer
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.MarketPriceItem
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory
@@ -117,20 +119,22 @@ class TakeOfferPresenter(
     ) {
         // todo add CompletableDeferred or callback to know when we have succeeded or failed
         // and get errors back
-        val result = tradesServiceFacade.takeOffer(
-            takeOfferModel.offerItemPresentationVO.bisqEasyOffer,
-            takeOfferModel.baseAmount,
-            takeOfferModel.quoteAmount,
-            takeOfferModel.baseSidePaymentMethod,
-            takeOfferModel.quoteSidePaymentMethod,
-            takeOfferStatus,
-            takeOfferErrorMessage
-        )
-        if (result.isSuccess) {
-            tradesServiceFacade.selectOpenTrade(result.getOrThrow())
-        } else {
-            // todo
-            log.w { "Take offer failed ${result.exceptionOrNull()}" }
+        withContext(IODispatcher) {
+            val result = tradesServiceFacade.takeOffer(
+                takeOfferModel.offerItemPresentationVO.bisqEasyOffer,
+                takeOfferModel.baseAmount,
+                takeOfferModel.quoteAmount,
+                takeOfferModel.baseSidePaymentMethod,
+                takeOfferModel.quoteSidePaymentMethod,
+                takeOfferStatus,
+                takeOfferErrorMessage
+            )
+            if (result.isSuccess) {
+                tradesServiceFacade.selectOpenTrade(result.getOrThrow())
+            } else {
+                // todo
+                log.w { "Take offer failed ${result.exceptionOrNull()}" }
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -138,7 +138,7 @@ class TakeOfferReviewPresenter(
                 setShowTakeOfferSuccessDialog(true)
             } catch (e: Exception) {
                 log.e("Take offer failed", e)
-                takeOfferErrorMessage.value = e.message ?: ("Take offer failed with exception: " + e.toString().truncate(20))
+                takeOfferErrorMessage.value = e.message ?: ("Take offer failed with exception: " + e.toString().truncate(50))
             } finally {
                 setShowTakeOfferProgressDialog(false)
                 enableInteractive()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -60,13 +60,13 @@ class TakeOfferReviewPresenter(
     }
 
     override fun onViewAttached() {
-        presenterScope.launch {
+        this.presenterScope.launch {
             takeOfferStatus.collect { value ->
                 log.i { "takeOfferStatus: $value" }
                 //todo show state
             }
         }
-        presenterScope.launch {
+        this.presenterScope.launch {
             takeOfferErrorMessage
                 .drop(1) // To ignore the first init message
                 .collect { message ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -111,6 +111,7 @@ class TakeOfferReviewPresenter(
     override fun onViewUnattaching() {
         jobs.forEach { it.cancel() }
         jobs.clear()
+        super.onViewUnattaching()
     }
 
     fun onBack() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -119,7 +119,7 @@ class TakeOfferReviewPresenter(
 
     fun onTakeOffer() {
         setShowTakeOfferProgressDialog(true)
-        enableInteractive(false)
+        disableInteractive()
 
         jobs.forEach { it.cancel() }
         jobs.clear()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -109,7 +109,7 @@ class TakeOfferReviewPresenter(
     }
 
     fun onTakeOffer() {
-        backgroundScope.launch {
+        ioScope.launch {
             setShowTakeOfferProgressDialog(true)
             try {
                 enableInteractive(false)


### PR DESCRIPTION
This PR fixes incorrect usage of coroutine scopes.
We have been applying the result from non UI dispatcher scope (IO usually) to the UI layer which can cause issues.
Best is to follow  the below pattern which use `withContext` to switch the context and blocks until that call is completed. Then we are back on the `presenterScope`. I applied it to most of the code but left the settings and account presentations out as I got a bit tired of it, and as I guess its a good exercise for the authors of that code to apply that pattern.

@rodvar @nostrbuddha Could you apply that in a follow up PR?

```
presenterScope.launch { 
    withContext(IODispatcher){
         // service call...
    }
}
```

If there is no result applied to the presenter we can launch directly on the ioScope. 

```
ioScope.launch {
             // service call...
        }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new data structure to encapsulate status and error flows for the take offer process.
  - Enhanced offer-taking flow with improved status and error management.
- **Refactor**
  - Updated coroutine management across the app to use an I/O-optimized dispatcher, improving background task efficiency.
  - Streamlined UI interaction handling by centralizing coroutine scopes and simplifying interactivity controls.
  - Improved coroutine context usage in trading, chat, user profile, and settings flows for better responsiveness and clarity.
  - Corrected WebSocket client status handling and refined state flow naming for connectivity monitoring.
  - Enhanced error handling and coroutine lifecycle management in key presenters.
- **Chores**
  - Removed deprecated background dispatcher in favor of a unified I/O dispatcher.
  - Simplified coroutine scope declarations and updated dispatcher imports throughout the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->