### PR TITLE
Release/anode 0.0.40

### DIFF
--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -101,7 +101,7 @@ android {
                 srcDir("${layout.buildDirectory}/generated/source/proto/debug/java")
                 srcDir("${layout.buildDirectory}/generated/source/proto/release/java")
                 proto {
-                    srcDir("${layout.buildDirectory}/extracted-include-protos/debug")
+                    srcDir("${layout.buildDirectory}/extracted-include-protos/release")
                 }
             }
         }

--- a/androidNode/proguard-rules.pro
+++ b/androidNode/proguard-rules.pro
@@ -311,3 +311,16 @@
     @org.koin.core.annotation.* <fields>;
     @org.koin.core.annotation.* <methods>;
 }
+
+# Keep Logback and SLF4J classes (MISSING - this is the issue!)
+-keep class ch.qos.logback.** { *; }
+-keep class org.slf4j.** { *; }
+-dontwarn ch.qos.logback.**
+-dontwarn org.slf4j.**
+
+# Keep Bisq logging classes specifically
+-keep class bisq.common.logging.** { *; }
+
+# Keep logback configuration classes that use reflection
+-keep class ch.qos.logback.core.rolling.** { *; }
+-keep class ch.qos.logback.classic.** { *; }

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ client.ios.version=0.0.7
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=3
 client.android.version.code=6
-node.android.version.code=4
+node.android.version.code=5
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ android.suppressUnsupportedCompileSdk=35
 shared.version=0.0.16
 
 node.name=Bisq
-node.android.version=0.0.40
+node.android.version=0.0.41
 
 client.name=Bisq Connect
 client.android.version=0.0.37
@@ -37,7 +37,7 @@ client.ios.version=0.0.7
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=3
 client.android.version.code=6
-node.android.version.code=5
+node.android.version.code=6
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ android.suppressUnsupportedCompileSdk=35
 shared.version=0.0.16
 
 node.name=Bisq
-node.android.version=0.0.34
+node.android.version=0.0.40
 
 client.name=Bisq Connect
 client.android.version=0.0.37


### PR DESCRIPTION
 - for design review purposes, internal only.
 - fix issue on relesae builds not bootstrapping (missing proguard for log4j in jars)
 - fix proto files pickup for release (was using debug which is inexistent when buildin for release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android node version and version code.
  * Adjusted build configuration to use the correct proto source directory for release builds.
  * Enhanced Proguard rules to better support logging frameworks and prevent issues with logback and SLF4J classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->