### PR TITLE
release/aconnect_0.0.31

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ node.name=Bisq
 node.android.version=0.0.4
 
 client.name=Bisq Connect
-client.android.version=0.0.30
+client.android.version=0.0.31
 client.ios.version=0.0.7
 
 # Release

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionSha256Sum=57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
 - contribs to #135 
 - bump up aconnect version for pre-release 
 - include gradle dist sha256 sum in wrapper props as recommended by f-droid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android client version number.
  - Added SHA-256 checksum verification for Gradle distribution to enhance build integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->