### PR TITLE
do not include dependencies metadata on release builds (android apps)

### DIFF
--- a/androidClient/build.gradle.kts
+++ b/androidClient/build.gradle.kts
@@ -92,6 +92,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            dependenciesInfo {
+                includeInApk = false
+                includeInBundle = false
+            }
             isDebuggable = false
         }
         getByName("debug") {

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -139,6 +139,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            dependenciesInfo {
+                includeInApk = false
+                includeInBundle = false
+            }
             isDebuggable = false
         }
         getByName("debug") {


### PR DESCRIPTION
 - do not include dependencies info on release builds for android apps(security enhancement)
 - contribs to #135 preparation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release build configuration to exclude dependency metadata from APKs and app bundles, reducing package size for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->