### PR TITLE
Feature/non foreground notifications

### DIFF
--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainActivity.kt
@@ -42,6 +42,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        MainApplication.setupKoinDI(applicationContext)
+
         presenter.attachView(this)
         enableEdgeToEdge(SystemBarStyle.dark(Color.TRANSPARENT), SystemBarStyle.dark(Color.TRANSPARENT))
 

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainApplication.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/MainApplication.kt
@@ -1,29 +1,34 @@
 package network.bisq.mobile.client
 
 import android.app.Application
+import android.content.Context
 import network.bisq.mobile.client.di.androidClientModule
 import network.bisq.mobile.client.di.clientModule
 import network.bisq.mobile.domain.di.domainModule
 import network.bisq.mobile.domain.di.serviceModule
 import network.bisq.mobile.presentation.di.presentationModule
 import org.koin.android.ext.koin.androidContext
-import org.koin.core.context.GlobalContext
 
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 
 class MainApplication: Application() {
+    companion object {
+        private val clientModules = listOf(domainModule, serviceModule, presentationModule, clientModule, androidClientModule)
+
+        fun setupKoinDI(appContext: Context) {
+            // very important to avoid issues from the abuse of DI single {} singleton instances
+            stopKoin()
+            startKoin {
+                androidContext(appContext)
+                // order is important, last one is picked for each interface/class key
+                modules(clientModules)
+            }
+        }
+    }
     override fun onCreate() {
         super.onCreate()
 
-        setupKoinDI()
-    }
-
-    private fun setupKoinDI() {
-        if (GlobalContext.getOrNull() == null) {
-            startKoin {
-                androidContext(this@MainApplication)
-                modules(listOf(domainModule, serviceModule, presentationModule, clientModule, androidClientModule))
-            }
-        }
+        setupKoinDI(this)
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainActivity.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/MainActivity.kt
@@ -18,6 +18,9 @@ import network.bisq.mobile.presentation.ui.App
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import org.koin.android.ext.android.inject
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 
 class MainActivity : ComponentActivity() {
     private val presenter : MainPresenter by inject()
@@ -39,6 +42,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        cleanupKoin()
+
         presenter.attachView(this)
 
         setContent {
@@ -46,6 +51,11 @@ class MainActivity : ComponentActivity() {
         }
 
         handleDynamicPermissions()
+    }
+
+    private fun cleanupKoin() {
+        // this is needed here to ensure cleanups in "zombie state"
+        MainApplication.setupKoinDI(applicationContext)
     }
 
     override fun onStart() {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -90,8 +90,6 @@ val androidNodeModule = module {
 
     single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
 
-    // this line showcases both, the possibility to change behaviour of the app by changing one definition
-    // and binding the same obj to 2 different abstractions
     single<MainPresenter> {
         NodeMainPresenter(
             get(),

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -6,11 +6,14 @@ class NotificationServiceWrapper: ObservableObject {
 
     init() {
         self.notificationServiceController = get()
+        self.notificationServiceController.registerBackgroundTask()
     }
 }
 
 @main
 struct iosClient: App {
+
+//    @Environment(\.scenePhase) var scenePhase
     @StateObject var notificationServiceWrapper = NotificationServiceWrapper()
 
     init() {
@@ -21,6 +24,12 @@ struct iosClient: App {
         WindowGroup {
             ContentView()
                 .environmentObject(notificationServiceWrapper)
+//                .onChange(of: scenePhase) { newPhase in
+//                    if newPhase == .active {
+//                        // ensure no zombie mode - TODO not working causes crash
+//                        DependenciesProviderHelper().doInitKoin()
+//                    }
+//                }
         }
     }
 }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/notifications/controller/NotificationServiceController.android.kt
@@ -62,9 +62,9 @@ actual class NotificationServiceController (private val appForegroundController:
     actual override fun stopService() {
         // TODO we need to leave the service running if the user is ok with it
         if (isRunning) {
-            deleteNotificationChannel()
             val intent = Intent(context, BisqForegroundService::class.java)
             context.stopService(intent)
+            deleteNotificationChannel()
             isRunning = false
         } else {
             log.w { "Service is not running, skipping stop call" }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/di/ClientModule.ios.kt
@@ -13,11 +13,7 @@ import org.koin.dsl.module
 val iosClientModule = module {
     single<UrlLauncher> { IOSUrlLauncher() }
     single<AppForegroundController> { AppForegroundController() } bind ForegroundDetector::class
-    single<NotificationServiceController> {
-        NotificationServiceController(get()).apply {
-            this.registerBackgroundTask()
-        }
-    }
+    single<NotificationServiceController> { NotificationServiceController(get()) }
 
     single { ClientConnectivityService(get()) } bind ConnectivityService::class
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -74,15 +74,20 @@ open class MainPresenter(
         super.onPause()
     }
 
+    @CallSuper
+    override fun onDestroying() {
+        // to stop notification service and fully kill app (no zombie mode)
+        onResumeServices()
+        super.onDestroying()
+    }
+
     protected open fun onResumeServices() {
         openTradesNotificationService.stopNotificationService()
     }
 
     protected open fun onPauseServices() {
         connectivityService.stopMonitoring()
-//        FIXME this is causing issues with restarting the app after manual kill
-//        openTradesNotificationService.launchNotificationService()
-
+        openTradesNotificationService.launchNotificationService()
     }
 
     // Toggle action

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/DependenciesProviderHelper.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/DependenciesProviderHelper.kt
@@ -8,6 +8,7 @@ import network.bisq.mobile.domain.di.domainModule
 import network.bisq.mobile.domain.di.iosClientModule
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.Qualifier
 
@@ -17,6 +18,7 @@ import org.koin.core.qualifier.Qualifier
 class DependenciesProviderHelper {
 
     fun initKoin() {
+        stopKoin()
         val instance = startKoin {
             modules(listOf(domainModule, presentationModule, clientModule, iosClientModule, iosPresentationModule))
         }


### PR DESCRIPTION
 - contribs to #183 
 - re-enabled background open trades notification service
 - app kill does proper cleanup now
 - ensure abuse of singletons in DI does not cause problems on reinit of app (Koin deps cleanup)
 - fix android security exception on channel cleanup (bad sequence)
 - pull iOS BC registration out of koin instantiation (risks app crash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app stability by ensuring dependency injection is always properly reinitialized, preventing issues with lingering or "zombie" app states.
  - Fixed notification service shutdown sequence to ensure clean termination without leaving background processes.

- **Refactor**
  - Streamlined and centralized dependency injection setup across both Android and iOS, ensuring consistent and reliable initialization and cleanup.
  - Simplified and clarified dependency injection module definitions for easier maintenance.

- **Chores**
  - Removed outdated or redundant comments to improve code clarity.
  - Disabled a scene phase handler on iOS to prevent app crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->