### PR TITLE
bugfix/test_connectivity_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ You need to run the seed node as explained above + the http-api module with the 
  -Dapplication.appName=bisq2_restApi_clear
  -Dapplication.network.supportedTransportTypes.2=CLEAR
  -Dapplication.devMode=true
+ -Dapplication.devModeReputationScore=50000
 ```
 
 Default networking setup for the WebSocket (WS) connection can be found in `gradle.properties` file. You can change there for locally building pointing at the ip you are interested in.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -47,7 +47,7 @@ class ClientApplicationBootstrapFacade(
                     setState("bootstrap.connectedToTrustedNode".i18n())
                     setProgress(1.0f)
                 } catch (e: Exception) {
-                    log.e(e) { "Failed to connect to trusted node" }
+                    log.e(e) { "Failed to connect to trusted node: ${e.message}" }
                     setState("No connectivity")
                     setProgress(1.0f)
                 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -103,11 +103,17 @@ class ClientUserProfileServiceFacade(
     }
 
     override suspend fun getSelectedUserProfile(): UserProfileVO {
-        val apiResult = apiGateway.getSelectedUserProfile()
-        if (apiResult.isFailure) {
-            throw apiResult.exceptionOrNull()!!
+        try {
+            val apiResult = apiGateway.getSelectedUserProfile()
+            if (apiResult.isFailure) {
+                throw apiResult.exceptionOrNull()!!
+            }
+            return apiResult.getOrThrow()
+        } catch (e: Exception) {
+            log.e(e) { "Failed to get selected user profile from service facade" }
+            throw e
         }
-        return apiResult.getOrThrow()
+
     }
 
     override suspend fun findUserIdentities(ids: List<String>): List<UserIdentityVO> {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.websocket
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -15,8 +16,8 @@ import kotlin.concurrent.Volatile
  * Provider to handle dynamic host/port changes
  */
 class WebSocketClientProvider(
-    defaultHost: String,
-    defaultPort: Int,
+    private val defaultHost: String,
+    private val defaultPort: Int,
     private val settingsRepository: SettingsRepository,
     private val clientFactory: (String, Int) -> WebSocketClient) : Logging {
 
@@ -32,44 +33,7 @@ class WebSocketClientProvider(
 
     @Volatile
     private var currentClient: WebSocketClient? = null
-
-    init {
-        // Listen to changes in WebSocket configuration and update the client
-        // TODO launching on init means it will be checking settings change from app cold start, probably better after first usage of the provider
-        ioScope.launch {
-            try {
-                val mutex = Mutex()
-                settingsRepository.data.collect { newSettings ->
-                    mutex.withLock {
-                        var host = defaultHost
-                        var port = defaultPort
-                        newSettings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
-                            log.d { "new bisq url detected $url "}
-                            parseUri(url).apply {
-                                host = first
-                                port = second
-                            }
-                        }
-                        // only update if there was actually a change
-                        if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
-                            if (currentClient != null) {
-                                log.d { "trusted node changing from ${currentClient!!.host}:${currentClient!!.port} to $host:$port" }
-                            }
-                            if (currentClient?.isConnected() == true) {
-                                currentClient?.disconnect()
-                            }
-                            currentClient = createClient(host, port)
-                            log.d { "Websocket client updated with url $host:$port" }
-                            log.d { "Websocket client - connecting" }
-                            currentClient?.connect()
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                log.e(e) { "Error updating WebSocket client with new settings." }
-            }
-        }
-    }
+    private var connectionReady = CompletableDeferred<Boolean>()
 
     suspend fun testClient(host: String, port: Int): Boolean {
         val client = createClient(host, port)
@@ -98,9 +62,51 @@ class WebSocketClientProvider(
     fun get(): WebSocketClient {
         if (currentClient == null) {
             runBlocking {
+                lunchObserveSettingsChange()
                 settingsRepository.fetch()
+                connectionReady.await()
             }
         }
         return currentClient!!
+    }
+
+    private fun lunchObserveSettingsChange() {
+        // Listen to changes in WebSocket configuration and update the client
+        ioScope.launch {
+            try {
+                val mutex = Mutex()
+                settingsRepository.data.collect { newSettings ->
+                    mutex.withLock {
+                        var host = defaultHost
+                        var port = defaultPort
+                        newSettings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                            log.d { "new bisq url detected $url "}
+                            parseUri(url).apply {
+                                host = first
+                                port = second
+                            }
+                        }
+                        // only update if there was actually a change
+                        if (currentClient == null || currentClient!!.host != host || currentClient!!.port != port) {
+                            if (currentClient != null) {
+                                log.d { "trusted node changing from ${currentClient!!.host}:${currentClient!!.port} to $host:$port" }
+                            }
+                            if (currentClient?.isConnected() == true) {
+                                currentClient?.disconnect()
+                            }
+                            currentClient = createClient(host, port)
+                            log.d { "Websocket client updated with url $host:$port" }
+                            log.d { "Websocket client - connecting" }
+                            currentClient?.connect()
+                            if (!connectionReady.isCompleted) {
+                                connectionReady.complete(true)
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                log.e(e) { "Error updating WebSocket client with new settings." }
+            }
+        }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.domain.service
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.data.IODispatcher
@@ -28,6 +29,7 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
             webSocketClientProvider.get().let {
                 if (!it.isDemo()) {
                     it.connect(true)
+                    delay(250L)
                     it.connect()
                 }
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/TrustedNodeService.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.domain.service
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
@@ -17,6 +18,8 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
     var isConnected: Boolean = false
     private var observingConnectivity = false
 
+    private var connectivityObserverJob: Job? = null
+
     /**
      * Connects to the trusted node, throws an exception if connection fails
      */
@@ -27,7 +30,7 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
         runCatching {
             // first test connect and proceed to establish it if test passes
             webSocketClientProvider.get().let {
-                if (!it.isDemo()) {
+                if (!it.isDemo() && !it.isConnected()) {
                     it.connect(true)
                     delay(250L)
                     it.connect()
@@ -36,7 +39,7 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
         }.onSuccess {
             log.d { "Connected to trusted node" }
         }.onFailure {
-            log.e(it) { "ERROR: FAILED to connect to trusted node - details above" }
+            log.e(it) { "ERROR: FAILED to connect to trusted node - ${it.message}" }
             throw it
         }
     }
@@ -46,9 +49,9 @@ class TrustedNodeService(private val webSocketClientProvider: WebSocketClientPro
     }
 
     private fun observeConnectivity() {
-        ioScope.launch {
+        connectivityObserverJob = ioScope.launch {
             webSocketClientProvider.get().webSocketClientStatus.collect {
-                log.d { "connectivity status changed - connected = $it" }
+                log.d { "connectivity status changed to $it" }
                 isConnected = webSocketClientProvider.get().isConnected()
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -45,6 +45,8 @@ open class ClientMainPresenter(
     urlLauncher: UrlLauncher
 ) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, urlLauncher) {
 
+    private var lastConnectedStatus: Boolean? = null
+
     override fun onViewAttached() {
         super.onViewAttached()
         validateVersion()
@@ -64,9 +66,12 @@ open class ClientMainPresenter(
         connectivityService.startMonitoring()
         presenterScope.launch {
             webSocketClientProvider.get().webSocketClientStatus.collect {
-                if (webSocketClientProvider.get().isConnected()) {
+                if (webSocketClientProvider.get().isConnected() && lastConnectedStatus != true) {
                     log.d { "connectivity status changed to $it - reconnecting services" }
                     reactiveServices()
+                    lastConnectedStatus = true
+                } else {
+                    lastConnectedStatus = false
                 }
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -57,7 +57,6 @@ open class ClientMainPresenter(
     override fun onViewUnattaching() {
         // For Tor we might want to leave it running while in background to avoid delay of re-connect
         // when going into foreground again.
-        // presenterScope.launch {  webSocketClient.disconnect() }
         deactivateServices()
         super.onViewUnattaching()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -130,10 +130,15 @@ open class CreateProfilePresenter(
             job = presenterScope.launch {
                 withContext(Dispatchers.Default) {
                     // takes 200 -1000 ms
-                    userProfileService.generateKeyPair { id, nym, profileIcon ->
-                        setId(id)
-                        setNym(nym)
-                        setProfileIcon(profileIcon)
+                    runCatching {
+                        userProfileService.generateKeyPair { id, nym, profileIcon ->
+                            setId(id)
+                            setNym(nym)
+                            setProfileIcon(profileIcon)
+                        }
+                    }.onFailure {
+                        disableInteractive()
+                        showSnackbar("Generating the key pair failed. Profile generation won't work")
                     }
                 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -155,6 +155,7 @@ open class SplashPresenter(
     }
 
     private fun navigateToAgreement() {
+        log.d { "Navigating to agreement" }
         navigateTo(Routes.Agreement) {
             it.popUpTo(Routes.Splash.name) { inclusive = true }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -21,7 +21,7 @@ class TrustedNodeSetupPresenter(
     private val webSocketClientProvider: WebSocketClientProvider
 ) : BasePresenter(mainPresenter), ITrustedNodeSetupPresenter {
 
-    private val _isBisqApiUrlValid = MutableStateFlow(false)
+    private val _isBisqApiUrlValid = MutableStateFlow(true)
     override val isBisqApiUrlValid: StateFlow<Boolean> = _isBisqApiUrlValid
 
     private val _isBisqApiVersionValid = MutableStateFlow(true)
@@ -89,7 +89,6 @@ class TrustedNodeSetupPresenter(
             val success = withContext(IODispatcher) {
                 webSocketClientProvider.testClient(connectionSettings.first, connectionSettings.second)
             }
-            _isLoading.value = false
 
             if (success) {
                 val validateVersion = withContext(IODispatcher) {
@@ -104,14 +103,17 @@ class TrustedNodeSetupPresenter(
                     if (!isWorkflow) {
                         navigateBack()
                     }
+                    _isConnected.value = true
                 } else {
                     log.d { "Invalid version cannot connect" }
                     showSnackbar("Trusted node incompatible version, cannot connect")
+                    _isConnected.value = false
                 }
-                _isConnected.value = true
+                _isLoading.value = false
             } else {
                 showSnackbar("Could not connect to given url ${_bisqApiUrl.value}, please try again with another setup")
                 _isConnected.value = false
+                _isLoading.value = false
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -83,11 +83,11 @@ class TrustedNodeSetupPresenter(
 
     override fun testConnection(isWorkflow: Boolean) {
         _isLoading.value = true
-        log.i { "Test: " + _bisqApiUrl.value }
+        log.d { "Test: ${_bisqApiUrl.value} isWorkflow $isWorkflow" }
         val connectionSettings = WebSocketClientProvider.parseUri(_bisqApiUrl.value)
         presenterScope.launch {
             val success = withContext(IODispatcher) {
-                webSocketClientProvider.testClient(connectionSettings.first, connectionSettings.second)
+                return@withContext webSocketClientProvider.testClient(connectionSettings.first, connectionSettings.second)
             }
 
             if (success) {
@@ -101,10 +101,12 @@ class TrustedNodeSetupPresenter(
                     log.d { "Connected successfully to ${_bisqApiUrl.value} is workflow: $isWorkflow" }
                     showSnackbar("Connected successfully to ${_bisqApiUrl.value}, settings updated")
                     if (!isWorkflow) {
+                        _isLoading.value = false
                         navigateBack()
                     }
                     _isConnected.value = true
                 } else {
+                    webSocketClientProvider.get().disconnect(isTest = true)
                     log.d { "Invalid version cannot connect" }
                     showSnackbar("Trusted node incompatible version, cannot connect")
                     _isConnected.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -93,13 +94,19 @@ class TrustedNodeSetupPresenter(
             if (success) {
                 val validateVersion = withContext(IODispatcher) {
                     updateTrustedNodeSettings()
+                    delay(250L)
+                    webSocketClientProvider.get().await()
                     validateVersion()
                 }
                 if (validateVersion) {
+                    log.d { "Connected successfully to ${_bisqApiUrl.value} is workflow: $isWorkflow" }
                     showSnackbar("Connected successfully to ${_bisqApiUrl.value}, settings updated")
                     if (!isWorkflow) {
                         navigateBack()
                     }
+                } else {
+                    log.d { "Invalid version cannot connect" }
+                    showSnackbar("Trusted node incompatible version, cannot connect")
                 }
                 _isConnected.value = true
             } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -91,13 +91,13 @@ class TrustedNodeSetupPresenter(
             }
 
             if (success) {
-                val validateVersion = withContext(IODispatcher) {
+                val isCompatibleVersion = withContext(IODispatcher) {
                     updateTrustedNodeSettings()
                     delay(250L)
                     webSocketClientProvider.get().await()
                     validateVersion()
                 }
-                if (validateVersion) {
+                if (isCompatibleVersion) {
                     log.d { "Connected successfully to ${_bisqApiUrl.value} is workflow: $isWorkflow" }
                     showSnackbar("Connected successfully to ${_bisqApiUrl.value}, settings updated")
                     if (!isWorkflow) {


### PR DESCRIPTION
Draft PR still working on issue when using a trusted node address other than default is looping trying to connect to the default in the background causing all sort of connectivity issues

 - fix test button stopped working when connection successful on trusted node settings screen
 - improve corroutines usages in web socket related classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved WebSocket connection reliability with automatic reconnection using exponential backoff and clearer connection status updates.
  - Added a method to await WebSocket connection readiness for smoother user experience.

- **Bug Fixes**
  - Enhanced error handling and user feedback during profile creation and user profile retrieval.
  - Reduced redundant service reactivation when the connection status remains unchanged.

- **Improvements**
  - Refined connection testing and validation flow for trusted node setup, including better loading state handling and success/failure messaging.
  - Added additional logging for easier troubleshooting and state tracking.
  - Introduced a slight delay between consecutive trusted node connection attempts to improve stability.
  - Updated local environment setup instructions with new JVM parameter for reputation score configuration.
  - Improved WebSocket client management with synchronized settings observation and ensured connection readiness before use.
  - Enhanced logging detail for connection failures and navigation actions for better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->