### PR TITLE
node_tests_passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17 (Azul Zulu)
+      - name: Set up JDK 21 (Azul Zulu)
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'zulu'
           cache: gradle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: ./gradlew clean assembleDebug -x androidNode:assembleDebug --info
 
       - name: Run all project tests
-        run: ./gradlew test -x androidNode:test
+        run: ./gradlew test
 
       - name: Run androidClient Tests
         run: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: ./gradlew clean assembleDebug -x androidNode:assembleDebug --info
 
       - name: Run all project tests
-        run: ./gradlew test
+        run: ./gradlew test -x androidNode:test
 
       - name: Run androidClient Tests
         run: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -17,12 +17,13 @@ val versionCodeValue = (project.findProperty("node.android.version.code") as Str
 val sharedVersion = project.findProperty("shared.version") as String
 
 kotlin {
-    jvmToolchain(21) // Set JVM toolchain to Java 21
+    // using JDK21 for full bisq2 compatibility
+    jvmToolchain(21)
     
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_21) // Update from JVM_17 to JVM_21
+            jvmTarget.set(JvmTarget.JVM_21)
         }
     }
 
@@ -165,8 +166,10 @@ android {
         buildConfig = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21 // Update from VERSION_17
-        targetCompatibility = JavaVersion.VERSION_21 // Update from VERSION_17
+        // for bisq2 jars full compatibility
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+        isCoreLibraryDesugaringEnabled = true
     }
     testOptions {
         unitTests.isIncludeAndroidResources = true
@@ -240,6 +243,8 @@ dependencies {
     implementation(libs.koin.core)
     implementation(libs.koin.android)
     implementation(libs.logging.kermit)
+
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }
 
 // ensure tests run on the same Java version as the main code

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -17,10 +17,12 @@ val versionCodeValue = (project.findProperty("node.android.version.code") as Str
 val sharedVersion = project.findProperty("shared.version") as String
 
 kotlin {
+    jvmToolchain(21) // Set JVM toolchain to Java 21
+    
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.JVM_21) // Update from JVM_17 to JVM_21
         }
     }
 
@@ -163,8 +165,8 @@ android {
         buildConfig = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21 // Update from VERSION_17
+        targetCompatibility = JavaVersion.VERSION_21 // Update from VERSION_17
     }
     testOptions {
         unitTests.isIncludeAndroidResources = true
@@ -240,11 +242,11 @@ dependencies {
     implementation(libs.logging.kermit)
 }
 
-// ensure tests run on J17
+// ensure tests run on the same Java version as the main code
 tasks.withType<Test> {
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21)) // Update from 17 to 21
         }
     )
 }

--- a/androidNode/src/main/resources/android.conf
+++ b/androidNode/src/main/resources/android.conf
@@ -7,6 +7,7 @@ application {
     ignoreSignatureVerification = false
     memoryReportIntervalSec = 600
     includeThreadListInMemoryReport = true
+    checkInstanceLock = false
 
     security = {
         keyBundle = {

--- a/androidNode/src/release/resources/android.conf
+++ b/androidNode/src/release/resources/android.conf
@@ -7,6 +7,7 @@ application {
     ignoreSignatureVerification = false
     memoryReportIntervalSec = 600
     includeThreadListInMemoryReport = true
+    checkInstanceLock = false
 
     security = {
         keyBundle = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidx-core-ktx = "1.13.1"
 androidx-espresso-core = "3.6.1"
 androidx-material = "1.12.0"
 
+desugar_jdk_libs = "2.1.5"
 roboelectric = "4.10.3"
 androidx-test = "1.6.1"
 androidx-test-junit = "1.2.1"
@@ -77,6 +78,7 @@ multiplatform-settings = "1.2.0"
 [libraries]
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 jetbrains-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinReflect" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit-v180 = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlinTestJunit" }


### PR DESCRIPTION
 - contribs to #30 
 - use Java21 for node tests (bisq2 jars deps)
 - fix latest bisq2 update compilation issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option, `checkInstanceLock`, to the application settings with a default value of `false`.

- **Chores**
  - Updated build configuration and CI workflows to use JDK 21 for Android development and testing.
  - Enabled core library desugaring with added support for desugar JDK libraries to ensure compatibility with Java 21 features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->