### PR TITLE
 Reptutation WS API

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
@@ -2,9 +2,9 @@ package network.bisq.mobile.android.node.service.reputation
 
 import bisq.common.observable.Pin
 import bisq.user.reputation.ReputationService
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
@@ -67,23 +67,8 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
             Mappings.ReputationScoreMapping.fromBisq2Model(it)
         }
 
-        /*
-                _reputationByUserProfileId.update { current ->
-                    current.toMutableMap().apply {
-                        this[userProfileId] = reputation
-                    }.toMap()
-                }
-                */
-
-        /*
-        _reputationByUserProfileId.value = _reputationByUserProfileId.value.toMutableMap().apply {
-            this[userProfileId] = reputation
+        _reputationByUserProfileId.update { current ->
+            current + (userProfileId to reputation)
         }
-        */
-
-        val profileScoreMap = reputationByUserProfileId.value.toMutableMap()
-        profileScoreMap[userProfileId] = reputation
-
-        _reputationByUserProfileId.value = profileScoreMap
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
@@ -1,6 +1,10 @@
 package network.bisq.mobile.android.node.service.reputation
 
+import android.content.res.Resources.NotFoundException
+import bisq.common.observable.Pin
 import bisq.user.reputation.ReputationService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
@@ -11,23 +15,53 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
     ReputationServiceFacade {
     private val reputationService: ReputationService by lazy { applicationService.reputationService.get() }
 
+    // Properties
+    private val _reputationByUserProfileId: MutableStateFlow<Map<String, ReputationScoreVO>> = MutableStateFlow(emptyMap())
+    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId
+
+    // Misc
+    private var selectedReputationPin: Pin? = null
+
+    // Life cycle
     override fun activate() {
         super<ServiceFacade>.activate()
+        observeReputation()
     }
 
     override fun deactivate() {
+        selectedReputationPin?.unbind()
+        selectedReputationPin = null
         super<ServiceFacade>.deactivate()
     }
 
+    // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
+        val reputation = reputationByUserProfileId.value[userProfileId]
+        if (reputation == null) {
+            return Result.failure(NotFoundException())
+        } else {
+            return Result.success(reputation)
+        }
+    }
+
+    // Private
+    private fun observeReputation() {
+        selectedReputationPin = reputationService.userProfileIdWithScoreChange.addObserver{ userProfileId ->
+            try {
+                updateUserReputation(userProfileId)
+            } catch (e: Exception) {
+                log.e("Failed to update user reputation", e)
+            }
+        }
+    }
+
+    private fun updateUserReputation(userProfileId: String) {
         val reputation = reputationService.getReputationScore(userProfileId).let {
             Mappings.ReputationScoreMapping.fromBisq2Model(it)
         }
-        return Result.success(reputation)
-    }
+        val profileScoreMap = reputationByUserProfileId.value.toMutableMap()
+        profileScoreMap[userProfileId] = reputation
 
-    override suspend fun getScoreByUserProfileId(): Result<Map<String, Long>> {
-        return Result.success(reputationService.scoreByUserProfileId)
+        _reputationByUserProfileId.value = profileScoreMap
     }
-
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
@@ -41,10 +41,10 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
         val reputation = reputationByUserProfileId.value[userProfileId]
-        if (reputation == null) {
-            return Result.failure(NoSuchElementException())
+        return if (reputation == null) {
+            Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not cached yet"))
         } else {
-            return Result.success(reputation)
+            Result.success(reputation)
         }
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -21,7 +21,7 @@ import network.bisq.mobile.client.service.market.ClientMarketPriceServiceFacade
 import network.bisq.mobile.client.service.market.MarketPriceApiGateway
 import network.bisq.mobile.client.service.mediation.ClientMediationServiceFacade
 import network.bisq.mobile.client.service.mediation.MediationApiGateway
-import network.bisq.mobile.client.service.mediation.ReputationApiGateway
+import network.bisq.mobile.client.service.reputation.ReputationApiGateway
 import network.bisq.mobile.client.service.offers.ClientOffersServiceFacade
 import network.bisq.mobile.client.service.offers.OfferbookApiGateway
 import network.bisq.mobile.client.service.reputation.ClientReputationServiceFacade
@@ -207,6 +207,6 @@ val clientModule = module {
     single<LanguageServiceFacade> { ClientLanguageServiceFacade() }
 
     single { ReputationApiGateway(get()) }
-    single<ReputationServiceFacade> { ClientReputationServiceFacade(get()) }
+    single<ReputationServiceFacade> { ClientReputationServiceFacade(get(), get()) }
 
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
@@ -27,7 +27,11 @@ class ClientReputationServiceFacade(
     override fun activate() {
         super<ServiceFacade>.activate()
         serviceScope.launch {
-            subscribeReputation()
+            runCatching {
+                subscribeReputation()
+            }.onFailure {
+                log.w { "Failed to activate client reputation service" }
+            }
         }
     }
 
@@ -38,10 +42,10 @@ class ClientReputationServiceFacade(
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
         val reputation = reputationByUserProfileId.value[userProfileId]
-        if (reputation == null) {
-            return Result.failure(IllegalStateException("Reputation for userId=$userProfileId not cached yet"))
+        return if (reputation == null) {
+            Result.failure(IllegalStateException("Reputation for userId=$userProfileId not cached yet"))
         } else {
-            return Result.success(reputation)
+            Result.success(reputation)
         }
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
@@ -1,24 +1,69 @@
 package network.bisq.mobile.client.service.reputation
 
-import network.bisq.mobile.client.service.mediation.ReputationApiGateway
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
+
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
 
-class ClientReputationServiceFacade(val apiGateway: ReputationApiGateway) : ServiceFacade(), ReputationServiceFacade {
+class ClientReputationServiceFacade(
+    val apiGateway: ReputationApiGateway,
+    private val json: Json,
+) : ServiceFacade(), ReputationServiceFacade {
+
+    // Properties
+    private val _reputationByUserProfileId = MutableStateFlow<Map<String, ReputationScoreVO>>(emptyMap())
+    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId
+
+    // Misc
+    private var offersSequenceNumber = atomic(-1)
+
+    // Life cycle
     override fun activate() {
         super<ServiceFacade>.activate()
+        serviceScope.launch {
+            subscribeReputation()
+        }
     }
 
     override fun deactivate() {
         super<ServiceFacade>.deactivate()
     }
 
+    // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
-        return apiGateway.getReputation(userProfileId)
+        val reputation = reputationByUserProfileId.value[userProfileId]
+        if (reputation == null) {
+            return Result.failure(Exception())
+        } else {
+            return Result.success(reputation)
+        }
     }
 
-    override suspend fun getScoreByUserProfileId(): Result<Map<String, Long>> {
-        return apiGateway.getScoreByUserProfileId()
+    // Private
+    private suspend fun subscribeReputation() {
+        val observer = apiGateway.subscribeUserReputation()
+        observer.webSocketEvent.collect { webSocketEvent ->
+            if (webSocketEvent?.deferredPayload == null) {
+                return@collect
+            }
+            if (offersSequenceNumber.value >= webSocketEvent.sequenceNumber) {
+                log.w {
+                    "Sequence number is larger or equal than the one we " +
+                            "received from the backend. We ignore that event."
+                }
+                return@collect
+            }
+            offersSequenceNumber.value = webSocketEvent.sequenceNumber
+            val webSocketEventPayload: WebSocketEventPayload<Map<String, ReputationScoreVO>> =
+                WebSocketEventPayload.from(json, webSocketEvent)
+            val payload: Map<String, ReputationScoreVO> = webSocketEventPayload.payload
+            _reputationByUserProfileId.value = payload
+        }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
@@ -9,6 +9,11 @@ class ReputationApiGateway(
     private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
     suspend fun subscribeUserReputation(): WebSocketEventObserver {
-        return webSocketClientProvider.get().subscribe(Topic.REPUTATION)
+        try {
+            return webSocketClientProvider.get().subscribe(Topic.REPUTATION)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to subscribe to reputation events: ${e.message}" }
+            throw e
+        }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
@@ -1,19 +1,14 @@
-package network.bisq.mobile.client.service.mediation
+package network.bisq.mobile.client.service.reputation
 
-import network.bisq.mobile.client.websocket.api_proxy.WebSocketApiClient
-import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.client.websocket.WebSocketClientProvider
+import network.bisq.mobile.client.websocket.subscription.Topic
+import network.bisq.mobile.client.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.domain.utils.Logging
 
 class ReputationApiGateway(
-    private val webSocketApiClient: WebSocketApiClient
+    private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
-    private val basePath = "reputation"
-
-    suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
-        return webSocketApiClient.get("$basePath/scores/$userProfileId")
-    }
-
-    suspend fun getScoreByUserProfileId(): Result<Map<String, Long>> {
-        return webSocketApiClient.get("$basePath/scores")
+    suspend fun subscribeUserReputation(): WebSocketEventObserver {
+        return webSocketClientProvider.get().subscribe(Topic.USER_REPUTATION)
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
@@ -9,6 +9,6 @@ class ReputationApiGateway(
     private val webSocketClientProvider: WebSocketClientProvider,
 ) : Logging {
     suspend fun subscribeUserReputation(): WebSocketEventObserver {
-        return webSocketClientProvider.get().subscribe(Topic.USER_REPUTATION)
+        return webSocketClientProvider.get().subscribe(Topic.REPUTATION)
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -48,9 +48,11 @@ class WebSocketClientProvider(
                     }
                     // only update if there was actually a change
                     if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
+                        /*
                         if (currentClient?.isConnected() == true) {
                             currentClient?.disconnect()
                         }
+                        */
                         log.d { "Websocket client updated with url $host:$port" }
                         currentClient = createClient(host, port)
                     }
@@ -70,6 +72,7 @@ class WebSocketClientProvider(
                 return true
             }
             // if connection is refused, catch will execute returning false
+            log.i { "testClient: $url" }
             client.connect(true)
             return client.isConnected()
         } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -48,11 +48,9 @@ class WebSocketClientProvider(
                     }
                     // only update if there was actually a change
                     if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
-                        /*
                         if (currentClient?.isConnected() == true) {
                             currentClient?.disconnect()
                         }
-                        */
                         log.d { "Websocket client updated with url $host:$port" }
                         currentClient = createClient(host, port)
                     }
@@ -72,7 +70,6 @@ class WebSocketClientProvider(
                 return true
             }
             // if connection is refused, catch will execute returning false
-            log.i { "testClient: $url" }
             client.connect(true)
             return client.isConnected()
         } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Topic.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Topic.kt
@@ -7,6 +7,7 @@ import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTra
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVO
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationDto
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationDto
+import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -19,4 +20,5 @@ enum class Topic(val typeOf: KType) {
     TRADE_PROPERTIES(typeOf<List<Map<String, TradePropertiesDto>>>()),
     TRADE_CHAT_MESSAGES(typeOf<List<BisqEasyOpenTradeMessageDto>>()),
     CHAT_REACTIONS(typeOf<List<BisqEasyOpenTradeMessageReactionVO>>()),
+    USER_REPUTATION(typeOf<Map<String, ReputationScoreVO>>()),
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Topic.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/Topic.kt
@@ -20,5 +20,5 @@ enum class Topic(val typeOf: KType) {
     TRADE_PROPERTIES(typeOf<List<Map<String, TradePropertiesDto>>>()),
     TRADE_CHAT_MESSAGES(typeOf<List<BisqEasyOpenTradeMessageDto>>()),
     CHAT_REACTIONS(typeOf<List<BisqEasyOpenTradeMessageReactionVO>>()),
-    USER_REPUTATION(typeOf<Map<String, ReputationScoreVO>>()),
+    REPUTATION(typeOf<Map<String, ReputationScoreVO>>()),
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/reputation/ReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/reputation/ReputationServiceFacade.kt
@@ -1,10 +1,13 @@
 package network.bisq.mobile.domain.service.reputation
 
+import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 
 interface ReputationServiceFacade : LifeCycleAware {
+
+    val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>>
+
     suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO>
 
-    suspend fun getScoreByUserProfileId(): Result<Map<String, Long>>
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -376,7 +376,7 @@ class CreateOfferAmountPresenter(
     }
 
     private suspend fun getPeersScoreByUserProfileId(): Map<String, Long> {
-        val myProfileIds = userProfileServiceFacade.getUserIdentityIds().toHashSet()
+        val myProfileIds: Set<String> = userProfileServiceFacade.getUserIdentityIds().toSet()
         val scoreByUserProfileId = reputationServiceFacade.reputationByUserProfileId.value
         return scoreByUserProfileId
             .filterKeys { it !in myProfileIds }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -377,9 +377,10 @@ class CreateOfferAmountPresenter(
 
     private suspend fun getPeersScoreByUserProfileId(): Map<String, Long> {
         val myProfileIds = userProfileServiceFacade.getUserIdentityIds()
-        val scoreByUserProfileId = reputationServiceFacade.getScoreByUserProfileId().getOrNull() ?: emptyMap()
-        return scoreByUserProfileId.filter { (key, _) -> !myProfileIds.contains(key) }
-
+        val scoreByUserProfileId = reputationServiceFacade.reputationByUserProfileId.value
+        return scoreByUserProfileId
+            .filter { (key, _) -> !myProfileIds.contains(key) }
+            .mapValues { it.value.totalScore }
     }
 
     private fun applyRangeAmountSliderValue(rangeSliderPosition: ClosedFloatingPointRange<Float>) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -376,10 +376,10 @@ class CreateOfferAmountPresenter(
     }
 
     private suspend fun getPeersScoreByUserProfileId(): Map<String, Long> {
-        val myProfileIds = userProfileServiceFacade.getUserIdentityIds()
+        val myProfileIds = userProfileServiceFacade.getUserIdentityIds().toHashSet()
         val scoreByUserProfileId = reputationServiceFacade.reputationByUserProfileId.value
         return scoreByUserProfileId
-            .filter { (key, _) -> !myProfileIds.contains(key) }
+            .filterKeys { it !in myProfileIds }
             .mapValues { it.value.totalScore }
     }
 


### PR DESCRIPTION
Changed from REST calls to WS subscription for real time push from server.

Depends on https://github.com/bisq-network/bisq2/pull/3455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a live, cached reputation map for user profiles, enabling real-time updates and reactive access to reputation data.
  - Added a public stream for reputation scores, allowing instant retrieval of reputation information without waiting for remote queries.

- **Refactor**
  - Updated reputation retrieval to use local cache and reactive streams instead of direct service calls.
  - Improved efficiency and reliability of reputation updates via event-driven WebSocket subscriptions.
  - Streamlined internal logic for filtering and mapping reputation data.

- **Chores**
  - Adjusted dependency injection and internal wiring to support new reputation caching and streaming mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->