### PR TITLE
restore_android_node_ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,30 +75,22 @@ jobs:
           echo "CLI_KEY_ALIAS=yourCliKeyAlias" >> local.properties
           echo "KEY_PASSWORD=yourKeyPassword" >> local.properties
           echo "CLI_KEY_PASSWORD=yourCliKeyPassword" >> local.properties
-                                                                        
-      - name: Build project
-        env:
-          CI: true
-        run: ./gradlew clean assembleDebug --info
 
-      - name: Run all project tests
+      # CI:true is costly so we sum all tasks in one instruction                                   #
+      - name: Build project and do node specific tasks
         env:
           CI: true
-        run: ./gradlew test
+        run: |
+          ./gradlew clean assembleDebug --info
+          ./gradlew test
+          ./gradlew androidNode:testDebugUnitTest androidNode:connectedDebugAndroidTest
 
       - name: Run androidClient Tests
         env:
           CI: true
         run: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest
 
-      - name: Run androidNode Tests
-        env:
-          CI: true
-        run: ./gradlew androidNode:testDebugUnitTest androidNode:connectedDebugAndroidTest
-
       # TODO ios specific and run on emulator if needed
       - name: Run iOS Tests
         if: startsWith(matrix.os, 'macos')
-        env:
-          CI: true
         run: ./gradlew shared:presentation:iosSimulatorArm64Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
           xcodebuild -version
 #          sudo xcode-select -s /Applications/Xcode_15.0.app
 
-#      TODO: restore androidNode once dependant bisq2 jars get published in a public maven repo
       # Create a fake local.properties file
       - name: Create fake local.properties
         run: |
@@ -78,19 +77,28 @@ jobs:
           echo "CLI_KEY_PASSWORD=yourCliKeyPassword" >> local.properties
                                                                         
       - name: Build project
-        run: ./gradlew clean assembleDebug -x androidNode:assembleDebug --info
+        env:
+          CI: true
+        run: ./gradlew clean assembleDebug --info
 
       - name: Run all project tests
-        run: ./gradlew test -x androidNode:test
+        env:
+          CI: true
+        run: ./gradlew test
 
       - name: Run androidClient Tests
+        env:
+          CI: true
         run: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest
 
-#      TODO: restore androidNode once dependant bisq2 jars get published in a public maven repo
-#      - name: Run androidNode Tests
-#        run: ./gradlew androidNode:testDebugUnitTest androidNode:connectedDebugAndroidTest
+      - name: Run androidNode Tests
+        env:
+          CI: true
+        run: ./gradlew androidNode:testDebugUnitTest androidNode:connectedDebugAndroidTest
 
       # TODO ios specific and run on emulator if needed
       - name: Run iOS Tests
         if: startsWith(matrix.os, 'macos')
+        env:
+          CI: true
         run: ./gradlew shared:presentation:iosSimulatorArm64Test

--- a/README.md
+++ b/README.md
@@ -60,27 +60,31 @@ If you are a mobile enthusiast and feel driven by Bisq goals, please reach out!
 
  - Java: 17.0.12.fx-zulu JDK (sdkman env file is avail in project root)
  - Ruby: v3+ (for iOS Cocoapods 1.15+)
- - IDE: We use and recommend Fleet, but you may as well use the IDE of your preference. For iOS testing you will need XCode.
-
-**note**: at the time of writing Fleet is in preview, it can get unstable so it's recommended to switch to Android Studio / Xcode as needed. For example, the first time you try to run the iosClient most probably you will need to do it from Xcode.
+ - IDE: We recommend using Android Studio with the Kotlin Multiplatform Mobile (KMP) plugin. For iOS testing you will need XCode.
 
 ### Getting started
 
  1. Get [sdkman](https://sdkman.io/) installed since the project uses JDK 
- 2. Open [Fleet IDE](https://www.jetbrains.com/help/fleet/getting-started.html), IntelliJ IDEA, or Android Studio and open the project root folder.
- 3. Wait for the smart mode to run the `Pre-flight` or `Gradle` to download the dependencies. This will let you know what's missing in your machine to run the project. 
+ 2. Open Android Studio with the Kotlin Multiplatform Mobile plugin installed and open the project root folder.
+ 3. Wait for the Gradle sync to complete and download the dependencies. This will let you know what's missing in your machine to run the project. 
     1. If you are on a MacOS computer building the iOS app you can go ahead and run `setup_ios.sh` script and build the project and run it in your device or emulator.
     2. For Android it can run on any machine, just run the preconfigured configurations `androidClient` and/or `androidNode`
 
-Alternatively, you could run `./gradlew clean build` (1) first from terminal and then open with your IDE of preference.
+Alternatively, you could run `./gradlew clean build` first from terminal and then open with Android Studio.
 
 ### `Getting started for Android Node`
 
-Addicionally, for the `androidNode` module to build you need to have its dependent Bisq2 jars in your local maven2 repository ('~/.m2/repository`). Here are the steps to do that
+For the `androidNode` module to build, you need the Bisq2 dependencies. There are two ways to get them:
 
-1. download [Bisq2](https://github.com/bisq-network/bisq2) if you don't have it already
-2. follow Bisq2 root `README.md` steps to build the project
-3. run `./gradlew publishAll` // this will install all the jars you need in your m2 repo
+#### Option 1: For developers (using local Maven repository)
+
+1. Download [Bisq2](https://github.com/bisq-network/bisq2) if you don't have it already
+2. Follow Bisq2 root `README.md` steps to build the project
+3. Run `./gradlew publishAll` // this will install all the jars you need in your m2 repo
+
+#### Option 2: For CI (using remote Maven repository)
+
+The CI environment automatically uses our remote Maven repository to get the Bisq2 dependencies. No additional setup is required.
 
 Done! Alternatively if you are interested only in contributing for the `xClients` you can just build them individually instead of building the whole project.
 
@@ -122,7 +126,7 @@ Please refer to [this README](shared/presentation/src/commonMain/kotlin/network/
 
  - Some Apple M chips have trouble with cocoapods, follow [this guide](https://stackoverflow.com/questions/64901180/how-to-run-cocoapods-on-apple-silicon-m1/66556339#66556339) to fix it
  - On MacOS: non-homebrew versions of Ruby will cause problems
- - On MacOS: If Fleet Pre-flight gives error "Gradle not found" and running the (1) terminal command doesn't even run, you need to install gradle with `homebrew` and then run `gradle wrapper` on the root. Then reopen Fleet and try the Pre-flight again.
+ - On MacOS: If Gradle sync fails with "Gradle not found" error, you may need to install gradle with `homebrew` and then run `gradle wrapper` on the root. Then reopen Android Studio and try syncing again.
 
 ### Initial Project Structure
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,13 +22,28 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // for androidNode till we get bisq-core libs published to a public repo
-        mavenLocal()
+        
+        // Check if we're running in CI environment
+        val isCi = System.getenv("CI") == "true"
+        
+        if (isCi) {
+            // Use the remote Maven repository for CI builds
+            maven {
+                url = uri("http://104.154.164.188");
+                isAllowInsecureProtocol = true
+                credentials {
+                    username = "bisq-ci"
+                    password = System.getenv("MAVEN_PASSWORD") ?: "bisq-mobile-ci-21!"
+                }
+            }
+        } else {
+            // Use mavenLocal for developer builds
+            mavenLocal()
+        }
+        
         maven {
             url = uri("https://jitpack.io")
         }
-    }
-    repositories {
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,10 +22,11 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // always, for faster builds
+        mavenLocal()
         
         // Check if we're running in CI environment
         val isCi = System.getenv("CI") == "true"
-        
         if (isCi) {
             // Use the remote Maven repository for CI builds
             maven {
@@ -36,11 +37,8 @@ dependencyResolutionManagement {
                     password = System.getenv("MAVEN_PASSWORD") ?: "bisq-mobile-ci-21!"
                 }
             }
-        } else {
-            // Use mavenLocal for developer builds
-            mavenLocal()
         }
-        
+
         maven {
             url = uri("https://jitpack.io")
         }


### PR DESCRIPTION
 - fixes #30 
 - restore android node to ci build and test validation
 - configure CI env to allow developers to continue using their local
 - update readme (+ also remove fleet details as its now unsupported in favour of android studio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to enable full build and test coverage for the androidNode module, consolidating build and test steps with consistent CI environment variables.
  - Adjusted dependency resolution to always include local Maven and conditionally add a remote Maven repository during CI builds.

- **Documentation**
  - Updated README to recommend Android Studio with the KMP plugin, clarified setup instructions for androidNode dependencies, and improved troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->