### PR TITLE
UI polish: Notification sync, Supported languages in Create offer

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -137,7 +137,7 @@ val presentationModule = module {
     factory { TakeOfferReviewPresenter(get(), get(), get()) }
 
     // Create offer
-    single { CreateOfferPresenter(get(), get(), get()) }
+    single { CreateOfferPresenter(get(), get(), get(), get()) }
     factory { CreateOfferDirectionPresenter(get(), get(), get(), get()) }
     factory { CreateOfferMarketPresenter(get(), get(), get()) }
     factory { CreateOfferPricePresenter(get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
@@ -17,15 +17,18 @@ import network.bisq.mobile.domain.data.replicated.offer.price.spec.FixPriceSpecV
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.FloatPriceSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.MarketPriceSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.PriceSpecVOExtensions.getPriceQuoteVO
+import network.bisq.mobile.domain.data.replicated.settings.SettingsVO
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
+import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 
 class CreateOfferPresenter(
     mainPresenter: MainPresenter,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
-    private val offersServiceFacade: OffersServiceFacade
+    private val offersServiceFacade: OffersServiceFacade,
+    private val settingsServiceFacade: SettingsServiceFacade,
 ) : BasePresenter(mainPresenter) {
     enum class PriceType {
         PERCENTAGE,
@@ -153,7 +156,8 @@ class CreateOfferPresenter(
             else FloatPriceSpecVO(createOfferModel.percentagePriceValue)
         }
 
-        val supportedLanguageCodes: Set<String> = setOf("en") //todo
+        val settings: SettingsVO = settingsServiceFacade.getSettings().getOrThrow()
+        val supportedLanguageCodes: Set<String> = settings.supportedLanguageCodes
 
         withContext(IODispatcher) {
             offersServiceFacade.createOffer(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -111,7 +111,7 @@ fun CreateOfferReviewOfferScreen() {
                         )
                         InfoBox(
                             label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
-                            value = presenter.amountToPay,
+                            value = presenter.amountToReceive,
                         )
                     }
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -348,7 +348,7 @@ class OfferbookPresenter(
             try {
                 // Set up the dialog content
                 setupReputationDialogContent(item)
-                
+
                 // Show the dialog
                 _showNotEnoughReputationDialog.value = true
             } catch (e: Exception) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -38,15 +38,28 @@ class OpenTradeListPresenter(
                 }
             }
         }
-
-        collectUI(mainPresenter.tradesWithUnreadMessages)  {
-            _tradesWithUnreadMessages.value = it
-        }
     }
 
     override fun onViewAttached() {
         super.onViewAttached()
         tradesServiceFacade.resetSelectedTradeToNull()
+
+        launchUI {
+            combine(
+                mainPresenter.tradesWithUnreadMessages,
+                tradesServiceFacade.openTradeItems
+            ) { unreadMessages, openTrades ->
+                Pair(unreadMessages, openTrades)
+            }.collect { (unreadMessages, openTrades) ->
+                _tradesWithUnreadMessages.value = unreadMessages
+                _openTradeItems.value = openTrades
+            }
+        }
+    }
+
+    override fun onViewUnattaching() {
+        _tradesWithUnreadMessages.value = emptyMap()
+        super.onViewUnattaching()
     }
 
     fun isRead(trade: TradeItemPresentationModel): Boolean {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -27,19 +27,6 @@ class OpenTradeListPresenter(
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
 
-    init {
-        collectUI(mainPresenter.languageCode) {
-            _openTradeItems.value = tradesServiceFacade.openTradeItems.value.map {
-                it.apply {
-                    quoteAmountWithCode =
-                        "${NumberFormatter.format(it.quoteAmount.toDouble() / 10000.0)} ${it.quoteCurrencyCode}"
-                    formattedPrice = PriceSpecFormatter.getFormattedPriceSpec(it.bisqEasyOffer.priceSpec, true)
-                    formattedBaseAmount = NumberFormatter.btcFormat(it.baseAmount)
-                }
-            }
-        }
-    }
-
     override fun onViewAttached() {
         super.onViewAttached()
         tradesServiceFacade.resetSelectedTradeToNull()
@@ -47,12 +34,20 @@ class OpenTradeListPresenter(
         launchUI {
             combine(
                 mainPresenter.tradesWithUnreadMessages,
-                tradesServiceFacade.openTradeItems
-            ) { unreadMessages, openTrades ->
+                tradesServiceFacade.openTradeItems,
+                mainPresenter.languageCode
+            ) { unreadMessages, openTrades, _ ->
                 Pair(unreadMessages, openTrades)
             }.collect { (unreadMessages, openTrades) ->
                 _tradesWithUnreadMessages.value = unreadMessages
-                _openTradeItems.value = openTrades
+                _openTradeItems.value = openTrades.map {
+                    it.apply {
+                        quoteAmountWithCode =
+                            "${NumberFormatter.format(it.quoteAmount.toDouble() / 10000.0)} ${it.quoteCurrencyCode}"
+                        formattedPrice = PriceSpecFormatter.getFormattedPriceSpec(it.bisqEasyOffer.priceSpec, true)
+                        formattedBaseAmount = NumberFormatter.btcFormat(it.baseAmount)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
 1. [Fix] Notification: Be in My Trades tab. When someone takes my offer, the badge count increments immediately in bottom bar. But the trade card is not rendering. It renders only when switching between views.
 2. Create offer flow takes `General settings :: Supported languages` into account. (https://github.com/bisq-network/bisq-mobile/issues/345)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Offer creation now dynamically supports multiple languages based on user settings, rather than being limited to English.
- **Bug Fixes**
	- Corrected the displayed amount in the offer review screen to show the correct "to receive" value for sell offers.
- **Improvements**
	- Enhanced trade list updates to better reflect unread messages and open trades, and improved state management when navigating away from the trade list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->