### PR TITLE
 - Take offer layout fix (#260)

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Checkbox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Checkbox.kt
@@ -40,7 +40,7 @@ fun BisqCheckbox(
             enabled = !disabled,
             colors = CheckboxColors(
                 uncheckedBoxColor = BisqTheme.colors.secondary,
-                uncheckedBorderColor = BisqTheme.colors.backgroundColor,
+                uncheckedBorderColor = BisqTheme.colors.mid_grey20,
                 uncheckedCheckmarkColor = BisqTheme.colors.secondary,
 
                 checkedBoxColor = BisqTheme.colors.secondary,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
@@ -135,10 +135,7 @@ fun MultiScreenWizardScaffold(
         // as BissScrollScaffold's params, rather than creating a column here?
 
         Column(
-            modifier = Modifier.fillMaxHeight().padding(
-                horizontal = BisqUIConstants.ScreenPadding,
-                vertical = BisqUIConstants.ScreenPadding
-            ),
+            modifier = Modifier.fillMaxHeight(),
             horizontalAlignment = horizontalAlignment,
             verticalArrangement = Arrangement.Top,
         ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBox
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxSats
+import network.bisq.mobile.presentation.ui.components.molecules.info.InfoRow
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoRowContainer
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -43,10 +44,24 @@ fun CreateOfferReviewOfferScreen() {
                 label = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
                 value = presenter.headLine,
             )
-            InfoBox(
-                label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                value = presenter.quoteSidePaymentMethodDisplayString,
-            )
+
+            if (presenter.quoteSidePaymentMethodDisplayString.length + presenter.baseSidePaymentMethodDisplayString.length < 30) {
+                InfoRow(
+                    label1 = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                    value1 = presenter.quoteSidePaymentMethodDisplayString,
+                    label2 = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                    value2 = presenter.baseSidePaymentMethodDisplayString,
+                )
+            } else {
+                InfoBox(
+                    label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                    value = presenter.quoteSidePaymentMethodDisplayString,
+                )
+                InfoBox(
+                    label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                    value = presenter.baseSidePaymentMethodDisplayString
+                )
+            }
             if (presenter.isRangeOffer) {
                 if (presenter.direction == DirectionEnum.BUY) {
                     InfoBox(
@@ -57,7 +72,11 @@ fun CreateOfferReviewOfferScreen() {
                         label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                         valueComposable = {
                             Row {
-                                BtcSatsText(presenter.formattedBaseRangeMinAmount, noCode = true, fontSize = FontSize.H6)
+                                BtcSatsText(
+                                    presenter.formattedBaseRangeMinAmount,
+                                    noCode = true,
+                                    fontSize = FontSize.H6
+                                )
                                 BisqText.baseRegular(" - ")
                                 BtcSatsText(presenter.formattedBaseRangeMaxAmount, fontSize = FontSize.H6)
                             }
@@ -72,7 +91,11 @@ fun CreateOfferReviewOfferScreen() {
                         label = "bisqEasy.tradeWizard.review.toSend".i18n().uppercase(),
                         valueComposable = {
                             Row {
-                                BtcSatsText(presenter.formattedBaseRangeMinAmount, noCode = true, fontSize = FontSize.H6)
+                                BtcSatsText(
+                                    presenter.formattedBaseRangeMinAmount,
+                                    noCode = true,
+                                    fontSize = FontSize.H6
+                                )
                                 BisqText.baseRegular(" - ")
                                 BtcSatsText(presenter.formattedBaseRangeMaxAmount, fontSize = FontSize.H6)
                             }
@@ -119,15 +142,6 @@ fun CreateOfferReviewOfferScreen() {
                     }
                 },
                 subvalue = presenter.priceDetails
-            )
-
-            InfoBox(
-                label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
-                value = presenter.quoteSidePaymentMethodDisplayString
-            )
-            InfoBox(
-                label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                value = presenter.baseSidePaymentMethodDisplayString
             )
 
             InfoBox(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -44,24 +44,14 @@ fun CreateOfferReviewOfferScreen() {
                 label = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
                 value = presenter.headLine,
             )
-
-            if (presenter.quoteSidePaymentMethodDisplayString.length + presenter.baseSidePaymentMethodDisplayString.length < 30) {
-                InfoRow(
-                    label1 = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                    value1 = presenter.quoteSidePaymentMethodDisplayString,
-                    label2 = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
-                    value2 = presenter.baseSidePaymentMethodDisplayString,
-                )
-            } else {
-                InfoBox(
-                    label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                    value = presenter.quoteSidePaymentMethodDisplayString,
-                )
-                InfoBox(
-                    label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
-                    value = presenter.baseSidePaymentMethodDisplayString
-                )
-            }
+            InfoBox(
+                label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                value = presenter.quoteSidePaymentMethodDisplayString,
+            )
+            InfoBox(
+                label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                value = presenter.baseSidePaymentMethodDisplayString
+            )
             if (presenter.isRangeOffer) {
                 if (presenter.direction == DirectionEnum.BUY) {
                     InfoBox(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
@@ -3,9 +3,11 @@ package network.bisq.mobile.presentation.ui.uicases.take_offer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.i18n.i18n
@@ -43,12 +45,13 @@ fun TakeOfferReviewTradeScreen() {
     ) {
         BisqText.h3Regular("bisqEasy.takeOffer.progress.review".i18n())
         BisqGap.V2()
-        Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)) {
-            InfoRow(
-                label1 = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
-                value1 = presenter.headLine,
-                label2 = "bisqEasy.tradeState.phase2".i18n().uppercase(),
-                value2 = presenter.quoteSidePaymentMethodDisplayString,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)
+        ) {
+            InfoBox(
+                label = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
+                value = presenter.headLine,
             )
             if (presenter.takersDirection.isBuy) {
                 if (presenter.isSmallScreen()) {
@@ -119,12 +122,23 @@ fun TakeOfferReviewTradeScreen() {
                 }
             )
 
-            InfoRow(
-                label1 = "bisqEasy.tradeState.phase2".i18n(),
-                value1 = presenter.quoteSidePaymentMethodDisplayString,
-                label2 = "Bitcoin settlement", //TODO:i18n
-                value2 = presenter.baseSidePaymentMethodDisplayString,
-            )
+            if (presenter.quoteSidePaymentMethodDisplayString.length + presenter.baseSidePaymentMethodDisplayString.length < 30) {
+                InfoRow(
+                    label1 = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                    value1 = presenter.quoteSidePaymentMethodDisplayString,
+                    label2 = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                    value2 = presenter.baseSidePaymentMethodDisplayString,
+                )
+            } else {
+                InfoBox(
+                    label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                    value = presenter.quoteSidePaymentMethodDisplayString,
+                )
+                InfoBox(
+                    label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                    value = presenter.baseSidePaymentMethodDisplayString,
+                )
+            }
 
             InfoBox(
                 label = "bisqEasy.tradeWizard.review.feeDescription".i18n(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
@@ -122,23 +122,14 @@ fun TakeOfferReviewTradeScreen() {
                 }
             )
 
-            if (presenter.quoteSidePaymentMethodDisplayString.length + presenter.baseSidePaymentMethodDisplayString.length < 30) {
-                InfoRow(
-                    label1 = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                    value1 = presenter.quoteSidePaymentMethodDisplayString,
-                    label2 = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
-                    value2 = presenter.baseSidePaymentMethodDisplayString,
-                )
-            } else {
-                InfoBox(
-                    label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
-                    value = presenter.quoteSidePaymentMethodDisplayString,
-                )
-                InfoBox(
-                    label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
-                    value = presenter.baseSidePaymentMethodDisplayString,
-                )
-            }
+            InfoBox(
+                label = "bisqEasy.takeOffer.review.method.fiat".i18n(),
+                value = presenter.quoteSidePaymentMethodDisplayString,
+            )
+            InfoBox(
+                label = "bisqEasy.takeOffer.review.method.bitcoin".i18n(),
+                value = presenter.baseSidePaymentMethodDisplayString,
+            )
 
             InfoBox(
                 label = "bisqEasy.tradeWizard.review.feeDescription".i18n(),


### PR DESCRIPTION
 - Fix for https://github.com/bisq-network/bisq-mobile/issues/260
 - Radio button border in unselected state;
 - MultiScreenWizard - Reduce padding to match other screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the unchecked checkbox border color for improved visual consistency.
  - Removed extra padding from the multi-screen wizard layout for a cleaner appearance.

- **New Features**
  - Enhanced payment method display on offer review screens with side-by-side and separate presentations for better readability.

- **Refactor**
  - Simplified and improved layout structure of payment method information on offer review screens for a clearer and more user-friendly interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->