### PR TITLE
UI fixes: Settings module

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Chip.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Chip.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 @Composable
 fun BisqChip(
     label: String = "",
+    showRemove: Boolean = true,
     onClick: ((String) -> Unit)? = null,
     onRemove: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
@@ -27,10 +28,12 @@ fun BisqChip(
         label = { BisqText.baseRegular(label, modifier = Modifier.padding(top= 12.dp)) },
         selected = false,
         trailingIcon = {
-            IconButton(
-                onClick = { onRemove?.invoke(label) }
-            ) {
-                CloseIcon(modifier = Modifier.size(InputChipDefaults.AvatarSize))
+            if (showRemove) {
+                IconButton(
+                    onClick = { onRemove?.invoke(label) }
+                ) {
+                    CloseIcon(modifier = Modifier.size(InputChipDefaults.AvatarSize))
+                }
             }
         },
         modifier = modifier,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/DropDown.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/DropDown.kt
@@ -108,12 +108,14 @@ fun BisqDropDown(
             ) {
                 selected.forEach { pair ->
                     BisqChip(
-                        if (chipShowOnlyKey) pair.first else pair.second,
+                        label = if (chipShowOnlyKey) pair.first else pair.second,
+                        showRemove = selected.size != 1,
                         onRemove = {
                             selected = selected - pair
                             onSetChanged?.invoke(selected)
                             searchText = ""
-                        })
+                        }
+                    )
                 }
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsScreen.kt
@@ -111,7 +111,6 @@ fun GeneralSettingsScreen() {
             },
             searchable = true,
             chipMultiSelect = true,
-            // chipShowOnlyKey = true
         )
 
         BisqHDivider()
@@ -159,7 +158,7 @@ fun GeneralSettingsScreen() {
                     return@BisqTextField "Value cannot be empty"
                 }
                 if (parsedValue < 1 || parsedValue > 10) {
-                    return@BisqTextField "settings.trade.maxTradePriceDeviation.invalid".i18n(10)
+                    return@BisqTextField "settings.trade.maxTradePriceDeviation.invalid".i18n(1, 10)
                 }
                 return@BisqTextField null
             }
@@ -218,10 +217,6 @@ fun GeneralSettingsScreen() {
                     return@BisqTextField null
                 }
             )
-
-            BisqHDivider()
-
-            BisqText.h4Regular("settings.display.headline".i18n())
 
             BisqGap.V1()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.StateFlow
@@ -68,7 +67,7 @@ fun PaymentAccountSettingsScreen() {
 
     BisqScrollScaffold(
         topBar = { TopBar("user.paymentAccounts".i18n()) },
-        verticalArrangement = if (accounts.isEmpty()) Arrangement.Center else Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
         snackbarHostState = presenter.getSnackState(),
         isInteractive = presenter.isInteractive.collectAsState().value,
         shouldBlurBg = showConfirmationDialog,
@@ -95,9 +94,19 @@ fun PaymentAccountSettingsScreen() {
         if (accounts.isEmpty()) {
             Column(
                 modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
+                verticalArrangement = Arrangement.Top,
             ) {
+
+                BisqText.baseLightGrey("user.paymentAccounts.noAccounts.info".i18n())
+                BisqGap.V2()
+                BisqText.h2Regular("user.paymentAccounts.noAccounts.whySetup".i18n())
+                BisqGap.V1()
+                BisqText.baseRegular("user.paymentAccounts.noAccounts.whySetup.info".i18n())
+                BisqGap.V2()
+                BisqText.baseLightGrey("user.paymentAccounts.noAccounts.whySetup.note".i18n())
+
+                BisqGap.V2()
+
                 BisqButton(
                     text = "user.paymentAccounts.createAccount".i18n(),
                     onClick = { showBottomSheet = !showBottomSheet },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -144,8 +144,10 @@ class UserProfileSettingsPresenter(
                         // avoid flicker
                         delay(500L)
                     }
+                    showSnackbar("Save success") // TODO: i18n
                 }
             } catch (e: Exception) {
+                showSnackbar("Save failure") // TODO: i18n
                 log.e(e) { "Failed to save user profile settings" }
             } finally {
                 setShowLoading(false)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -88,6 +88,7 @@ fun UserProfileSettingsScreen() {
         topBar = { TopBar("user.userProfile".i18n(), showUserAvatar = false) },
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+        snackbarHostState = presenter.getSnackState(),
         isInteractive = presenter.isInteractive.collectAsState().value,
         shouldBlurBg = showDeleteConfirmation,
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPaymentMethodPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferPaymentMethodPresenter.kt
@@ -47,10 +47,6 @@ class TakeOfferPaymentMethodPresenter(
         quoteCurrencyCode = offerListItem.bisqEasyOffer.market.quoteCurrencyCode
     }
 
-    override fun onViewAttached() {
-        super.onViewAttached()
-    }
-
     override fun onViewUnattaching() {
         dismissSnackbar()
         super.onViewUnattaching()


### PR DESCRIPTION
Partial fixes for https://github.com/bisq-network/bisq-mobile/issues/337

1. General settings
  - Settings screen: Last remaining supported language cannot be removed;
  - Max trade price tolerance - Validation error fix;
  - Removed duplicate Display settings label
2. User profile - Snackbar for save, failure
3. Explainer text in Payment account settings screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added optional control to hide or show the remove icon on selection chips.
	- Displayed snackbar messages to inform users of success or failure when saving user profile settings.

- **Improvements**
	- Enhanced empty account state with additional guidance and information above the "Create Account" button.
	- Validation error messages for trade price deviation now show both minimum and maximum allowed values.

- **UI Updates**
	- Removed redundant section headers and dividers in general settings for a cleaner appearance.

- **Bug Fixes**
	- Minor UI alignment and arrangement adjustments for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->