### PR TITLE
Bugfix/manual kill/restart node connectivity loss

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
@@ -300,10 +300,6 @@ class AndroidApplicationService(
             }
     }
 
-    fun onStop() {
-        shutdown().join()
-    }
-
     override fun shutdown(): CompletableFuture<Boolean> {
         log.i("shutdown")
         // We shut down services in opposite order as they are initialized

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -52,10 +52,23 @@ class NodeMainPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-        log.d { "Make sure the service is initialized" }
-
         runCatching {
-            if (!applicationServiceCreated) {
+            if (applicationServiceCreated) {
+                log.d { "Application service already created, ensuring its activated" }
+                settingsServiceFacade.activate()
+                offersServiceFacade.activate()
+                marketPriceServiceFacade.activate()
+                tradesServiceFacade.activate()
+                tradeChatMessagesServiceFacade.activate()
+                languageServiceFacade.activate()
+
+                accountsServiceFacade.activate()
+                explorerServiceFacade.activate()
+                mediationServiceFacade.activate()
+                reputationServiceFacade.activate()
+                userProfileServiceFacade.activate()
+            } else {
+                log.d { "Application service not created, creating.." }
                 val filesDirsPath = (view as Activity).filesDir.toPath()
                 val applicationContext = (view as Activity).applicationContext
                 val applicationService =
@@ -92,19 +105,7 @@ class NodeMainPresenter(
                     }
                 applicationServiceCreated = true
                 connectivityService.startMonitoring()
-            } else {
-                settingsServiceFacade.activate()
-                offersServiceFacade.activate()
-                marketPriceServiceFacade.activate()
-                tradesServiceFacade.activate()
-                tradeChatMessagesServiceFacade.activate()
-                languageServiceFacade.activate()
-
-                accountsServiceFacade.activate()
-                explorerServiceFacade.activate()
-                mediationServiceFacade.activate()
-                reputationServiceFacade.activate()
-                userProfileServiceFacade.activate()
+                log.d { "Application service created, monitoring connectivity.." }
             }
         }.onFailure { e ->
             // TODO give user feedback (we could have a general error screen covering usual

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/bootstrap/NodeApplicationBootstrapFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/bootstrap/NodeApplicationBootstrapFacade.kt
@@ -5,6 +5,7 @@ import bisq.common.observable.Observable
 import bisq.common.observable.Pin
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.i18n.i18n
 
 class NodeApplicationBootstrapFacade(
     private val applicationService: AndroidApplicationService.Provider
@@ -22,12 +23,12 @@ class NodeApplicationBootstrapFacade(
         applicationServiceStatePin = applicationServiceState.addObserver { state: State ->
             when (state) {
                 State.INITIALIZE_APP -> {
-                    setState("Starting Bisq")
+                    setState("splash.applicationServiceState.INITIALIZE_APP".i18n())
                     setProgress(0f)
                 }
 
                 State.INITIALIZE_NETWORK -> {
-                    setState("Initialize P2P network")
+                    setState("splash.applicationServiceState.INITIALIZE_NETWORK".i18n())
                     setProgress(0.5f)
                 }
 
@@ -36,17 +37,17 @@ class NodeApplicationBootstrapFacade(
                 }
 
                 State.INITIALIZE_SERVICES -> {
-                    setState("Initialize services")
+                    setState("splash.applicationServiceState.INITIALIZE_SERVICES".i18n())
                     setProgress(0.75f)
                 }
 
                 State.APP_INITIALIZED -> {
-                    setState("Bisq started")
+                    setState("splash.applicationServiceState.APP_INITIALIZED".i18n())
                     setProgress(1f)
                 }
 
                 State.FAILED -> {
-                    setState("Startup failed")
+                    setState("splash.applicationServiceState.FAILED".i18n())
                     setProgress(0f)
                 }
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
@@ -15,7 +15,6 @@ import network.bisq.mobile.domain.service.ServiceFacade
  * Base definition for the connectivity service. Each app type should implement / override the default
  * based on its network type.
  */
-@Suppress("RedundantOverride")
 abstract class ConnectivityService : ServiceFacade() {
     companion object {
         const val TIMEOUT = 5000L

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -334,7 +334,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     @CallSuper
     override fun onViewAttached() {
-        log.i { "Lifecycle: View attached to presenter" }
+        log.i { "Lifecycle: View ${if (view != null) view!!::class.simpleName else ""} attached to presenter ${this::class.simpleName}" }
     }
 
     @CallSuper

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -66,13 +66,23 @@ open class MainPresenter(
 
     override fun onResume() {
         super.onResume()
-        openTradesNotificationService.stopNotificationService()
+        onResumeServices()
     }
 
     override fun onPause() {
-        connectivityService.stopMonitoring()
-        openTradesNotificationService.launchNotificationService()
+        onPauseServices()
         super.onPause()
+    }
+
+    protected open fun onResumeServices() {
+        openTradesNotificationService.stopNotificationService()
+    }
+
+    protected open fun onPauseServices() {
+        connectivityService.stopMonitoring()
+//        FIXME this is causing issues with restarting the app after manual kill
+//        openTradesNotificationService.launchNotificationService()
+
     }
 
     // Toggle action

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -140,10 +140,16 @@ class OfferbookPresenter(
                 require(item.isMyOffer)
                 presenterScope.launch {
                     withContext(IODispatcher) {
-                        offersServiceFacade.deleteOffer(item.offerId)
+                        val result = offersServiceFacade.deleteOffer(item.offerId).getOrDefault(false)
+                        log.d { "delete offer success $result" }
+                        if (result) {
+                            _showDeleteConfirmation.value = false
+                            deselectOffer()
+                        } else {
+                            log.w { "Failed to delete offer ${item.offerId}" }
+                            showSnackbar("Failed to delete offer ${item.offerId}, please try again", true)
+                        }
                     }
-                    _showDeleteConfirmation.value = false
-                    deselectOffer()
                 }
             }
         }.onFailure {


### PR DESCRIPTION
 - fixes #314 
 - disabled openTradesNotificationService background launch for now as it's the one causing the app being half-destroyed / zombie and consequently initiating faulty when launched again (after manual kill, I assume same would happen if the OS kills the app). Further dev is happening to restore the service in the context of #183 
 - better onDestroy resources cleanup
 - i18n for bootstrap
 - minor code refactors for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved localization for application state messages.
- **Bug Fixes**
	- Enhanced reliability of service activation and shutdown flows.
	- Improved error handling and feedback when deleting offers.
- **Refactor**
	- Streamlined lifecycle management for presenters and services.
	- Encapsulated service management logic for easier maintenance and extension.
- **Style**
	- Log messages now include more detailed context about attached views and presenters.
- **Chores**
	- Removed redundant annotations for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->