### PR TITLE
Profile sorting and copyToClipboard

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/SettingsTextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/SettingsTextField.kt
@@ -8,7 +8,8 @@ fun SettingsTextField(
     value: String,
     editable: Boolean = true,
     isTextArea: Boolean = false,
-    onValueChange: ((String, Boolean) -> Unit)? = null
+    onValueChange: ((String, Boolean) -> Unit)? = null,
+    trailingIcon: (@Composable () -> Unit)? = null
 ) {
     BisqTextField(
         label,
@@ -20,5 +21,6 @@ fun SettingsTextField(
                 onValueChange(newValue, isValid)
             }
         },
+        rightSuffix = trailingIcon
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -23,6 +23,7 @@ import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.SettingsTextField
 import network.bisq.mobile.presentation.ui.components.atoms.icons.UserIcon
+import network.bisq.mobile.presentation.ui.components.atoms.button.CopyIconButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.TopBar
@@ -95,18 +96,30 @@ fun UserProfileSettingsScreen() {
         BreadcrumbNavigation(path = menuPath) { index ->
             if (index == 0) settingsPresenter.settingsNavigateBack()
         }
-        // Bot Icon
+        
         UserProfileScreenHeader(presenter)
-
-        SettingsTextField(label = "Bot ID", value = botId, editable = false)
-
-        BisqGap.V1()
 
         SettingsTextField(label = "Nickname", value = nickname, editable = false)
 
         BisqGap.V1()
 
-        SettingsTextField(label = "Profile ID", value = profileId, editable = false)
+        // Bot ID with copy functionality
+        SettingsTextField(
+            label = "Bot ID", 
+            value = botId, 
+            editable = false,
+            trailingIcon = { CopyIconButton(value = botId) }
+        )
+
+        BisqGap.V1()
+
+        // Profile ID with copy functionality
+        SettingsTextField(
+            label = "Profile ID", 
+            value = profileId, 
+            editable = false,
+            trailingIcon = { CopyIconButton(value = profileId) }
+        )
 
         BisqGap.V1()
 


### PR DESCRIPTION
 - Fixes #426 
 - implemented right sorting and copy functionality for the user to easily copy importat profile info to clipboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy button icons to the "Bot ID" and "Profile ID" fields in the user profile settings screen, allowing users to easily copy these values.
* **Style**
  * Reordered fields in the user profile settings screen, displaying "Nickname" first, followed by "Bot ID" with the new copy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->