### PR TITLE
support for multiple obj repositories w/ existing KV multi platform storage

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Trade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Trade.kt
@@ -1,0 +1,30 @@
+package network.bisq.mobile.domain.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Trade model representing a trade in the system.
+ */
+@Serializable
+class Trade : BaseModel() {
+    var tradeId: String = ""
+    var makerNetworkId: String = ""
+    var takerNetworkId: String = ""
+    var offerAmount: Double = 0.0
+    var offerCurrency: String = ""
+    var price: Double = 0.0
+    var status: String = ""
+    var createdAt: Long = 0
+    var updatedAt: Long = 0
+    
+    init {
+        // Use tradeId as the BaseModel id
+        id = tradeId
+    }
+    
+    // Update id when tradeId changes
+    fun updateTradeId(newTradeId: String) {
+        tradeId = newTradeId
+        id = newTradeId
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Trade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/Trade.kt
@@ -1,30 +1,24 @@
 package network.bisq.mobile.domain.data.model
 
+import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 
 /**
  * Trade model representing a trade in the system.
  */
 @Serializable
-class Trade : BaseModel() {
-    var tradeId: String = ""
+class Trade(var tradeId: String = "") : BaseModel() {
     var makerNetworkId: String = ""
     var takerNetworkId: String = ""
     var offerAmount: Double = 0.0
     var offerCurrency: String = ""
     var price: Double = 0.0
     var status: String = ""
-    var createdAt: Long = 0
-    var updatedAt: Long = 0
+    var createdAt: Long = Clock.System.now().toEpochMilliseconds()
+    var updatedAt: Long = Clock.System.now().toEpochMilliseconds()
     
     init {
-        // Use tradeId as the BaseModel id
+        require(tradeId.isNotBlank()) { "Trade must have a non-blank tradeId" }
         id = tradeId
-    }
-    
-    // Update id when tradeId changes
-    fun updateTradeId(newTradeId: String) {
-        tradeId = newTradeId
-        id = newTradeId
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
@@ -104,6 +104,8 @@ abstract class MultiObjectRepository<out T : BaseModel>(
 
     /**
      * Clears all objects from the repository.
+     * Note: This method cancels the internal coroutine scope, making the repository
+     * instance unusable after calling this method. Create a new instance if needed.
      */
     suspend fun clear() {
         try {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
@@ -1,0 +1,118 @@
+package network.bisq.mobile.domain.data.repository
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.data.IODispatcher
+import network.bisq.mobile.domain.data.model.BaseModel
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import network.bisq.mobile.domain.utils.Logging
+
+/**
+ * Repository implementation for multiple objects. Allows for persistence if the persistence source is provided,
+ * otherwise it's memory-only.
+ *
+ * @param T a domain model that extends BaseModel
+ * @param persistenceSource <optional> persistence mechanism to use to save/load data for this repository. Otherwise it's mem-only.
+ * @param prototype <optional> an instance of T to use as prototype, can be null if no persistence source will be used
+ */
+abstract class MultiObjectRepository<out T : BaseModel>(
+    private val persistenceSource: PersistenceSource<T>? = null,
+    private val prototype: T? = null,
+) : Logging {
+
+    private val _dataMap = MutableStateFlow<Map<String, T>>(emptyMap())
+    val dataMap: StateFlow<Map<String, T>> = _dataMap
+
+    private val job = Job()
+    private val scope = CoroutineScope(job + IODispatcher)
+
+    /**
+     * Creates a new object in the repository.
+     * @param data The object to create
+     */
+    suspend fun create(data: @UnsafeVariance T) {
+        if (data.id.isBlank()) {
+            throw IllegalArgumentException("Cannot create an object with a blank ID")
+        }
+        
+        val currentMap = _dataMap.value.toMutableMap()
+        currentMap[data.id] = data
+        _dataMap.value = currentMap
+        
+        persistenceSource?.save(data)
+    }
+
+    /**
+     * Updates an existing object in the repository.
+     * @param data The object to update
+     */
+    suspend fun update(data: @UnsafeVariance T) {
+        if (data.id.isBlank()) {
+            throw IllegalArgumentException("Cannot update an object with a blank ID")
+        }
+        
+        val currentMap = _dataMap.value.toMutableMap()
+        currentMap[data.id] = data
+        _dataMap.value = currentMap
+        
+        persistenceSource?.save(data)
+    }
+
+    /**
+     * Deletes an object from the repository.
+     * @param data The object to delete
+     */
+    suspend fun delete(data: @UnsafeVariance T) {
+        if (data.id.isBlank()) {
+            throw IllegalArgumentException("Cannot delete an object with a blank ID")
+        }
+        
+        val currentMap = _dataMap.value.toMutableMap()
+        currentMap.remove(data.id)
+        _dataMap.value = currentMap
+        
+        persistenceSource?.delete(data)
+    }
+
+    /**
+     * Fetches all objects from the repository.
+     * @return A list of all objects
+     */
+    suspend fun fetchAll(): List<T> {
+        if (_dataMap.value.isEmpty() && persistenceSource != null && prototype != null) {
+            val items = persistenceSource.getAll(prototype)
+            val newMap = items.associateBy { it.id }
+            _dataMap.value = newMap
+        }
+        return _dataMap.value.values.toList()
+    }
+
+    /**
+     * Fetches a specific object by ID.
+     * @param id The ID of the object to fetch
+     * @return The object with the specified ID, or null if not found
+     */
+    suspend fun fetchById(id: String): T? {
+        if (_dataMap.value.isEmpty() && persistenceSource != null && prototype != null) {
+            fetchAll() // Load all data first
+        }
+        return _dataMap.value[id]
+    }
+
+    /**
+     * Clears all objects from the repository.
+     */
+    suspend fun clear() {
+        try {
+            persistenceSource?.clear()
+            scope.cancel()
+        } catch (e: Exception) {
+            log.e("Failed to cancel repository coroutine scope", e)
+        } finally {
+            _dataMap.value = emptyMap()
+        }
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -17,8 +17,6 @@ import network.bisq.mobile.domain.utils.Logging
  * @param T a domain model
  * @param persistenceSource <optional> persistance mechanism to use to save/load data for this repository. Otherwise its mem-only.
  * @param prototype <optional> an instance of T to use as prototype, can be null if no persistance source will be used
- *
- * TODO: create a map-based multi object repository when needed (might need to leverage some kind of id generation on the base model)
  */
 abstract class SingleObjectRepository<out T : BaseModel>(
     private val persistenceSource: PersistenceSource<T>? = null,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/TradeRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/TradeRepository.kt
@@ -6,6 +6,10 @@ import network.bisq.mobile.domain.data.persistance.PersistenceSource
 
 /**
  * Repository for managing multiple Trade objects.
+ *
+ * This implementation was designed for open trades tracking and therefore doesn't
+ * support large amounts of trades. To bring support filtering mechanisms need to be added
+ * on the find methods
  * 
  * @param persistenceSource Optional persistence mechanism to save/load trades
  * @param prototype Optional prototype instance of Trade

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/TradeRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/TradeRepository.kt
@@ -1,0 +1,54 @@
+package network.bisq.mobile.domain.data.repository
+
+import kotlinx.datetime.Clock
+import network.bisq.mobile.domain.data.model.Trade
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+
+/**
+ * Repository for managing multiple Trade objects.
+ * 
+ * @param persistenceSource Optional persistence mechanism to save/load trades
+ * @param prototype Optional prototype instance of Trade
+ */
+open class TradeRepository(
+    persistenceSource: PersistenceSource<Trade>? = null,
+    prototype: Trade? = null
+) : MultiObjectRepository<Trade>(persistenceSource, prototype) {
+    
+    /**
+     * Finds trades by status.
+     * 
+     * @param status The status to filter by
+     * @return List of trades with the specified status
+     */
+    suspend fun findByStatus(status: String): List<Trade> {
+        return fetchAll().filter { it.status == status }
+    }
+    
+    /**
+     * Finds trades by currency.
+     * 
+     * @param currency The currency to filter by
+     * @return List of trades with the specified currency
+     */
+    suspend fun findByCurrency(currency: String): List<Trade> {
+        return fetchAll().filter { it.offerCurrency == currency }
+    }
+    
+    /**
+     * Updates the status of a trade.
+     * 
+     * @param tradeId The ID of the trade to update
+     * @param newStatus The new status
+     * @return The updated trade, or null if not found
+     */
+    suspend fun updateStatus(tradeId: String, newStatus: String): Trade? {
+        val trade = fetchById(tradeId) ?: return null
+        val updatedTrade = trade.apply { 
+            status = newStatus
+            updatedAt = Clock.System.now().toEpochMilliseconds()
+        }
+        update(updatedTrade)
+        return updatedTrade
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.domain.data.repository.TradeRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.getPlatformSettings
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
@@ -28,6 +29,7 @@ val domainModule = module {
     single<BisqStatsRepository> { BisqStatsRepository() }
     single<SettingsRepository> { SettingsRepository(get()) }
     single<UserRepository> { UserRepository(get()) }
+    single<TradeRepository> { TradeRepository(get()) }
 
     // Services
     single<OpenTradesNotificationService> { OpenTradesNotificationService(get(), get()) }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 class SettingsRepositoryTest : KoinTest {
 
@@ -128,6 +129,18 @@ class SettingsRepositoryTest : KoinTest {
         // Verify settings are cleared
         val fetchedSettings = settingsRepository.fetch()
         assertNull(fetchedSettings)
+    }
+
+    @Test
+    fun testUpdateNonExistentSettings() = runBlocking {
+        // Try to update settings that haven't been created yet
+        val settings = createSampleSettings()
+        settingsRepository.update(settings)
+
+        // Verify the update operation still works
+        val fetchedSettings = settingsRepository.fetch()
+        assertNotNull(fetchedSettings)
+        assertEquals("https://api.bisq.network", fetchedSettings.bisqApiUrl)
     }
 
     private fun createSampleSettings(): Settings {

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryTest.kt
@@ -1,0 +1,140 @@
+package network.bisq.mobile.domain.data.repository
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import network.bisq.mobile.domain.data.model.Settings
+import network.bisq.mobile.domain.data.persistance.KeyValueStorage
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import network.bisq.mobile.domain.di.testModule
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import org.koin.core.qualifier.named
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SettingsRepositoryTest : KoinTest {
+
+    private lateinit var settingsRepository: SettingsRepository
+    private val persistenceSource: PersistenceSource<Settings> by inject(qualifier = named("settingsStorage"))
+
+    @BeforeTest
+    fun setup() {
+        startKoin {
+            modules(testModule)
+        }
+        settingsRepository = SettingsRepository(persistenceSource as KeyValueStorage<Settings>)
+    }
+
+    @AfterTest
+    fun teardown() {
+        runBlocking {
+            settingsRepository.clear()
+        }
+        stopKoin()
+    }
+
+    @Test
+    fun testCreateAndFetch() = runBlocking {
+        // Create settings
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Fetch settings
+        val fetchedSettings = settingsRepository.fetch()
+        assertNotNull(fetchedSettings)
+        assertEquals("https://api.bisq.network", fetchedSettings.bisqApiUrl)
+        assertEquals(true, fetchedSettings.firstLaunch)
+    }
+
+    @Test
+    fun testUpdate() = runBlocking {
+        // Create settings
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Update settings
+        val updatedSettings = settings.apply {
+            bisqApiUrl = "https://test-api.bisq.network"
+            firstLaunch = false
+        }
+        settingsRepository.update(updatedSettings)
+
+        // Verify update
+        val fetchedSettings = settingsRepository.fetch()
+        assertNotNull(fetchedSettings)
+        assertEquals("https://test-api.bisq.network", fetchedSettings.bisqApiUrl)
+        assertEquals(false, fetchedSettings.firstLaunch)
+    }
+
+    @Test
+    fun testDelete() = runBlocking {
+        // Create settings
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Delete settings
+        settingsRepository.delete(settings)
+
+        // Verify deletion
+        val fetchedSettings = settingsRepository.fetch()
+        assertNull(fetchedSettings)
+    }
+
+    @Test
+    fun testDataFlow() = runBlocking {
+        // Create settings
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Verify data flow emits the correct value
+        val flowValue = settingsRepository.data.first()
+        assertNotNull(flowValue)
+        assertEquals("https://api.bisq.network", flowValue.bisqApiUrl)
+        assertEquals(true, flowValue.firstLaunch)
+    }
+
+    @Test
+    fun testPersistence() = runBlocking {
+        // Create settings with explicit ID
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Create a new repository instance with the same prototype
+        val newRepository = SettingsRepository(
+            persistenceSource as KeyValueStorage<Settings>
+        )
+        val fetchedSettings = newRepository.fetch()
+        
+        assertNotNull(fetchedSettings, "Settings should be persisted and accessible by a new repository instance")
+        assertEquals("https://api.bisq.network", fetchedSettings.bisqApiUrl)
+        assertEquals(true, fetchedSettings.firstLaunch)
+    }
+
+    @Test
+    fun testClear() = runBlocking {
+        // Create settings
+        val settings = createSampleSettings()
+        settingsRepository.create(settings)
+
+        // Clear repository
+        settingsRepository.clear()
+
+        // Verify settings are cleared
+        val fetchedSettings = settingsRepository.fetch()
+        assertNull(fetchedSettings)
+    }
+
+    private fun createSampleSettings(): Settings {
+        return Settings().apply {
+            bisqApiUrl = "https://api.bisq.network"
+            firstLaunch = true
+            showChatRulesWarnBox = true
+        }
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/TradeRepositoryTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/TradeRepositoryTest.kt
@@ -158,14 +158,13 @@ class TradeRepositoryTest : KoinTest {
     }
 
     private fun createSampleTrade(id: String, currency: String, status: String): Trade {
-        return Trade().apply {
+        return Trade(id).apply {
             offerCurrency = currency
             this.status = status
             offerAmount = 1.0
             price = 50000.0
             createdAt = Clock.System.now().toEpochMilliseconds()
             updatedAt = createdAt
-            updateTradeId(id)
         }
     }
 }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/TradeRepositoryTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/TradeRepositoryTest.kt
@@ -1,0 +1,171 @@
+package network.bisq.mobile.domain.data.repository
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import network.bisq.mobile.domain.data.model.Trade
+import network.bisq.mobile.domain.data.persistance.KeyValueStorage
+import network.bisq.mobile.domain.data.persistance.PersistenceSource
+import network.bisq.mobile.domain.di.testModule
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class TradeRepositoryTest : KoinTest {
+
+    private lateinit var tradeRepository: TradeRepository
+    private val persistenceSource: PersistenceSource<Trade> by inject(qualifier = named("tradeStorage"))
+
+    @BeforeTest
+    fun setup() {
+        startKoin {
+            modules(testModule)
+        }
+        tradeRepository = TradeRepository(persistenceSource as KeyValueStorage<Trade>)
+    }
+
+    @AfterTest
+    fun teardown() {
+        runBlocking {
+            tradeRepository.clear()
+        }
+        stopKoin()
+    }
+
+    @Test
+    fun testCreateAndFetchById() = runBlocking {
+        // Create a trade
+        val trade = createSampleTrade("1", "BTC", "OPEN")
+        tradeRepository.create(trade)
+
+        // Fetch by ID
+        val fetchedTrade = tradeRepository.fetchById("1")
+        assertNotNull(fetchedTrade)
+        assertEquals("1", fetchedTrade.tradeId)
+        assertEquals("BTC", fetchedTrade.offerCurrency)
+        assertEquals("OPEN", fetchedTrade.status)
+    }
+
+    @Test
+    fun testFetchAll() = runBlocking {
+        // Create multiple trades
+        val trade1 = createSampleTrade("1", "BTC", "OPEN")
+        val trade2 = createSampleTrade("2", "ETH", "CLOSED")
+        tradeRepository.create(trade1)
+        tradeRepository.create(trade2)
+
+        // Fetch all
+        val allTrades = tradeRepository.fetchAll()
+        assertEquals(2, allTrades.size)
+        assertEquals(setOf("1", "2"), allTrades.map { it.tradeId }.toSet())
+    }
+
+    @Test
+    fun testUpdate() = runBlocking {
+        // Create a trade
+        val trade = createSampleTrade("1", "BTC", "OPEN")
+        tradeRepository.create(trade)
+
+        // Update the trade
+        val updatedTrade = trade.apply {
+            status = "IN_PROGRESS"
+            offerAmount = 2.0
+        }
+        tradeRepository.update(updatedTrade)
+
+        // Verify update
+        val fetchedTrade = tradeRepository.fetchById("1")
+        assertNotNull(fetchedTrade)
+        assertEquals("IN_PROGRESS", fetchedTrade.status)
+        assertEquals(2.0, fetchedTrade.offerAmount)
+    }
+
+    @Test
+    fun testDelete() = runBlocking {
+        // Create a trade
+        val trade = createSampleTrade("1", "BTC", "OPEN")
+        tradeRepository.create(trade)
+
+        // Delete the trade
+        tradeRepository.delete(trade)
+
+        // Verify deletion
+        val fetchedTrade = tradeRepository.fetchById("1")
+        assertNull(fetchedTrade)
+    }
+
+    @Test
+    fun testFindByStatus() = runBlocking {
+        // Create trades with different statuses
+        val trade1 = createSampleTrade("1", "BTC", "OPEN")
+        val trade2 = createSampleTrade("2", "ETH", "CLOSED")
+        val trade3 = createSampleTrade("3", "LTC", "OPEN")
+        tradeRepository.create(trade1)
+        tradeRepository.create(trade2)
+        tradeRepository.create(trade3)
+
+        // Find by status
+        val openTrades = tradeRepository.findByStatus("OPEN")
+        assertEquals(2, openTrades.size)
+        assertEquals(setOf("1", "3"), openTrades.map { it.tradeId }.toSet())
+    }
+
+    @Test
+    fun testFindByCurrency() = runBlocking {
+        // Create trades with different currencies
+        val trade1 = createSampleTrade("1", "BTC", "OPEN")
+        val trade2 = createSampleTrade("2", "ETH", "CLOSED")
+        val trade3 = createSampleTrade("3", "BTC", "CLOSED")
+        tradeRepository.create(trade1)
+        tradeRepository.create(trade2)
+        tradeRepository.create(trade3)
+
+        // Find by currency
+        val btcTrades = tradeRepository.findByCurrency("BTC")
+        assertEquals(2, btcTrades.size)
+        assertEquals(setOf("1", "3"), btcTrades.map { it.tradeId }.toSet())
+    }
+
+    @Test
+    fun testUpdateStatus() = runBlocking {
+        // Create a trade
+        val trade = createSampleTrade("1", "BTC", "OPEN")
+        tradeRepository.create(trade)
+
+        // Update status
+        val updatedTrade = tradeRepository.updateStatus("1", "COMPLETED")
+        assertNotNull(updatedTrade)
+        assertEquals("COMPLETED", updatedTrade.status)
+
+        // Verify update in repository
+        val fetchedTrade = tradeRepository.fetchById("1")
+        assertNotNull(fetchedTrade)
+        assertEquals("COMPLETED", fetchedTrade.status)
+    }
+
+    @Test
+    fun testUpdateNonExistentTrade() = runBlocking {
+        // Try to update a non-existent trade
+        val updatedTrade = tradeRepository.updateStatus("999", "COMPLETED")
+        assertNull(updatedTrade)
+    }
+
+    private fun createSampleTrade(id: String, currency: String, status: String): Trade {
+        return Trade().apply {
+            offerCurrency = currency
+            this.status = status
+            offerAmount = 1.0
+            price = 50000.0
+            createdAt = Clock.System.now().toEpochMilliseconds()
+            updatedAt = createdAt
+            updateTradeId(id)
+        }
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/di/TestModule.kt
@@ -3,18 +3,43 @@ package network.bisq.mobile.domain.di
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.domain.data.model.BaseModel
+import network.bisq.mobile.domain.data.model.Trade
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.persistance.PersistenceSource
 import org.koin.dsl.module
+import org.koin.core.qualifier.named
 
 val testModule = module {
+    // Use MapSettings for testing
     single<Settings> { MapSettings() }
 
-    single<PersistenceSource<*>> {
+    // Generic persistence source for BaseModel
+    single<PersistenceSource<BaseModel>> {
         KeyValueStorage(
             settings = get(),
-            serializer = { kotlinx.serialization.json.Json.encodeToString(it) },
-            deserializer = { kotlinx.serialization.json.Json.decodeFromString(it) }
+            serializer = { Json.encodeToString(it) },
+            deserializer = { Json.decodeFromString(it) }
+        )
+    }
+
+    // IMPORTANT: use named() qualifiers to retrieve the right one on testing (not necessary in app code)
+    // Specific persistence source for Trade
+    single<PersistenceSource<Trade>>(qualifier = named("tradeStorage")) {
+        KeyValueStorage(
+            settings = get(),
+            serializer = { Json.encodeToString(it) },
+            deserializer = { Json.decodeFromString<Trade>(it) }
+        )
+    }
+    
+    // Specific persistence source for Settings
+    single<PersistenceSource<network.bisq.mobile.domain.data.model.Settings>>(qualifier = named("settingsStorage")) {
+        KeyValueStorage(
+            settings = get(),
+            serializer = { Json.encodeToString(it) },
+            deserializer = { Json.decodeFromString<network.bisq.mobile.domain.data.model.Settings>(it) }
         )
     }
 }


### PR DESCRIPTION
 - contribs to #183 
 - Implement support for multiple object repository K-V storage and usage for Trade status tracing (removed TODO)
 - add unit test for new Trade Status repository
 - add unit test for untested singleObject repository scheme (on Settings one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for managing trades, including creation, updating, deletion, and querying by status or currency.
  - Added a repository for handling collections of trades with persistence and filtering capabilities.

- **Chores**
  - Integrated the trade management repository into the system's dependency injection module for streamlined access.

- **Tests**
  - Added comprehensive test suites for both trade and settings management, ensuring correct behavior for creation, updates, deletion, querying, and persistence.
  - Enhanced test dependency injection to support specific storage sources for trades and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->