### PR TITLE
bugfix/shared_res_not_needed_build_gradle

### DIFF
--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -167,8 +167,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 }
 
 tasks.withType<Copy> {


### PR DESCRIPTION
 - current kmp versions do not need this instruction anymore (was causing root warning on AndroidStudio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration by removing a resource directory from the Android setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->