### PR TITLE
Release/anode 0.0.33

### DIFF
--- a/androidNode/proguard-rules.pro
+++ b/androidNode/proguard-rules.pro
@@ -5,6 +5,75 @@
 ### protobuf deps
 -dontwarn java.lang.MatchException
 
+# Keep gRPC and Netty classes
+-keep class io.grpc.** { *; }
+-keep class io.netty.** { *; }
+-keep class io.grpc.netty.shaded.io.netty.** { *; }
+
+# Keep all the missing classes that are referenced but not directly used
+-dontwarn com.aayushatharva.brotli4j.**
+-dontwarn com.github.luben.zstd.**
+-dontwarn com.google.protobuf.nano.**
+-dontwarn com.jcraft.jzlib.**
+-dontwarn com.ning.compress.**
+-dontwarn com.oracle.svm.core.**
+-dontwarn lzma.sdk.**
+-dontwarn net.jpountz.lz4.**
+-dontwarn net.jpountz.xxhash.**
+-dontwarn org.apache.logging.log4j.**
+-dontwarn org.bouncycastle.openssl.**
+-dontwarn org.bouncycastle.operator.**
+-dontwarn org.bouncycastle.pkcs.**
+-dontwarn org.conscrypt.**
+-dontwarn org.eclipse.jetty.alpn.**
+-dontwarn org.eclipse.jetty.npn.**
+-dontwarn org.jboss.marshalling.**
+-dontwarn reactor.blockhound.**
+-dontwarn sun.security.x509.**
+
+# Don't shrink/obfuscate build-time plugins
+-dontwarn com.android.build.**
+-dontwarn com.google.protobuf.gradle.**
+-dontwarn org.codehaus.groovy.**
+-dontwarn javax.inject.**
+-dontwarn org.gradle.**
+-dontwarn org.bouncycastle.**
+-dontwarn javassist.**
+-dontwarn org.apache.maven.**
+-dontwarn kr.motd.maven.**
+-dontwarn org.eclipse.**
+
+# Optional: keep core Gradle plugin APIs if somehow referenced
+-keep class com.android.** { *; }
+-keep class org.gradle.** { *; }
+
+# Keep any native methods
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Keep all classes that might be used via reflection
+-keep class * implements java.io.Serializable { *; }
+
+# Keep all enum values
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# Keep all Bisq2 core classes
+-keep class bisq.** { *; }
+-keep class network.bisq.** { *; }
+
+# Keep all Protobuf-related classes
+-keep class com.google.protobuf.** { *; }
+
+# Keep all Bouncy Castle classes
+-keep class org.bouncycastle.** { *; }
+
+# Keep all Tor-related classes
+-keep class org.torproject.** { *; }
+
 -dontwarn com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector
 -dontwarn com.sun.jdi.VirtualMachine
 -dontwarn com.sun.jdi.event.Event

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.nonTransitiveRClass=true
 shared.version=0.0.15
 
 node.name=Bisq
-node.android.version=0.0.33
+node.android.version=0.0.34
 
 client.name=Bisq Connect
 client.android.version=0.0.33
@@ -30,7 +30,7 @@ client.ios.version=0.0.7
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=3
 client.android.version.code=3
-node.android.version.code=3
+node.android.version.code=4
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.nonTransitiveRClass=true
 shared.version=0.0.15
 
 node.name=Bisq
-node.android.version=0.0.4
+node.android.version=0.0.33
 
 client.name=Bisq Connect
 client.android.version=0.0.33


### PR DESCRIPTION
 - contribs to #364 
 - fix proguard rules updated to latest node jars code
 - bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android node version and version code.
  - Enhanced Proguard configuration to improve compatibility with third-party libraries and prevent build-time warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->