### PR TITLE
Fix/UI fixes 01

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -120,7 +120,7 @@ fun BisqTextField(
     val finalLabelColor by remember(disabled) {
         mutableStateOf(
             if (disabled) {
-                BisqTheme.colors.dark_grey50
+                BisqTheme.colors.mid_grey20
             } else {
                 whiteColor
             }
@@ -130,7 +130,7 @@ fun BisqTextField(
     val finalTextStyle by remember(disabled) {
         mutableStateOf(
             if(disabled) {
-                textStyle.copy(color = BisqTheme.colors.mid_grey10)
+                textStyle.copy(color = BisqTheme.colors.mid_grey20)
             } else {
                 textStyle
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -80,6 +80,7 @@ fun OpenTradeScreen() {
         floatingButton = {
             val icon = @Composable {
                 FloatingButton(
+                    enabled = presenter.isInteractive.collectAsState().value,
                     onClick = { presenter.onOpenChat() },
                 ) {
                     ChatIcon(modifier = Modifier.size(34.dp))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -77,6 +77,7 @@ fun TradeDetailsHeader() {
     }
 
     val isSell = presenter.directionEnum.isSell
+    val isInteractive = presenter.isInteractive.collectAsState().value
 
     Row(modifier = Modifier.clip(shape = RoundedCornerShape(12.dp))) {
         Column(
@@ -236,7 +237,7 @@ fun TradeDetailsHeader() {
             ) {
                 IconButton(
                     onClick = { presenter.onToggleHeader() },
-                    enabled = presenter.isInteractive.collectAsState().value,
+                    enabled = isInteractive,
                 ) {
                     UpIcon(
                         modifier = Modifier

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -62,7 +62,7 @@ fun TradeDetailsHeader() {
             animationSpec = tween(300)
         )
     }
-    var showDetails by remember { mutableStateOf(false) }
+    val showDetails by presenter.isShowDetails.collectAsState()
 
     val transitionState = remember {
         MutableTransitionState(showDetails).apply {
@@ -234,7 +234,10 @@ fun TradeDetailsHeader() {
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { showDetails = !showDetails }) {
+                IconButton(
+                    onClick = { presenter.onToggleHeader() },
+                    enabled = presenter.isInteractive.collectAsState().value,
+                ) {
                     UpIcon(
                         modifier = Modifier
                             .size(32.dp)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -70,6 +70,9 @@ class TradeDetailsHeaderPresenter(
     private val _peerAvatar: MutableStateFlow<PlatformImage?> = MutableStateFlow(null)
     val peerAvatar: StateFlow<PlatformImage?> = _peerAvatar
 
+    private val _isShowDetails: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isShowDetails: StateFlow<Boolean> = this._isShowDetails
+
     override fun onViewAttached() {
         super.onViewAttached()
 
@@ -308,6 +311,12 @@ class TradeDetailsHeaderPresenter(
                 enableInteractive()
             }
         }
+    }
+
+    fun onToggleHeader() {
+        disableInteractive()
+        this._isShowDetails.value = !this._isShowDetails.value
+        enableInteractive()
     }
 
     private fun reset() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1a.kt
@@ -58,6 +58,7 @@ fun BuyerState1a(
             )
             BisqButton(
                 text = "bisqEasy.tradeState.info.buyer.phase1a.walletHelpButton".i18n(), // Open wallet guide
+                disabled = !presenter.isInteractive.collectAsState().value,
                 onClick = { presenter.onOpenWalletGuide() },
                 type = BisqButtonType.Outline,
                 padding = PaddingValues(


### PR DESCRIPTION
 - Fix: BTC value in create offer review screen, didn't take premium percentage into account.
 - Fix: Fast double tap leads to double navigates with certain buttons in OpenTradeScreen.
 - Fix: TextField: Disabled state style - Improved to become more readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to expand or collapse trade details using a toggle button, with the state now managed by the presenter for consistency.
  * The floating chat button on the open trade screen is now enabled or disabled based on the interactive state of the screen.

* **Improvements**
  * The "Open wallet guide" button is now disabled when user interaction is not allowed.
  * Updated the appearance of disabled text fields with improved color contrast for better readability.

* **Bug Fixes**
  * Base-side coin values in offer creation are now dynamically calculated from fiat values and the current price quote, ensuring accurate conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->