### PR TITLE
`My trade` related UI fixes

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/OpenMediationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/trades/OpenMediationDialog.kt
@@ -18,6 +18,7 @@ fun OpenMediationDialog(
         confirmButtonText = "bisqEasy.mediation.request.confirm.openMediation".i18n(),
         horizontalAlignment = Alignment.Start,
         marginTop = BisqUIConstants.ScreenPaddingHalf,
+        verticalButtonPlacement = true,
         onDismiss = onDismiss,
         onConfirm = onCancelConfirm
     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuidePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuidePresenter.kt
@@ -30,7 +30,6 @@ class WalletGuidePresenter(
 
     fun receivingNextClick() {
         navigateBackTo(Routes.WalletGuideIntro, true, false)
-        navigateBack()
     }
 
     fun navigateToBlueWallet() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -139,10 +139,15 @@ fun TradeDetailsHeader() {
                     if (isSell) {
                         InfoBox(
                             label = presenter.rightAmountDescription,
-                            value = "$rightAmount $rightCode"
+                            value = "$rightAmount $rightCode",
+                            rightAlign = true
                         )
                     } else {
-                        InfoBoxSats(label = presenter.rightAmountDescription, value = rightAmount)
+                        InfoBoxSats(
+                            label = presenter.rightAmountDescription,
+                            value = rightAmount,
+                            rightAlign = true
+                        )
                     }
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -71,6 +71,7 @@ class BuyerState1aPresenter(
 
     fun onSend() {
         require(bitcoinPaymentData.value.isNotEmpty())
+        _showInvalidAddressDialog.value = false
 
         launchUI {
             withContext(IODispatcher) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
@@ -64,10 +64,10 @@ class SellerState3aPresenter(
     }
 
     fun onConfirmedBtcSent() {
-        if (!paymentProofValid.value) {
-            _showInvalidAddressDialog.value = true
-        } else {
+        if (paymentProof.value.isNullOrEmpty() || paymentProofValid.value) {
             confirmSend()
+        } else {
+            _showInvalidAddressDialog.value = true
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -1,9 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.trade_chat
 
-import kotlinx.coroutines.Job
+import androidx.compose.foundation.lazy.LazyListState
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
@@ -64,7 +64,7 @@ class TradeChatPresenter(
         super.onViewUnattaching()
     }
 
-    fun sendChatMessage(text: String) {
+    fun sendChatMessage(text: String, scope: CoroutineScope, scrollState: LazyListState) {
         val citation = quotedMessage.value?.let { quotedMessage ->
             quotedMessage.text?.let { text ->
                 CitationVO(
@@ -74,10 +74,11 @@ class TradeChatPresenter(
                 )
             }
         }
-            launchUI {
+        launchUI {
             withContext(IODispatcher) {
                 tradeChatMessagesServiceFacade.sendChatMessage(text, citation)
             }
+            scope.launch { scrollState.animateScrollToItem(Int.MAX_VALUE) }
             _quotedMessage.value = null
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatScreen.kt
@@ -25,7 +25,6 @@ fun TradeChatScreen() {
     val presenter: TradeChatPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    var chatText by remember { mutableStateOf("") }
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope() // TODO: How scopes are to be used?
     val selectedTrade by presenter.selectedTrade.collectAsState()
@@ -42,6 +41,7 @@ fun TradeChatScreen() {
     BisqStaticScaffold(
         topBar = { TopBar(title = "Chat - " + selectedTrade?.shortTradeId) },
     ) {
+
         ChatMessageList(
             messages = sortedChatMessages,
             presenter = presenter,
@@ -55,14 +55,10 @@ fun TradeChatScreen() {
             onReportUser = { message -> presenter.onReportUser(message) },
         )
         ChatInputField(
-            //value = chatText,
             quotedMessage = quotedMessage,
             placeholder = "chat.message.input.prompt".i18n(),
-            // onValueChanged = { chatText = it },
             onMessageSent = { text ->
-                chatText = ""
-                presenter.sendChatMessage(text)
-                scope.launch { scrollState.animateScrollToItem(Int.MAX_VALUE) }
+                presenter.sendChatMessage(text, scope, scrollState)
             },
             onCloseReply = { presenter.onReply(null) }
         )


### PR DESCRIPTION
Partial fixes for https://github.com/bisq-network/bisq-mobile/issues/337

1. Welcome guide - Last screen navigate back to current open trade
2. Buyer State1 - Hide `Invalid address dialog` after sending `Ignore`. Same for Seller State 3
3. Trade chat - Scroll to bottom on sending a new message.
4. Minor UI Improvements.