### PR TITLE
bugfix/navigation_swiping_between_tabs_issue

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -93,8 +93,8 @@ class WebSocketClient(
 
     suspend fun connect(isTest: Boolean = false) {
         log.i("Connecting to websocket at: $webSocketUrl")
-        if (webSocketClientStatus.value != WebSocketClientStatus.CONNECTED) {
-            try {
+        try {
+            if (webSocketClientStatus.value != WebSocketClientStatus.CONNECTED) {
                 _webSocketClientStatus.value = WebSocketClientStatus.CONNECTING
                 session = httpClient.webSocketSession { url(webSocketUrl) }
                 if (session?.isActive == true) {
@@ -105,14 +105,14 @@ class WebSocketClient(
                         log.d { "Websocket connected" }
                     }
                 }
-            } catch (e: Exception) {
-                log.e("Connecting websocket failed", e)
-                _webSocketClientStatus.value = WebSocketClientStatus.DISCONNECTED
-                if (isTest) {
-                    throw e
-                } else {
-                    reconnect()
-                }
+            }
+        } catch (e: Exception) {
+            log.e("Connecting websocket failed", e)
+            _webSocketClientStatus.value = WebSocketClientStatus.DISCONNECTED
+            if (isTest) {
+                throw e
+            } else {
+                reconnect()
             }
         }
     }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.android.kt
@@ -17,13 +17,14 @@ actual fun exitApp(view: Any?) {
     if (view == null) {
         android.os.Process.killProcess(android.os.Process.myPid())
     } else {
-//        (view as android.app.Activity).finish()
-        val activity = view as android.app.Activity
-        // Move task to the background (similar to pressing Home button)
-        val homeIntent = android.content.Intent(android.content.Intent.ACTION_MAIN)
-        homeIntent.addCategory(android.content.Intent.CATEGORY_HOME)
-        homeIntent.flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK
-        activity.startActivity(homeIntent)
+        if (view is android.app.Activity) {
+//            (view as android.app.Activity).finish()
+            // Move task to the background (similar to pressing Home button)
+            val homeIntent = android.content.Intent(android.content.Intent.ACTION_MAIN)
+            homeIntent.addCategory(android.content.Intent.CATEGORY_HOME)
+            homeIntent.flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+            view.startActivity(homeIntent)
+        }
     }
 }
 

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.android.kt
@@ -13,8 +13,18 @@ actual fun getPlatformPainter(platformImage: PlatformImage): Painter {
 
 actual fun getPlatformCurrentTimeProvider(): TimeProvider = AndroidCurrentTimeProvider()
 
-actual fun exitApp() {
-    // not used in Android
+actual fun exitApp(view: Any?) {
+    if (view == null) {
+        android.os.Process.killProcess(android.os.Process.myPid())
+    } else {
+//        (view as android.app.Activity).finish()
+        val activity = view as android.app.Activity
+        // Move task to the background (similar to pressing Home button)
+        val homeIntent = android.content.Intent(android.content.Intent.ACTION_MAIN)
+        homeIntent.addCategory(android.content.Intent.CATEGORY_HOME)
+        homeIntent.flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+        activity.startActivity(homeIntent)
+    }
 }
 
 actual fun getScreenWidthDp(): Int {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -107,6 +107,7 @@ interface ViewPresenter {
  */
 abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPresenter, Logging {
     companion object {
+        const val EXIT_WARNING_TIMEOUT = 3000L
         var isDemo = false
     }
 
@@ -276,17 +277,16 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
         when {
             isAtHome() -> {
                 if (exitWarningShown) {
-                    log.d { "view is $view"}
                     rootPresenter?.exitApp()
                     exitWarningShown = false // Reset after action
                 } else {
                     // Show warning first time
-                    showSnackbar("Swipe once again to exit")
+                    showSnackbar("Press/Swipe back again to exit")
                     exitWarningShown = true
 
                     // Set a timer to reset the warning state after a few seconds
                     presenterScope.launch {
-                        delay(3000L) // 3 seconds timeout for exit warning
+                        delay(EXIT_WARNING_TIMEOUT) // 3 seconds timeout for exit warning
                         exitWarningShown = false
                     }
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.kt
@@ -8,6 +8,6 @@ expect fun getPlatformPainter(platformImage: PlatformImage): Painter
 
 expect fun getPlatformCurrentTimeProvider(): TimeProvider
 
-expect fun exitApp()
+expect fun exitApp(view: Any? = null)
 
 expect fun getScreenWidthDp(): Int

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -88,6 +88,7 @@ class TrustedNodeSetupPresenter(
             val success = withContext(IODispatcher) {
                 webSocketClientProvider.testClient(connectionSettings.first, connectionSettings.second)
             }
+            _isLoading.value = false
 
             if (success) {
                 val validateVersion = withContext(IODispatcher) {

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/PlatformPresentationAbstractions.ios.kt
@@ -64,7 +64,7 @@ actual fun getPlatformPainter(platformImage: PlatformImage): Painter {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-actual fun exitApp() {
+actual fun exitApp(view: Any?) {
     UIApplication.sharedApplication.performSelector(NSSelectorFromString("suspend"))
 }
 


### PR DESCRIPTION
 - fixes #214 
 - fix swipe warning issue and home back navigation 
 - background the app whenever possible when exiting the app
 - fix test connection button loading indefinitely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a double-back press to exit confirmation on the home screen, prompting users with a warning before exiting the app.
- **Improvements**
  - Enhanced the app exit behavior on Android: pressing back twice moves the app to the background instead of closing it immediately.
  - Improved loading indicator handling during trusted node connection tests, ensuring it turns off after the test completes.
- **Bug Fixes**
  - Refined app exit handling to provide a more consistent and user-friendly experience across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->