### PR TITLE
Bugfix/avatar not loadiong right after profile creation

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -151,17 +151,18 @@ fun TopBar(
                         }
 
                     BisqGap.H1()
+                    val uniqueAvatar by presenter.uniqueAvatar.collectAsState()
                     if (showAnimation && connectivityStatus != ConnectivityService.ConnectivityStatus.DISCONNECTED) {
                         ShineOverlay {
                             UserIcon(
-                                presenter.uniqueAvatar.value,
+                                uniqueAvatar,
                                 modifier = userIconModifier,
                                 connectivityStatus = connectivityStatus
                             )
                         }
                     } else {
                         UserIcon(
-                            presenter.uniqueAvatar.value,
+                            uniqueAvatar,
                             modifier = userIconModifier,
                             connectivityStatus = connectivityStatus
                         )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
@@ -30,10 +30,6 @@ open class TopBarPresenter(
 
     override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> = connectivityService.status
 
-    init {
-        refresh()
-    }
-
     override fun onViewAttached() {
         super.onViewAttached()
         refresh()


### PR DESCRIPTION
 - Fixes #219 
 - collect events properly and avoid double refresh call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how the avatar image updates in the top bar, ensuring smoother and more consistent UI reactions to changes.
  * Adjusted the timing of data refresh so that updates occur when the view is attached, rather than during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->