### PR TITLE
Bugfixing/trusted test node connectivity

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/AndroidApplicationService.kt
@@ -206,7 +206,9 @@ class AndroidApplicationService(
             bondedRolesService
         )
 
+
         tradeService = TradeService(
+            TradeService.Config.from(getConfig("trade")),
             networkService,
             identityService,
             persistenceService,

--- a/androidNode/src/main/resources/android.conf
+++ b/androidNode/src/main/resources/android.conf
@@ -98,6 +98,16 @@ application {
             staticPublicKeysProvided = false        
         }
     }
+
+    trade = {
+        // TODO update when we support musig in mobile
+        muSig = {
+            grpcServer = {
+                host = "localhost"
+                port = 8008
+            }
+        }
+    }
     
     network = {
         version = 1

--- a/androidNode/src/release/resources/android.conf
+++ b/androidNode/src/release/resources/android.conf
@@ -98,6 +98,16 @@ application {
             staticPublicKeysProvided = false        
         }
     }
+
+    trade = {
+        // TODO update when we support musig in mobile
+        muSig = {
+            grpcServer = {
+                host = "localhost"
+                port = 8008
+            }
+        }
+    }
     
     network = {
         version = 1

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
@@ -27,11 +27,10 @@ class WebSocketApiClient(
     val httpClient: HttpClient,
     val webSocketClientProvider: WebSocketClientProvider,
     val json: Json,
-    host: String,
-    port: Int
+    private val defaultHost: String,
+    private val defaultPort: Int
 ) : Logging {
     val apiPath = "/api/v1/"
-    var apiUrl = "http://$host:$port$apiPath"
 
     // POST and PATCH request are not working yes on the backend.
     // So we use httpClient instead.
@@ -61,6 +60,7 @@ class WebSocketApiClient(
     suspend inline fun <reified T, reified R> patch(path: String, requestBody: R): Result<T> {
         if (useHttpClient) {
             try {
+                val apiUrl = currentApiUrl()
                 val response: HttpResponse = httpClient.patch(apiUrl + path) {
                     contentType(ContentType.Application.Json)
                     accept(ContentType.Application.Json)
@@ -79,6 +79,7 @@ class WebSocketApiClient(
     suspend inline fun <reified T, reified R> post(path: String, requestBody: R): Result<T> {
         if (useHttpClient) {
             try {
+                val apiUrl = currentApiUrl()
                 val response: HttpResponse = httpClient.post(apiUrl + path) {
                     contentType(ContentType.Application.Json)
                     accept(ContentType.Application.Json)
@@ -145,5 +146,12 @@ class WebSocketApiClient(
             val errorText = response.bodyAsText()
             Result.failure(WebSocketRestApiException(response.status, errorText))
         }
+    }
+
+    fun currentApiUrl(): String {
+        val wsClient = webSocketClientProvider.get()
+//        var defaultApiUrl = "http://$defaultHost:$defaultPort$apiPath"
+        val apiURL = "http://${wsClient.host}:${wsClient.port}$apiPath"
+        return apiURL
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -107,6 +107,7 @@ interface ViewPresenter {
  */
 abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPresenter, Logging {
     companion object {
+        const val DEFAULT_DELAY = 250L
         const val EXIT_WARNING_TIMEOUT = 3000L
         var isDemo = false
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -46,7 +46,7 @@ class TabContainerPresenter(
             createOfferPresenter.onStartCreateOffer()
             navigateTo(Routes.CreateOfferDirection)
         } catch (e: Exception) {
-            log.e(e) { "Failed to create offer" }
+            log.e(e) { "Failed to create offer: ${e.message}" }
         }
     }
 


### PR DESCRIPTION
 - contribs to #332 
 - fix api client not updating host/port with webclient
 - fix connection test loading indefintely on edge case where server
 - fix breaking changes on trade service api (bisq2 node) - @HenrikJannsen please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options for trade-related settings, including preliminary support for muSig connections.
  - Introduced a constant for default delay timing in the app's presentation layer.

- **Improvements**
  - Enhanced error logging for offer creation to include detailed exception messages.
  - Improved connection testing for trusted node setup with timeout handling, user feedback for timeouts, and robust loading state management.
  - Updated API client to dynamically determine the server URL based on the current WebSocket client state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->