### PR TITLE
bugfix node dissapearing offers after checking empty market

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NumOffersObserver.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NumOffersObserver.kt
@@ -3,12 +3,13 @@ package network.bisq.mobile.android.node.service.offers
 import bisq.bisq_easy.BisqEasyOfferbookMessageService
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel
 import bisq.common.observable.Pin
+import network.bisq.mobile.domain.utils.Logging
 
 class NumOffersObserver(
     private val bisqEasyOfferbookMessageService: BisqEasyOfferbookMessageService,
     private val channel: BisqEasyOfferbookChannel,
     val setNumOffers: (Int) -> Unit
-) {
+) : Logging {
     private var channelPin: Pin? = null
 
     init {
@@ -16,16 +17,24 @@ class NumOffersObserver(
     }
 
     fun resume() {
+        log.d { "Resuming NumOffersObserver for channel: ${channel.id}, market: ${channel.market.marketCodes}" }
         dispose()
-        channelPin = channel.chatMessages.addObserver { updateNumOffers() }
+        channelPin = channel.chatMessages.addObserver { 
+            log.d { "Chat messages changed for ${channel.market.marketCodes}, updating num offers" }
+            updateNumOffers() 
+        }
+        updateNumOffers() // Update immediately on resume
     }
 
     fun dispose() {
+        log.d { "Disposing NumOffersObserver for channel: ${channel.id}" }
         channelPin?.unbind()
         channelPin = null
     }
 
     private fun updateNumOffers() {
-        setNumOffers(bisqEasyOfferbookMessageService.getOffers(channel).count().toInt())
+        val count = bisqEasyOfferbookMessageService.getOffers(channel).count().toInt()
+        log.d { "Updated num offers for ${channel.market.marketCodes}: $count" }
+        setNumOffers(count)
     }
 }


### PR DESCRIPTION
 - fixes #379 
 - fix issue by ensuring sync cleanup of map associated with offer messages
 - improve logging to identify this issue and others easily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed debug logging throughout the offer management and observer features, providing enhanced visibility into lifecycle events, market selection, chat message updates, and offer counts.

- **Refactor**
  - Updated observer class to support logging for improved traceability of actions and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->