### PR TITLE
refactor/base_support_components_coroutines_jobs

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/market/ClientMarketPriceServiceFacade.kt
@@ -1,10 +1,7 @@
 package network.bisq.mobile.client.service.market
 
-import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
 import network.bisq.mobile.domain.data.model.MarketPriceItem
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
@@ -17,7 +14,7 @@ import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 
 class ClientMarketPriceServiceFacade(
     private val apiGateway: MarketPriceApiGateway,
-    private val json: Json
+    private val json: kotlinx.serialization.json.Json
 ) : ServiceFacade(), MarketPriceServiceFacade {
 
     // Properties
@@ -28,14 +25,15 @@ class ClientMarketPriceServiceFacade(
     override val selectedFormattedMarketPrice: StateFlow<String> = _selectedFormattedMarketPrice
 
     // Misc
-    private var selectedMarket: MarketVO = MarketVOFactory.USD// todo use persisted or user default
-    private val quotes = ConcurrentMap<String, PriceQuoteVO>()
+    private val quotes: MutableMap<String, PriceQuoteVO> = mutableMapOf()
+    private var selectedMarket: MarketVO? = null
 
     // Life cycle
     override fun activate() {
         super<ServiceFacade>.activate()
 
-        serviceScope.launch {
+        // Use the jobsManager to launch a coroutine instead of serviceScope directly
+        launchIO {
             val observer = apiGateway.subscribeMarketPrice()
             observer.webSocketEvent.collect { webSocketEvent ->
                 try {
@@ -52,10 +50,6 @@ class ClientMarketPriceServiceFacade(
                 }
             }
         }
-    }
-
-    override fun deactivate() {
-        super<ServiceFacade>.deactivate()
     }
 
     // API
@@ -81,13 +75,15 @@ class ClientMarketPriceServiceFacade(
     }
 
     private fun updateMarketPriceItem() {
-        val quoteCurrencyCode: String = selectedMarket.quoteCurrencyCode
-        quotes[quoteCurrencyCode]?.let { priceQuote ->
-            val formattedPrice = MarketPriceFormatter.format(priceQuote.value, selectedMarket)
-            val marketPriceItem = MarketPriceItem(selectedMarket, priceQuote, formattedPrice)
-            _selectedMarketPriceItem.value = marketPriceItem
-            _selectedFormattedMarketPrice.value = formattedPrice
-            log.i { "upDateMarketPriceItem: code=$quoteCurrencyCode; priceQuote =$priceQuote; formattedPrice =$formattedPrice" }
+        selectedMarket?.let {
+            val quoteCurrencyCode: String = it.quoteCurrencyCode
+            quotes[quoteCurrencyCode]?.let { priceQuote ->
+                val formattedPrice = MarketPriceFormatter.format(priceQuote.value, it)
+                val marketPriceItem = MarketPriceItem(it, priceQuote, formattedPrice)
+                _selectedMarketPriceItem.value = marketPriceItem
+                _selectedFormattedMarketPrice.value = formattedPrice
+                log.i { "upDateMarketPriceItem: code=$quoteCurrencyCode; priceQuote =$priceQuote; formattedPrice =$formattedPrice" }
+            }
         }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/di/DomainModule.kt
@@ -11,6 +11,8 @@ import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.getPlatformSettings
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import org.koin.dsl.module
 
 val domainModule = module {
@@ -35,4 +37,6 @@ val domainModule = module {
 
     // Services
     single<OpenTradesNotificationService> { OpenTradesNotificationService(get(), get()) }
+
+    factory<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
@@ -4,6 +4,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import network.bisq.mobile.domain.LifeCycleAware
+import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
 import org.koin.core.component.KoinComponent
@@ -45,7 +46,7 @@ abstract class ServiceFacade : LifeCycleAware, KoinComponent, Logging {
             log.i { "Deactivating service ${this::class.simpleName}" }
             
             // Clean up all jobs managed by the jobsManager
-            runBlocking {
+            CoroutineScope(IODispatcher).launch {
                 jobsManager.dispose()
             }
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
@@ -2,48 +2,36 @@ package network.bisq.mobile.domain.service
 
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.Flow
 import network.bisq.mobile.domain.LifeCycleAware
-import network.bisq.mobile.domain.data.IODispatcher
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Base class for lifecycle-aware service components that require coroutine-based background execution.
  *
- * `ServiceFacade` provides a lazily-initialized `CoroutineScope` (`serviceScope`) tied to a `SupervisorJob`,
- * which allows safe concurrent coroutine execution where failures in one child coroutine do not cancel others.
+ * `ServiceFacade` provides coroutine-based background execution through a centralized job management system.
+ * All coroutines are launched through the `jobsManager`, which ensures proper lifecycle management and cleanup.
  *
- * The scope is only created on first use (lazy initialization) and is automatically reset if the underlying job is cancelled.
- *
- * The `deactivate()` method cancels the current service scope and its associated job, ensuring a clean shutdown
- * of all running coroutines. Subclasses can override `activate()` to start background work as needed.
+ * The `deactivate()` method ensures a clean shutdown of all running coroutines.
+ * Subclasses can override `activate()` to start background work as needed.
  *
  * Typical usage pattern:
  * - Call `activate()` when the service is started (optionally overridden by subclasses)
- * - Launch coroutines via `serviceScope`
+ * - Launch coroutines via `launchIO()` or `collectIO()`
  * - Call `deactivate()` to cancel all coroutines and release resources
  */
-abstract class ServiceFacade : LifeCycleAware, Logging {
-    private var _serviceJob: Job? = null
-    private var _serviceScope: CoroutineScope? = null
+abstract class ServiceFacade : LifeCycleAware, KoinComponent, Logging {
     private var isActivated = atomic(false)
-
-    private val scopeMutex = Mutex()
-
+    
+    // we use KoinCompoent inject to avoid having to pass the manager as parameter on every single service
+    protected val jobsManager: CoroutineJobsManager by inject()
+    
+    // Provide access to the IO scope from the jobsManager
     protected val serviceScope: CoroutineScope
-        // thread-safe sync getter
-        get() {
-            _serviceScope?.let { scope ->
-                if (!scope.coroutineContext[Job]!!.isCancelled) {
-                    return scope
-                }
-            }
-            return runBlocking {
-                initializeScopeIfNeeded()
-                _serviceScope!!
-            }
-        }
+        get() = jobsManager.getIOScope()
 
     override fun activate() {
         require(!isActivated.value) { "activate called on ${this::class.simpleName} while service is already activated" }
@@ -53,26 +41,22 @@ abstract class ServiceFacade : LifeCycleAware, Logging {
     }
 
     override fun deactivate() {
-        if (!isActivated.value) {
-            log.w {
-                "deactivate called on ${this::class.simpleName} while service is not activated. " +
-                        "This might be a valid case if we shut down fast before service got activated."
+        if (isActivated.compareAndSet(expect = true, update = false)) {
+            log.i { "Deactivating service ${this::class.simpleName}" }
+            
+            // Clean up all jobs managed by the jobsManager
+            runBlocking {
+                jobsManager.dispose()
             }
         }
-        _serviceScope?.cancel()
-        _serviceJob = null
-        _serviceScope = null
-        isActivated.value = false
-
-        log.i { "${this::class.simpleName} deactivates" }
     }
-
-    private suspend fun initializeScopeIfNeeded() {
-        scopeMutex.withLock {
-            if (_serviceScope == null || _serviceJob?.isCancelled == true) {
-                _serviceJob = SupervisorJob()
-                _serviceScope = CoroutineScope(IODispatcher + _serviceJob!!)
-            }
-        }
+    
+    // Helper methods for launching coroutines with the jobsManager
+    protected fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
+        return jobsManager.launchIO(block)
+    }
+    
+    protected fun <T> collectIO(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return jobsManager.collectIO(flow, collector)
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineJobsManager.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineJobsManager.kt
@@ -1,0 +1,135 @@
+package network.bisq.mobile.domain.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import network.bisq.mobile.domain.data.IODispatcher
+
+/**
+ * Interface for managing coroutine jobs with lifecycle awareness.
+ * This helps centralize job management and disposal across the application.
+ */
+interface CoroutineJobsManager {
+    /**
+     * Add a job to be managed and automatically disposed when [dispose] is called.
+     * @param job The job to be managed
+     * @return The same job for chaining
+     */
+    fun addJob(job: Job): Job
+    
+    /**
+     * Launch a new coroutine in the UI scope and automatically manage its lifecycle.
+     * @param block The coroutine code to execute
+     * @return The created job
+     */
+    fun launchUI(block: suspend CoroutineScope.() -> Unit): Job
+    
+    /**
+     * Launch a new coroutine in the IO scope and automatically manage its lifecycle.
+     * @param block The coroutine code to execute
+     * @return The created job
+     */
+    fun launchIO(block: suspend CoroutineScope.() -> Unit): Job
+    
+    /**
+     * Collect a flow in the UI scope and automatically manage the job's lifecycle.
+     * @param flow The flow to collect
+     * @param collector The collector function
+     * @return The created job
+     */
+    fun <T> collectUI(flow: Flow<T>, collector: suspend (T) -> Unit): Job
+    
+    /**
+     * Collect a flow in the IO scope and automatically manage the job's lifecycle.
+     * @param flow The flow to collect
+     * @param collector The collector function
+     * @return The created job
+     */
+    fun <T> collectIO(flow: Flow<T>, collector: suspend (T) -> Unit): Job
+    
+    /**
+     * Dispose all managed jobs.
+     */
+    suspend fun dispose()
+    
+    /**
+     * Get the UI coroutine scope.
+     */
+    fun getUIScope(): CoroutineScope
+    
+    /**
+     * Get the IO coroutine scope.
+     */
+    fun getIOScope(): CoroutineScope
+}
+
+/**
+ * Implementation of [CoroutineJobsManager] that manages coroutine jobs and their lifecycle.
+ */
+class DefaultCoroutineJobsManager : CoroutineJobsManager, Logging {
+    private val jobs = mutableSetOf<Job>()
+    private val jobsMutex = Mutex()
+    private var uiScope = CoroutineScope(kotlinx.coroutines.Dispatchers.Main + SupervisorJob())
+    private var ioScope = CoroutineScope(IODispatcher + SupervisorJob())
+    
+    override fun addJob(job: Job): Job {
+        ioScope.launch {
+            jobsMutex.withLock {
+                jobs.add(job)
+            }
+        }
+        
+        job.invokeOnCompletion {
+            ioScope.launch {
+                jobsMutex.withLock {
+                    jobs.remove(job)
+                }
+            }
+        }
+        return job
+    }
+    
+    override fun launchUI(block: suspend CoroutineScope.() -> Unit): Job {
+        return addJob(uiScope.launch { block() })
+    }
+    
+    override fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
+        return addJob(ioScope.launch { block() })
+    }
+    
+    override fun <T> collectUI(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return launchUI {
+            flow.collect { collector(it) }
+        }
+    }
+    
+    override fun <T> collectIO(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return launchIO {
+            flow.collect { collector(it) }
+        }
+    }
+    
+    override suspend fun dispose() {
+        log.d { "Disposing coroutine jobs" }
+
+        jobsMutex.withLock {
+            log.d { "Disposing ${jobs.size} coroutine jobs" }
+            jobs.forEach { it.cancel() }
+            jobs.clear()
+        }
+
+        uiScope.cancel()
+        ioScope.cancel()
+        uiScope = CoroutineScope(kotlinx.coroutines.Dispatchers.Main + SupervisorJob())
+        ioScope = CoroutineScope(IODispatcher + SupervisorJob())
+    }
+    
+    override fun getUIScope(): CoroutineScope = uiScope
+    
+    override fun getIOScope(): CoroutineScope = ioScope
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -352,7 +352,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     @CallSuper
     override fun onViewUnattaching() {
         // Presenter level support for auto disposal
-        runBlocking { jobsManager.dispose() }
+        CoroutineScope(IODispatcher).launch { jobsManager.dispose() }
     }
 
     @CallSuper

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -6,21 +6,28 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Presenter methods accesible by all views. Views should extend this interface when defining the behaviour expected for their presenter.
@@ -105,7 +112,7 @@ interface ViewPresenter {
  * Base class allows to have a tree hierarchy of presenters. If the rootPresenter is null, this presenter acts as root
  * if root present is passed, this present attach itself to the root to get updates (consequently its dependants will be always empty
  */
-abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPresenter, Logging {
+abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPresenter, KoinComponent, Logging {
     companion object {
         const val DEFAULT_DELAY = 250L
         const val EXIT_WARNING_TIMEOUT = 3000L
@@ -114,11 +121,15 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     protected var view: Any? = null
 
-    // Coroutine scope for the presenter / UI.
-    protected var presenterScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-
-    // For network access, persistence or file IO
-    protected var ioScope = CoroutineScope(IODispatcher + SupervisorJob())
+    // we use KoinComponent to avoid having to pass the manager as parameter on efery single presenter
+    protected val jobsManager: CoroutineJobsManager by inject()
+    
+    // For backward compatibility - these will delegate to the jobsManager
+    protected val presenterScope: CoroutineScope
+        get() = jobsManager.getUIScope()
+    
+    protected val ioScope: CoroutineScope
+        get() = jobsManager.getIOScope()
 
     private val dependants = if (isRoot()) mutableListOf<BasePresenter>() else null
 
@@ -340,6 +351,8 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     @CallSuper
     override fun onViewUnattaching() {
+        // Presenter level support for auto disposal
+        runBlocking { jobsManager.dispose() }
     }
 
     @CallSuper
@@ -394,7 +407,6 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     }
 
     fun detachView() {
-        resetPresenterScope()
         onViewUnattaching()
         this.view = null
         log.i { "Lifecycle: View Dettached from Presenter" }
@@ -445,8 +457,9 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     private fun cleanup() {
         try {
-            resetPresenterScope()
-            resetIOScope()
+            runBlocking {
+                jobsManager.dispose()
+            }
             // copy to avoid concurrency exception - no problem with multiple on destroy calls
             dependants?.toList()?.forEach { it.onDestroy() }
         } catch (e: Exception) {
@@ -477,13 +490,20 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     override fun isDemo(): Boolean = rootPresenter?.isDemo() ?: false
 
-    private fun resetPresenterScope() {
-        this.presenterScope.cancel()
-        this.presenterScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    // Presenter-level helper methods for launching coroutines with the jobsManager
+    protected fun launchUI(block: suspend CoroutineScope.() -> Unit): Job {
+        return jobsManager.launchUI(block)
     }
-
-    private fun resetIOScope() {
-        this.ioScope.cancel()
-        this.ioScope = CoroutineScope(IODispatcher + SupervisorJob())
+    
+    protected fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
+        return jobsManager.launchIO(block)
+    }
+    
+    protected fun <T> collectUI(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return jobsManager.collectUI(flow, collector)
+    }
+    
+    protected fun <T> collectIO(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return jobsManager.collectIO(flow, collector)
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -30,6 +30,8 @@ open class SplashPresenter(
     val state: StateFlow<String> = applicationBootstrapFacade.state
     val progress: StateFlow<Float> = applicationBootstrapFacade.progress
 
+    private var hasNavigatedAway = false
+
     override fun onViewAttached() {
         super.onViewAttached()
         
@@ -38,9 +40,9 @@ open class SplashPresenter(
         }
         
         collectUI(progress) { value ->
-            log.d { "Splash Progress: $value" }
-            when {
-                value == 1.0f -> navigateToNextScreen()
+            if (value == 1.0f && !hasNavigatedAway) {
+                hasNavigatedAway = true
+                navigateToNextScreen()
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -1,18 +1,13 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
-import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.Settings
 import network.bisq.mobile.domain.data.model.User
 import network.bisq.mobile.domain.data.replicated.settings.SettingsVO
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.data.repository.UserRepository
-import network.bisq.mobile.domain.getDeviceLanguageCode
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
@@ -23,7 +18,7 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 
 open class SplashPresenter(
     mainPresenter: MainPresenter,
-    private val applicationBootstrapFacade: ApplicationBootstrapFacade,
+    applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val userProfileService: UserProfileServiceFacade,
     private val userRepository: UserRepository,
     private val settingsRepository: SettingsRepository,
@@ -35,52 +30,19 @@ open class SplashPresenter(
     val state: StateFlow<String> = applicationBootstrapFacade.state
     val progress: StateFlow<Float> = applicationBootstrapFacade.progress
 
-    private var jobs: MutableSet<Job> = mutableSetOf()
-
     override fun onViewAttached() {
         super.onViewAttached()
-        jobs.add(presenterScope.launch {
-            val settings: Settings = withContext(IODispatcher) {
-                settingsRepository.fetch() ?: Settings()
+        
+        collectUI(state) { value ->
+            log.d { "Splash State: $value" }
+        }
+        
+        collectUI(progress) { value ->
+            log.d { "Splash Progress: $value" }
+            when {
+                value == 1.0f -> navigateToNextScreen()
             }
-
-            if (settings.firstLaunch) {
-                withContext(IODispatcher) {
-                    val deviceLanguageCode = getDeviceLanguageCode()
-                    val i18nSupportedCodes = languageServiceFacade.i18nPairs.value.map { it.first }
-                    if (i18nSupportedCodes.contains(deviceLanguageCode)) {
-                        settingsServiceFacade.setLanguageCode(deviceLanguageCode)
-                    } else {
-                        settingsServiceFacade.setLanguageCode("en")
-                    }
-                }
-            }
-
-            withContext(IODispatcher) {
-                userRepository.fetch()?.let {
-                    it.lastActivity = Clock.System.now().toEpochMilliseconds()
-                    userRepository.update(it)
-                }
-            }
-
-            log.d { "collecting splash progress" }
-            progress.collect { value ->
-                log.d { "Splash Progress: $value" }
-                when {
-                    value == 1.0f -> navigateToNextScreen()
-                }
-            }
-        })
-
-        // todo this should happen after connection to backend is configured if client mode
-        // and it must not be cancelled at onViewUnattaching in case the presenter is just quickly activated
-        // best its not called from a presenter but a service which checks if the url to backend is set...
-    }
-
-    override fun onViewUnattaching() {
-        jobs.forEach { it.cancel() }
-        jobs.clear()
-        super.onViewUnattaching()
+        }
     }
 
     private fun navigateToNextScreen() {
@@ -171,15 +133,6 @@ open class SplashPresenter(
             settings.bisqApiUrl.isNotEmpty() && hasProfile -> navigateToCreateProfile()
             else -> navigateToHome() // TODO: Ideally this shouldn't happen here
         }
-//        when {
-//            settings.bisqApiUrl.isEmpty() -> {
-//                navigateTo(Routes.TrustedNodeSetup.name) {
-//                    popUpTo(Routes.Splash.name) { inclusive = true }
-//                }
-//            }
-////            settings.firstLaunch -> navigateToCreateProfile()
-//            else -> navigateToHome()
-//        }
         return true
     }
 }


### PR DESCRIPTION
 - thread-safe coroutine manager helper class with default implementation and di factory to use in different components
 - injection on base classes (ServiceFacade and BasePresenter), providing helper methods to use in childs and delete all duplicated overhead code
 - examples of aplication on SplashPresenter and ClientMarketPriceServiceFacade respectively

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized coroutine management using a new job manager, simplifying lifecycle handling across presenters and services.
  - Presenter and service classes now delegate coroutine launching and flow collection to the job manager, improving code clarity and consistency.
  - Splash screen logic is streamlined to reactively collect UI state and progress without manual coroutine management.
  - Improved thread safety and null handling in market price service for more reliable data updates.

- **Chores**
  - Updated dependency injection to provide the new coroutine job manager throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->