### PR TITLE
Update/trade notification

### DIFF
--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/AndroidClientMainPresenter.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/AndroidClientMainPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client
 
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
@@ -34,6 +35,7 @@ class AndroidClientMainPresenter(
     settingsServiceFacade: SettingsServiceFacade,
     tradesServiceFacade: TradesServiceFacade,
     userProfileServiceFacade: UserProfileServiceFacade,
+    tradeReadStateRepository: TradeReadStateRepository,
     openTradesNotificationService: OpenTradesNotificationService,
     webSocketClientProvider: WebSocketClientProvider,
     urlLauncher: UrlLauncher
@@ -52,6 +54,7 @@ class AndroidClientMainPresenter(
     tradesServiceFacade,
     userProfileServiceFacade,
     openTradesNotificationService,
+    tradeReadStateRepository,
     webSocketClientProvider,
     urlLauncher
 ) {

--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/AndroidClientModule.kt
@@ -49,6 +49,7 @@ val androidClientModule = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     } bind AppPresenter::class

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -108,6 +108,7 @@ val androidNodeModule = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     } bind AppPresenter::class

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -5,7 +5,7 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.MainActivity
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.domain.UrlLauncher
-import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
@@ -41,10 +41,10 @@ class NodeMainPresenter(
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
-    private val tradeMessageMapRepository: TradeMessageMapRepository,
+    private val tradeReadStateRepository: TradeReadStateRepository,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
-) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {
+) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeReadStateRepository, urlLauncher) {
 
     private var applicationServiceCreated = false
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -40,9 +40,10 @@ class NodeMainPresenter(
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
+    private val tradeMessageMapRepository: tradeMessageMapRepository,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
-) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, urlLauncher) {
+) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {
 
     private var applicationServiceCreated = false
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -5,6 +5,7 @@ import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.MainActivity
 import network.bisq.mobile.android.node.service.AndroidMemoryReportService
 import network.bisq.mobile.domain.UrlLauncher
+import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
@@ -40,7 +41,7 @@ class NodeMainPresenter(
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
-    private val tradeMessageMapRepository: tradeMessageMapRepository,
+    private val tradeMessageMapRepository: TradeMessageMapRepository,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
 ) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
@@ -314,6 +314,10 @@ class NodeTradesServiceFacade(applicationService: AndroidApplicationService.Prov
         return Result.success(Unit)
     }
 
+    override fun resetSelectedTradeToNull() {
+        _selectedTrade.value = null
+    }
+
     // Private
     private suspend fun doTakeOffer(
         bisqEasyOffer: BisqEasyOffer,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -124,7 +124,9 @@ class ClientTradeChatMessagesServiceFacade(
                     val tradeId = _allBisqEasyOpenTradeMessages.value.find {
                         it.messageId == reaction.chatMessageId
                     }?.tradeId
-                    if (tradeId != null) {
+                    if (tradeId == null) {
+                        log.d { "No message found for reaction: messageId=${reaction.chatMessageId}" }
+                    } else {
                         updateChatMessages(tradeId = tradeId)
                     }
                 } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -125,6 +125,10 @@ class ClientTradesServiceFacade(
         return Result.success(Unit)
     }
 
+    override fun resetSelectedTradeToNull() {
+        _selectedTrade.value = null
+    }
+
     // Private
     private fun handleTradeItemPresentationChange(payload: List<TradeItemPresentationDto>, modificationType: ModificationType) {
         if (modificationType == ModificationType.REPLACE ||

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/TradeMessageMap.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/TradeMessageMap.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.domain.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+open class TradeMessageMap: BaseModel() {
+    // tradeId to messageCount
+    open var map: Map<String, Int> = emptyMap()
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/TradeReadState.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/TradeReadState.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.domain.data.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-open class TradeMessageMap: BaseModel() {
+open class TradeReadState: BaseModel() {
     // tradeId to messageCount
     open var map: Map<String, Int> = emptyMap()
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.data.repository
 
 import network.bisq.mobile.domain.data.model.BisqStats
 import network.bisq.mobile.domain.data.model.Settings
+import network.bisq.mobile.domain.data.model.TradeMessageMap
 import network.bisq.mobile.domain.data.model.User
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 
@@ -10,3 +11,4 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 open class BisqStatsRepository : SingleObjectRepository<BisqStats>()
 open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>) : SingleObjectRepository<Settings>(keyValueStorage, Settings())
 open class UserRepository(keyValueStorage: KeyValueStorage<User>) : SingleObjectRepository<User>(keyValueStorage, User())
+open class TradeMessageRepository(keyValueStorage: KeyValueStorage<TradeMessageMap>) : SingleObjectRepository<TradeMessageMap>(keyValueStorage, TradeMessageMap())

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.domain.data.repository
 
 import network.bisq.mobile.domain.data.model.BisqStats
 import network.bisq.mobile.domain.data.model.Settings
-import network.bisq.mobile.domain.data.model.TradeMessageMap
+import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.model.User
 import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 
@@ -11,4 +11,4 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 open class BisqStatsRepository : SingleObjectRepository<BisqStats>()
 open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>) : SingleObjectRepository<Settings>(keyValueStorage, Settings())
 open class UserRepository(keyValueStorage: KeyValueStorage<User>) : SingleObjectRepository<User>(keyValueStorage, User())
-open class TradeMessageMapRepository(keyValueStorage: KeyValueStorage<TradeMessageMap>) : SingleObjectRepository<TradeMessageMap>(keyValueStorage, TradeMessageMap())
+open class TradeReadStateRepository(keyValueStorage: KeyValueStorage<TradeReadState>) : SingleObjectRepository<TradeReadState>(keyValueStorage, TradeReadState())

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/Repositories.kt
@@ -11,4 +11,4 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 open class BisqStatsRepository : SingleObjectRepository<BisqStats>()
 open class SettingsRepository(keyValueStorage: KeyValueStorage<Settings>) : SingleObjectRepository<Settings>(keyValueStorage, Settings())
 open class UserRepository(keyValueStorage: KeyValueStorage<User>) : SingleObjectRepository<User>(keyValueStorage, User())
-open class TradeMessageRepository(keyValueStorage: KeyValueStorage<TradeMessageMap>) : SingleObjectRepository<TradeMessageMap>(keyValueStorage, TradeMessageMap())
+open class TradeMessageMapRepository(keyValueStorage: KeyValueStorage<TradeMessageMap>) : SingleObjectRepository<TradeMessageMap>(keyValueStorage, TradeMessageMap())

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -7,7 +7,7 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.data.repository.TradeRepository
-import network.bisq.mobile.domain.data.repository.TradeMessageRepository
+import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.getPlatformSettings
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
@@ -31,7 +31,7 @@ val domainModule = module {
     single<SettingsRepository> { SettingsRepository(get()) }
     single<UserRepository> { UserRepository(get()) }
     single<TradeRepository> { TradeRepository(get()) }
-    single<TradeMessageRepository> { TradeMessageRepository(get()) }
+    single<TradeMessageMapRepository> { TradeMessageMapRepository(get()) }
 
     // Services
     single<OpenTradesNotificationService> { OpenTradesNotificationService(get(), get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -7,7 +7,7 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.data.repository.TradeRepository
-import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.getPlatformSettings
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
@@ -31,7 +31,7 @@ val domainModule = module {
     single<SettingsRepository> { SettingsRepository(get()) }
     single<UserRepository> { UserRepository(get()) }
     single<TradeRepository> { TradeRepository(get()) }
-    single<TradeMessageMapRepository> { TradeMessageMapRepository(get()) }
+    single<TradeReadStateRepository> { TradeReadStateRepository(get()) }
 
     // Services
     single<OpenTradesNotificationService> { OpenTradesNotificationService(get(), get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -7,6 +7,7 @@ import network.bisq.mobile.domain.data.persistance.KeyValueStorage
 import network.bisq.mobile.domain.data.repository.BisqStatsRepository
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.data.repository.TradeRepository
+import network.bisq.mobile.domain.data.repository.TradeMessageRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.getPlatformSettings
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
@@ -30,6 +31,7 @@ val domainModule = module {
     single<SettingsRepository> { SettingsRepository(get()) }
     single<UserRepository> { UserRepository(get()) }
     single<TradeRepository> { TradeRepository(get()) }
+    single<TradeMessageRepository> { TradeMessageRepository(get()) }
 
     // Services
     single<OpenTradesNotificationService> { OpenTradesNotificationService(get(), get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradesServiceFacade.kt
@@ -42,4 +42,6 @@ interface TradesServiceFacade : LifeCycleAware {
     suspend fun btcConfirmed(): Result<Unit>
 
     suspend fun exportTradeDate(): Result<Unit>
+
+    fun resetSelectedTradeToNull()
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.IODispatcher
+import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
@@ -41,7 +42,7 @@ open class ClientMainPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     openTradesNotificationService: OpenTradesNotificationService,
-    private val tradeMessageMapRepository: tradeMessageMapRepository,
+    private val tradeMessageMapRepository: TradeMessageMapRepository,
     private val webSocketClientProvider: WebSocketClientProvider,
     urlLauncher: UrlLauncher
 ) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -6,7 +6,7 @@ import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.IODispatcher
-import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
@@ -42,10 +42,10 @@ open class ClientMainPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     openTradesNotificationService: OpenTradesNotificationService,
-    private val tradeMessageMapRepository: TradeMessageMapRepository,
+    private val tradeReadStateRepository: TradeReadStateRepository,
     private val webSocketClientProvider: WebSocketClientProvider,
     urlLauncher: UrlLauncher
-) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {
+) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeReadStateRepository, urlLauncher) {
 
     private var lastConnectedStatus: Boolean? = null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -41,9 +41,10 @@ open class ClientMainPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     openTradesNotificationService: OpenTradesNotificationService,
+    private val tradeMessageMapRepository: tradeMessageMapRepository,
     private val webSocketClientProvider: WebSocketClientProvider,
     urlLauncher: UrlLauncher
-) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, urlLauncher) {
+) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeMessageMapRepository, urlLauncher) {
 
     private var lastConnectedStatus: Boolean? = null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -78,15 +78,12 @@ open class MainPresenter(
                 tradeList
             }.collect {
                 val readState = tradeReadStateRepository.fetch() ?: TradeReadState()
-                log.d { "open trade chats: [[[start]]] ${readState.map.size}" }
                 _tradesWithUnreadMessages.value = it.map { trade ->
                     val chatSize = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-                    log.d { "open trade chats: ${trade.tradeId} --> $chatSize" }
                     return@map trade.tradeId to chatSize
                 }.filter { idSizePair ->
                     val recordedSize = readState.map[idSizePair.first]
                     if (recordedSize != null && recordedSize >= idSizePair.second) {
-                        log.d { "open trade chats: ${idSizePair.first} --> is read" }
                         return@filter false
                     }
                     return@filter true

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.setDefaultLocale
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 /**
@@ -31,7 +32,6 @@ open class MainPresenter(
     private val urlLauncher: UrlLauncher
 ) : BasePresenter(null), AppPresenter {
 
-    val NOTIFICATION_SYNC_INTERVAL = 30_000L//60_000L
     override lateinit var navController: NavHostController
     override lateinit var tabNavController: NavHostController
 
@@ -65,7 +65,7 @@ open class MainPresenter(
         val notificationTimerFlow = flow {
             while (true) {
                 emit(Unit)
-                delay(NOTIFICATION_SYNC_INTERVAL)
+                delay(BisqConfig.NOTIFICATION_SYNC_INTERVAL)
             }
         }
 
@@ -78,6 +78,7 @@ open class MainPresenter(
                 tradeList
             }.collect {
                 val readState = tradeReadStateRepository.fetch() ?: TradeReadState()
+                _readMessageCountsByTrade.value = readState.map
                 _tradesWithUnreadMessages.value = it.map { trade ->
                     val chatSize = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
                     return@map trade.tradeId to chatSize
@@ -106,9 +107,6 @@ open class MainPresenter(
             .take(1)
             .launchIn(presenterScope)
 
-        presenterScope.launch {
-
-        }
     }
 
     override fun onResume() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation
 
 import androidx.annotation.CallSuper
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -50,6 +51,8 @@ open class MainPresenter(
     private val _readMessageCountsByTrade = MutableStateFlow(emptyMap<String, Int>())
     override val readMessageCountsByTrade: StateFlow<Map<String, Int>> = _readMessageCountsByTrade
 
+    private var job: Job? = null
+
     init {
         val localeCode = getDeviceLanguageCode()
         val screenWidth = getScreenWidthDp()
@@ -69,7 +72,7 @@ open class MainPresenter(
             }
         }
 
-        ioScope.launch {
+        job = ioScope.launch {
             combine(
                 tradesServiceFacade.openTradeItems,
                 tradesServiceFacade.selectedTrade,
@@ -121,6 +124,7 @@ open class MainPresenter(
 
     @CallSuper
     override fun onDestroying() {
+        job?.cancel()
         // to stop notification service and fully kill app (no zombie mode)
         onResumeServices()
         super.onDestroying()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -31,7 +31,7 @@ open class MainPresenter(
     private val urlLauncher: UrlLauncher
 ) : BasePresenter(null), AppPresenter {
 
-    val NOTIFICATION_SYNC_INTERVAL = 25_000L//60_000L
+    val NOTIFICATION_SYNC_INTERVAL = 30_000L//60_000L
     override lateinit var navController: NavHostController
     override lateinit var tabNavController: NavHostController
 
@@ -46,6 +46,9 @@ open class MainPresenter(
 
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
+
+    private val _readMessageCountsByTrade = MutableStateFlow(emptyMap<String, Int>())
+    override val readMessageCountsByTrade: StateFlow<Map<String, Int>> = _readMessageCountsByTrade
 
     init {
         val localeCode = getDeviceLanguageCode()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -171,7 +171,7 @@ val presentationModule = module {
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get(), get()) }
 
-    single { TradeChatPresenter(get(), get(), get(), get()) }
+    single { TradeChatPresenter(get(), get(), get(), get(), get()) }
 
     single { TradeGuidePresenter(get(), get()) } bind TradeGuidePresenter::class
     single { WalletGuidePresenter(get()) } bind WalletGuidePresenter::class

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -88,7 +88,7 @@ val presentationModule = module {
     factory<AgreementPresenter> { AgreementPresenter(get(), get()) } bind IAgreementPresenter::class
 
     single { OnBoardingPresenter(get(), get(), get()) } bind IOnboardingPresenter::class
-    single { TabContainerPresenter(get(), get()) } bind ITabContainerPresenter::class
+    single { TabContainerPresenter(get(), get(), get()) } bind ITabContainerPresenter::class
 
     single<SettingsPresenter> { SettingsPresenter(get(), get()) } bind ISettingsPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -165,11 +165,11 @@ val presentationModule = module {
 
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    factory { OpenTradeListPresenter(get(), get(), get()) }
+    factory { OpenTradeListPresenter(get(), get(), get(), get()) }
     single { TradeDetailsHeaderPresenter(get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
-    factory { OpenTradePresenter(get(), get(), get()) }
+    factory { OpenTradePresenter(get(), get(), get(), get()) }
 
     single { TradeChatPresenter(get(), get(), get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -165,7 +165,7 @@ val presentationModule = module {
 
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    factory { OpenTradeListPresenter(get(), get(), get(), get()) }
+    factory { OpenTradeListPresenter(get(), get(), get()) }
     single { TradeDetailsHeaderPresenter(get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -67,7 +67,7 @@ import org.koin.dsl.module
 
 val presentationModule = module {
     single<MainPresenter> {
-        ClientMainPresenter(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+        ClientMainPresenter(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
     } bind AppPresenter::class
 
     single<TopBarPresenter> { TopBarPresenter(get(), get(), get(), get()) } bind ITopBarPresenter::class

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -4,6 +4,7 @@ import ErrorOverlay
 import androidx.compose.runtime.*
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.ViewPresenter
@@ -26,7 +27,7 @@ interface AppPresenter : ViewPresenter {
 
     val isSmallScreen: StateFlow<Boolean>
 
-    val unreadTrades: StateFlow<Map<String, Int>>
+    val tradesWithUnreadMessages: StateFlow<Map<String, Int>>
 
     // Actions
     fun toggleContentVisibility()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -26,6 +26,8 @@ interface AppPresenter : ViewPresenter {
 
     val isSmallScreen: StateFlow<Boolean>
 
+    val unreadTrades: StateFlow<Map<String, Int>>
+
     // Actions
     fun toggleContentVisibility()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -4,7 +4,6 @@ import ErrorOverlay
 import androidx.compose.runtime.*
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.ViewPresenter

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -28,6 +28,7 @@ interface AppPresenter : ViewPresenter {
     val isSmallScreen: StateFlow<Boolean>
 
     val tradesWithUnreadMessages: StateFlow<Map<String, Int>>
+    val readMessageCountsByTrade: StateFlow<Map<String, Int>>
 
     // Actions
     fun toggleContentVisibility()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
@@ -1,0 +1,5 @@
+package network.bisq.mobile.presentation.ui
+
+object BisqConfig {
+    const val NOTIFICATION_SYNC_INTERVAL = 60_000L
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Card.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Card.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -18,12 +19,13 @@ fun BisqCard(
     borderRadius: Dp = BisqUIConstants.ScreenPaddingHalf,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    backgroundColor: Color = BisqTheme.colors.dark_grey40,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
         modifier = Modifier
             .clip(RoundedCornerShape(borderRadius))
-            .background(BisqTheme.colors.dark_grey40)
+            .background(backgroundColor)
             .padding(padding)
             .fillMaxWidth(),
         horizontalAlignment = horizontalAlignment,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
@@ -46,8 +46,8 @@ fun AnimatedBadge(
     )
 
     Badge(
-        containerColor = BisqTheme.colors.danger,
-        contentColor = BisqTheme.colors.white,
+        containerColor = BisqTheme.colors.warningHover,
+        contentColor = BisqTheme.colors.dark_grey20,
         modifier = Modifier
             .offset(y = (-4).dp)
             .graphicsLayer {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
@@ -1,0 +1,61 @@
+package network.bisq.mobile.presentation.ui.components.atoms.animations
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
+
+@Composable
+fun AnimatedBadge(
+    content: @Composable RowScope.() -> Unit
+) {
+
+    val transition = rememberInfiniteTransition(label = "badgePulse")
+    val scale by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.1f,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = 5600 // 600ms pulse + 5000ms delay
+                1.2f at 300 // halfway scale up
+                1f at 600 // back to normal (end of pulse)
+                1f at 5600 // hold until next repeat
+            },
+            repeatMode = RepeatMode.Restart
+        ), label = "scale"
+    )
+
+    val rotateX by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 10f,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = 5600 // 600ms pulse + 5000ms delay
+                10f at 300 // halfway scale up
+                0f at 600 // back to normal (end of pulse)
+                0f at 5600 // hold until next repeat
+            },
+            repeatMode = RepeatMode.Restart
+        ), label = "rotateX"
+    )
+
+    Badge(
+        containerColor = BisqTheme.colors.danger,
+        contentColor = BisqTheme.colors.white,
+        modifier = Modifier
+            .offset(y = (-4).dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                rotationZ = rotateX
+            }
+    ) {
+        content()
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
@@ -13,43 +12,52 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
 fun AnimatedBadge(
+    showAnimation: Boolean,
     content: @Composable RowScope.() -> Unit
 ) {
 
-    val transition = rememberInfiniteTransition(label = "badgePulse")
-    val scale by transition.animateFloat(
-        initialValue = 1f,
-        targetValue = 1.1f,
-        animationSpec = infiniteRepeatable(
-            animation = keyframes {
-                durationMillis = 5600 // 600ms pulse + 5000ms delay
-                1.2f at 300 // halfway scale up
-                1f at 600 // back to normal (end of pulse)
-                1f at 5600 // hold until next repeat
-            },
-            repeatMode = RepeatMode.Restart
-        ), label = "scale"
-    )
+    val scale: Float
+    val rotateX: Float
 
-    val rotateX by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 10f,
-        animationSpec = infiniteRepeatable(
-            animation = keyframes {
-                durationMillis = 5600 // 600ms pulse + 5000ms delay
-                10f at 300 // halfway scale up
-                0f at 600 // back to normal (end of pulse)
-                0f at 5600 // hold until next repeat
-            },
-            repeatMode = RepeatMode.Restart
-        ), label = "rotateX"
-    )
+    if (showAnimation) {
+        val transition = rememberInfiniteTransition(label = "badgePulse")
+        scale = transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 1.1f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = 5600 // 600ms pulse + 5000ms delay
+                    1.2f at 300 // halfway scale up
+                    1f at 600 // back to normal (end of pulse)
+                    1f at 5600 // hold until next repeat
+                },
+                repeatMode = RepeatMode.Restart
+            ), label = "scale"
+        ).value
+
+        rotateX = transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 10f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = 5600 // 600ms pulse + 5000ms delay
+                    10f at 300 // halfway scale up
+                    0f at 600 // back to normal (end of pulse)
+                    0f at 5600 // hold until next repeat
+                },
+                repeatMode = RepeatMode.Restart
+            ), label = "rotateX"
+        ).value
+    } else {
+        scale = 1f
+        rotateX = 0f
+    }
 
     Badge(
         containerColor = BisqTheme.colors.warningHover,
         contentColor = BisqTheme.colors.dark_grey20,
         modifier = Modifier
-            .offset(y = (-4).dp)
+            .offset(x = 8.dp, y = (-8).dp)
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -44,6 +44,17 @@ fun BottomNavigation(
                 onClick = { onItemClick(navigationItem) },
                 icon = {
 
+                    val icon = @Composable {
+                        Image(
+                            painter = painterResource(navigationItem.icon),
+                            contentDescription = "",
+                            modifier = Modifier.size(24.dp),
+                            colorFilter = ColorFilter.tint(
+                                color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
+                            )
+                        )
+                    }
+
                     if (index == 2 && unreadTradeCount > 0) {
                         BadgedBox(
                             badge = {
@@ -56,24 +67,10 @@ fun BottomNavigation(
                                 }
                             }
                         ) {
-                            Image(
-                                painter = painterResource(navigationItem.icon),
-                                contentDescription = "",
-                                modifier = Modifier.size(24.dp),
-                                colorFilter = ColorFilter.tint(
-                                    color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
-                                )
-                            )
+                            icon()
                         }
                     } else {
-                        Image(
-                            painter = painterResource(navigationItem.icon),
-                            contentDescription = "",
-                            modifier = Modifier.size(24.dp),
-                            colorFilter = ColorFilter.tint(
-                                color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
-                            )
-                        )
+                        icon()
                     }
                 },
                 label = {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -26,6 +26,8 @@ fun BottomNavigation(
     onItemClick: (BottomNavigationItem) -> Unit
 ) {
 
+    val NOTIFICATION_TAB_INDEX = 2
+
     NavigationBar(
         containerColor = BisqTheme.colors.backgroundColor
     ) {
@@ -56,7 +58,7 @@ fun BottomNavigation(
                         )
                     }
 
-                    if (index == 2 && unreadTradeCount > 0) {
+                    if (index == NOTIFICATION_TAB_INDEX && unreadTradeCount > 0) {
                         BadgedBox(
                             badge = {
                                 AnimatedBadge(showAnimation = showAnimation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -48,7 +48,11 @@ fun BottomNavigation(
                         BadgedBox(
                             badge = {
                                 AnimatedBadge {
-                                    BisqText.xsmallLight(unreadTradeCount.toString(), textAlign = TextAlign.Center)
+                                    BisqText.xsmallLight(
+                                        unreadTradeCount.toString(),
+                                        textAlign = TextAlign.Center,
+                                        color = BisqTheme.colors.dark_grey20
+                                    )
                                 }
                             }
                         ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -26,7 +26,7 @@ fun BottomNavigation(
     onItemClick: (BottomNavigationItem) -> Unit
 ) {
 
-    val NOTIFICATION_TAB_INDEX = 2
+    val MY_TRADES_TAB_INDEX = 2
 
     NavigationBar(
         containerColor = BisqTheme.colors.backgroundColor
@@ -58,7 +58,7 @@ fun BottomNavigation(
                         )
                     }
 
-                    if (index == NOTIFICATION_TAB_INDEX && unreadTradeCount > 0) {
+                    if (index == MY_TRADES_TAB_INDEX && unreadTradeCount > 0) {
                         BadgedBox(
                             badge = {
                                 AnimatedBadge(showAnimation = showAnimation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -3,22 +3,20 @@ package network.bisq.mobile.presentation.ui.navigation
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.animations.AnimatedBadge
 import network.bisq.mobile.presentation.ui.composeModels.BottomNavigationItem
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun BottomNavigation(
     items: List<BottomNavigationItem>,
@@ -26,10 +24,12 @@ fun BottomNavigation(
     onItemClick: (BottomNavigationItem) -> Unit
 ) {
 
+    val badgeCount = 10
+
     NavigationBar(
         containerColor = BisqTheme.colors.backgroundColor
     ) {
-        items.forEach { navigationItem ->
+        items.forEachIndexed { index, navigationItem ->
             NavigationBarItem(
                 colors = NavigationBarItemColors(
                     selectedIndicatorColor = BisqTheme.colors.backgroundColor,
@@ -44,11 +44,67 @@ fun BottomNavigation(
                 selected = currentRoute == navigationItem.route,
                 onClick = { onItemClick(navigationItem) },
                 icon = {
+
+                    if (index == 2 && badgeCount > 0) {
+                        BadgedBox(
+                            badge = {
+                                AnimatedBadge {
+                                    BisqText.xsmallLight(badgeCount.toString(), textAlign = TextAlign.Center)
+                                }
+                            }
+                        ) {
+                            Image(
+                                painter = painterResource(navigationItem.icon),
+                                contentDescription = "",
+                                modifier = Modifier.size(24.dp),
+                                colorFilter = ColorFilter.tint(
+                                    color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
+                                )
+                            )
+                        }
+                    } else {
+                        Image(
+                            painter = painterResource(navigationItem.icon),
+                            contentDescription = "",
+                            modifier = Modifier.size(24.dp),
+                            colorFilter = ColorFilter.tint(
+                                color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
+                            )
+                        )
+                    }
+
+                    /*
+                    Box(contentAlignment = Alignment.TopEnd) {
+                        Image(
+                            painter = painterResource(navigationItem.icon),
+                            contentDescription = "",
+                            modifier = Modifier.size(24.dp),
+                            colorFilter = ColorFilter.tint(
+                                color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
+                            )
+                        )
+                        if (index == 2 && badgeCount > 0) {
+                            Box(
+                                modifier = Modifier
+                                    .offset(x = 12.dp, y = (-4).dp)
+                                    .size(20.dp)
+                                    .clip(CircleShape)
+                                    .background(BisqTheme.colors.primary),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                BisqText.xsmallLight(badgeCount.toString(), textAlign = TextAlign.Center)
+                            }
+                        }
+                    }
+                    */
+
+                    /*
                     Image(
                         painterResource(navigationItem.icon), "",
                         modifier = Modifier.size(24.dp),
                         colorFilter = ColorFilter.tint(color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White)
                     )
+                    */
                 },
                 label = {
                     BisqText.baseRegular(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -75,39 +75,6 @@ fun BottomNavigation(
                             )
                         )
                     }
-
-                    /*
-                    Box(contentAlignment = Alignment.TopEnd) {
-                        Image(
-                            painter = painterResource(navigationItem.icon),
-                            contentDescription = "",
-                            modifier = Modifier.size(24.dp),
-                            colorFilter = ColorFilter.tint(
-                                color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White
-                            )
-                        )
-                        if (index == 2 && badgeCount > 0) {
-                            Box(
-                                modifier = Modifier
-                                    .offset(x = 12.dp, y = (-4).dp)
-                                    .size(20.dp)
-                                    .clip(CircleShape)
-                                    .background(BisqTheme.colors.primary),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                BisqText.xsmallLight(badgeCount.toString(), textAlign = TextAlign.Center)
-                            }
-                        }
-                    }
-                    */
-
-                    /*
-                    Image(
-                        painterResource(navigationItem.icon), "",
-                        modifier = Modifier.size(24.dp),
-                        colorFilter = ColorFilter.tint(color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else Color.White)
-                    )
-                    */
                 },
                 label = {
                     BisqText.baseRegular(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -22,6 +22,7 @@ fun BottomNavigation(
     items: List<BottomNavigationItem>,
     currentRoute: String,
     unreadTradeCount: Int,
+    showAnimation: Boolean,
     onItemClick: (BottomNavigationItem) -> Unit
 ) {
 
@@ -58,7 +59,7 @@ fun BottomNavigation(
                     if (index == 2 && unreadTradeCount > 0) {
                         BadgedBox(
                             badge = {
-                                AnimatedBadge {
+                                AnimatedBadge(showAnimation = showAnimation) {
                                     BisqText.xsmallLight(
                                         unreadTradeCount.toString(),
                                         textAlign = TextAlign.Center,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -21,10 +21,9 @@ import org.jetbrains.compose.resources.painterResource
 fun BottomNavigation(
     items: List<BottomNavigationItem>,
     currentRoute: String,
+    unreadTradeCount: Int,
     onItemClick: (BottomNavigationItem) -> Unit
 ) {
-
-    val badgeCount = 10
 
     NavigationBar(
         containerColor = BisqTheme.colors.backgroundColor
@@ -45,11 +44,11 @@ fun BottomNavigation(
                 onClick = { onItemClick(navigationItem) },
                 icon = {
 
-                    if (index == 2 && badgeCount > 0) {
+                    if (index == 2 && unreadTradeCount > 0) {
                         BadgedBox(
                             badge = {
                                 AnimatedBadge {
-                                    BisqText.xsmallLight(badgeCount.toString(), textAlign = TextAlign.Center)
+                                    BisqText.xsmallLight(unreadTradeCount.toString(), textAlign = TextAlign.Center)
                                 }
                             }
                         ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -1,14 +1,40 @@
 package network.bisq.mobile.presentation.ui.uicases
 
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter
 
 class TabContainerPresenter(
-    mainPresenter: MainPresenter,
+    private val mainPresenter: MainPresenter,
     private val createOfferPresenter: CreateOfferPresenter,
 ) : BasePresenter(mainPresenter), ITabContainerPresenter {
+
+    private val _unreadTrades: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
+    override val unreadTrades: StateFlow<Map<String, Int>> = _unreadTrades
+
+    private var job: Job? = null
+
+    override fun onViewAttached() {
+        super.onViewAttached()
+
+        job = presenterScope.launch {
+            mainPresenter.unreadTrades.collect{ _unreadTrades.value = it }
+        }
+    }
+
+    override fun onViewUnattaching() {
+        job?.cancel()
+        job = null
+        super.onViewUnattaching()
+    }
 
     override fun createOffer() {
         try {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -1,12 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases
 
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
-import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -17,8 +14,8 @@ class TabContainerPresenter(
     private val createOfferPresenter: CreateOfferPresenter,
 ) : BasePresenter(mainPresenter), ITabContainerPresenter {
 
-    private val _unreadTrades: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
-    override val unreadTrades: StateFlow<Map<String, Int>> = _unreadTrades
+    private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
+    override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
 
     private var job: Job? = null
 
@@ -26,7 +23,7 @@ class TabContainerPresenter(
         super.onViewAttached()
 
         job = presenterScope.launch {
-            mainPresenter.unreadTrades.collect{ _unreadTrades.value = it }
+            mainPresenter.tradesWithUnreadMessages.collect{ _tradesWithUnreadMessages.value = it }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -12,10 +13,12 @@ import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPrese
 class TabContainerPresenter(
     private val mainPresenter: MainPresenter,
     private val createOfferPresenter: CreateOfferPresenter,
+    private val settingsServiceFacade: SettingsServiceFacade,
 ) : BasePresenter(mainPresenter), ITabContainerPresenter {
 
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
+    override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
 
     private var job: Job? = null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -30,6 +30,7 @@ class TabContainerPresenter(
     override fun onViewUnattaching() {
         job?.cancel()
         job = null
+        _tradesWithUnreadMessages.value = emptyMap()
         super.onViewUnattaching()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -28,7 +28,7 @@ val navigationListItem = listOf(
 )
 
 interface ITabContainerPresenter : ViewPresenter {
-    val unreadTrades: StateFlow<Map<String, Int>>
+    val tradesWithUnreadMessages: StateFlow<Map<String, Int>>
     fun createOffer()
 }
 
@@ -42,7 +42,7 @@ fun TabContainerScreen() {
             navBackStackEntry?.destination?.route
         }
     }
-    val unreadTradeCount by presenter.unreadTrades.collectAsState()
+    val tradesWithUnreadMessages by presenter.tradesWithUnreadMessages.collectAsState()
 
     RememberPresenterLifecycle(presenter)
 
@@ -72,7 +72,7 @@ fun TabContainerScreen() {
             BottomNavigation(
                 items = navigationListItem,
                 currentRoute = currentRoute.orEmpty(),
-                unreadTradeCount = unreadTradeCount.size,
+                unreadTradeCount = tradesWithUnreadMessages.size,
                 onItemClick = { currentNavigationItem ->
                     Routes.fromString(currentNavigationItem.route)?.let { presenter.navigateToTab(it) }
                 })

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -29,6 +29,7 @@ val navigationListItem = listOf(
 
 interface ITabContainerPresenter : ViewPresenter {
     val tradesWithUnreadMessages: StateFlow<Map<String, Int>>
+    val showAnimation: StateFlow<Boolean>
     fun createOffer()
 }
 
@@ -43,6 +44,7 @@ fun TabContainerScreen() {
         }
     }
     val tradesWithUnreadMessages by presenter.tradesWithUnreadMessages.collectAsState()
+    val showAnimation by presenter.showAnimation.collectAsState()
 
     RememberPresenterLifecycle(presenter)
 
@@ -73,6 +75,7 @@ fun TabContainerScreen() {
                 items = navigationListItem,
                 currentRoute = currentRoute.orEmpty(),
                 unreadTradeCount = tradesWithUnreadMessages.size,
+                showAnimation = showAnimation,
                 onItemClick = { currentNavigationItem ->
                     Routes.fromString(currentNavigationItem.route)?.let { presenter.navigateToTab(it) }
                 })

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -1,9 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import bisqapps.shared.presentation.generated.resources.Res
@@ -11,11 +8,13 @@ import bisqapps.shared.presentation.generated.resources.icon_home
 import bisqapps.shared.presentation.generated.resources.icon_market
 import bisqapps.shared.presentation.generated.resources.icon_settings
 import bisqapps.shared.presentation.generated.resources.icon_trades
+import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.button.BisqFABAddButton
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.composeModels.BottomNavigationItem
+import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.navigation.BottomNavigation
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.navigation.graph.TabNavGraph
@@ -29,6 +28,7 @@ val navigationListItem = listOf(
 )
 
 interface ITabContainerPresenter : ViewPresenter {
+    val unreadTrades: StateFlow<Map<String, Int>>
     fun createOffer()
 }
 
@@ -42,6 +42,9 @@ fun TabContainerScreen() {
             navBackStackEntry?.destination?.route
         }
     }
+    val unreadTradeCount by presenter.unreadTrades.collectAsState()
+
+    RememberPresenterLifecycle(presenter)
 
     BisqStaticScaffold(
         topBar = {
@@ -69,6 +72,7 @@ fun TabContainerScreen() {
             BottomNavigation(
                 items = navigationListItem,
                 currentRoute = currentRoute.orEmpty(),
+                unreadTradeCount = unreadTradeCount.size,
                 onItemClick = { currentNavigationItem ->
                     Routes.fromString(currentNavigationItem.route)?.let { presenter.navigateToTab(it) }
                 })

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
@@ -42,7 +42,6 @@ import org.koin.compose.koinInject
 fun OpenTradeListScreen() {
     val presenter: OpenTradeListPresenter = koinInject()
 
-    // val readMessageCountsByTrade by presenter.readMessageCountsByTrade.collectAsState()
     val tradesWithUnreadMessages by presenter.tradesWithUnreadMessages.collectAsState()
 
     val sortedList =
@@ -50,10 +49,8 @@ fun OpenTradeListScreen() {
 
     RememberPresenterLifecycle(presenter)
 
-    fun isTradeUnread(trade: TradeItemPresentationModel): Boolean {
-        // val chatCount = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-        //val recordedCount = read[trade.tradeId]
-        return trade.tradeId in tradesWithUnreadMessages.keys
+    fun isTradeUnread(tradeId: String): Boolean {
+        return tradeId in tradesWithUnreadMessages.keys
     }
 
     if (presenter.tradeGuideVisible.collectAsState().value) {
@@ -103,7 +100,7 @@ fun OpenTradeListScreen() {
                 }
             }
             items(sortedList) { trade ->
-                val isUnread = isTradeUnread(trade) //, readMessageCountsByTrade)
+                val isUnread = isTradeUnread(trade.tradeId)
                 OpenTradeListItem(
                     trade,
                     isUnread = isUnread,
@@ -119,7 +116,7 @@ fun OpenTradeListScreen() {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             items(sortedList) { trade ->
-                val isUnread = isTradeUnread(trade) //, readMessageCountsByTrade)
+                val isUnread = isTradeUnread(trade.tradeId)
                 OpenTradeListItem(
                     trade,
                     isUnread = isUnread,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
@@ -42,17 +42,18 @@ import org.koin.compose.koinInject
 fun OpenTradeListScreen() {
     val presenter: OpenTradeListPresenter = koinInject()
 
-    val readMessageCountsByTrade by presenter.readMessageCountsByTrade.collectAsState()
+    // val readMessageCountsByTrade by presenter.readMessageCountsByTrade.collectAsState()
+    val tradesWithUnreadMessages by presenter.tradesWithUnreadMessages.collectAsState()
 
     val sortedList =
         presenter.openTradeItems.collectAsState().value.sortedByDescending { it.bisqEasyTradeModel.takeOfferDate }
 
     RememberPresenterLifecycle(presenter)
 
-    fun isTradeUnread(trade: TradeItemPresentationModel, read: Map<String, Int>): Boolean {
-        val chatCount = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-        val recordedCount = read[trade.tradeId]
-        return recordedCount == null || recordedCount < chatCount
+    fun isTradeUnread(trade: TradeItemPresentationModel): Boolean {
+        // val chatCount = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
+        //val recordedCount = read[trade.tradeId]
+        return trade.tradeId in tradesWithUnreadMessages.keys
     }
 
     if (presenter.tradeGuideVisible.collectAsState().value) {
@@ -102,7 +103,7 @@ fun OpenTradeListScreen() {
                 }
             }
             items(sortedList) { trade ->
-                val isUnread = isTradeUnread(trade, readMessageCountsByTrade)
+                val isUnread = isTradeUnread(trade) //, readMessageCountsByTrade)
                 OpenTradeListItem(
                     trade,
                     isUnread = isUnread,
@@ -118,7 +119,7 @@ fun OpenTradeListScreen() {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             items(sortedList) { trade ->
-                val isUnread = isTradeUnread(trade, readMessageCountsByTrade)
+                val isUnread = isTradeUnread(trade) //, readMessageCountsByTrade)
                 OpenTradeListItem(
                     trade,
                     isUnread = isUnread,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
@@ -24,11 +24,11 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 @Composable
 fun OpenTradeListItem(
     item: TradeItemPresentationModel,
+    isUnread: Boolean,
     onSelect: () -> Unit,
 ) {
-    val hasUpdate = true
-    val bgColor = if (hasUpdate)
-        BisqTheme.colors.primary.copy(alpha = 0.35f)
+    val bgColor = if (isUnread)
+        BisqTheme.colors.warning.copy(alpha = 0.15f)
     else
         BisqTheme.colors.dark_grey40
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
@@ -26,7 +26,13 @@ fun OpenTradeListItem(
     item: TradeItemPresentationModel,
     onSelect: () -> Unit,
 ) {
-    BisqCard {
+    val hasUpdate = true
+    val bgColor = if (hasUpdate)
+        BisqTheme.colors.primary.copy(alpha = 0.35f)
+    else
+        BisqTheme.colors.dark_grey40
+
+    BisqCard(backgroundColor = bgColor) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -3,7 +3,9 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.data.model.TradeMessageMap
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
 import network.bisq.mobile.domain.formatters.NumberFormatter
 import network.bisq.mobile.domain.formatters.PriceSpecFormatter
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
@@ -15,7 +17,8 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 class OpenTradeListPresenter(
     mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
-    private val settingsServiceFacade: SettingsServiceFacade
+    private val settingsServiceFacade: SettingsServiceFacade,
+    private val tradeMessageMapRepository: TradeMessageMapRepository,
 ) : BasePresenter(mainPresenter) {
 
     private val _openTradeItems: MutableStateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
@@ -42,6 +45,9 @@ class OpenTradeListPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
+        this.presenterScope.launch {
+            val readTradeMap = tradeMessageMapRepository.fetch() ?: TradeMessageMap()
+        }
     }
 
     fun onOpenTradeGuide() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -46,7 +46,6 @@ class OpenTradeListPresenter(
                 }
 
                 mainPresenter.tradesWithUnreadMessages.collect {
-                    log.d { "open trade [OpenTradeListPresenter] ${it.size}"}
                     _tradesWithUnreadMessages.value = it
                     _readMessageCountsByTrade.value = mainPresenter.readMessageCountsByTrade.value
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -49,7 +49,7 @@ class OpenTradeListPresenter(
                 mainPresenter.tradesWithUnreadMessages.collect {
                     log.d { "open trade [OpenTradeListPresenter] ${it.size}"}
                     _tradesWithUnreadMessages.value = it
-                    _readMessageCountsByTrade.value = (tradeReadStateRepository.fetch() ?: TradeReadState()).map
+                    _readMessageCountsByTrade.value = mainPresenter.readMessageCountsByTrade.value
                 }
             }
         }
@@ -57,6 +57,7 @@ class OpenTradeListPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
+        tradesServiceFacade.resetSelectedTradeToNull()
     }
 
     fun isRead(trade: TradeItemPresentationModel): Boolean {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -2,7 +2,6 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades
 
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.formatters.NumberFormatter

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import network.bisq.mobile.domain.data.model.TradeMessageMap
+import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum.BTC_CONFIRMED
@@ -16,7 +16,7 @@ import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqE
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum.PEER_CANCELLED
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum.PEER_REJECTED
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum.REJECTED
-import network.bisq.mobile.domain.data.repository.TradeMessageMapRepository
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -27,7 +27,7 @@ class OpenTradePresenter(
     mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
     val tradeFlowPresenter: TradeFlowPresenter,
-    private val tradeMessageMapRepository: TradeMessageMapRepository,
+    private val tradeReadStateRepository: TradeReadStateRepository,
 ) : BasePresenter(mainPresenter) {
 
     private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
@@ -64,13 +64,9 @@ class OpenTradePresenter(
 
         this.presenterScope.launch {
             openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
-                val tradeMessage = tradeMessageMapRepository.fetch() ?: TradeMessageMap()
-                val readTradeMap = tradeMessage.map.toMutableMap()
-                readTradeMap[openTradeItemModel.tradeId] = openTradeItemModel.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-                val updateTradeMessage = TradeMessageMap().apply {
-                    map = readTradeMap
-                }
-                tradeMessageMapRepository.update(updateTradeMessage)
+                val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
+                readState[openTradeItemModel.tradeId] = openTradeItemModel.bisqEasyOpenTradeChannelModel.chatMessages.value.size
+                tradeReadStateRepository.update(TradeReadState().apply { map = readState })
 
                 tradeStateChanged(tradeState)
             }
@@ -87,7 +83,7 @@ class OpenTradePresenter(
         _tradeAbortedBoxVisible.value = false
         _tradeProcessBoxVisible.value = false
         _isInMediation.value = false
-        tradesServiceFacade.resetSelectedTradeToNull()
+        // tradesServiceFacade.resetSelectedTradeToNull()
         super.onViewUnattaching()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -83,7 +83,6 @@ class OpenTradePresenter(
         _tradeAbortedBoxVisible.value = false
         _tradeProcessBoxVisible.value = false
         _isInMediation.value = false
-        // tradesServiceFacade.resetSelectedTradeToNull()
         super.onViewUnattaching()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -34,7 +34,7 @@ fun TradeDetailsHeader() {
     val presenter: TradeDetailsHeaderPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val item: TradeItemPresentationModel = presenter.selectedTrade.value!!
+    val item: TradeItemPresentationModel = presenter.selectedTrade.collectAsState().value ?: return
     val interruptTradeButtonText by presenter.interruptTradeButtonText.collectAsState()
     val openMediationButtonText by presenter.openMediationButtonText.collectAsState()
     val isInMediation by presenter.isInMediation.collectAsState()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -294,6 +294,9 @@ class TradeDetailsHeaderPresenter(
         }
     }
 
+    // nostrbuddha: I commented this function's call
+    // Since reset happens, when moving from Trade screen to Chat screen,
+    // when navigating pop, many vars are being empty
     private fun reset() {
         direction = ""
         leftAmountDescription = ""

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -31,7 +31,8 @@ class TradeDetailsHeaderPresenter(
         COMPLETED
     }
 
-    private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> = MutableStateFlow(tradesServiceFacade.selectedTrade.value)
+    private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> =
+        MutableStateFlow(tradesServiceFacade.selectedTrade.value)
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade
 
     var direction: String = ""
@@ -110,14 +111,22 @@ class TradeDetailsHeaderPresenter(
         }
 
         tradeStateJob = this.presenterScope.launch {
-            openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
-                tradeStateChanged(tradeState)
+            try {
+                openTradeItemModel.bisqEasyTradeModel.tradeState.collect { tradeState ->
+                    tradeStateChanged(tradeState)
+                }
+            } catch (e: Exception) {
+                log.e { "Error collecting tradeState $e" }
             }
         }
 
         mediationJob = this.presenterScope.launch {
-            openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation.collect { isInMediation ->
-                this@TradeDetailsHeaderPresenter._isInMediation.value = isInMediation
+            try {
+                openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation.collect { isInMediation ->
+                    this@TradeDetailsHeaderPresenter._isInMediation.value = isInMediation
+                }
+            } catch (e: Exception) {
+                log.e { "Error collecting mediationState $e" }
             }
         }
     }
@@ -309,10 +318,10 @@ class TradeDetailsHeaderPresenter(
         direction = ""
         leftAmountDescription = ""
         _leftAmount.value = ""
-        _leftCode.value  = ""
+        _leftCode.value = ""
         rightAmountDescription = ""
-        _rightAmount.value  = ""
-        _rightCode.value  = ""
+        _rightAmount.value = ""
+        _rightCode.value = ""
 
         _tradeCloseType.value = null
         _isInMediation.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -19,7 +19,7 @@ import network.bisq.mobile.presentation.MainPresenter
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TradeDetailsHeaderPresenter(
-    mainPresenter: MainPresenter,
+    private var mainPresenter: MainPresenter,
     var tradesServiceFacade: TradesServiceFacade,
     var mediationServiceFacade: MediationServiceFacade,
 ) : BasePresenter(mainPresenter) {
@@ -65,6 +65,12 @@ class TradeDetailsHeaderPresenter(
     val isInMediation: StateFlow<Boolean> = this._isInMediation
 
     init {
+
+    }
+
+    override fun onViewAttached() {
+        super.onViewAttached()
+
         presenterScope.launch {
             mainPresenter.languageCode
                 .flatMapLatest { tradesServiceFacade.selectedTrade }
@@ -86,10 +92,7 @@ class TradeDetailsHeaderPresenter(
                     }
                 }
         }
-    }
 
-    override fun onViewAttached() {
-        super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
 
@@ -119,7 +122,7 @@ class TradeDetailsHeaderPresenter(
     }
 
     override fun onViewUnattaching() {
-        // reset()
+        reset()
         super.onViewUnattaching()
     }
 
@@ -294,9 +297,6 @@ class TradeDetailsHeaderPresenter(
         }
     }
 
-    // nostrbuddha: I commented this function's call
-    // Since reset happens, when moving from Trade screen to Chat screen,
-    // when navigating pop, many vars are being empty
     private fun reset() {
         direction = ""
         leftAmountDescription = ""
@@ -312,6 +312,6 @@ class TradeDetailsHeaderPresenter(
         _openMediationButtonText.value = ""
         _showInterruptionConfirmationDialog.value = false
         _showMediationConfirmationDialog.value = false
-        _selectedTrade.value = null
+        // _selectedTrade.value = null
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -30,7 +30,7 @@ class TradeDetailsHeaderPresenter(
         COMPLETED
     }
 
-    private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
+    private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> = MutableStateFlow(tradesServiceFacade.selectedTrade.value)
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade
 
     var direction: String = ""
@@ -65,7 +65,6 @@ class TradeDetailsHeaderPresenter(
     val isInMediation: StateFlow<Boolean> = this._isInMediation
 
     init {
-        _selectedTrade.value = tradesServiceFacade.selectedTrade.value
         presenterScope.launch {
             mainPresenter.languageCode
                 .flatMapLatest { tradesServiceFacade.selectedTrade }
@@ -120,7 +119,7 @@ class TradeDetailsHeaderPresenter(
     }
 
     override fun onViewUnattaching() {
-        reset()
+        // reset()
         super.onViewUnattaching()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -45,7 +45,7 @@ class TradeChatPresenter(
         require(tradesServiceFacade.selectedTrade.value != null)
         val selectedTrade = tradesServiceFacade.selectedTrade.value!!
 
-        this.presenterScope.launch {
+        jobs.add(this.presenterScope.launch {
             val settings = withContext(IODispatcher) { settingsRepository.fetch() }
             settings?.let { _showChatRulesWarnBox.value = it.showChatRulesWarnBox }
             val bisqEasyOpenTradeChannelModel = selectedTrade.bisqEasyOpenTradeChannelModel
@@ -59,7 +59,7 @@ class TradeChatPresenter(
                     tradeReadStateRepository.update(TradeReadState().apply { map = readState })
                 }
             }
-        }
+        })
     }
 
     override fun onViewUnattaching() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -53,9 +53,11 @@ class TradeChatPresenter(
             bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
                 _chatMessages.value = messages.toList()
 
-                val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
-                readState[selectedTrade.tradeId] = _chatMessages.value.size
-                tradeReadStateRepository.update(TradeReadState().apply { map = readState })
+                withContext(IODispatcher) {
+                    val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
+                    readState[selectedTrade.tradeId] = _chatMessages.value.size
+                    tradeReadStateRepository.update(TradeReadState().apply { map = readState })
+                }
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -6,12 +6,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
+import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.utils.Logging
@@ -23,6 +25,7 @@ class TradeChatPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
     private val tradeChatMessagesServiceFacade: TradeChatMessagesServiceFacade,
     private val settingsRepository: SettingsRepository,
+    private val tradeReadStateRepository: TradeReadStateRepository,
 ) : BasePresenter(mainPresenter), Logging {
     private var jobs: MutableSet<Job> = mutableSetOf()
 
@@ -49,6 +52,10 @@ class TradeChatPresenter(
 
             bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
                 _chatMessages.value = messages.toList()
+
+                val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
+                readState[selectedTrade.tradeId] = _chatMessages.value.size
+                tradeReadStateRepository.update(TradeReadState().apply { map = readState })
             }
         }
     }


### PR DESCRIPTION
For https://github.com/bisq-network/bisq-mobile/issues/302

What's done:
 - MainPresenter looks for changes in openTradeItems, selectedTrade and also checks every 30s (Should make it to 60s? or more?)
 - Finds trade with recent / unread messages and show a badge count in `My trades` tab, with a subtle animation.
 - On clicking the tab, trades with recent messages are highlighted in a different color. (Used the warning/orange color as in bisq2 desktop app)
 - On clicking a specific trade, only that trade is marked as read. Let's say, you got 4 trades going on, and 2 of them needs attention. You check the first trade, get back to listing. Now the second trade is still highlighted.

<img width="452" alt="Screenshot 2025-05-14 at 7 23 06 AM" src="https://github.com/user-attachments/assets/b470809e-5c42-4932-aa1a-3656d95b2890" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added animated unread message badges to the bottom navigation bar, displaying the count of trades with unread messages.
  - Trade list items now visually indicate unread messages with a highlighted background.
  - Unread and read message counts per trade are tracked and updated in real-time across the app.
  - Introduced persistent tracking of read message counts per trade to maintain read state across sessions.
  - Added a new animated badge component with pulsing animation for notifications.
  - Added a configurable background color parameter to card components for enhanced UI customization.

- **Enhancements**
  - Improved trade list and navigation UI to provide clearer feedback on unread messages.
  - Reset trade selection state appropriately when navigating between screens.
  - Optimized chat message updates to refresh only affected trades for better performance.
  - Enhanced safety and stability in UI components by handling nullable trade selections gracefully.
  - Added periodic synchronization of unread message counts for open trades.
  - Integrated unread message tracking into multiple UI layers and presenters for consistent state management.
  - Managed coroutine lifecycles more robustly in chat message handling and UI presenters.

- **Bug Fixes**
  - Prevented unexpected state resets on navigation by adjusting view lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->