### PR TITLE
Fix/dialog blur dismiss

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -164,20 +164,20 @@ val presentationModule = module {
     factory { SellerState1Presenter(get(), get(), get()) }
     factory { SellerState2aPresenter(get(), get()) }
     factory { SellerState2bPresenter(get(), get()) }
-    factory { SellerState3aPresenter(get(), get()) }
+    single { SellerState3aPresenter(get(), get()) }
     factory { SellerStateMainChain3bPresenter(get(), get(), get()) }
     factory { SellerStateLightning3bPresenter(get(), get()) }
-    factory { SellerState4Presenter(get(), get()) }
+    single { SellerState4Presenter(get(), get()) }
 
     // Trade Buyer
-    factory { BuyerState1aPresenter(get(), get()) }
+    single { BuyerState1aPresenter(get(), get()) }
     // BuyerState1bPresenter does not exist as it a static UI
     factory { BuyerState2aPresenter(get(), get()) }
     factory { BuyerState2bPresenter(get(), get()) }
     factory { BuyerState3aPresenter(get(), get()) }
     factory { BuyerStateMainChain3bPresenter(get(), get(), get()) }
     factory { BuyerStateLightning3bPresenter(get(), get()) }
-    factory { BuyerState4Presenter(get(), get()) }
+    single { BuyerState4Presenter(get(), get()) }
 
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -182,7 +182,7 @@ val presentationModule = module {
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { OpenTradeListPresenter(get(), get(), get()) }
-    factory { TradeDetailsHeaderPresenter(get(), get(), get()) }
+    single { TradeDetailsHeaderPresenter(get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
@@ -31,6 +31,7 @@ fun MultiScreenWizardScaffold(
     snackbarHostState: SnackbarHostState? = null,
     isInteractive: Boolean = true,
     showJumpToBottom: Boolean = false,
+    shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
 
@@ -42,9 +43,10 @@ fun MultiScreenWizardScaffold(
         vArrangement: Arrangement.Vertical,
         snackbarHostState: SnackbarHostState?,
         jumpToBottom: Boolean,
+        shouldBlurBg: Boolean,
         content: @Composable ColumnScope.() -> Unit
     ) -> Unit =
-        if (useStaticScaffold) { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState,_showJumpToBottom, innerContent ->
+        if (useStaticScaffold) { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState,_showJumpToBottom, _shouldBlurBg, innerContent ->
             BisqStaticScaffold(
                 padding = padding,
                 topBar = topBar,
@@ -53,9 +55,10 @@ fun MultiScreenWizardScaffold(
                 verticalArrangement = verticalArrangement,
                 snackbarHostState = snackState,
                 isInteractive = isInteractive,
+                shouldBlurBg = _shouldBlurBg,
                 content = innerContent
             )
-        } else { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, innerContent ->
+        } else { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, _shouldBlurBg, innerContent ->
             BisqScrollScaffold(
                 padding = padding,
                 topBar = topBar,
@@ -65,6 +68,7 @@ fun MultiScreenWizardScaffold(
                 snackbarHostState = snackState,
                 isInteractive = isInteractive,
                 showJumpToBottom = _showJumpToBottom,
+                shouldBlurBg = _shouldBlurBg,
                 content = innerContent
             )
         }
@@ -129,6 +133,7 @@ fun MultiScreenWizardScaffold(
         Arrangement.Top,
         snackbarHostState,
         showJumpToBottom,
+        shouldBlurBg,
     ) {
 
         // TODO: Should pass these values to the column deep inside BisqScrollLayout

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
@@ -5,10 +5,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import network.bisq.mobile.presentation.ui.components.organisms.BisqSnackbar
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -31,10 +30,12 @@ fun BisqScrollScaffold(
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     isInteractive: Boolean = true,
     showJumpToBottom: Boolean = false,
+    shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
 
     Scaffold(
+        modifier = Modifier.blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero),
         containerColor = BisqTheme.colors.backgroundColor,
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import network.bisq.mobile.presentation.ui.components.organisms.BisqSnackbar
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -30,10 +31,12 @@ fun BisqStaticScaffold(
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     isInteractive: Boolean = true,
+    shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
 
     Scaffold(
+        modifier = Modifier.blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero),
         containerColor = BisqTheme.colors.backgroundColor,
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
@@ -33,36 +33,23 @@ fun BisqDialog(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(dismissOnClickOutside = dismissOnClickOutside)
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(
-                    onClick = { if (dismissOnClickOutside) onDismissRequest() },
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                )
-                .padding(top = marginTop)
+        Card(
+            modifier = Modifier.wrapContentHeight(),
+            colors = CardColors(
+                containerColor = BisqTheme.colors.dark_grey40,
+                contentColor = Color.Unspecified,
+                disabledContainerColor = Color.Unspecified,
+                disabledContentColor = Color.Unspecified,
+            ),
+            shape = RoundedCornerShape(16.dp),
         ) {
-            Card(
+            Column(
                 modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth(),
-                colors = CardColors(
-                    containerColor = BisqTheme.colors.dark_grey40,
-                    contentColor = Color.Unspecified,
-                    disabledContainerColor = Color.Unspecified,
-                    disabledContentColor = Color.Unspecified,
-                ),
-                shape = RoundedCornerShape(16.dp),
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = horizontalAlignment,
             ) {
-                Column(
-                    modifier = Modifier
-                        .padding(padding)
-                        .verticalScroll(rememberScrollState()),
-                    horizontalAlignment = horizontalAlignment,
-                ) {
-                    content()
-                }
+                content()
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/ConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/ConfirmationDialog.kt
@@ -18,7 +18,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun ConfirmationDialog(
-    headline: String = "",
+    headline: String = "confirmation.areYouSure".i18n(),
     headlineColor: Color = BisqTheme.colors.white,
     headlineLeftIcon: (@Composable () -> Unit)? = null,
     message: String = "",
@@ -33,6 +33,7 @@ fun ConfirmationDialog(
     BisqDialog(
         horizontalAlignment = horizontalAlignment,
         marginTop = marginTop,
+        onDismissRequest = onDismiss
     ) {
         if (headline.isNotEmpty()) {
             if (headlineLeftIcon == null) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/OpenMediationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/OpenMediationDialog.kt
@@ -12,7 +12,6 @@ fun OpenMediationDialog(
     onCancelConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-
     WarningConfirmationDialog(
         headline = "bisqEasy.mediation.request.confirm.headline".i18n(),
         message = "bisqEasy.mediation.request.confirm.msg".i18n(),
@@ -22,5 +21,4 @@ fun OpenMediationDialog(
         onDismiss = onDismiss,
         onConfirm = onCancelConfirm
     )
-
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/RootNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/graph/RootNavGraph.kt
@@ -15,7 +15,7 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.uicases.TabContainerScreen
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferAmountSelectorScreen
-import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferBuySellScreen
+import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferDirectionScreen
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferCurrencySelectorScreen
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPaymentMethodSelectorScreen
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferReviewOfferScreen
@@ -89,7 +89,7 @@ fun RootNavGraph(rootNavController: NavHostController) {
         }
 
         val createOfferScreens: List<Pair<Routes, @Composable () -> Unit>> = listOf(
-            Routes.CreateOfferDirection to { CreateOfferBuySellScreen() },
+            Routes.CreateOfferDirection to { CreateOfferDirectionScreen() },
             Routes.CreateOfferMarket to { CreateOfferCurrencySelectorScreen() },
             Routes.CreateOfferAmount to { CreateOfferAmountSelectorScreen() },
             Routes.CreateOfferPrice to { CreateOfferTradePriceSelectorScreen() },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountScreen.kt
@@ -42,7 +42,8 @@ fun CreateOfferAmountSelectorScreen() {
         stepIndex = 3,
         stepsLength = 6,
         prevOnClick = { presenter.onBack() },
-        nextOnClick = { presenter.onNext() }
+        nextOnClick = { presenter.onNext() },
+        shouldBlurBg = showLimitPopup,
     ) {
 
         BisqText.h3Regular(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionScreen.kt
@@ -21,7 +21,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
 @Composable
-fun CreateOfferBuySellScreen() {
+fun CreateOfferDirectionScreen() {
     val presenter: CreateOfferDirectionPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
@@ -33,7 +33,8 @@ fun CreateOfferBuySellScreen() {
         stepsLength = 6,
         horizontalAlignment = Alignment.Start,
         prevOnClick = { presenter.onBack() },
-        nextOnClick = { presenter.onNext() }
+        nextOnClick = { presenter.onNext() },
+        shouldBlurBg = showSellerReputationWarning
     ) {
         BisqText.h3Regular(presenter.headline)
 
@@ -66,12 +67,12 @@ fun CreateOfferBuySellScreen() {
         )
         BisqGap.VHalf()
         BisqText.largeLightGrey("Experienced Bisq users with reputation can act as seller") //TODO:i18n
+    }
 
-        if (showSellerReputationWarning) {
-                SellerReputationWarningDialog(
-                    onDismiss = { presenter.onDismissSellerReputationWarning() },
-                    onLearnReputation = { presenter.showLearnReputation() },
-                )
-            }
+    if (showSellerReputationWarning) {
+        SellerReputationWarningDialog(
+            onDismiss = { presenter.onDismissSellerReputationWarning() },
+            onLearnReputation = { presenter.showLearnReputation() },
+        )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPriceScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPriceScreen.kt
@@ -46,6 +46,7 @@ fun CreateOfferTradePriceSelectorScreen() {
         nextButtonText = "action.next".i18n(),
         nextOnClick = { presenter.onNext() },
         nextDisabled = !presenter.formattedPercentagePriceValid.collectAsState().value,
+        shouldBlurBg = showWhyPopup,
     ) {
         BisqText.h3Regular(
             text = "What is your trade price?", // TODO:i18n "bisqEasy.price.headline".i18n(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
@@ -44,7 +44,8 @@ fun OfferbookScreen() {
                 onClick = { presenter.createOffer() },
                 enabled = !presenter.isDemo()
             )
-        }
+        },
+        shouldBlurBg = showDeleteConfirmation || showNotEnoughReputationDialog
     ) {
         DirectionToggle(
             offerDirections,
@@ -53,26 +54,6 @@ fun OfferbookScreen() {
         )
 
         BisqGap.V1()
-
-        if (showDeleteConfirmation) {
-            ConfirmationDialog(
-                headline = "bisqEasy.offerbook.chatMessage.deleteOffer.confirmation".i18n(),
-                onConfirm = { presenter.onConfirmedDeleteOffer() },
-                onDismiss = { presenter.onDismissDeleteOffer() }
-            )
-        }
-
-        if (showNotEnoughReputationDialog) {
-            WebLinkConfirmationDialog(
-                link = "https://bisq.wiki/Reputation#How_to_build_reputation",
-                headline = presenter.notEnoughReputationHeadline,
-                message = presenter.notEnoughReputationMessage,
-                confirmButtonText = "confirmation.yes".i18n(),
-                dismissButtonText = "hyperlinks.openInBrowser.no".i18n(),
-                onConfirm = { presenter.onLearnHowToBuildReputation() },
-                onDismiss = { presenter.onDismissNotEnoughReputationDialog() }
-            )
-        }
 
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -86,5 +67,26 @@ fun OfferbookScreen() {
             }
         }
     }
+
+    if (showDeleteConfirmation) {
+        ConfirmationDialog(
+            headline = "bisqEasy.offerbook.chatMessage.deleteOffer.confirmation".i18n(),
+            onConfirm = { presenter.onConfirmedDeleteOffer() },
+            onDismiss = { presenter.onDismissDeleteOffer() }
+        )
+    }
+
+    if (showNotEnoughReputationDialog) {
+        WebLinkConfirmationDialog(
+            link = "https://bisq.wiki/Reputation#How_to_build_reputation",
+            headline = presenter.notEnoughReputationHeadline,
+            message = presenter.notEnoughReputationMessage,
+            confirmButtonText = "confirmation.yes".i18n(),
+            dismissButtonText = "hyperlinks.openInBrowser.no".i18n(),
+            onConfirm = { presenter.onLearnHowToBuildReputation() },
+            onDismiss = { presenter.onDismissNotEnoughReputationDialog() }
+        )
+    }
+
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -8,10 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
@@ -56,12 +53,16 @@ fun OpenTradeScreen() {
     val buyerState4ShowCloseTradeDialog by buyerState4Presenter.showCloseTradeDialog.collectAsState()
     val sellerState4ShowCloseTradeDialog by sellerState4Presenter.showCloseTradeDialog.collectAsState()
 
-    val shouldBlurBg = showInterruptionConfirmationDialog
-            || showMediationConfirmationDialog
-            || buyerState1aShowInvalidAddressDialog
-            || sellerState3aShowInvalidAddressDialog
-            || buyerState4ShowCloseTradeDialog
-            || sellerState4ShowCloseTradeDialog
+    val shouldBlurBg by remember {
+        derivedStateOf {
+            showInterruptionConfirmationDialog ||
+                    showMediationConfirmationDialog ||
+                    buyerState1aShowInvalidAddressDialog ||
+                    sellerState3aShowInvalidAddressDialog ||
+                    buyerState4ShowCloseTradeDialog ||
+                    sellerState4ShowCloseTradeDialog
+        }
+    }
 
     RememberPresenterLifecycle(presenter, {
         presenter.setTradePaneScrollState(scrollState)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -263,19 +263,4 @@ fun TradeDetailsHeader() {
         }
     }
 
-    if (showInterruptionConfirmationDialog) {
-        CancelTradeDialog(
-            onCancelConfirm = { presenter.onInterruptTrade() },
-            onDismiss = { presenter.onCloseInterruptionConfirmationDialog() },
-            isBuyer = presenter.directionEnum.isBuy,
-            isRejection = tradeCloseType == TradeDetailsHeaderPresenter.TradeCloseType.REJECT
-        )
-    }
-
-    if (showMediationConfirmationDialog) {
-        OpenMediationDialog(
-            onCancelConfirm = { presenter.onOpenMediation() },
-            onDismiss = { presenter.onCloseMediationConfirmationDialog() },
-        )
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
@@ -69,11 +69,4 @@ fun BuyerState1a(
         }
     }
 
-    if (showInvalidAddressDialog) {
-        InvalidAddressConfirmationDialog(
-            addressType = addressFieldType,
-            onConfirm = presenter::onSend,
-            onDismiss = { presenter.setShowInvalidAddressDialog(false) },
-        )
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
@@ -75,6 +75,5 @@ fun BuyerState1a(
             onConfirm = presenter::onSend,
             onDismiss = { presenter.setShowInvalidAddressDialog(false) },
         )
-
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3a.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3a.kt
@@ -115,11 +115,4 @@ fun SellerState3a(
         )
     }
 
-    if (showInvalidAddressDialog) {
-        InvalidPaymentProofConfirmationDialog(
-            paymentProofType = if (isLightning) PaymentProofType.LightningPreImage else PaymentProofType.BitcoinTx,
-            onDismiss = { presenter.setShowInvalidAddressDialog(false) },
-            onConfirm = presenter::confirmSend,
-        )
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4.kt
@@ -31,7 +31,6 @@ fun State4(
     val tradeItemModel = presenter.selectedTrade.value
     val quoteAmount = tradeItemModel?.quoteAmountWithCode ?: ""
     val baseAmount = tradeItemModel?.formattedBaseAmount ?: ""
-    val showCloseTradeDialog = presenter.showCloseTradeDialog.collectAsState().value
 
     Column {
         BisqGap.V1()
@@ -81,10 +80,4 @@ fun State4(
         }
     }
 
-    if (showCloseTradeDialog) {
-        CloseTradeDialog(
-            onDismiss = presenter::onDismissCloseTrade,
-            onConfirm = presenter::onConfirmCloseTrade,
-        )
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4.kt
@@ -78,12 +78,13 @@ fun State4(
                 )
             }
 
-            if (showCloseTradeDialog) {
-                CloseTradeDialog(
-                    onDismiss = presenter::onDismissCloseTrade,
-                    onConfirm = presenter::onConfirmCloseTrade,
-                )
-            }
         }
+    }
+
+    if (showCloseTradeDialog) {
+        CloseTradeDialog(
+            onDismiss = presenter::onDismissCloseTrade,
+            onConfirm = presenter::onConfirmCloseTrade,
+        )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
@@ -71,6 +71,7 @@ fun PaymentAccountSettingsScreen() {
         topBar = { TopBar("user.paymentAccounts".i18n()) },
         verticalArrangement = if (accounts.isEmpty()) Arrangement.Center else Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
         snackbarHostState = presenter.getSnackState(),
+        shouldBlurBg = showConfirmationDialog,
     ) {
         if (accounts.isNotEmpty()) {
             BreadcrumbNavigation(path = menuPath) { index ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -89,7 +89,8 @@ fun UserProfileSettingsScreen() {
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
         isInteractive = presenter.isInteractive.collectAsState().value,
-        ) {
+        shouldBlurBg = showDeleteConfirmation,
+    ) {
         BreadcrumbNavigation(path = menuPath) { index ->
             if (index == 0) settingsPresenter.settingsNavigateBack()
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
@@ -42,6 +42,7 @@ fun TakeOfferReviewTradeScreen() {
         nextOnClick = { presenter.onTakeOffer() },
         snackbarHostState = presenter.getSnackState(),
         isInteractive = presenter.isInteractive.collectAsState().value,
+        shouldBlurBg = showProgressDialog || showSuccessDialog,
     ) {
         BisqText.h3Regular("bisqEasy.takeOffer.progress.review".i18n())
         BisqGap.V2()
@@ -149,16 +150,16 @@ fun TakeOfferReviewTradeScreen() {
                 }
             )
         }
-
-        if (showProgressDialog) {
-            TakeOfferProgressDialog()
-        }
-
-        if (showSuccessDialog) {
-            TakeOfferSuccessDialog(
-                onShowTrades = { presenter.onGoToOpenTrades() }
-            )
-        }
-
     }
+
+    if (showProgressDialog) {
+        TakeOfferProgressDialog()
+    }
+
+    if (showSuccessDialog) {
+        TakeOfferSuccessDialog(
+            onShowTrades = { presenter.onGoToOpenTrades() }
+        )
+    }
+
 }


### PR DESCRIPTION
 - Fix for https://github.com/bisq-network/bisq-mobile/issues/301
 - Background blur for all dialogs.
 - Dismiss on clicking outside the dialog - Made it work proper for all dialogs.
 - BisqDialog - Code cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced optional background blur effects in various screens and dialogs, enhancing visual focus during popups and confirmations.
  - Added the ability to conditionally blur the background in scaffold components and wizards.

- **Improvements**
  - Dialogs and confirmation popups now trigger background blur for better user experience.
  - Dialog handling and state management in the Open Trade screen have been significantly enhanced, consolidating dialog logic and improving clarity.
  - Default confirmation dialog headlines are now localized.

- **Refactor**
  - Dialog rendering logic was reorganized in several screens for improved structure and maintainability.
  - Some composable functions and screens were renamed for consistency.
  - Dialog components were repositioned outside main scaffold content for cleaner UI layering.

- **Style**
  - Dialog containers updated to use Card components for a more polished appearance.

- **Chores**
  - Dependency injection scopes updated for certain presenters to improve resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->