### PR TITLE
bugfix/ios_not_builidng

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -59,7 +59,7 @@ class NodeMainPresenter(
     }
 
     override fun isDevMode(): Boolean {
-        return isDemo() || BuildNodeConfig.DEBUG
+        return isDemo() || BuildNodeConfig.IS_DEBUG
     }
 
     private fun initNodeServices() {

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -38,7 +38,7 @@ buildConfig {
         buildConfigField("WS_PORT", project.findProperty("client.x.trustednode.port").toString())
         buildConfigField("WS_ANDROID_HOST", project.findProperty("client.android.trustednode.ip").toString())
         buildConfigField("WS_IOS_HOST", project.findProperty("client.ios.trustednode.ip").toString())
-        buildConfigField("DEBUG", project.gradle.startParameter.taskNames.any { it.contains("debug", ignoreCase = true) })
+        buildConfigField("IS_DEBUG", project.gradle.startParameter.taskNames.any { it.contains("debug", ignoreCase = true) })
     }
     forClass("network.bisq.mobile.android.node", className = "BuildNodeConfig") {
         buildConfigField("APP_NAME", project.findProperty("node.name").toString())
@@ -48,7 +48,7 @@ buildConfig {
         buildConfigField("SHARED_LIBS_VERSION", project.version.toString())
         buildConfigField("BUILD_TS", System.currentTimeMillis())
         buildConfigField("BISQ_CORE_VERSION", bisqCoreVersion)
-        buildConfigField("DEBUG", project.gradle.startParameter.taskNames.any { it.contains("debug", ignoreCase = true) })
+        buildConfigField("IS_DEBUG", project.gradle.startParameter.taskNames.any { it.contains("debug", ignoreCase = true) })
 
     }
 //    buildConfigField("APP_SECRET", "Z3JhZGxlLWphdmEtYnVpbGRjb25maWctcGx1Z2lu")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -101,7 +101,7 @@ open class ClientMainPresenter(
     }
 
     override fun isDevMode(): Boolean {
-        return isDemo() || BuildConfig.DEBUG
+        return isDemo() || BuildConfig.IS_DEBUG
     }
 
     private fun activateServices() {


### PR DESCRIPTION
 - fix ios not builidng due to DEBUG flag build config conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal checks for development mode to use a new configuration flag. No changes to app behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->