### PR TITLE
Update/UI polish - For startup screens

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/layout/Gap.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/layout/Gap.kt
@@ -46,7 +46,7 @@ object BisqGap {
 
     @Composable
     fun V5() {
-        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding5X))
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding8X))
     }
 
     @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/layout/Gap.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/layout/Gap.kt
@@ -46,6 +46,21 @@ object BisqGap {
 
     @Composable
     fun V5() {
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding5X))
+    }
+
+    @Composable
+    fun V6() {
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding6X))
+    }
+
+    @Composable
+    fun V7() {
+        Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding7X))
+    }
+
+    @Composable
+    fun V8() {
         Spacer(modifier = Modifier.height(BisqUIConstants.ScreenPadding8X))
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -61,6 +61,7 @@ fun TopBar(
     backConfirmation: Boolean = false,
     backBehavior: (() -> Unit)? = null,
     isFlowScreen: Boolean = false,
+    showUserAvatar: Boolean = true,
     stepText: String = "",
 ) {
     val presenter: ITopBarPresenter = koinInject()
@@ -73,8 +74,8 @@ fun TopBar(
     val currentTab = tabNavController.currentBackStackEntryAsState().value?.destination?.route
 
     val showBackButton = (customBackButton == null &&
-                          navController.previousBackStackEntry != null &&
-                          !presenter.isAtHome())
+            navController.previousBackStackEntry != null &&
+            !presenter.isAtHome())
 
     val connectivityStatus = presenter.connectivityStatus.collectAsState().value
 
@@ -135,32 +136,36 @@ fun TopBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
 
-                val userIconModifier = Modifier
-                    .size(30.dp)
-                    .alpha(if (presenter.avatarEnabled(currentTab)) 1.0f else 0.5f)
-                    .clickable {
-                        if (presenter.avatarEnabled(currentTab)) {
-                            presenter.navigateToUserProfile()
-                        }
-                    }
-
 //                TODO implement full feature after MVP
 //                BellIcon()
-                Spacer(modifier = Modifier.width(12.dp))
-                if (showAnimation && connectivityStatus != ConnectivityService.ConnectivityStatus.DISCONNECTED) {
-                    ShineOverlay {
+
+                if (showUserAvatar) {
+
+                    val userIconModifier = Modifier
+                        .size(30.dp)
+                        .alpha(if (presenter.avatarEnabled(currentTab)) 1.0f else 0.5f)
+                        .clickable {
+                            if (presenter.avatarEnabled(currentTab)) {
+                                presenter.navigateToUserProfile()
+                            }
+                        }
+
+                    BisqGap.H1()
+                    if (showAnimation && connectivityStatus != ConnectivityService.ConnectivityStatus.DISCONNECTED) {
+                        ShineOverlay {
+                            UserIcon(
+                                presenter.uniqueAvatar.value,
+                                modifier = userIconModifier,
+                                connectivityStatus = connectivityStatus
+                            )
+                        }
+                    } else {
                         UserIcon(
                             presenter.uniqueAvatar.value,
                             modifier = userIconModifier,
                             connectivityStatus = connectivityStatus
                         )
                     }
-                } else {
-                    UserIcon(
-                        presenter.uniqueAvatar.value,
-                        modifier = userIconModifier,
-                        connectivityStatus = connectivityStatus
-                    )
                 }
             }
         },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/BisqDialog.kt
@@ -25,7 +25,7 @@ fun BisqDialog(
     onDismissRequest: () -> Unit = {},
     dismissOnClickOutside: Boolean = true,
     padding: Dp = BisqUIConstants.ScreenPadding2X,
-    marginTop: Dp = BisqUIConstants.ScreenPadding5X,
+    marginTop: Dp = BisqUIConstants.ScreenPadding8X,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     content: @Composable ColumnScope.() -> Unit = {}
 ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/ConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/ConfirmationDialog.kt
@@ -24,7 +24,7 @@ fun ConfirmationDialog(
     message: String = "",
     confirmButtonText: String = "confirmation.yes".i18n(),
     dismissButtonText: String = "confirmation.no".i18n(),
-    marginTop: Dp = BisqUIConstants.ScreenPadding5X,
+    marginTop: Dp = BisqUIConstants.ScreenPadding8X,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalButtonPlacement: Boolean = false,
     onConfirm: () -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/InformationConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/InformationConfirmationDialog.kt
@@ -14,7 +14,7 @@ fun InformationConfirmationDialog(
     message: String = "",
     confirmButtonText: String = "confirmation.ok".i18n(),
     dismissButtonText: String = "action.cancel".i18n(),
-    marginTop: Dp = BisqUIConstants.ScreenPadding5X,
+    marginTop: Dp = BisqUIConstants.ScreenPadding8X,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     verticalButtonPlacement: Boolean = true,
     onConfirm: () -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/WarningConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/WarningConfirmationDialog.kt
@@ -14,7 +14,7 @@ fun WarningConfirmationDialog(
     message: String = "",
     confirmButtonText: String = "confirmation.ok".i18n(),
     dismissButtonText: String = "action.cancel".i18n(),
-    marginTop: Dp = BisqUIConstants.ScreenPadding5X,
+    marginTop: Dp = BisqUIConstants.ScreenPadding8X,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalButtonPlacement: Boolean = false,
     onConfirm: () -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/PagerView.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/PagerView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
 import network.bisq.mobile.presentation.ui.theme.*
 import org.jetbrains.compose.resources.DrawableResource
@@ -39,7 +40,7 @@ fun BisqPagerView(pagerState: PagerState, pageItems: List<PagerViewItem>) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(36.dp, Alignment.CenterVertically),
-            ) {
+        ) {
             HorizontalPager(
                 pageSpacing = 56.dp,
                 contentPadding = PaddingValues(horizontal = 36.dp),
@@ -55,10 +56,10 @@ fun BisqPagerView(pagerState: PagerState, pageItems: List<PagerViewItem>) {
                         title = item.title,
                         desc = item.desc,
                         index = index,
-                        )
+                    )
                 }
             }
-                PagerLineIndicator(pagerState = pagerState)
+            PagerLineIndicator(pagerState = pagerState)
         }
     }
 
@@ -72,32 +73,26 @@ fun PagerSingleItem(
     desc: String,
     index: Int
 ) {
-    Box(
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
-            .clip(RoundedCornerShape(18.dp)),
-        contentAlignment = Alignment.Center,
+            .fillMaxWidth()
+            .height(420.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(color = BisqTheme.colors.dark_grey30)
+            .padding(vertical = 56.dp)
     ) {
-        Column(
-            verticalArrangement = Arrangement.SpaceBetween,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(color = BisqTheme.colors.dark_grey30)
-                .padding(vertical = 56.dp)
-        ) {
-            Image(painterResource(image), title, modifier = Modifier.size(120.dp),)
-            Spacer(modifier = Modifier.height(if (index == 1) 48.dp else 70.dp))
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                BisqText.h4Regular(title)
-                Spacer(modifier = Modifier.height(24.dp))
-                BisqText.largeRegularGrey(
-                    text = desc,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    textAlign = TextAlign.Center,
-                )
-            }
+        Image(painterResource(image), title, modifier = Modifier.size(120.dp))
+        BisqGap.V4()
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            BisqText.h4Regular(title)
+            BisqGap.V2()
+            BisqText.largeRegularGrey(
+                text = desc,
+                modifier = Modifier.padding(horizontal = 16.dp),
+                textAlign = TextAlign.Center,
+            )
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/TakeOfferProgressDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/TakeOfferProgressDialog.kt
@@ -21,15 +21,16 @@ import org.jetbrains.compose.resources.painterResource
 fun TakeOfferProgressDialog() {
 
     BisqDialog(dismissOnClickOutside = false) {
+        val imageSize = BisqUIConstants.ScreenPadding8X
         Box {
             RotatingImage(
                 painterResource(Res.drawable.bisq_easy_circle),
-                modifier = Modifier.size(BisqUIConstants.ScreenPadding8X)
+                modifier = Modifier.size(imageSize)
             )
             Image(
                 painterResource(Res.drawable.bisq_easy),
-                "",
-                modifier = Modifier.size(BisqUIConstants.ScreenPadding8X)
+                contentDescription = "",
+                modifier = Modifier.size(imageSize)
             )
         }
         BisqText.h4Regular(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/TakeOfferProgressDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/TakeOfferProgressDialog.kt
@@ -24,12 +24,12 @@ fun TakeOfferProgressDialog() {
         Box {
             RotatingImage(
                 painterResource(Res.drawable.bisq_easy_circle),
-                modifier = Modifier.size(BisqUIConstants.ScreenPadding5X)
+                modifier = Modifier.size(BisqUIConstants.ScreenPadding8X)
             )
             Image(
                 painterResource(Res.drawable.bisq_easy),
                 "",
-                modifier = Modifier.size(BisqUIConstants.ScreenPadding5X)
+                modifier = Modifier.size(BisqUIConstants.ScreenPadding8X)
             )
         }
         BisqText.h4Regular(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/CancelTradeDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/CancelTradeDialog.kt
@@ -29,7 +29,7 @@ fun CancelTradeDialog(
         message = warningText1,
         horizontalAlignment = Alignment.Start,
         marginTop = if (isRejection)
-            BisqUIConstants.ScreenPadding5X
+            BisqUIConstants.ScreenPadding8X
         else
             BisqUIConstants.ScreenPaddingHalf,
         onDismiss = onDismiss,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
@@ -12,7 +12,10 @@ object BisqUIConstants {
     val ScreenPadding2X = 24.dp
     val ScreenPadding3X = 36.dp
     val ScreenPadding4X = 48.dp
-    val ScreenPadding5X = 96.dp
+    val ScreenPadding5X = 60.dp
+    val ScreenPadding6X = 72.dp
+    val ScreenPadding7X = 84.dp
+    val ScreenPadding8X = 96.dp
 
     val StaticTopPadding = 36.dp
     val ScrollTopPadding = 24.dp

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
@@ -1,15 +1,21 @@
 package network.bisq.mobile.presentation.ui.uicases.offerbook
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.BisqFABAddButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
@@ -17,6 +23,7 @@ import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.WebLinkConfirmationDialog
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
 @Composable
@@ -53,10 +60,15 @@ fun OfferbookScreen() {
             onStateChange = { direction -> presenter.onSelectDirection(direction) }
         )
 
+        if (sortedFilteredOffers.isEmpty()) {
+            NoOffersSection(presenter)
+            return@BisqStaticScaffold
+        }
+
         BisqGap.V1()
 
         LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             items(sortedFilteredOffers) { item ->
@@ -90,3 +102,22 @@ fun OfferbookScreen() {
 
 }
 
+
+@Composable
+fun NoOffersSection(presenter: OfferbookPresenter) {
+    Column(
+        modifier = Modifier.padding(vertical = BisqUIConstants.ScreenPadding4X).fillMaxHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        BisqText.h4LightGrey(
+            text = "There are no offers", //TODO: i18n
+            textAlign = TextAlign.Center
+        )
+        BisqGap.V4()
+        BisqButton(
+            text = "offer.createOffer".i18n(), // Create offer
+            onClick = presenter::createOffer
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -85,7 +85,7 @@ fun UserProfileSettingsScreen() {
     })
 
     BisqScrollScaffold(
-        topBar = { TopBar("user.userProfile".i18n()) },
+        topBar = { TopBar("user.userProfile".i18n(), showUserAvatar = false) },
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
         isInteractive = presenter.isInteractive.collectAsState().value,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/AgreementScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/AgreementScreen.kt
@@ -38,7 +38,7 @@ fun AgreementScreen() {
 
     // TODO: Enhancement phase: To add a language dropdown, so as to render the agreement in supported languages
     BisqScrollScaffold(
-        topBar = { TopBar("tac.headline".i18n()) },
+        topBar = { TopBar("tac.headline".i18n(), showUserAvatar = false) },
         bottomBar = {
             Column(
                 modifier = Modifier.padding(all = BisqUIConstants.ScreenPaddingHalf),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -1,6 +1,10 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.datetime.Clock
@@ -76,16 +80,13 @@ open class CreateProfilePresenter(
     }
 
     fun validateNickname(nickname: String): String? {
-        val result = when {
+        return when {
             nickname.length < 3 -> "Min length: 3 characters"
             nickname.length > 100 -> "Max length: 100 characters"
             else -> null
+        }.also {
+            _nickNameValid.value = it == null
         }
-        _nickNameValid.value = if (result == null)
-            true
-        else
-            false
-        return result
     }
 
     // UI handlers

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -1,11 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.IODispatcher
@@ -48,6 +45,9 @@ open class CreateProfilePresenter(
         _nickName.value = value
     }
 
+    private val _nickNameValid = MutableStateFlow(false)
+    val nickNameValid: StateFlow<Boolean> get() = _nickNameValid
+
     private val _generateKeyPairInProgress = MutableStateFlow(false)
     val generateKeyPairInProgress: StateFlow<Boolean> get() = _generateKeyPairInProgress
 
@@ -59,6 +59,7 @@ open class CreateProfilePresenter(
 
     // Lifecycle
     override fun onViewAttached() {
+        super.onViewAttached()
         generateKeyPair()
     }
 
@@ -75,11 +76,16 @@ open class CreateProfilePresenter(
     }
 
     fun validateNickname(nickname: String): String? {
-        return when {
+        val result = when {
             nickname.length < 3 -> "Min length: 3 characters"
-            nickname.length > 256 -> "Max length: 256 characters"
+            nickname.length > 100 -> "Max length: 100 characters"
             else -> null
         }
+        _nickNameValid.value = if (result == null)
+            true
+        else
+            false
+        return result
     }
 
     // UI handlers
@@ -151,6 +157,8 @@ open class CreateProfilePresenter(
                         lastActivity = Clock.System.now().toEpochMilliseconds()
                     })
                 }
+
+                delay(1000L)
 
                 _generateKeyPairInProgress.value = false
                 log.i { "Hide busy animation for generateKeyPair" }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -1,7 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfileScreen.kt
@@ -1,20 +1,16 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
@@ -22,8 +18,10 @@ import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
 import network.bisq.mobile.presentation.ui.components.atoms.icons.rememberPlatformImagePainter
+import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
 @Composable
@@ -35,21 +33,23 @@ fun CreateProfileScreen(
     val generateKeyPairInProgress by presenter.generateKeyPairInProgress.collectAsState()
     val createAndPublishInProgress by presenter.createAndPublishInProgress.collectAsState()
     val nickName by presenter.nickName.collectAsState()
+    val nickNameValid by presenter.nickNameValid.collectAsState()
     val profileIcon by presenter.profileIcon.collectAsState()
     val nym by presenter.nym.collectAsState()
     val id by presenter.id.collectAsState()
+    val botSize = BisqUIConstants.ScreenPadding5X
 
     BisqScrollScaffold {
         BisqLogo()
-        Spacer(modifier = Modifier.height(24.dp))
+        BisqGap.V2()
         BisqText.h1LightGrey("onboarding.createProfile.headline".i18n())
-        Spacer(modifier = Modifier.height(12.dp))
+        BisqGap.V1()
         BisqText.baseRegularGrey(
             text = "onboarding.createProfile.subTitle".i18n(),
-            modifier = Modifier.padding(horizontal = 24.dp),
+            modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding2X),
             textAlign = TextAlign.Center,
         )
-        Spacer(modifier = Modifier.height(36.dp))
+        BisqGap.V3()
         BisqTextField(
             label = "onboarding.createProfile.nickName".i18n(),
             value = nickName,
@@ -59,43 +59,52 @@ fun CreateProfileScreen(
                 return@BisqTextField presenter.validateNickname(it)
             }
         )
-        Spacer(modifier = Modifier.height(36.dp))
+        BisqGap.V3()
 
-        profileIcon?.let { profileIcon ->
-            val painter = rememberPlatformImagePainter(profileIcon)
-            Button(contentPadding = PaddingValues(0.dp),
-                enabled = !generateKeyPairInProgress,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = Color.Black // Or any color you want for the text/icon
-                ),
-                elevation = ButtonDefaults.buttonElevation(0.dp),
-                onClick = { presenter.onGenerateKeyPair() }) {
-                Image(
-                    painter = painter,
-                    contentDescription = "User profile icon generated from the hash of the public key",
-                    modifier = Modifier.height(60.dp).width(60.dp)
-                )
+        if (generateKeyPairInProgress) {
+            CircularProgressIndicator(modifier = Modifier.size(botSize))
+        } else {
+            profileIcon?.let { profileIcon ->
+                val painter = rememberPlatformImagePainter(profileIcon)
+                Button(
+                    contentPadding = PaddingValues(BisqUIConstants.Zero),
+                    enabled = !generateKeyPairInProgress,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = Color.Black // Or any color you want for the text/icon
+                    ),
+                    elevation = ButtonDefaults.buttonElevation(BisqUIConstants.Zero),
+                    onClick = { presenter.onGenerateKeyPair() }) {
+                    Image(
+                        painter = painter,
+                        contentDescription = "User profile icon generated from the hash of the public key",
+                        modifier = Modifier.size(botSize)
+                    )
+                }
             }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
-        BisqText.baseRegular(nym)
-        Spacer(modifier = Modifier.height(12.dp))
-        BisqText.smallRegularGrey(id)
-        Spacer(modifier = Modifier.height(38.dp))
+        val nymText = if (generateKeyPairInProgress) {
+            "onboarding.createProfile.nym.generating".i18n()
+        } else {
+            nym
+        }
+
+        BisqGap.V3()
+        BisqText.baseRegular(nymText)
+        BisqGap.V3()
         BisqButton(
             text = "onboarding.createProfile.regenerate".i18n(),
             type = BisqButtonType.Grey,
             disabled = generateKeyPairInProgress,
-            padding = PaddingValues(horizontal = 64.dp, vertical = 12.dp),
+            padding = PaddingValues(horizontal = BisqUIConstants.ScreenPadding5X, vertical = BisqUIConstants.ScreenPadding),
             onClick = { presenter.onGenerateKeyPair() }
         )
-        Spacer(modifier = Modifier.height(40.dp))
+        BisqGap.V3()
         BisqButton(
             "action.next".i18n(),
             onClick = { presenter.onCreateAndPublishNewUserProfile() },
-            disabled = nickName.isEmpty() || createAndPublishInProgress
+            disabled = nickName.isEmpty() || createAndPublishInProgress || generateKeyPairInProgress || !nickNameValid
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -1,14 +1,10 @@
 package network.bisq.mobile.presentation.ui.uicases.startup
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
@@ -16,6 +12,7 @@ import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
+import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.components.organisms.BisqPagerView
 import network.bisq.mobile.presentation.ui.composeModels.PagerViewItem
@@ -49,11 +46,11 @@ fun OnBoardingScreen() {
 
     BisqScrollScaffold {
         BisqLogo()
-        Spacer(modifier = Modifier.height(24.dp))
+        BisqGap.V2()
         BisqText.h1LightGrey("onboarding.bisq2.headline".i18n())
-        Spacer(modifier = Modifier.height(24.dp))
+        BisqGap.V2()
         BisqPagerView(pagerState, finalPages)
-        Spacer(modifier = Modifier.height(24.dp))
+        BisqGap.V2()
 
         BisqButton(
             text = if (pagerState.currentPage == presenter.indexesToShow.lastIndex)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqProgressBar
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
@@ -16,8 +15,7 @@ import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
 @Composable
-fun SplashScreen(
-) {
+fun SplashScreen() {
     val presenter: SplashPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
@@ -27,9 +25,6 @@ fun SplashScreen(
 
         Column {
             BisqProgressBar(presenter.progress.collectAsState().value)
-
-            // TODO: Get this from presenter
-            val networkType = "splash.bootstrapState.network.TOR".i18n()
 
             BisqText.baseRegularGrey(
                 text = presenter.state.collectAsState().value,


### PR DESCRIPTION
Partial fixes for https://github.com/bisq-network/bisq-mobile/issues/337

- User Agreement Screen
  - Profile pic should be hidden in the Topbar
- Onboarding screen
  - Cards should have same height.
- Create profile
  - Add loader for bot creation process, as in Desktop
  - Disable `next` on validation errors, bot creation process.
  - Max length validation should be 100 characters, as in Desktop

- Offerbook - Listing
  - Some text in Empty listing. Like "No offers available. CTA: Create offer"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an empty state to the Offerbook screen with a message and "Create offer" button when no offers are available.
  - Introduced new vertical gap sizes for enhanced layout spacing options.

- **Improvements**
  - Standardized and expanded vertical spacing and padding across dialogs, layouts, and components for consistent UI.
  - Updated the TopBar to allow toggling the user avatar display.
  - Enhanced the Create Profile flow with improved nickname validation, feedback, and UI responsiveness.
  - Simplified and unified layout spacing using standardized gap components.
  - Improved layout and styling of pager views and progress dialogs for better visual structure.

- **UI Adjustments**
  - Adjusted padding constants for finer control and consistency throughout the app.
  - Refined dialog margins and progress indicator sizes for better visual balance.
  - Disabled user avatar display in specific screens for a cleaner interface.

- **Bug Fixes**
  - Enforced stricter nickname length validation during profile creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->