### PR TITLE
bugfix/do_not_proceed_bootstrap_when_no_connectivity

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -62,7 +62,7 @@ val androidNodeModule = module {
 
     single { AndroidApplicationService.Provider() }
 
-    single<ApplicationBootstrapFacade> { NodeApplicationBootstrapFacade(get()) }
+    single<ApplicationBootstrapFacade> { NodeApplicationBootstrapFacade(get(), get()) }
 
     single<MarketPriceServiceFacade> { NodeMarketPriceServiceFacade(get()) }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSplashPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSplashPresenter.kt
@@ -36,7 +36,6 @@ class NodeSplashPresenter(
     }
 
     override suspend fun hasConnectivity(): Boolean {
-        // Use the NodeConnectivityService to check actual peer connections
         return mainPresenter.isConnected()
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSplashPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeSplashPresenter.kt
@@ -11,7 +11,7 @@ import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.uicases.startup.SplashPresenter
 
 class NodeSplashPresenter(
-    mainPresenter: MainPresenter,
+    private val mainPresenter: MainPresenter,
     applicationBootstrapFacade: ApplicationBootstrapFacade,
     userProfileService: UserProfileServiceFacade,
     userRepository: UserRepository,
@@ -36,7 +36,7 @@ class NodeSplashPresenter(
     }
 
     override suspend fun hasConnectivity(): Boolean {
-        // TODO implement for node
-        return true
+        // Use the NodeConnectivityService to check actual peer connections
+        return mainPresenter.isConnected()
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/bootstrap/NodeApplicationBootstrapFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/bootstrap/NodeApplicationBootstrapFacade.kt
@@ -3,18 +3,21 @@ package network.bisq.mobile.android.node.service.bootstrap
 import bisq.application.State
 import bisq.common.observable.Observable
 import bisq.common.observable.Pin
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.domain.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.i18n.i18n
 
 class NodeApplicationBootstrapFacade(
-    private val applicationService: AndroidApplicationService.Provider
+    private val applicationService: AndroidApplicationService.Provider,
+    private val connectivityService: ConnectivityService
 ) : ApplicationBootstrapFacade() {
 
-    // Dependencies
     private val applicationServiceState: Observable<State> by lazy { applicationService.state.get() }
+    private var connectivityJob: Job? = null
 
-    // Misc
     private var applicationServiceStatePin: Pin? = null
 
     override fun activate() {
@@ -53,8 +56,18 @@ class NodeApplicationBootstrapFacade(
                 State.APP_INITIALIZED -> {
                     isActive = true
                     log.i { "Bootstrap activated" }
-                    setState("splash.applicationServiceState.APP_INITIALIZED".i18n())
-                    setProgress(1f)
+                    
+                    // Check connectivity before completing bootstrap
+                    if (connectivityService.isConnected()) {
+                        onInitialized()
+                    } else {
+                        setState("bootstrap.noConnectivity".i18n())
+                        setProgress(0.95f) // Not fully complete
+                        connectivityJob = connectivityService.runWhenConnected {
+                            log.d { "Bootstrap: Connectivity restored, completing initialization" }
+                            onInitialized()
+                        }
+                    }
                 }
 
                 State.FAILED -> {
@@ -65,12 +78,19 @@ class NodeApplicationBootstrapFacade(
         }
     }
 
+    private fun onInitialized() {
+        setState("splash.applicationServiceState.APP_INITIALIZED".i18n())
+        setProgress(1f)
+    }
+
     private fun onInitializeAppState() {
         setState("splash.applicationServiceState.INITIALIZE_APP".i18n())
         setProgress(0f)
     }
 
     override fun deactivate() {
+        connectivityJob?.cancel()
+        connectivityJob = null
         applicationServiceStatePin?.unbind()
         applicationServiceStatePin = null
         isActive = false

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
@@ -20,7 +20,7 @@ class NodeConnectivityService(private val applicationService: AndroidApplication
 
     override fun isConnected(): Boolean {
         val connections = currentConnections()
-        log.d { "Connected peers = $connections" }
+        log.v { "Connected peers = $connections" }
         return connections > 0
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
@@ -1550,6 +1550,7 @@ object GeneratedResourceBundles_cs {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "Žádné připojení: Čekání na připojení pro opakování",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
@@ -632,7 +632,7 @@ object GeneratedResourceBundles_de {
             "bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.sortTitle" to "Sortieren nach:",
             "bisqEasy.tradeWizard.review.priceDescription.taker" to "Handelspreis",
             "bisqEasy.takeOffer.review.sendTakeOfferMessageFeedback.subTitle" to "Das Senden der Nachricht zum Akzeptieren des Angebots kann bis zu 2 Minuten dauern",
-            "bisqEasy.walletGuide.receive.headline" to "Bitcoin in deiner Wallet empfangen",
+            "bootstrap.noConnectivity" to "Keine Verbindung: Bitte überprüfen Sie Ihre Internetverbindung und starten Sie neu",
             "bisqEasy.tradeWizard.selectOffer.noMatchingOffers.headline" to "Keine passenden Angebote gefunden",
             "bisqEasy.walletGuide.tabs.headline" to "Wallet-Anleitung",
             "bisqEasy.offerbook.offerList.table.columns.fiatAmount" to "{0} Betrag",
@@ -1548,9 +1548,11 @@ object GeneratedResourceBundles_de {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "Keine Verbindung: Warte auf Verbindung für erneuten Versuch",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",
         ),
     )
 }
+

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
@@ -1566,6 +1566,7 @@ object GeneratedResourceBundles_en {
             "max" to "Max",
             "error.exception" to "Exception",
             "genericError.errorMessage" to "Error message:",
+            "bootstrap.noConnectivity" to "No Connectivity: Waiting to retry",
             "mobile.openTrades.inMediation.banner" to "A mediator has joined the trade chat.\nPlease use the trade chat to get assistance from the mediator.",
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
@@ -659,7 +659,7 @@ object GeneratedResourceBundles_es {
             "bisqEasy.tradeWizard.progress.amountAndPrice.selectOffer" to "Cantidad",
             "bisqEasy.offerDetails.makersTradeTerms" to "Términos comerciales del creador",
             "bisqEasy.openTrades.chat.attach.tooltip" to "Restaurar chat de nuevo en la ventana principal",
-            "bisqEasy.tradeWizard.amount.seller.limitInfo" to "Tu cantidad máxima de venta es {0}.",
+            "bootstrap.noConnectivity" to "Sin conectividad: Por favor, compruebe su conexión a internet y reinicie",
             "bisqEasy.privateChats.table.myUser" to "Mi perfil",
             "bisqEasy.tradeState.info.phase4.exportTrade" to "Exportar datos de la operación",
             "bisqEasy.tradeWizard.selectOffer.subHeadline" to "Se recomienda intercambiar con usuarios con alta reputación.",
@@ -1548,9 +1548,11 @@ object GeneratedResourceBundles_es {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "No Connectivity: Waiting to retry",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",
         ),
     )
 }
+

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
@@ -1548,7 +1548,7 @@ object GeneratedResourceBundles_es {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
-            "bootstrap.noConnectivity" to "No Connectivity: Waiting to retry",
+            "bootstrap.noConnectivity" to "Sin conectividad: Esperando conexión para reintentar",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
@@ -1548,6 +1548,7 @@ object GeneratedResourceBundles_it {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "Nessuna connettività: In attesa di connessione per riprovare",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
@@ -1533,6 +1533,7 @@ object GeneratedResourceBundles_pcm {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "No Connectivity: Dey wait for connection to try again",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
@@ -1548,6 +1548,7 @@ object GeneratedResourceBundles_pt_BR {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "Sem conectividade: Aguardando conectividade para tentar novamente",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
@@ -1548,6 +1548,7 @@ object GeneratedResourceBundles_ru {
             "mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo" to "Use the trade ID {0} for the ''Reason for payment'' field",
             "min" to "Min",
             "bootstrap.connectedToTrustedNode" to "Connected to trusted node",
+            "bootstrap.noConnectivity" to "Нет соединения: Ожидание подключения для повторной попытки",
             "confirmation.areYouSure" to "Are you sure?",
             "genericError.headline" to "An error occurred",
             "mobile.reputation.learnMore" to "Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/resources/mobile/default.properties
+++ b/shared/domain/src/commonMain/resources/mobile/default.properties
@@ -57,6 +57,8 @@ data.add=Add
 data.remove=Remove
 data.redacted=Data has been removed for privacy and security reasons
 
+bootstrap.noConnectivity=No connectivity: Waiting to retry
+
 offer.createOffer=Create offer
 offer.takeOffer.buy.button=Buy Bitcoin
 offer.takeOffer.sell.button=Sell Bitcoin

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -127,6 +127,10 @@ open class MainPresenter(
         super.onDestroying()
     }
 
+    fun isConnected(): Boolean {
+        return connectivityService.isConnected()
+    }
+
     open fun reactivateServices() {
         log.d { "Reactivating services default: skip" }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -50,8 +50,11 @@ open class SplashPresenter(
     private fun navigateToNextScreen() {
         log.d { "Navigating to next screen" }
         launchUI {
+            // Check connectivity first
             if (!hasConnectivity()) {
+                log.d { "No connectivity detected, navigating to trusted node setup" }
                 navigateToTrustedNodeSetup()
+                return@launchUI
             }
 
             if (webSocketClientProvider?.get()?.isDemo() == true) {


### PR DESCRIPTION
 - fixes #358 
 - bugfix do not proceed bootstrap if there is no connectivity
 - added job to resume bootstrap when connectivity is restored based on connectivity service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The app now detects network connectivity during startup and waits for a connection before completing initialization.
	- Added messages in multiple languages to inform users when there is no connectivity and the app is waiting to retry.
- **Improvements**
	- Enhanced startup flow to redirect users to the trusted node setup screen if no network connection is available.
	- Connectivity checks are now more robust and integrated into the app's initialization process.
	- Added ability to defer actions until network connectivity is restored, improving app responsiveness.
- **Bug Fixes**
	- Connectivity status is now accurately reflected during app startup, preventing premature completion when offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->