### PR TITLE
Fix/notification badge

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -22,7 +22,7 @@ import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import org.koin.core.component.KoinComponent
@@ -487,7 +487,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     }
 
     override fun navigateToReportError() {
-        navigateToUrl(BisqConfig.BISQ_MOBILE_GH_ISSUES)
+        navigateToUrl(BisqLinks.BISQ_MOBILE_GH_ISSUES)
     }
 
     protected open fun isDevMode(): Boolean {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -23,6 +23,7 @@ import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import org.koin.core.component.KoinComponent
@@ -477,7 +478,9 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
         }
     }
     open fun navigateToUrl(url: String) {
+        disableInteractive()
         rootPresenter?.navigateToUrl(url)
+        enableInteractive()
     }
 
     override fun onCloseGenericErrorPanel() {
@@ -485,9 +488,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     }
 
     override fun navigateToReportError() {
-        disableInteractive()
-        navigateToUrl("https://github.com/bisq-network/bisq-mobile/issues")
-        enableInteractive()
+        navigateToUrl(BisqConfig.BISQ_MOBILE_GH_ISSUES)
     }
 
     protected open fun isDevMode(): Boolean {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -2,10 +2,8 @@ package network.bisq.mobile.presentation
 
 import androidx.annotation.CallSuper
 import androidx.navigation.NavHostController
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.UrlLauncher
@@ -18,12 +16,12 @@ import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.setDefaultLocale
 import network.bisq.mobile.presentation.ui.AppPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 /**
  * Main Presenter as an example of implementation for now.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 open class MainPresenter(
     private val connectivityService: ConnectivityService,
     private val openTradesNotificationService: OpenTradesNotificationService,
@@ -63,50 +61,19 @@ open class MainPresenter(
         log.i { "Screen width: $screenWidth" }
         log.i { "Small screen: ${_isSmallScreen.value}" }
 
-        val notificationTimerFlow = flow {
-            while (true) {
-                emit(Unit)
-                delay(BisqConfig.NOTIFICATION_SYNC_INTERVAL)
-            }
-        }
-
-        launchIO {
-            combine(
-                tradesServiceFacade.openTradeItems,
-                tradesServiceFacade.selectedTrade,
-                notificationTimerFlow.onStart { emit(Unit) }
-            ) { tradeList, selectedTrade, _ ->
-                tradeList
-            }.collect {
-                val readState = tradeReadStateRepository.fetch() ?: TradeReadState()
-                _readMessageCountsByTrade.value = readState.map
-                _tradesWithUnreadMessages.value = it.map { trade ->
-                    val chatSize = trade.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-                    return@map trade.tradeId to chatSize
-                }.filter { idSizePair ->
-                    val recordedSize = readState.map[idSizePair.first]
-                    if (recordedSize != null && recordedSize >= idSizePair.second) {
-                        return@filter false
-                    }
-                    return@filter true
-                }.toMap()
-            }
-        }
+        observeNotifications()
     }
+
 
     @CallSuper
     override fun onViewAttached() {
         super.onViewAttached()
 
-        languageCode
-            .filter { it.isNotEmpty() }
-            .onEach {
-                // I18nSupport.initialize(it) // Done in App.kt, before view initializes
-                setDefaultLocale(it)
-                settingsService.setLanguageCode(it)
-            }
-            .take(1)
-            .launchIn(presenterScope)
+        languageCode.filter { it.isNotEmpty() }.onEach {
+            // I18nSupport.initialize(it) // Done in App.kt, before view initializes
+            setDefaultLocale(it)
+            settingsService.setLanguageCode(it)
+        }.take(1).launchIn(presenterScope)
 
     }
 
@@ -172,5 +139,35 @@ open class MainPresenter(
     }
 
     override fun isDemo(): Boolean = false
+
+    private fun observeNotifications() {
+        launchIO {
+            tradesServiceFacade.openTradeItems.flatMapLatest { tradeList ->
+                // Combine all chatMessages StateFlows from each trade
+                val combinedChatMessages = combine(tradeList.map { trade ->
+                    trade.bisqEasyOpenTradeChannelModel.chatMessages.map { messages -> trade.tradeId to messages.size }
+                }) { tradeIdSizePairs ->
+                    tradeIdSizePairs.toMap() // Map<tradeId, chatSize>
+                }.onStart { emit(emptyMap()) }
+
+                // Combine chatMessages
+                //  + currently selectedTrade (to capture update of TradeReadState in OpenTradePresenter)
+                combine(
+                    combinedChatMessages, tradesServiceFacade.selectedTrade
+                ) { chatSizes, selectedTrade -> Triple(tradeList, chatSizes, selectedTrade) }
+            }.collect { (tradeList, chatSizes, _) ->
+                val readState = tradeReadStateRepository.fetch() ?: TradeReadState()
+
+                _readMessageCountsByTrade.value = readState.map
+                _tradesWithUnreadMessages.value = tradeList.map { trade ->
+                    val chatSize = chatSizes[trade.tradeId] ?: 0
+                    trade.tradeId to chatSize
+                }.filter { (tradeId, chatSize) ->
+                    val recordedSize = readState.map[tradeId]
+                    recordedSize == null || recordedSize < chatSize
+                }.toMap()
+            }
+        }
+    }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -152,7 +152,7 @@ val presentationModule = module {
     single { SellerState3aPresenter(get(), get()) }
     factory { SellerStateMainChain3bPresenter(get(), get(), get()) }
     factory { SellerStateLightning3bPresenter(get(), get()) }
-    single { SellerState4Presenter(get(), get()) }
+    single { SellerState4Presenter(get(), get(), get()) }
 
     // Trade Buyer
     single { BuyerState1aPresenter(get(), get()) }
@@ -162,13 +162,13 @@ val presentationModule = module {
     factory { BuyerState3aPresenter(get(), get()) }
     factory { BuyerStateMainChain3bPresenter(get(), get(), get()) }
     factory { BuyerStateLightning3bPresenter(get(), get()) }
-    single { BuyerState4Presenter(get(), get()) }
+    single { BuyerState4Presenter(get(), get(), get()) }
 
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { OpenTradeListPresenter(get(), get(), get(), get()) }
     single { TradeDetailsHeaderPresenter(get(), get(), get(), get()) }
-    factory { InterruptedTradePresenter(get(), get(), get()) }
+    factory { InterruptedTradePresenter(get(), get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -17,9 +17,14 @@ import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPayme
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPricePresenter
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferReviewPresenter
-import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuidePresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuideOverviewPresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuideProcessPresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuideSecurityPresenter
 import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuideTradeRulesPresenter
-import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuidePresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuideDownloadPresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuideIntroPresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuideNewPresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuideReceivingPresenter
 import network.bisq.mobile.presentation.ui.uicases.offerbook.OfferbookMarketPresenter
 import network.bisq.mobile.presentation.ui.uicases.offerbook.OfferbookPresenter
 import network.bisq.mobile.presentation.ui.uicases.open_trades.OpenTradeListPresenter
@@ -175,9 +180,14 @@ val presentationModule = module {
 
     factory { TradeChatPresenter(get(), get(), get(), get(), get(), get()) }
 
-    single { TradeGuidePresenter(get()) } bind TradeGuidePresenter::class
+    single { TradeGuideOverviewPresenter(get()) } bind TradeGuideOverviewPresenter::class
+    single { TradeGuideSecurityPresenter(get()) } bind TradeGuideSecurityPresenter::class
+    single { TradeGuideProcessPresenter(get()) } bind TradeGuideProcessPresenter::class
     single { TradeGuideTradeRulesPresenter(get(), get()) } bind TradeGuideTradeRulesPresenter::class
-    single { WalletGuidePresenter(get()) } bind WalletGuidePresenter::class
+    single { WalletGuideIntroPresenter(get()) } bind WalletGuideIntroPresenter::class
+    single { WalletGuideDownloadPresenter(get()) } bind WalletGuideDownloadPresenter::class
+    single { WalletGuideNewPresenter(get()) } bind WalletGuideNewPresenter::class
+    single { WalletGuideReceivingPresenter(get()) } bind WalletGuideReceivingPresenter::class
 
     factory<TimeProvider> { getPlatformCurrentTimeProvider() }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPrese
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPricePresenter
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferReviewPresenter
 import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuidePresenter
+import network.bisq.mobile.presentation.ui.uicases.guide.TradeGuideTradeRulesPresenter
 import network.bisq.mobile.presentation.ui.uicases.guide.WalletGuidePresenter
 import network.bisq.mobile.presentation.ui.uicases.offerbook.OfferbookMarketPresenter
 import network.bisq.mobile.presentation.ui.uicases.offerbook.OfferbookPresenter
@@ -174,7 +175,8 @@ val presentationModule = module {
 
     factory { TradeChatPresenter(get(), get(), get(), get(), get(), get()) }
 
-    single { TradeGuidePresenter(get(), get()) } bind TradeGuidePresenter::class
+    single { TradeGuidePresenter(get()) } bind TradeGuidePresenter::class
+    single { TradeGuideTradeRulesPresenter(get(), get()) } bind TradeGuideTradeRulesPresenter::class
     single { WalletGuidePresenter(get()) } bind WalletGuidePresenter::class
 
     factory<TimeProvider> { getPlatformCurrentTimeProvider() }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/BisqLinks.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/BisqLinks.kt
@@ -1,6 +1,6 @@
 package network.bisq.mobile.presentation.ui
 
-object BisqConfig {
+object BisqLinks {
     const val BISQ_EASY_WIKI_URL = "https://bisq.wiki/Bisq_Easy"
     const val REPUTATION_BASE_WIKI_URL = "https://bisq.wiki/Reputation"
     const val REPUTATION_BUILD_WIKI_URL = "https://bisq.wiki/Reputation#How_to_build_reputation"

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
@@ -1,5 +1,4 @@
 package network.bisq.mobile.presentation.ui
 
 object BisqConfig {
-    const val NOTIFICATION_SYNC_INTERVAL = 60_000L
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
@@ -4,7 +4,7 @@ object BisqConfig {
     const val BISQ_EASY_WIKI_URL = "https://bisq.wiki/Bisq_Easy"
     const val REPUTATION_BASE_WIKI_URL = "https://bisq.wiki/Reputation"
     const val REPUTATION_BUILD_WIKI_URL = "https://bisq.wiki/Reputation#How_to_build_reputation"
-    const val BLUE_WALLET_TUTORIAL_1_URL= "https://www.youtube.com/watch?v=NqY3wBhloH4"
-    const val BLUE_WALLET_TUTORIAL_2_URL= "https://www.youtube.com/watch?v=imMX7i4qpmg"
-    const val BISQ_MOBILE_GH_ISSUES= "https://github.com/bisq-network/bisq-mobile/issues"
+    const val BLUE_WALLET_TUTORIAL_1_URL = "https://www.youtube.com/watch?v=NqY3wBhloH4"
+    const val BLUE_WALLET_TUTORIAL_2_URL = "https://www.youtube.com/watch?v=imMX7i4qpmg"
+    const val BISQ_MOBILE_GH_ISSUES = "https://github.com/bisq-network/bisq-mobile/issues"
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/Config.kt
@@ -1,4 +1,10 @@
 package network.bisq.mobile.presentation.ui
 
 object BisqConfig {
+    const val BISQ_EASY_WIKI_URL = "https://bisq.wiki/Bisq_Easy"
+    const val REPUTATION_BASE_WIKI_URL = "https://bisq.wiki/Reputation"
+    const val REPUTATION_BUILD_WIKI_URL = "https://bisq.wiki/Reputation#How_to_build_reputation"
+    const val BLUE_WALLET_TUTORIAL_1_URL= "https://www.youtube.com/watch?v=NqY3wBhloH4"
+    const val BLUE_WALLET_TUTORIAL_2_URL= "https://www.youtube.com/watch?v=imMX7i4qpmg"
+    const val BISQ_MOBILE_GH_ISSUES= "https://github.com/bisq-network/bisq-mobile/issues"
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
@@ -14,8 +14,8 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 @Composable
 fun AnimatedBadge(
     showAnimation: Boolean,
-    xOffet: Dp = 8.dp,
-    yOffet: Dp = (-8).dp,
+    xOffset: Dp = 8.dp,
+    yOffset: Dp = (-8).dp,
     content: @Composable RowScope.() -> Unit
 ) {
 
@@ -60,7 +60,7 @@ fun AnimatedBadge(
         containerColor = BisqTheme.colors.warningHover,
         contentColor = BisqTheme.colors.dark_grey20,
         modifier = Modifier
-            .offset(x = xOffet, y = yOffet)
+            .offset(x = xOffset, y = yOffset)
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/animations/AnimatedBadge.kt
@@ -7,12 +7,15 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
 fun AnimatedBadge(
     showAnimation: Boolean,
+    xOffet: Dp = 8.dp,
+    yOffet: Dp = (-8).dp,
     content: @Composable RowScope.() -> Unit
 ) {
 
@@ -57,7 +60,7 @@ fun AnimatedBadge(
         containerColor = BisqTheme.colors.warningHover,
         contentColor = BisqTheme.colors.dark_grey20,
         modifier = Modifier
-            .offset(x = 8.dp, y = (-8).dp)
+            .offset(x = xOffet, y = yOffet)
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.NoteText
 import network.bisq.mobile.presentation.ui.components.atoms.button.GreyCloseButton
@@ -35,7 +36,7 @@ fun ReputationBasedBuyerLimitsPopup(
 
         NoteText(
             "bisqEasy.tradeWizard.amount.buyer.limitInfo.overlay.linkToWikiText".i18n(),
-            linkText = "https://bisq.wiki/Reputation",
+            linkText = BisqConfig.REPUTATION_BUILD_WIKI_URL,
             openConfirmation = true,
             onLinkClick = onRepLinkClick
         )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.NoteText
 import network.bisq.mobile.presentation.ui.components.atoms.button.GreyCloseButton
@@ -36,7 +36,7 @@ fun ReputationBasedBuyerLimitsPopup(
 
         NoteText(
             "bisqEasy.tradeWizard.amount.buyer.limitInfo.overlay.linkToWikiText".i18n(),
-            linkText = BisqConfig.REPUTATION_BUILD_WIKI_URL,
+            linkText = BisqLinks.REPUTATION_BUILD_WIKI_URL,
             openConfirmation = true,
             onLinkClick = onRepLinkClick
         )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.GreyCloseButton
@@ -38,7 +38,7 @@ fun ReputationBasedSellerLimitsPopup(
 
         LinkButton(
             text = "bisqEasy.tradeWizard.amount.limitInfo.overlay.learnHowToBuildReputation".i18n(),
-            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
+            link = BisqLinks.REPUTATION_BUILD_WIKI_URL,
             type = BisqButtonType.Outline,
             padding = PaddingValues(horizontal = BisqUIConstants.ScreenPadding, vertical = 8.dp),
             fullWidth = true,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.GreyCloseButton
@@ -37,7 +38,7 @@ fun ReputationBasedSellerLimitsPopup(
 
         LinkButton(
             text = "bisqEasy.tradeWizard.amount.limitInfo.overlay.learnHowToBuildReputation".i18n(),
-            link = "https://bisq.wiki/Reputation#How_to_build_reputation",
+            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
             type = BisqButtonType.Outline,
             padding = PaddingValues(horizontal = BisqUIConstants.ScreenPadding, vertical = 8.dp),
             fullWidth = true,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/SellerReputationWarningDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/SellerReputationWarningDialog.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -54,7 +54,7 @@ fun SellerReputationWarningDialog(
 
         LinkButton(
             text = "bisqEasy.tradeWizard.directionAndMarket.feedback.gainReputation".i18n(),
-            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
+            link = BisqLinks.REPUTATION_BUILD_WIKI_URL,
             type = BisqButtonType.Default,
             color = BisqTheme.colors.white,
             onClick = onLearnReputation,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/SellerReputationWarningDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/offer/SellerReputationWarningDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -53,7 +54,7 @@ fun SellerReputationWarningDialog(
 
         LinkButton(
             text = "bisqEasy.tradeWizard.directionAndMarket.feedback.gainReputation".i18n(),
-            link = "https://bisq.wiki/Reputation#How_to_build_reputation",
+            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
             type = BisqButtonType.Default,
             color = BisqTheme.colors.white,
             onClick = onLearnReputation,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ViewPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -124,7 +125,7 @@ fun WelcomeCard(
         // Footer Link
         LinkButton(
             footerLink,
-            link = "https://bisq.wiki/Bisq_Easy",
+            link = BisqConfig.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ViewPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
@@ -125,7 +125,7 @@ fun WelcomeCard(
         // Footer Link
         LinkButton(
             footerLink,
-            link = BisqConfig.BISQ_EASY_WIKI_URL,
+            link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 open class DashboardPresenter(
@@ -47,9 +48,7 @@ open class DashboardPresenter(
     }
 
     override fun navigateLearnMore() {
-        disableInteractive()
-        navigateToUrl("https://bisq.wiki/Bisq_Easy")
-        enableInteractive()
+        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
     }
 
     private fun refresh() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
@@ -10,7 +10,7 @@ import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 open class DashboardPresenter(
@@ -48,7 +48,7 @@ open class DashboardPresenter(
     }
 
     override fun navigateLearnMore() {
-        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
+        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
     }
 
     private fun refresh() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -31,7 +31,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.helpers.AmountValidator
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter.AmountType
@@ -242,11 +242,11 @@ class CreateOfferAmountPresenter(
     }
 
     fun navigateToReputation() {
-        navigateToUrl(BisqConfig.REPUTATION_BASE_WIKI_URL)
+        navigateToUrl(BisqLinks.REPUTATION_BASE_WIKI_URL)
     }
 
     fun navigateToBuildReputation() {
-        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
+        navigateToUrl(BisqLinks.REPUTATION_BUILD_WIKI_URL)
     }
 
     fun validateTextField(value: String): String? {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.helpers.AmountValidator
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter.AmountType
@@ -241,15 +242,11 @@ class CreateOfferAmountPresenter(
     }
 
     fun navigateToReputation() {
-        disableInteractive()
-        navigateToUrl("https://bisq.wiki/Reputation")
-        enableInteractive()
+        navigateToUrl(BisqConfig.REPUTATION_BASE_WIKI_URL)
     }
 
     fun navigateToBuildReputation() {
-        disableInteractive()
-        navigateToUrl("https://bisq.wiki/Reputation#How_to_build_reputation")
-        enableInteractive()
+        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
     }
 
     fun validateTextField(value: String): String? {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class CreateOfferDirectionPresenter(
@@ -63,9 +64,7 @@ class CreateOfferDirectionPresenter(
 
     fun showLearnReputation() {
         setShowSellerReputationWarning(false)
-        disableInteractive()
-        navigateToUrl("https://bisq.wiki/Reputation#How_to_build_reputation")
-        enableInteractive()
+        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
     }
 
     fun onDismissSellerReputationWarning() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -12,7 +12,7 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class CreateOfferDirectionPresenter(
@@ -64,7 +64,7 @@ class CreateOfferDirectionPresenter(
 
     fun showLearnReputation() {
         setShowSellerReputationWarning(false)
-        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
+        navigateToUrl(BisqLinks.REPUTATION_BUILD_WIKI_URL)
     }
 
     fun onDismissSellerReputationWarning() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideOverview.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideOverview.kt
@@ -12,7 +12,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun TradeGuideOverview() {
-    val presenter: TradeGuidePresenter = koinInject()
+    val presenter: TradeGuideOverviewPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideOverviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideOverviewPresenter.kt
@@ -1,0 +1,19 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class TradeGuideOverviewPresenter(
+    mainPresenter: MainPresenter,
+) : BasePresenter(mainPresenter) {
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun overviewNextClick() {
+        navigateTo(Routes.TradeGuideSecurity)
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuidePresenter.kt
@@ -1,18 +1,12 @@
 package network.bisq.mobile.presentation.ui.uicases.guide
 
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuidePresenter(
     mainPresenter: MainPresenter,
-    private val settingsServiceFacade: SettingsServiceFacade
 ) : BasePresenter(mainPresenter) {
-
-    val tradeRulesConfirmed: StateFlow<Boolean> = settingsServiceFacade.tradeRulesConfirmed
 
     fun prevClick() {
         navigateBack()
@@ -28,17 +22,6 @@ class TradeGuidePresenter(
 
     fun processNextClick() {
         navigateTo(Routes.TradeGuideTradeRules)
-    }
-
-    fun tradeRulesNextClick() {
-        launchUI {
-            val isConfirmed = tradeRulesConfirmed.first()
-            if (!isConfirmed) {
-                settingsServiceFacade.confirmTradeRules(true)
-            }
-            navigateBackTo(Routes.TradeGuideSecurity, true, false)
-            navigateBack()
-        }
     }
 
     fun navigateSecurityLearnMore() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
@@ -13,7 +13,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun TradeGuideProcess() {
-    val presenter: TradeGuidePresenter = koinInject()
+    val presenter: TradeGuideProcessPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -43,7 +43,7 @@ fun TradeGuideProcess() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = BisqConfig.BISQ_EASY_WIKI_URL,
+            link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcess.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -42,7 +43,7 @@ fun TradeGuideProcess() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = "https://bisq.wiki/Bisq_Easy",
+            link = BisqConfig.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideProcessPresenter(
@@ -17,7 +18,7 @@ class TradeGuideProcessPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl("https://bisq.wiki/Bisq_Easy")
+        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideProcessPresenter(
@@ -18,7 +18,7 @@ class TradeGuideProcessPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
+        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideProcessPresenter.kt
@@ -1,0 +1,23 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class TradeGuideProcessPresenter(
+    mainPresenter: MainPresenter,
+) : BasePresenter(mainPresenter) {
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun processNextClick() {
+        navigateTo(Routes.TradeGuideTradeRules)
+    }
+
+    fun navigateSecurityLearnMore() {
+        navigateToUrl("https://bisq.wiki/Bisq_Easy")
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -38,7 +39,7 @@ fun TradeGuideSecurity() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = "https://bisq.wiki/Bisq_Easy",
+            link = BisqConfig.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -39,7 +39,7 @@ fun TradeGuideSecurity() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = BisqConfig.BISQ_EASY_WIKI_URL,
+            link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurity.kt
@@ -13,7 +13,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun TradeGuideSecurity() {
-    val presenter: TradeGuidePresenter = koinInject()
+    val presenter: TradeGuideSecurityPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
@@ -4,7 +4,7 @@ import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
-class TradeGuidePresenter(
+class TradeGuideSecurityPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
 
@@ -12,16 +12,8 @@ class TradeGuidePresenter(
         navigateBack()
     }
 
-    fun overviewNextClick() {
-        navigateTo(Routes.TradeGuideSecurity)
-    }
-
     fun securityNextClick() {
         navigateTo(Routes.TradeGuideProcess)
-    }
-
-    fun processNextClick() {
-        navigateTo(Routes.TradeGuideTradeRules)
     }
 
     fun navigateSecurityLearnMore() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideSecurityPresenter(
@@ -17,7 +18,7 @@ class TradeGuideSecurityPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl("https://bisq.wiki/Bisq_Easy")
+        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideSecurityPresenter.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideSecurityPresenter(
@@ -18,7 +18,7 @@ class TradeGuideSecurityPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
+        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCheckbox
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
@@ -45,7 +45,7 @@ fun TradeGuideTradeRules() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = BisqConfig.BISQ_EASY_WIKI_URL,
+            link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCheckbox
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
@@ -44,7 +45,7 @@ fun TradeGuideTradeRules() {
 
         LinkButton(
             "action.learnMore".i18n(),
-            link = "https://bisq.wiki/Bisq_Easy",
+            link = BisqConfig.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() }
         )
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
@@ -15,7 +15,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun TradeGuideTradeRules() {
-    val presenter: TradeGuidePresenter = koinInject()
+    val presenter: TradeGuideTradeRulesPresenter = koinInject()
     val userAgreed by presenter.tradeRulesConfirmed.collectAsState()
     var _userAgreed by remember { mutableStateOf(userAgreed) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.first
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideTradeRulesPresenter(
@@ -30,7 +31,7 @@ class TradeGuideTradeRulesPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl("https://bisq.wiki/Bisq_Easy")
+        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.first
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class TradeGuideTradeRulesPresenter(
@@ -31,7 +31,7 @@ class TradeGuideTradeRulesPresenter(
     }
 
     fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqConfig.BISQ_EASY_WIKI_URL)
+        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
@@ -1,0 +1,36 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class TradeGuideTradeRulesPresenter(
+    mainPresenter: MainPresenter,
+    private val settingsServiceFacade: SettingsServiceFacade
+) : BasePresenter(mainPresenter) {
+
+    val tradeRulesConfirmed: StateFlow<Boolean> = settingsServiceFacade.tradeRulesConfirmed
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun tradeRulesNextClick() {
+        launchUI {
+            val isConfirmed = tradeRulesConfirmed.first()
+            if (!isConfirmed) {
+                settingsServiceFacade.confirmTradeRules(true)
+            }
+            navigateBackTo(Routes.TradeGuideSecurity, true, false)
+            navigateBack()
+        }
+    }
+
+    fun navigateSecurityLearnMore() {
+        navigateToUrl("https://bisq.wiki/Bisq_Easy")
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownload.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownload.kt
@@ -17,7 +17,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun WalletGuideDownload() {
-    val presenter: WalletGuidePresenter = koinInject()
+    val presenter: WalletGuideDownloadPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownloadPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownloadPresenter.kt
@@ -1,0 +1,27 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class WalletGuideDownloadPresenter(
+    mainPresenter: MainPresenter,
+) : BasePresenter(mainPresenter) {
+
+    val blueWalletLink = "https://bluewallet.io"
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun downloadNextClick() {
+        navigateTo(Routes.WalletGuideNewWallet)
+    }
+
+    fun navigateToBlueWallet() {
+        disableInteractive()
+        navigateToUrl(blueWalletLink)
+        enableInteractive()
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownloadPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideDownloadPresenter.kt
@@ -19,9 +19,7 @@ class WalletGuideDownloadPresenter(
     }
 
     fun navigateToBlueWallet() {
-        disableInteractive()
         navigateToUrl(blueWalletLink)
-        enableInteractive()
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideIntro.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideIntro.kt
@@ -11,7 +11,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun WalletGuideIntro() {
-    val presenter: WalletGuidePresenter = koinInject()
+    val presenter: WalletGuideIntroPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideIntroPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideIntroPresenter.kt
@@ -1,0 +1,19 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class WalletGuideIntroPresenter(
+    mainPresenter: MainPresenter,
+) : BasePresenter(mainPresenter) {
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun introNextClick() {
+        navigateTo(Routes.WalletGuideDownload)
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideNewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideNewPresenter.kt
@@ -1,0 +1,19 @@
+package network.bisq.mobile.presentation.ui.uicases.guide
+
+import network.bisq.mobile.presentation.BasePresenter
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.navigation.Routes
+
+class WalletGuideNewPresenter(
+    mainPresenter: MainPresenter,
+) : BasePresenter(mainPresenter) {
+
+    fun prevClick() {
+        navigateBack()
+    }
+
+    fun newWalletNextClick() {
+        navigateTo(Routes.WalletGuideReceiving)
+    }
+
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideNewWallet.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideNewWallet.kt
@@ -15,7 +15,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun WalletGuideNewWallet() {
-    val presenter: WalletGuidePresenter = koinInject()
+    val presenter: WalletGuideNewPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
@@ -62,7 +62,7 @@ fun WalletGuideReceiving() {
         LinkButton(
             "bisqEasy.walletGuide.receive.link2".i18n(),
             link = presenter.tutorial2Link,
-            onClick = { presenter.navigateToBlueWalletTutorial1() }
+            onClick = { presenter.navigateToBlueWalletTutorial2() }
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
@@ -21,7 +21,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun WalletGuideReceiving() {
-    val presenter: WalletGuidePresenter = koinInject()
+    val presenter: WalletGuideReceivingPresenter = koinInject()
 
     RememberPresenterLifecycle(presenter)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import kotlinx.coroutines.delay
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
@@ -55,13 +56,13 @@ fun WalletGuideReceiving() {
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link1".i18n(),
-            link = presenter.tutorial1Link,
+            link = BisqConfig.BLUE_WALLET_TUTORIAL_1_URL,
             onClick = { presenter.navigateToBlueWalletTutorial1() }
         )
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link2".i18n(),
-            link = presenter.tutorial2Link,
+            link = BisqConfig.BLUE_WALLET_TUTORIAL_2_URL,
             onClick = { presenter.navigateToBlueWalletTutorial2() }
         )
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import kotlinx.coroutines.delay
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
@@ -56,13 +56,13 @@ fun WalletGuideReceiving() {
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link1".i18n(),
-            link = BisqConfig.BLUE_WALLET_TUTORIAL_1_URL,
+            link = BisqLinks.BLUE_WALLET_TUTORIAL_1_URL,
             onClick = { presenter.navigateToBlueWalletTutorial1() }
         )
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link2".i18n(),
-            link = BisqConfig.BLUE_WALLET_TUTORIAL_2_URL,
+            link = BisqLinks.BLUE_WALLET_TUTORIAL_2_URL,
             onClick = { presenter.navigateToBlueWalletTutorial2() }
         )
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
@@ -4,11 +4,10 @@ import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
-class WalletGuidePresenter(
+class WalletGuideReceivingPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
 
-    val blueWalletLink = "https://bluewallet.io"
     val tutorial1Link = "https://www.youtube.com/watch?v=NqY3wBhloH4"
     val tutorial2Link = "https://www.youtube.com/watch?v=imMX7i4qpmg"
 
@@ -16,37 +15,13 @@ class WalletGuidePresenter(
         navigateBack()
     }
 
-    fun introNextClick() {
-        navigateTo(Routes.WalletGuideDownload)
-    }
-
-    fun downloadNextClick() {
-        navigateTo(Routes.WalletGuideNewWallet)
-    }
-
-    fun newWalletNextClick() {
-        navigateTo(Routes.WalletGuideReceiving)
-    }
-
     fun receivingNextClick() {
         navigateBackTo(Routes.WalletGuideIntro, true, false)
-    }
-
-    fun navigateToBlueWallet() {
-        disableInteractive()
-        navigateToUrl(blueWalletLink)
-        enableInteractive()
     }
 
     fun navigateToBlueWalletTutorial1() {
         disableInteractive()
         navigateToUrl(tutorial1Link)
-        enableInteractive()
-    }
-
-    fun navigateToBlueWalletTutorial2() {
-        disableInteractive()
-        navigateToUrl(tutorial2Link)
         enableInteractive()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
@@ -9,9 +9,6 @@ class WalletGuideReceivingPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
 
-    val tutorial1Link = "https://www.youtube.com/watch?v=NqY3wBhloH4"
-    val tutorial2Link = "https://www.youtube.com/watch?v=imMX7i4qpmg"
-
     fun prevClick() {
         navigateBack()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class WalletGuideReceivingPresenter(
@@ -20,9 +21,11 @@ class WalletGuideReceivingPresenter(
     }
 
     fun navigateToBlueWalletTutorial1() {
-        disableInteractive()
-        navigateToUrl(tutorial1Link)
-        enableInteractive()
+        navigateToUrl(BisqConfig.BLUE_WALLET_TUTORIAL_1_URL)
+    }
+
+    fun navigateToBlueWalletTutorial2() {
+        navigateToUrl(BisqConfig.BLUE_WALLET_TUTORIAL_2_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceivingPresenter.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.guide
 
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 
 class WalletGuideReceivingPresenter(
@@ -18,11 +18,11 @@ class WalletGuideReceivingPresenter(
     }
 
     fun navigateToBlueWalletTutorial1() {
-        navigateToUrl(BisqConfig.BLUE_WALLET_TUTORIAL_1_URL)
+        navigateToUrl(BisqLinks.BLUE_WALLET_TUTORIAL_1_URL)
     }
 
     fun navigateToBlueWalletTutorial2() {
-        navigateToUrl(BisqConfig.BLUE_WALLET_TUTORIAL_2_URL)
+        navigateToUrl(BisqLinks.BLUE_WALLET_TUTORIAL_2_URL)
     }
 
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -31,7 +31,7 @@ import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter
 import network.bisq.mobile.presentation.ui.uicases.take_offer.TakeOfferPresenter
@@ -293,7 +293,7 @@ class OfferbookPresenter(
         // val canBuyerTakeOffer = isReputationNotCached || sellersScore >= requiredReputationScoreForMinOrFixed
         val canBuyerTakeOffer = sellersScore >= requiredReputationScoreForMinOrFixed
         if (!canBuyerTakeOffer) {
-            val link = "hyperlinks.openInBrowser.attention".i18n(BisqConfig.REPUTATION_BUILD_WIKI_URL)
+            val link = "hyperlinks.openInBrowser.attention".i18n(BisqLinks.REPUTATION_BUILD_WIKI_URL)
             if (bisqEasyOffer.direction == DirectionEnum.SELL) {
                 // SELL offer: Maker wants to sell Bitcoin, so they are the seller
                 // Taker (me) wants to buy Bitcoin - checking if seller has enough reputation
@@ -368,7 +368,7 @@ class OfferbookPresenter(
 
     fun onLearnHowToBuildReputation() {
         _showNotEnoughReputationDialog.value = false
-        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
+        navigateToUrl(BisqLinks.REPUTATION_BUILD_WIKI_URL)
     }
 
     private suspend fun setupReputationDialogContent(item: OfferItemPresentationModel) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter
 import network.bisq.mobile.presentation.ui.uicases.take_offer.TakeOfferPresenter
@@ -44,9 +45,6 @@ class OfferbookPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val reputationServiceFacade: ReputationServiceFacade
 ) : BasePresenter(mainPresenter) {
-    companion object {
-        const val REPUTATION_WIKI_URL = "https://bisq.wiki/Reputation#How_to_build_reputation"
-    }
 
     //todo for dev testing its more convenient
     private val _selectedDirection = MutableStateFlow(DirectionEnum.SELL)
@@ -295,7 +293,7 @@ class OfferbookPresenter(
         // val canBuyerTakeOffer = isReputationNotCached || sellersScore >= requiredReputationScoreForMinOrFixed
         val canBuyerTakeOffer = sellersScore >= requiredReputationScoreForMinOrFixed
         if (!canBuyerTakeOffer) {
-            val link = "hyperlinks.openInBrowser.attention".i18n(REPUTATION_WIKI_URL)
+            val link = "hyperlinks.openInBrowser.attention".i18n(BisqConfig.REPUTATION_BUILD_WIKI_URL)
             if (bisqEasyOffer.direction == DirectionEnum.SELL) {
                 // SELL offer: Maker wants to sell Bitcoin, so they are the seller
                 // Taker (me) wants to buy Bitcoin - checking if seller has enough reputation
@@ -370,7 +368,7 @@ class OfferbookPresenter(
 
     fun onLearnHowToBuildReputation() {
         _showNotEnoughReputationDialog.value = false
-        navigateToUrl(REPUTATION_WIKI_URL)
+        navigateToUrl(BisqConfig.REPUTATION_BUILD_WIKI_URL)
     }
 
     private suspend fun setupReputationDialogContent(item: OfferItemPresentationModel) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqConfig
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.BisqFABAddButton
@@ -93,7 +94,7 @@ fun OfferbookScreen() {
 
     if (showNotEnoughReputationDialog) {
         WebLinkConfirmationDialog(
-            link = "https://bisq.wiki/Reputation#How_to_build_reputation",
+            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
             headline = presenter.notEnoughReputationHeadline,
             message = presenter.notEnoughReputationMessage,
             confirmButtonText = "confirmation.yes".i18n(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.ui.BisqConfig
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.BisqFABAddButton
@@ -94,7 +94,7 @@ fun OfferbookScreen() {
 
     if (showNotEnoughReputationDialog) {
         WebLinkConfirmationDialog(
-            link = BisqConfig.REPUTATION_BUILD_WIKI_URL,
+            link = BisqLinks.REPUTATION_BUILD_WIKI_URL,
             headline = presenter.notEnoughReputationHeadline,
             message = presenter.notEnoughReputationMessage,
             confirmButtonText = "confirmation.yes".i18n(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -70,9 +70,7 @@ class OpenTradeListPresenter(
     }
 
     fun onOpenTradeGuide() {
-        disableInteractive()
         navigateTo(Routes.TradeGuideOverview)
-        enableInteractive()
     }
 
     fun onCloseTradeGuideConfirmation() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -66,7 +66,7 @@ class OpenTradePresenter(
         super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
-        var initMsgCount : Int? = null
+        var initReadCount : Int? = null
 
         collectUI(openTradeItemModel.bisqEasyTradeModel.tradeState) { tradeState ->
             tradeStateChanged(tradeState)
@@ -76,10 +76,10 @@ class OpenTradePresenter(
             val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
             readState[openTradeItemModel.tradeId] = it.size
             tradeReadStateRepository.update(TradeReadState().apply { map = readState })
-            if (initMsgCount == null) {
-                initMsgCount = readState[openTradeItemModel.tradeId]
+            if (initReadCount == null) {
+                initReadCount = readState[openTradeItemModel.tradeId]
             }
-            _newMsgCount.update { _ -> it.size - initMsgCount!! }
+            _newMsgCount.update { _ -> it.size - initReadCount!! }
         }
 
         collectUI(openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -64,12 +64,14 @@ class OpenTradePresenter(
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
 
         collectUI(openTradeItemModel.bisqEasyTradeModel.tradeState) { tradeState ->
-            val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
-            readState[openTradeItemModel.tradeId] =
-                openTradeItemModel.bisqEasyOpenTradeChannelModel.chatMessages.value.size
-            tradeReadStateRepository.update(TradeReadState().apply { map = readState })
 
             tradeStateChanged(tradeState)
+        }
+
+        collectUI(openTradeItemModel.bisqEasyOpenTradeChannelModel.chatMessages) {
+            val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
+            readState[openTradeItemModel.tradeId] = it.size
+            tradeReadStateRepository.update(TradeReadState().apply { map = readState })
         }
 
         collectUI(openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -39,6 +39,9 @@ class OpenTradePresenter(
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> = _isInMediation
 
+    private val _newMsgCount: MutableStateFlow<Int> = MutableStateFlow(2)
+    val newMsgCount: StateFlow<Int> = _newMsgCount
+
     private var _tradePaneScrollState: MutableStateFlow<ScrollState?> = MutableStateFlow(null)
     private var _coroutineScope: CoroutineScope? = null
 
@@ -62,9 +65,9 @@ class OpenTradePresenter(
         super.onViewAttached()
         require(tradesServiceFacade.selectedTrade.value != null)
         val openTradeItemModel = tradesServiceFacade.selectedTrade.value!!
+        var initMsgCount : Int? = null
 
         collectUI(openTradeItemModel.bisqEasyTradeModel.tradeState) { tradeState ->
-
             tradeStateChanged(tradeState)
         }
 
@@ -72,6 +75,10 @@ class OpenTradePresenter(
             val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
             readState[openTradeItemModel.tradeId] = it.size
             tradeReadStateRepository.update(TradeReadState().apply { map = readState })
+            if (initMsgCount == null) {
+                initMsgCount = readState[openTradeItemModel.tradeId]
+            }
+            _newMsgCount.update { _ -> it.size - initMsgCount!! }
         }
 
         collectUI(openTradeItemModel.bisqEasyOpenTradeChannelModel.isInMediation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -39,7 +39,8 @@ class OpenTradePresenter(
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> = _isInMediation
 
-    private val _newMsgCount: MutableStateFlow<Int> = MutableStateFlow(2)
+    // New chat count to display over Chat FAB
+    private val _newMsgCount: MutableStateFlow<Int> = MutableStateFlow(0)
     val newMsgCount: StateFlow<Int> = _newMsgCount
 
     private var _tradePaneScrollState: MutableStateFlow<ScrollState?> = MutableStateFlow(null)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -8,11 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BadgedBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isBuy
+import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.animations.AnimatedBadge
 import network.bisq.mobile.presentation.ui.components.atoms.button.FloatingButton
 import network.bisq.mobile.presentation.ui.components.atoms.icons.ChatIcon
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -21,6 +25,7 @@ import network.bisq.mobile.presentation.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.ui.components.molecules.inputfield.PaymentProofType
 import network.bisq.mobile.presentation.ui.components.organisms.trades.*
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states.*
 import org.koin.compose.koinInject
 
@@ -45,6 +50,7 @@ fun OpenTradeScreen() {
     val tradeCloseType by headerPresenter.tradeCloseType.collectAsState()
     val showInterruptionConfirmationDialog by headerPresenter.showInterruptionConfirmationDialog.collectAsState()
     val showMediationConfirmationDialog by headerPresenter.showMediationConfirmationDialog.collectAsState()
+    val newMsgCount by presenter.newMsgCount.collectAsState()
 
     val buyerState1aAddressFieldType by buyerState1aPresenter.bitcoinLnAddressFieldType.collectAsState()
     val buyerState1aShowInvalidAddressDialog by buyerState1aPresenter.showInvalidAddressDialog.collectAsState()
@@ -72,10 +78,27 @@ fun OpenTradeScreen() {
     BisqStaticScaffold(
         topBar = { TopBar("Trade ID: ${presenter.selectedTrade.value?.shortTradeId}") },
         floatingButton = {
-            FloatingButton(
-                onClick = { presenter.onOpenChat() },
-            ) {
-                ChatIcon(modifier = Modifier.size(34.dp))
+            val icon = @Composable {
+                FloatingButton(
+                    onClick = { presenter.onOpenChat() },
+                ) {
+                    ChatIcon(modifier = Modifier.size(34.dp))
+                }
+            }
+
+            if (newMsgCount == 0) {
+                icon()
+            } else {
+                BadgedBox(badge = {
+                    AnimatedBadge(showAnimation = true, xOffet = (-4).dp) {
+                        BisqText.xsmallLight(
+                            newMsgCount.toString(),
+                            textAlign = TextAlign.Center, color = BisqTheme.colors.dark_grey20
+                        )
+                    }
+                }) {
+                    icon()
+                }
             }
         },
         shouldBlurBg = shouldBlurBg,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -90,7 +90,7 @@ fun OpenTradeScreen() {
                 icon()
             } else {
                 BadgedBox(badge = {
-                    AnimatedBadge(showAnimation = true, xOffet = (-4).dp) {
+                    AnimatedBadge(showAnimation = true, xOffset = (-4).dp) {
                         BisqText.xsmallLight(
                             newMsgCount.toString(),
                             textAlign = TextAlign.Center, color = BisqTheme.colors.dark_grey20

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState4Presenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.MainPresenter
@@ -7,7 +8,8 @@ import network.bisq.mobile.presentation.MainPresenter
 class BuyerState4Presenter(
     mainPresenter: MainPresenter,
     tradesServiceFacade: TradesServiceFacade,
-) : State4Presenter(mainPresenter, tradesServiceFacade) {
+    tradeReadStateRepository: TradeReadStateRepository,
+) : State4Presenter(mainPresenter, tradesServiceFacade, tradeReadStateRepository) {
 
     override fun getMyDirectionString(): String {
         return "bisqEasy.tradeCompleted.header.myDirection.buyer".i18n() // I bought

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState4Presenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.MainPresenter
@@ -7,7 +8,8 @@ import network.bisq.mobile.presentation.MainPresenter
 class SellerState4Presenter(
     mainPresenter: MainPresenter,
     tradesServiceFacade: TradesServiceFacade,
-) : State4Presenter(mainPresenter, tradesServiceFacade) {
+    tradeReadStateRepository: TradeReadStateRepository,
+) : State4Presenter(mainPresenter, tradesServiceFacade, tradeReadStateRepository) {
 
     override fun getMyDirectionString(): String {
         return "bisqEasy.tradeCompleted.header.myDirection.seller".i18n() // I sold

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -1,19 +1,23 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
+import network.bisq.mobile.domain.data.model.TradeReadState
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
+import kotlin.collections.orEmpty
+import kotlin.collections.toMutableMap
 
 abstract class State4Presenter(
     mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
+    private val tradeReadStateRepository: TradeReadStateRepository,
 ) : BasePresenter(mainPresenter) {
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
 
@@ -35,6 +39,7 @@ abstract class State4Presenter(
 
     fun onConfirmCloseTrade() {
         launchUI {
+            val tradeId = selectedTrade.value!!.tradeId
             val result = withContext(IODispatcher) { tradesServiceFacade.closeTrade() }
 
             when {
@@ -45,6 +50,9 @@ abstract class State4Presenter(
                 }
 
                 result.isSuccess -> {
+                    val readState = tradeReadStateRepository.fetch()?.map.orEmpty().toMutableMap()
+                    readState.remove(tradeId)
+                    tradeReadStateRepository.update(TradeReadState().apply { map = readState })
                     _showCloseTradeDialog.value = false
                     navigateBack()
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -39,13 +39,18 @@ abstract class State4Presenter(
 
     fun onConfirmCloseTrade() {
         launchUI {
-            val tradeId = selectedTrade.value!!.tradeId
+            val tradeId = selectedTrade.value?.tradeId ?: run {
+                _showCloseTradeDialog.value = false
+                GenericErrorHandler.handleGenericError("No trade selected for closure")
+                return@launchUI
+            }
             val result = withContext(IODispatcher) { tradesServiceFacade.closeTrade() }
 
             when {
                 result.isFailure -> {
                     _showCloseTradeDialog.value = false
-                    result.exceptionOrNull()?.let { exception -> GenericErrorHandler.handleGenericError(exception.message) }
+                    result.exceptionOrNull()
+                        ?.let { exception -> GenericErrorHandler.handleGenericError(exception.message) }
                         ?: GenericErrorHandler.handleGenericError("No Exception is set in result failure")
                 }
 
@@ -61,7 +66,7 @@ abstract class State4Presenter(
     }
 
     fun onExportTradeDate() {
-            launchIO {
+        launchIO {
             tradesServiceFacade.exportTradeDate()
         }
     }


### PR DESCRIPTION
Fixes for https://github.com/bisq-network/bisq-mobile/issues/390
 * Notifications happen in real time now
 * Captured notification for all states
 * Inside open trade screen, the Chat FAB button now gets a notification count badge, for any message / state updates that happens for the current trade. This way the user wont miss out on any messages that he receives while in trade screen.

Fixes for https://github.com/bisq-network/bisq-mobile/issues/356
 * FIX: Wallet guide / Trade interaction getting disabled on fast navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added animated badges to the chat button, displaying the count of new unread messages in open trades.
  - Introduced more granular navigation and presenters for Trade Guide and Wallet Guide screens, improving step-by-step guidance.

- **Improvements**
  - Enhanced notification tracking for chat messages, providing more responsive unread message updates.
  - Presenter logic for open trades and guides was modularized for better navigation and state management.
  - Badge position in the UI can now be customized.
  - Centralized external URLs in configuration for easier maintenance and consistency across the app.
  - Streamlined UI interaction state handling during navigation to external links.
  - Updated various UI components to use centralized URL constants instead of hardcoded links.

- **Bug Fixes**
  - Read states for trades are now properly cleared when trades are closed.

- **Chores**
  - Updated dependency injection and presenter constructors to support new features and improved state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->