### PR TITLE
Bugfix/using non default trusted node onboarding

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -37,6 +37,10 @@ class ClientApplicationBootstrapFacade(
             if (trustedNodeService.isConnected) {
                 setState("bootstrap.connectedToTrustedNode".i18n())
                 setProgress(1.0f)
+            } else if (url == null) {
+                // fresh install escenario, let it proceed to onboarding
+                setState("bootstrap.connectedToTrustedNode".i18n())
+                setProgress(1.0f)
             } else {
                 try {
                     if (!trustedNodeService.isDemo()) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -171,14 +171,11 @@ class WebSocketClient(
     }
 
     private fun reconnect() {
-        // Cancel any existing reconnect job
-        reconnectJob?.cancel()
-        
-        // Only proceed if we're not already reconnecting
         if (isReconnecting) {
             log.d { "Reconnect already in progress, skipping" }
             return
         }
+        reconnectJob?.cancel()
         
         reconnectJob = ioScope.launch {
             isReconnecting = true

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClientProvider.kt
@@ -38,6 +38,9 @@ class WebSocketClientProvider(
     private var currentClient: WebSocketClient? = null
     private var connectionReady = CompletableDeferred<Boolean>()
 
+    /**
+     * Test connection to a new host/port
+     */
     suspend fun testClient(host: String, port: Int): Boolean {
         val client = createClient(host, port)
         // not including path websocket will get connection refused
@@ -67,16 +70,61 @@ class WebSocketClientProvider(
     fun get(): WebSocketClient {
         if (currentClient == null) {
             runBlocking {
+                initializeWithSavedSettings()
                 launchObserveSettingsChange()
-                settingsRepository.fetch()
                 connectionReady.await()
             }
         }
         return currentClient!!
     }
+    
+    /**
+     * Initialize the client with saved settings if available, otherwise use defaults
+     */
+    private suspend fun initializeWithSavedSettings() {
+        mutex.withLock {
+            if (currentClient == null) {
+                // Fetch settings first
+                val settings = settingsRepository.fetch()
+                
+                // Determine host and port from settings or defaults
+                var host = defaultHost
+                var port = defaultPort
+                
+                settings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                    try {
+                        parseUri(url).apply {
+                            host = first
+                            port = second
+                            log.d { "Using saved settings for trusted node: $host:$port" }
+                        }
+                    } catch (e: Exception) {
+                        log.e(e) { "Error parsing saved URL $url, falling back to defaults" }
+                    }
+                }
 
+                currentClient = createClient(host, port)
+                log.d { "Websocket client initialized with url $host:$port" }
+                
+                try {
+                    currentClient?.connect()
+                    log.d { "Connected to trusted node at $host:$port" }
+                } catch (e: Exception) {
+                    log.e(e) { "Failed to connect to trusted node at $host:$port" }
+                    // We don't complete connectionReady here as we'll let the observer handle it
+                }
+
+                if (!connectionReady.isCompleted) {
+                    connectionReady.complete(true)
+                }
+            }
+        }
+    }
+
+    /**
+     * Launches a coroutine to observe settings changes and update the WebSocket client accordingly.
+     */
     private fun launchObserveSettingsChange() {
-        // Listen to changes in WebSocket configuration and update the client
         if (observeSettingsJob?.isActive == true) {
             log.w { "already observing settings changes" }
             return
@@ -85,31 +133,29 @@ class WebSocketClientProvider(
             try {
                 settingsRepository.data.collect { newSettings ->
                     mutex.withLock {
-                        var host = defaultHost
-                        var port = defaultPort
                         newSettings?.bisqApiUrl?.takeIf { it.isNotBlank() }?.let { url ->
-                            parseUri(url).apply {
-                                if (isDifferentFromCurrentClient(first, second)) {
-                                    log.d { "new bisq url detected $url" }
+                            try {
+                                val (newHost, newPort) = parseUri(url)
+
+                                if (isDifferentFromCurrentClient(newHost, newPort)) {
+                                    if (currentClient != null) {
+                                        log.d { "trusted node changing from ${currentClient!!.host}:${currentClient!!.port} to $newHost:$newPort" }
+                                    }
+                                    if (currentClient?.isConnected() == true) {
+                                        currentClient?.disconnect()
+                                    }
+                                    currentClient = createClient(newHost, newPort)
+                                    log.d { "Websocket client updated with url $newHost:$newPort" }
+                                    log.d { "Websocket client - connecting" }
+                                    currentClient?.connect()
+                                    if (!connectionReady.isCompleted) {
+                                        connectionReady.complete(true)
+                                    }
+                                } else {
+                                    log.v { "skip url update, no change"}
                                 }
-                                host = first
-                                port = second
-                            }
-                        }
-                        // only update if there was actually a change
-                        if (isDifferentFromCurrentClient(host, port)) {
-                            if (currentClient != null) {
-                                log.d { "trusted node changing from ${currentClient!!.host}:${currentClient!!.port} to $host:$port" }
-                            }
-                            if (currentClient?.isConnected() == true) {
-                                currentClient?.disconnect()
-                            }
-                            currentClient = createClient(host, port)
-                            log.d { "Websocket client updated with url $host:$port" }
-                            log.d { "Websocket client - connecting" }
-                            currentClient?.connect()
-                            if (!connectionReady.isCompleted) {
-                                connectionReady.complete(true)
+                            } catch (e: Exception) {
+                                log.e(e) { "Error parsing or connecting to new URL $url" }
                             }
                         }
                     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
@@ -133,7 +133,7 @@ class WebSocketApiClient(
                 }
             }
         } catch (e: Exception) {
-            log.e(e) { "Failed to get WS request result" }
+            log.e(e) { "Failed to get WS request result: ${e.message}" }
             return Result.failure(e)
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/api_proxy/WebSocketApiClient.kt
@@ -12,6 +12,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
@@ -132,6 +133,9 @@ class WebSocketApiClient(
                     return Result.failure(WebSocketRestApiException(response.httpStatusCode, body))
                 }
             }
+        } catch (e: CancellationException) {
+            // no log on cancellation
+            return Result.failure(e)
         } catch (e: Exception) {
             log.e(e) { "Failed to get WS request result: ${e.message}" }
             return Result.failure(e)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/ServiceFacade.kt
@@ -45,11 +45,16 @@ abstract class ServiceFacade : LifeCycleAware, KoinComponent, Logging {
         if (isActivated.compareAndSet(expect = true, update = false)) {
             log.i { "Deactivating service ${this::class.simpleName}" }
             
-            // Clean up all jobs managed by the jobsManager
+            // Clean up all jobs managed by the jobsManager in a new scope because this will be killed
             CoroutineScope(IODispatcher).launch {
                 jobsManager.dispose()
             }
         }
+    }
+
+    protected fun reactivate() {
+        deactivate()
+        activate()
     }
     
     // Helper methods for launching coroutines with the jobsManager

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineJobsManager.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineJobsManager.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import network.bisq.mobile.domain.data.IODispatcher
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Interface for managing coroutine jobs with lifecycle awareness.
@@ -23,7 +25,7 @@ interface CoroutineJobsManager {
      * @param block The coroutine code to execute
      * @return The created job
      */
-    fun launchUI(block: suspend CoroutineScope.() -> Unit): Job
+    fun launchUI(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> Unit): Job
     
     /**
      * Launch a new coroutine in the IO scope and automatically manage its lifecycle.
@@ -70,7 +72,7 @@ interface CoroutineJobsManager {
 class DefaultCoroutineJobsManager : CoroutineJobsManager, Logging {
     private val jobs = mutableSetOf<Job>()
     private val jobsMutex = Mutex()
-    private var uiScope = CoroutineScope(kotlinx.coroutines.Dispatchers.Main + SupervisorJob())
+    private var uiScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var ioScope = CoroutineScope(IODispatcher + SupervisorJob())
     
     override fun addJob(job: Job): Job {
@@ -87,8 +89,8 @@ class DefaultCoroutineJobsManager : CoroutineJobsManager, Logging {
         return job
     }
     
-    override fun launchUI(block: suspend CoroutineScope.() -> Unit): Job {
-        return addJob(uiScope.launch { block() })
+    override fun launchUI(context: CoroutineContext,  block: suspend CoroutineScope.() -> Unit): Job {
+        return addJob(uiScope.launch(context) { block() })
     }
     
     override fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -126,17 +126,22 @@ open class MainPresenter(
     override fun onDestroying() {
         job?.cancel()
         // to stop notification service and fully kill app (no zombie mode)
-        onResumeServices()
+        stopOpenTradeNotificationsService()
         super.onDestroying()
     }
 
     protected open fun onResumeServices() {
-        openTradesNotificationService.stopNotificationService()
+        stopOpenTradeNotificationsService()
+        connectivityService.startMonitoring()
     }
 
     protected open fun onPauseServices() {
         connectivityService.stopMonitoring()
         openTradesNotificationService.launchNotificationService()
+    }
+
+    private fun stopOpenTradeNotificationsService() {
+        openTradesNotificationService.stopNotificationService()
     }
 
     // Toggle action

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -51,8 +51,6 @@ open class MainPresenter(
     private val _readMessageCountsByTrade = MutableStateFlow(emptyMap<String, Int>())
     override val readMessageCountsByTrade: StateFlow<Map<String, Int>> = _readMessageCountsByTrade
 
-    private var job: Job? = null
-
     init {
         val localeCode = getDeviceLanguageCode()
         val screenWidth = getScreenWidthDp()
@@ -72,7 +70,7 @@ open class MainPresenter(
             }
         }
 
-        job = ioScope.launch {
+        launchIO {
             combine(
                 tradesServiceFacade.openTradeItems,
                 tradesServiceFacade.selectedTrade,
@@ -124,10 +122,13 @@ open class MainPresenter(
 
     @CallSuper
     override fun onDestroying() {
-        job?.cancel()
         // to stop notification service and fully kill app (no zombie mode)
         stopOpenTradeNotificationsService()
         super.onDestroying()
+    }
+
+    open fun reactivateServices() {
+        // default do nth
     }
 
     protected open fun onResumeServices() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -10,6 +10,9 @@ import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter
 
+/**
+ * Main presenter for the display when landing the user on the app ready to be used.
+ */
 class TabContainerPresenter(
     private val mainPresenter: MainPresenter,
     private val createOfferPresenter: CreateOfferPresenter,
@@ -19,30 +22,24 @@ class TabContainerPresenter(
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
     override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
-
-    private var job: Job? = null
+    private var foceServicesReactivation = false
 
     override fun onViewAttached() {
         super.onViewAttached()
 
-        job = presenterScope.launch {
+        onceOffReactivateServices()
+        launchUI {
             mainPresenter.tradesWithUnreadMessages.collect{ _tradesWithUnreadMessages.value = it }
         }
     }
 
     override fun onViewUnattaching() {
-        job?.cancel()
-        job = null
         _tradesWithUnreadMessages.value = emptyMap()
         super.onViewUnattaching()
     }
 
     override fun createOffer() {
         try {
-//            if (isDemo()) {
-//                showSnackbar("Create offer is disabled in demo mode")
-//                return
-//            }
             createOfferPresenter.onStartCreateOffer()
             navigateTo(Routes.CreateOfferDirection)
         } catch (e: Exception) {
@@ -50,4 +47,13 @@ class TabContainerPresenter(
         }
     }
 
+    private fun onceOffReactivateServices() {
+        if (!foceServicesReactivation) {
+            log.d { "User landed on home, reactivating services.." }
+            launchIO {
+                mainPresenter.reactivateServices()
+                foceServicesReactivation = true
+            }
+        }
+    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -1,9 +1,7 @@
 package network.bisq.mobile.presentation.ui.uicases
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -22,7 +20,7 @@ class TabContainerPresenter(
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
     override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
-    private var foceServicesReactivation = false
+    private var forceServicesReactivation = false
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -48,11 +46,11 @@ class TabContainerPresenter(
     }
 
     private fun onceOffReactivateServices() {
-        if (!foceServicesReactivation) {
+        if (!forceServicesReactivation) {
             log.d { "User landed on home, reactivating services.." }
             launchIO {
                 mainPresenter.reactivateServices()
-                foceServicesReactivation = true
+                forceServicesReactivation = true
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferMarketPresenter.kt
@@ -87,8 +87,12 @@ class CreateOfferMarketPresenter(
 
     private fun commitToModel() {
         if (isValid()) {
-            createOfferPresenter.commitMarket(market!!)
-            offersServiceFacade.selectOfferbookMarket(marketListItem!!)
+            runCatching {
+                createOfferPresenter.commitMarket(market!!)
+                offersServiceFacade.selectOfferbookMarket(marketListItem!!)
+            }.onFailure {
+                log.e(it) { "Failed to comit to model ${it.message}" }
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
@@ -74,7 +74,9 @@ class CreateOfferPresenter(
         createOfferModel = CreateOfferModel()
 
         createOfferModel.apply {
-            priceQuote = marketPriceServiceFacade.selectedMarketPriceItem.value!!.priceQuote
+            marketPriceServiceFacade.selectedMarketPriceItem.value?.let {
+                priceQuote = it.priceQuote
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -123,15 +123,7 @@ class CreateOfferReviewPresenter(
     }
 
     private fun onGoToOfferList() {
-        this.presenterScope.launch {
-            // FIXME without clearing the backstack it does not work
-            val rootNavController = getRootNavController()
-            var currentBackStack = rootNavController.currentBackStack.value
-            while (currentBackStack.size > 2) {
-                rootNavController.popBackStack()
-                currentBackStack = rootNavController.currentBackStack.value
-            }
-            navigateToTab(Routes.TabOfferbook)
-        }
+        navigateBackTo(Routes.TabContainer)
+        navigateToTab(Routes.TabOfferbook)
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -105,8 +105,11 @@ open class CreateProfilePresenter(
                     /* navigateTo(Routes.TrustedNodeSetup) {
                          it.popUpTo(Routes.CreateProfile.name) { inclusive = true }
                      }  */
+                    
+                    // Navigate to TabContainer and completely clear the back stack
+                    // This ensures the user can never navigate back to onboarding screens
                     navigateTo(Routes.TabContainer) {
-                        it.popUpTo(Routes.Onboarding.name) { inclusive = true }
+                        it.popUpTo(Routes.Splash.name) { inclusive = true }
                     }
                     enableInteractive()
                 }.onFailure { e ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
@@ -22,6 +24,8 @@ import org.koin.compose.koinInject
 
 interface IOnboardingPresenter : ViewPresenter {
 
+    val buttonText: StateFlow<String>
+
     val onBoardingData: List<PagerViewItem>
 
     val indexesToShow: List<Number>
@@ -34,6 +38,8 @@ fun OnBoardingScreen() {
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { presenter.indexesToShow.size })
+
+    val mainButtonText = presenter.buttonText.collectAsState().value
 
     RememberPresenterLifecycle(presenter)
 
@@ -51,7 +57,7 @@ fun OnBoardingScreen() {
 
         BisqButton(
             text = if (pagerState.currentPage == presenter.indexesToShow.lastIndex)
-                "Create profile" //TODO:i18n
+                mainButtonText
             else
                 "action.next".i18n(),
             onClick = { presenter.onNextButtonClick(coroutineScope, pagerState) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
 import network.bisq.mobile.domain.data.model.Settings
 import network.bisq.mobile.domain.data.model.User
@@ -60,11 +59,11 @@ open class SplashPresenter(
             }
 
             runCatching {
-                val settings: SettingsVO = settingsServiceFacade.getSettings().getOrThrow()
-                val settingsMobile: Settings = settingsRepository.fetch() ?: Settings()
+                val profileSettings: SettingsVO = settingsServiceFacade.getSettings().getOrThrow()
+                val deviceSettings: Settings = settingsRepository.fetch() ?: Settings()
                 val user: User? = userRepository.fetch()
 
-                if (!settings.isTacAccepted) {
+                if (!profileSettings.isTacAccepted) {
                     navigateToAgreement()
                 } else {
                     // only fetch profile with connectivity
@@ -78,11 +77,11 @@ open class SplashPresenter(
                         // 2b) xClients being able to connect with remote instance happening successfuly as part of services init?
                         navigateToHome()
                         // Scenario 2: Loading up for first time for both androidNode and xClients
-                    } else if (settingsMobile.firstLaunch) {
+                    } else if (deviceSettings.firstLaunch) {
                         navigateToOnboarding()
                         // Scenario 3: Handle others based on app type
                     } else {
-                        doCustomNavigationLogic(settingsMobile, hasProfile)
+                        doCustomNavigationLogic(deviceSettings, hasProfile)
                     }
                 }
             }.onFailure {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
+import kotlin.coroutines.cancellation.CancellationException
 
 open class SplashPresenter(
     mainPresenter: MainPresenter,
@@ -49,7 +50,7 @@ open class SplashPresenter(
 
     private fun navigateToNextScreen() {
         log.d { "Navigating to next screen" }
-        presenterScope.launch {
+        launchUI {
             if (!hasConnectivity()) {
                 navigateToTrustedNodeSetup()
             }
@@ -85,6 +86,7 @@ open class SplashPresenter(
                     }
                 }
             }.onFailure {
+                if (it is CancellationException) return@launchUI
                 log.e(it) { "Failed to navigate out of splash" }
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -88,6 +88,11 @@ class TrustedNodeSetupPresenter(
     }
 
     override fun testConnection(isWorkflow: Boolean) {
+        if (!isWorkflow) {
+            // FIXME temporary solution to avoid changing node without the corresponding profile reset
+            showSnackbar("If you want to use a different node, you need to remove the app storage or uninstall/reinstall")
+            return
+        }
         _isLoading.value = true
         log.d { "Test: ${_bisqApiUrl.value} isWorkflow $isWorkflow" }
         val connectionSettings = WebSocketClientProvider.parseUri(_bisqApiUrl.value)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -53,7 +53,7 @@ class TrustedNodeSetupPresenter(
     private fun initialize() {
         log.i { "View attached to Trusted node presenter" }
 
-        presenterScope.launch {
+        launchUI {
             try {
                 val data = withContext(IODispatcher) {
                     settingsRepository.fetch()
@@ -96,9 +96,8 @@ class TrustedNodeSetupPresenter(
         _isLoading.value = true
         log.d { "Test: ${_bisqApiUrl.value} isWorkflow $isWorkflow" }
         val connectionSettings = WebSocketClientProvider.parseUri(_bisqApiUrl.value)
-        
-        // Create a job that we can cancel if needed
-        val connectionJob = presenterScope.launch {
+
+        val connectionJob = launchUI {
             try {
                 // Add a timeout to prevent indefinite waiting
                 val success = withTimeout(15000) { // 15 second timeout
@@ -144,9 +143,8 @@ class TrustedNodeSetupPresenter(
                 _isLoading.value = false
             }
         }
-        
-        // Optional: Add a safety timeout at the presenter level
-        presenterScope.launch {
+
+        launchUI {
             delay(SAFEGUARD_TEST_TIMEOUT) // 20 seconds as a fallback
             if (_isLoading.value) {
                 log.w { "Force stopping connection test after 20 seconds" }
@@ -167,7 +165,8 @@ class TrustedNodeSetupPresenter(
     }
 
     override fun navigateToNextScreen() {
-        navigateTo(Routes.CreateProfile)
+        // access to profile setup should be handled by splash
+        goBackToSetupScreen()
     }
 
     override fun goBackToSetupScreen() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -53,7 +53,7 @@ interface ITrustedNodeSetupPresenter : ViewPresenter {
      */
     fun validateWsUrl(url: String): String?
 
-    fun testConnection(isWorkflow: Boolean = true)
+    fun testConnection(isWorkflow: Boolean)
 
     fun navigateToNextScreen()
 
@@ -178,7 +178,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
             BisqButton(
                 text = "Test Connection", // TODO:i18n
                 onClick = {
-                    presenter.testConnection()
+                    presenter.testConnection(isWorkflow)
                 },
                 padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                 disabled = !presenter.isBisqApiUrlValid.collectAsState().value,
@@ -196,7 +196,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     BisqButton(
                         text = "Test Connection", // TODO:i18n
                         color = if (bisqApiUrl.isEmpty()) BisqTheme.colors.mid_grey10 else BisqTheme.colors.light_grey10,
-                        onClick = { presenter.testConnection() },
+                        onClick = { presenter.testConnection(isWorkflow) },
                         padding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
                     )
                 }


### PR DESCRIPTION
 - fixes #332 
 - overall robustness improved by leveraging new coroutine manager in key areas related to bisq connect WS usages app
 - now usage of the app is solid including when the app has just been installed and configured
 - temporarily disable edit of trusted node on settings (to correctly allow this we need a profile cleanup and land the user back in the onboarding)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved onboarding flow by skipping trusted node connection when no node is configured on fresh installs.
  - Added a way to reactivate services during the app lifecycle for better reliability.
  - Introduced reactive button text in onboarding for dynamic UI updates.

- **Bug Fixes**
  - Prevented possible crashes when starting offer creation if market data is unavailable.
  - Enhanced error handling when committing offer market selection.
  - Improved error handling and logging for network requests and connection attempts.
  - Added early exit with user guidance when changing node is disallowed.

- **Refactor**
  - Simplified coroutine and job management across presenters and services for better performance and maintainability.
  - Streamlined navigation logic after profile creation and offer review.
  - Improved handling of service activation and deactivation for smoother app operation.
  - Centralized coroutine launching with flexible context support.
  - Refactored notification service management and service reactivation triggers.

- **Style**
  - Minor code and import cleanups for improved readability.

- **Documentation**
  - Added descriptive comments to clarify presenter roles and method purposes.

- **Chores**
  - Updated method signatures to require explicit parameters, improving code clarity and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->