### PR TITLE
Update/Peer avatar

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
 
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
@@ -42,10 +43,47 @@ class ClientReputationServiceFacade(
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
         val reputation = reputationByUserProfileId.value[userProfileId]
-        return if (reputation == null) {
-            Result.failure(IllegalStateException("Reputation for userId=$userProfileId not cached yet"))
-        } else {
-            Result.success(reputation)
+        return when {
+            BuildNodeConfig.IS_DEBUG -> reputationDevStub(userProfileId)
+            reputation == null -> Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not cached yet"))
+            else -> Result.success(reputation)
+        }
+    }
+
+    private fun reputationDevStub(userProfileId: String): Result<ReputationScoreVO> {
+        val reputation = reputationByUserProfileId.value[userProfileId]
+        // Hardcoded rep for dev/testing
+        // val myId = "f346be"
+        val myId = "7730e" // replace with mobile User's ID
+        val bobId = "e35fe38" // replace with bisq2 user's ID
+        return when {
+            userProfileId.startsWith(myId) -> {
+                Result.success(
+                    ReputationScoreVO(
+                        totalScore = 7000,  // Default value will be 0, as bisq-mobile user wont have any rep to start with
+                        // Try with different values: 0, <1200, 1200, 1200+
+                        fiveSystemScore = 3.5, ranking = 10
+                    )
+                )
+            }
+
+            userProfileId.startsWith(bobId) -> {
+                Result.success(
+                    ReputationScoreVO(
+                        totalScore = 10000, // Default value is 0, as devModeReputationScore set is bisq2, is not propagating to mobile.
+                        fiveSystemScore = 4.2, ranking = 3
+                    )
+                )
+            }
+
+            reputation == null -> {
+                Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not cached yet"))
+            }
+
+            else -> {
+                log.w { "Dev stuff for $userProfileId not setup, returning current network reputation" }
+                Result.success(reputation)
+            }
         }
     }
 
@@ -58,8 +96,7 @@ class ClientReputationServiceFacade(
             }
             if (reputationSequenceNumber.value >= webSocketEvent.sequenceNumber) {
                 log.w {
-                    "Sequence number is larger or equal than the one we " +
-                            "received from the backend. We ignore that event."
+                    "Sequence number is larger or equal than the one we " + "received from the backend. We ignore that event."
                 }
                 return@collect
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -135,4 +135,9 @@ class ClientUserProfileServiceFacade(
         val delayDuration = min(1000.0, max(200.0, (200 + random - requestDuration).toDouble())).toLong()
         delay(delayDuration)
     }
+
+    override suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage {
+        // TODO: Actual implementation
+        return PlatformImage.deserialize(byteArrayOf())
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -30,6 +30,8 @@ class ClientUserProfileServiceFacade(
     private val _selectedUserProfile: MutableStateFlow<UserProfileVO?> = MutableStateFlow(null)
     override val selectedUserProfile: StateFlow<UserProfileVO?> = _selectedUserProfile
 
+    override val avatarMap: MutableMap<String, PlatformImage?> = mutableMapOf<String, PlatformImage?>()
+
     // Misc
     override fun activate() {
         super<ServiceFacade>.activate()
@@ -136,7 +138,7 @@ class ClientUserProfileServiceFacade(
         delay(delayDuration)
     }
 
-    override suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage {
+    override suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage? {
         // TODO: Actual implementation
         return PlatformImage.deserialize(byteArrayOf())
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
@@ -2,7 +2,6 @@ package network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
@@ -47,17 +46,11 @@ class BisqEasyOpenTradeMessageModel(
     val citationString: String = citation?.text ?: ""
     val isMyMessage: Boolean = senderUserProfileId == myUserProfileId
 
-    var senderAvatar: PlatformImage? = null
-
     fun isMyChatReaction(reaction: BisqEasyOpenTradeMessageReactionVO): Boolean {
         return myUserProfileId == reaction.senderUserProfile.id
     }
 
     fun setReactions(chatMessageReactions: List<BisqEasyOpenTradeMessageReactionVO>) {
         _chatReactions.value = chatMessageReactions
-    }
-
-    fun setSenderAvatarImage(avatar: PlatformImage?) {
-        senderAvatar = avatar
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
@@ -16,10 +17,12 @@ class BisqEasyOpenTradeMessageModel(
     myUserProfile: UserProfileVO,
     chatReactions: List<BisqEasyOpenTradeMessageReactionVO>
 ) {
-    private val senderUserProfile: UserProfileVO = bisqEasyOpenTradeMessage.senderUserProfile
+    val senderUserProfile: UserProfileVO = bisqEasyOpenTradeMessage.senderUserProfile
     private val myUserProfileId = myUserProfile.id
 
-    private val _chatReactions: MutableStateFlow<List<BisqEasyOpenTradeMessageReactionVO>> = MutableStateFlow(chatReactions)
+    private val _chatReactions: MutableStateFlow<List<BisqEasyOpenTradeMessageReactionVO>> = MutableStateFlow(
+        chatReactions
+    )
     val chatReactions: StateFlow<List<BisqEasyOpenTradeMessageReactionVO>> = _chatReactions
 
     // Delegates of BisqEasyOpenTradeMessageDto
@@ -34,6 +37,7 @@ class BisqEasyOpenTradeMessageModel(
     val citationAuthorUserName = bisqEasyOpenTradeMessage.citationAuthorUserProfile?.userName
 
     val textString: String = text ?: ""
+
     // Used for protocol log message
     var decodedText: String = text?.let { I18nSupport.decode(it) } ?: ""
 
@@ -43,10 +47,17 @@ class BisqEasyOpenTradeMessageModel(
     val citationString: String = citation?.text ?: ""
     val isMyMessage: Boolean = senderUserProfileId == myUserProfileId
 
+    var senderAvatar: PlatformImage? = null
+
     fun isMyChatReaction(reaction: BisqEasyOpenTradeMessageReactionVO): Boolean {
         return myUserProfileId == reaction.senderUserProfile.id
     }
+
     fun setReactions(chatMessageReactions: List<BisqEasyOpenTradeMessageReactionVO>) {
         _chatReactions.value = chatMessageReactions
+    }
+
+    fun setSenderAvatarImage(avatar: PlatformImage?) {
+        senderAvatar = avatar
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
@@ -40,7 +40,6 @@ class TradeItemPresentationModel(tradeItemPresentationDto: TradeItemPresentation
     val myUserProfile = if (bisqEasyTradeModel.isMaker) makerUserProfile else takerUserProfile
     val myUserName = myUserProfile.userName
     val peersUserProfile = if (bisqEasyTradeModel.isMaker) takerUserProfile else makerUserProfile
-    var peersUserAvatar: PlatformImage? = null
     val peersReputationScore = tradeItemPresentationDto.peersReputationScore
     val peersUserName = peersUserProfile.userName
     val mediator = bisqEasyTradeModel.contract.mediator
@@ -54,10 +53,6 @@ class TradeItemPresentationModel(tradeItemPresentationDto: TradeItemPresentation
     val quoteCurrencyCode: String = bisqEasyOffer.market.quoteCurrencyCode
     var quoteAmountWithCode = "$formattedQuoteAmount $quoteCurrencyCode"
     val baseAmountWithCode = "$formattedBaseAmount $baseCurrencyCode"
-
-    fun setPeersUserAvatarImage(avatar: PlatformImage?) {
-        peersUserAvatar = avatar
-    }
 
     fun reformat(): TradeItemPresentationModel {
         return apply {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.domain.data.replicated.presentation.open_trades
 
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelModel
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.BisqEasyTradeDto
@@ -39,6 +40,7 @@ class TradeItemPresentationModel(tradeItemPresentationDto: TradeItemPresentation
     val myUserProfile = if (bisqEasyTradeModel.isMaker) makerUserProfile else takerUserProfile
     val myUserName = myUserProfile.userName
     val peersUserProfile = if (bisqEasyTradeModel.isMaker) takerUserProfile else makerUserProfile
+    var peersUserAvatar: PlatformImage? = null
     val peersReputationScore = tradeItemPresentationDto.peersReputationScore
     val peersUserName = peersUserProfile.userName
     val mediator = bisqEasyTradeModel.contract.mediator
@@ -53,12 +55,14 @@ class TradeItemPresentationModel(tradeItemPresentationDto: TradeItemPresentation
     var quoteAmountWithCode = "$formattedQuoteAmount $quoteCurrencyCode"
     val baseAmountWithCode = "$formattedBaseAmount $baseCurrencyCode"
 
+    fun setPeersUserAvatarImage(avatar: PlatformImage?) {
+        peersUserAvatar = avatar
+    }
+
     fun reformat(): TradeItemPresentationModel {
         return apply {
-            quoteAmountWithCode =
-                "${NumberFormatter.format(quoteAmount.toDouble() / 10000.0)} $quoteCurrencyCode"
-            formattedPrice =
-                PriceSpecFormatter.getFormattedPriceSpec(bisqEasyOffer.priceSpec, true)
+            quoteAmountWithCode = "${NumberFormatter.format(quoteAmount.toDouble() / 10000.0)} $quoteCurrencyCode"
+            formattedPrice = PriceSpecFormatter.getFormattedPriceSpec(bisqEasyOffer.priceSpec, true)
             formattedBaseAmount = NumberFormatter.btcFormat(baseAmount)
             formattedQuoteAmount = NumberFormatter.format(quoteAmount.toDouble() / 10000.0)
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVOExtension.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVOExtension.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.domain.data.replicated.user.profile
 
 import kotlinx.serialization.Serializable
+import network.bisq.mobile.domain.PlatformImage
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.hexToByteArray
 
 @Serializable
@@ -8,4 +10,8 @@ object UserProfileVOExtension {
     val UserProfileVO.id get() = networkId.pubKey.id
 
     val UserProfileVO.pubKeyHashAsByteArray: ByteArray get() = networkId.pubKey.hash.hexToByteArray()
+
+    suspend fun UserProfileVO.getAvatarImage(userProfileServiceFacade: UserProfileServiceFacade): PlatformImage {
+        return userProfileServiceFacade.getUserAvatar(this)
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVOExtension.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVOExtension.kt
@@ -11,7 +11,7 @@ object UserProfileVOExtension {
 
     val UserProfileVO.pubKeyHashAsByteArray: ByteArray get() = networkId.pubKey.hash.hexToByteArray()
 
-    suspend fun UserProfileVO.getAvatarImage(userProfileServiceFacade: UserProfileServiceFacade): PlatformImage {
+    suspend fun UserProfileVO.getAvatarImage(userProfileServiceFacade: UserProfileServiceFacade): PlatformImage? {
         return userProfileServiceFacade.getUserAvatar(this)
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
@@ -60,4 +60,9 @@ interface UserProfileServiceFacade : LifeCycleAware {
      * @return UserIdentity if exists, null otherwise
      */
     suspend fun findUserIdentities(ids: List<String>): List<UserIdentityVO>
+
+    /**
+     * @return Get avatar of the user
+     */
+    suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
@@ -10,6 +10,8 @@ interface UserProfileServiceFacade : LifeCycleAware {
 
     val selectedUserProfile: StateFlow<UserProfileVO?>
 
+    val avatarMap: MutableMap<String, PlatformImage?>
+
     /**
      * Returns true if there is a user identity already created.
      * This should be used to detect a first time user who has no identity created yet and where
@@ -64,5 +66,5 @@ interface UserProfileServiceFacade : LifeCycleAware {
     /**
      * @return Get avatar of the user
      */
-    suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage
+    suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage?
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -167,7 +167,7 @@ val presentationModule = module {
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { OpenTradeListPresenter(get(), get(), get(), get()) }
-    single { TradeDetailsHeaderPresenter(get(), get(), get()) }
+    single { TradeDetailsHeaderPresenter(get(), get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -166,13 +166,13 @@ val presentationModule = module {
 
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    factory { OpenTradeListPresenter(get(), get(), get()) }
+    factory { OpenTradeListPresenter(get(), get(), get(), get()) }
     single { TradeDetailsHeaderPresenter(get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get(), get()) }
 
-    factory { TradeChatPresenter(get(), get(), get(), get(), get()) }
+    factory { TradeChatPresenter(get(), get(), get(), get(), get(), get()) }
 
     single { TradeGuidePresenter(get(), get()) } bind TradeGuidePresenter::class
     single { WalletGuidePresenter(get()) } bind WalletGuidePresenter::class

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfile.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfile.kt
@@ -8,14 +8,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bot_image
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.StarRating
 import network.bisq.mobile.presentation.ui.components.atoms.icons.LanguageIcon
+import network.bisq.mobile.presentation.ui.components.atoms.icons.rememberPlatformImagePainter
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.jetbrains.compose.resources.painterResource
@@ -23,6 +26,7 @@ import org.jetbrains.compose.resources.painterResource
 @Composable
 fun UserProfile(
     user: UserProfileVO,
+    userAvatar: PlatformImage? = null,
     reputation: StateFlow<ReputationScoreVO>,
     supportedLanguageCodes: List<String>,
     showUserName: Boolean = true,
@@ -30,12 +34,18 @@ fun UserProfile(
 ) {
     val fiveSystemScore: Double = reputation.collectAsState().value.fiveSystemScore
 
+    var painter: Painter = if (userAvatar == null) {
+        painterResource(Res.drawable.img_bot_image)
+    } else {
+        rememberPlatformImagePainter(userAvatar)
+    }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
     ) {
         Image(
-            painterResource(Res.drawable.img_bot_image), "",
+            painter, "",
             modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
         )
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfileRow.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfileRow.kt
@@ -8,13 +8,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bot_image
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.StarRating
+import network.bisq.mobile.presentation.ui.components.atoms.icons.rememberPlatformImagePainter
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.jetbrains.compose.resources.painterResource
 
@@ -23,17 +26,24 @@ fun UserProfileRow(
     user: UserProfileVO,
     reputation: ReputationScoreVO,
     showUserName: Boolean = true,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    userAvatar: PlatformImage? = null,
 ) {
     val fiveSystemScore = reputation.fiveSystemScore
+
+    var painter: Painter = if (userAvatar == null) {
+        painterResource(Res.drawable.img_bot_image)
+    } else {
+        rememberPlatformImagePainter(userAvatar)
+    }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Image(
-            painterResource(Res.drawable.img_bot_image), "",
-            modifier = Modifier.size(36.dp)
+            painter, "",
+            modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
         )
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (showUserName) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
@@ -20,15 +20,14 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun ProfileIconAndText(
-    message: BisqEasyOpenTradeMessageModel
+    message: BisqEasyOpenTradeMessageModel,
+    userAvatar: PlatformImage? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(
             vertical = BisqUIConstants.ScreenPaddingHalf, horizontal = BisqUIConstants.ScreenPadding
         ), horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding)
     ) {
-        var userAvatar: PlatformImage? = message.senderAvatar
-
         var painter: Painter = if (userAvatar == null) {
             painterResource(Res.drawable.img_bot_image)
         } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.ui.components.molecules.chat
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -7,28 +8,36 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.painter.Painter
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.img_bot_image
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
+import network.bisq.mobile.presentation.ui.components.atoms.icons.rememberPlatformImagePainter
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun ProfileIconAndText(
     message: BisqEasyOpenTradeMessageModel
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(
-            vertical = BisqUIConstants.ScreenPaddingHalf,
-            horizontal = BisqUIConstants.ScreenPadding
-        ),
-        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding)
+        verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(
+            vertical = BisqUIConstants.ScreenPaddingHalf, horizontal = BisqUIConstants.ScreenPadding
+        ), horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding)
     ) {
+        var userAvatar: PlatformImage? = message.senderAvatar
+
+        var painter: Painter = if (userAvatar == null) {
+            painterResource(Res.drawable.img_bot_image)
+        } else {
+            rememberPlatformImagePainter(userAvatar)
+        }
+
         val icon = @Composable {
-            DynamicImage(
-                "drawable/img_bot_image.png", //todo
-                modifier = Modifier.size(32.dp)
+            Image(
+                painter = painter, "", modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
             )
         }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/TextMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/TextMessageBox.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.ReactionEnum
@@ -25,6 +26,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 @Composable
 fun TextMessageBox(
     message: BisqEasyOpenTradeMessageModel,
+    userAvatar: PlatformImage? = null,
     onScrollToMessage: (String) -> Unit = {},
     onAddReaction: (ReactionEnum) -> Unit,
     onRemoveReaction: (BisqEasyOpenTradeMessageReactionVO) -> Unit,
@@ -66,7 +68,7 @@ fun TextMessageBox(
                         }
                     }) {
                 }
-                ProfileIconAndText(message)
+                ProfileIconAndText(message, userAvatar)
             }
         }
         val messageBox = @Composable {
@@ -84,7 +86,7 @@ fun TextMessageBox(
                     if (message.citation != null) {
                         quoteAndProfileIconAndText()
                     } else {
-                        ProfileIconAndText(message)
+                        ProfileIconAndText(message, userAvatar)
                     }
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
@@ -33,6 +34,7 @@ fun ChatMessageList(
     messages: List<BisqEasyOpenTradeMessageModel>,
     presenter: TradeChatPresenter,
     scrollState: LazyListState,
+    avatarMap: Map<String, PlatformImage?>,
     modifier: Modifier = Modifier,
     onAddReaction: (BisqEasyOpenTradeMessageModel, ReactionEnum) -> Unit = { message: BisqEasyOpenTradeMessageModel, reaction: ReactionEnum -> },
     onRemoveReaction: (BisqEasyOpenTradeMessageModel, BisqEasyOpenTradeMessageReactionVO) -> Unit = { message: BisqEasyOpenTradeMessageModel, reaction: BisqEasyOpenTradeMessageReactionVO -> },
@@ -65,6 +67,7 @@ fun ChatMessageList(
                     } else {
                         TextMessageBox(
                             message = message,
+                            userAvatar = avatarMap.get(message.senderUserProfile.nym),
                             onScrollToMessage = { id ->
                                 val index = messages.indexOfFirst { it.id == id }
                                 if (index >= 0) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.displayString
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.mirror
@@ -34,6 +35,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 @Composable
 fun OfferCard(
     item: OfferItemPresentationModel,
+    userAvatar: PlatformImage? = null,
     onSelectOffer: () -> Unit,
 ) {
     val userName = item.userName.collectAsState().value
@@ -88,6 +90,7 @@ fun OfferCard(
     ) {
         UserProfile(
             user = item.makersUserProfile,
+            userAvatar = userAvatar,
             reputation = item.makersReputationScore,
             supportedLanguageCodes = item.bisqEasyOffer.supportedLanguageCodes,
             showUserName = false,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -66,8 +66,10 @@ class OfferbookPresenter(
 
     lateinit var selectedUserProfile: UserProfileVO
 
-    private val _avatarMap: MutableStateFlow<Map<String, PlatformImage>> = MutableStateFlow(emptyMap())
-    val avatarMap: StateFlow<Map<String, PlatformImage>> = _avatarMap
+    private val _avatarMap: MutableStateFlow<Map<String, PlatformImage?>> = MutableStateFlow(
+        emptyMap()
+    )
+    val avatarMap: StateFlow<Map<String, PlatformImage?>> = _avatarMap
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -145,10 +147,11 @@ class OfferbookPresenter(
         }
 
         launchUI {
-            val currentAvatarMap = _avatarMap.value.toMutableMap()
-            if (currentAvatarMap[item.makersUserProfile.nym] == null) {
-                currentAvatarMap[item.makersUserProfile.nym] = userProfileServiceFacade.getUserAvatar(
-                    item.makersUserProfile
+            val userProfile = item.makersUserProfile
+            if (_avatarMap.value[userProfile.nym] == null) {
+                val currentAvatarMap = _avatarMap.value.toMutableMap()
+                currentAvatarMap[userProfile.nym] = userProfileServiceFacade.getUserAvatar(
+                    userProfile
                 )
                 _avatarMap.value = currentAvatarMap
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
@@ -41,6 +41,7 @@ fun OfferbookScreen() {
     val selectedDirection by presenter.selectedDirection.collectAsState()
     val showDeleteConfirmation by presenter.showDeleteConfirmation.collectAsState()
     val showNotEnoughReputationDialog by presenter.showNotEnoughReputationDialog.collectAsState()
+    val userAvatarMap by presenter.avatarMap.collectAsState()
 
     BisqStaticScaffold(
         topBar = { TopBar(title = "offers".i18n()) },
@@ -76,6 +77,7 @@ fun OfferbookScreen() {
                     onSelectOffer = {
                         presenter.onOfferSelected(item)
                     },
+                    userAvatar = userAvatarMap.get(item.makersUserProfile.nym),
                 )
             }
         }
@@ -112,7 +114,7 @@ fun NoOffersSection(presenter: OfferbookPresenter) {
         verticalArrangement = Arrangement.Center
     ) {
         BisqText.h4LightGrey(
-            text = "There are no offers", //TODO: i18n
+            text = "mobile.offerBookScreen.noOffersSection.thereAreNoOffers".i18n(),
             textAlign = TextAlign.Center
         )
         BisqGap.V4()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListComposable.kt
@@ -41,6 +41,8 @@ fun OpenTradeListScreen() {
     val sortedList =
         presenter.openTradeItems.collectAsState().value.sortedByDescending { it.bisqEasyTradeModel.takeOfferDate }
 
+    val userAvatarMap by presenter.avatarMap.collectAsState()
+
     RememberPresenterLifecycle(presenter)
 
     fun isTradeUnread(tradeId: String): Boolean {
@@ -103,7 +105,8 @@ fun OpenTradeListScreen() {
                     OpenTradeListItem(
                         trade,
                         isUnread = isUnread,
-                        { presenter.onSelect(trade) }
+                        userAvatar = userAvatarMap.get(trade.peersUserProfile.nym),
+                        onSelect = { presenter.onSelect(trade) }
                     )
                 }
             }
@@ -119,7 +122,8 @@ fun OpenTradeListScreen() {
                     OpenTradeListItem(
                         trade,
                         isUnread = isUnread,
-                        { presenter.onSelect(trade) }
+                        userAvatar = userAvatarMap.get(trade.peersUserProfile.nym),
+                        onSelect = { presenter.onSelect(trade) }
                     )
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
@@ -55,7 +55,8 @@ fun OpenTradeListItem(
                     UserProfileRow(
                         item.peersUserProfile,
                         item.peersReputationScore,
-                        true
+                        true,
+                        userAvatar = item.peersUserAvatar,
                     )
                 }
                 BisqText.smallLightGrey("${item.formattedDate} ${item.formattedTime}")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -24,6 +25,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 @Composable
 fun OpenTradeListItem(
     item: TradeItemPresentationModel,
+    userAvatar: PlatformImage? = null,
     isUnread: Boolean,
     onSelect: () -> Unit,
 ) {
@@ -56,7 +58,7 @@ fun OpenTradeListItem(
                         item.peersUserProfile,
                         item.peersReputationScore,
                         true,
-                        userAvatar = item.peersUserAvatar,
+                        userAvatar = userAvatar,
                     )
                 }
                 BisqText.smallLightGrey("${item.formattedDate} ${item.formattedTime}")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.domain.formatters.NumberFormatter
 import network.bisq.mobile.domain.formatters.PriceSpecFormatter
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -14,6 +15,7 @@ class OpenTradeListPresenter(
     private val mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
     private val settingsServiceFacade: SettingsServiceFacade,
+    private val userProfileServiceFacade: UserProfileServiceFacade
 ) : BasePresenter(mainPresenter) {
 
     private val _openTradeItems: MutableStateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
@@ -48,6 +50,12 @@ class OpenTradeListPresenter(
                         formattedBaseAmount = NumberFormatter.btcFormat(it.baseAmount)
                     }
                 }
+            }
+        }
+
+        launchUI {
+            tradesServiceFacade.openTradeItems.value.forEach { tradeItem ->
+                tradeItem.setPeersUserAvatarImage(userProfileServiceFacade.getUserAvatar(tradeItem.peersUserProfile))
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades
 
 import kotlinx.coroutines.flow.*
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.formatters.NumberFormatter
 import network.bisq.mobile.domain.formatters.PriceSpecFormatter
@@ -29,6 +30,9 @@ class OpenTradeListPresenter(
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
 
+    private val _avatarMap: MutableStateFlow<Map<String, PlatformImage?>> = MutableStateFlow(emptyMap())
+    val avatarMap: StateFlow<Map<String, PlatformImage?>> = _avatarMap
+
     override fun onViewAttached() {
         super.onViewAttached()
         tradesServiceFacade.resetSelectedTradeToNull()
@@ -55,7 +59,14 @@ class OpenTradeListPresenter(
 
         launchUI {
             tradesServiceFacade.openTradeItems.value.forEach { tradeItem ->
-                tradeItem.setPeersUserAvatarImage(userProfileServiceFacade.getUserAvatar(tradeItem.peersUserProfile))
+                val userProfile = tradeItem.peersUserProfile
+                if (_avatarMap.value[userProfile.nym] == null) {
+                    val currentAvatarMap = _avatarMap.value.toMutableMap()
+                    currentAvatarMap[userProfile.nym] = userProfileServiceFacade.getUserAvatar(
+                        userProfile
+                    )
+                    _avatarMap.value = currentAvatarMap
+                }
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -42,6 +42,7 @@ fun TradeDetailsHeader() {
     val leftCode by presenter.leftCode.collectAsState()
     val rightAmount by presenter.rightAmount.collectAsState()
     val rightCode by presenter.rightCode.collectAsState()
+    val peerAvatar by presenter.peerAvatar.collectAsState()
 
     val enterTransition = remember {
         expandVertically(
@@ -103,7 +104,7 @@ fun TradeDetailsHeader() {
                         item.peersUserProfile,
                         item.peersReputationScore,
                         true,
-                        userAvatar = item.peersUserAvatar,
+                        userAvatar = peerAvatar,
                     )
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -102,7 +102,8 @@ fun TradeDetailsHeader() {
                     UserProfileRow(
                         item.peersUserProfile,
                         item.peersReputationScore,
-                        true
+                        true,
+                        userAvatar = item.peersUserAvatar,
                     )
                 }
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -6,12 +6,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.withContext
+import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.service.mediation.MediationServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -21,6 +23,7 @@ class TradeDetailsHeaderPresenter(
     private val mainPresenter: MainPresenter,
     var tradesServiceFacade: TradesServiceFacade,
     var mediationServiceFacade: MediationServiceFacade,
+    val userProfileServiceFacade: UserProfileServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
     enum class TradeCloseType {
@@ -63,6 +66,9 @@ class TradeDetailsHeaderPresenter(
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> = this._isInMediation
+
+    private val _peerAvatar: MutableStateFlow<PlatformImage?> = MutableStateFlow(null)
+    val peerAvatar: StateFlow<PlatformImage?> = _peerAvatar
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -110,6 +116,10 @@ class TradeDetailsHeaderPresenter(
 
         collectUI(openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation) {
             this@TradeDetailsHeaderPresenter._isInMediation.value = it
+        }
+
+        launchUI {
+            _peerAvatar.value = userProfileServiceFacade.getUserAvatar(openTradeItemModel.peersUserProfile)
         }
 
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -25,6 +26,7 @@ class TradeChatPresenter(
     private val tradeChatMessagesServiceFacade: TradeChatMessagesServiceFacade,
     private val settingsRepository: SettingsRepository,
     private val tradeReadStateRepository: TradeReadStateRepository,
+    private val userProfileServiceFacade: UserProfileServiceFacade,
 ) : BasePresenter(mainPresenter), Logging {
 
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
@@ -50,6 +52,10 @@ class TradeChatPresenter(
 
             bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
                 _chatMessages.value = messages.toList()
+
+                messages.toList().forEach { message ->
+                    message.setSenderAvatarImage(userProfileServiceFacade.getUserAvatar(message.senderUserProfile))
+                }
 
                 withContext(IODispatcher) {
                     val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatScreen.kt
@@ -4,14 +4,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.buildAnnotatedString
-import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.TopBar
@@ -31,6 +27,7 @@ fun TradeChatScreen() {
     val chatMessages by presenter.chatMessages.collectAsState()
     val quotedMessage by presenter.quotedMessage.collectAsState()
     val sortedChatMessages = chatMessages.sortedBy { it.date }
+    val userAvatarMap by presenter.avatarMap.collectAsState()
 
     /*   var quotedMessage by remember {
            mutableStateOf<BisqEasyOpenTradeMessageModel?>(null)
@@ -47,6 +44,7 @@ fun TradeChatScreen() {
             presenter = presenter,
             modifier = Modifier.weight(1f),
             scrollState = scrollState,
+            avatarMap = userAvatarMap,
             onAddReaction = { message, reaction -> presenter.onAddReaction(message, reaction) },
             onRemoveReaction = { message, reaction -> presenter.onRemoveReaction(message, reaction) },
             onReply = { message -> presenter.onReply(message) },


### PR DESCRIPTION
Fix for https://github.com/bisq-network/bisq-mobile/issues/357
 1. UserServiceFacade has a global cache of Avatars (Map<user's nym, PlatformImage>)
 2. On calling UserServiceFacade.getUserAvatar(), cache is looked up. If not present, avatar is loaded via `CatHashService.getImage()`
 3. Screens like Offerbookscreen, MyOpenTrades, TradeChat, OpenTradeHeader needs these avatars. They maintain a StateFlow<Map<User's nym, PlatformImage>>. This will be a sub-set of global cache of avatars, specific only to this page.
 4. Tested with 4-5 users and 15+ offers.
 5. Once @rodvar reviewed this, I can do performance testing with 20+ users and 100+ offers.