### PR TITLE
Fix/UI fixes 02

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AmountSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AmountSlider.kt
@@ -7,9 +7,13 @@ import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
@@ -17,60 +21,67 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 fun AmountSlider(
     value: Float,
     onValueChange: (Float) -> Unit,
-    max: Float? = null,
+    min: Float = 0f,
+    max: Float = 1f,
     leftMarker: Float? = null,
     rightMarker: Float? = null,
     modifier: Modifier = Modifier,
 ) {
+    require(min < max) { "min must be less than max" }
 
-    // max and rightMarker cannot be > 1
-    // leftMarker cannot be < 0
+    // Normalize a real value to [0f..1f] range
+    fun Float.normalized(): Float = ((this - min) / (max - min)).coerceIn(0f, 1f)
+
+    val normalizedValue = value.normalized()
+    val normalizedLeftMarker = leftMarker?.normalized()
+    val normalizedRightMarker = rightMarker?.normalized()
 
     val dragState = rememberDraggableState { delta ->
-        val newValue = (value + delta / 1000f).coerceIn(0f, max ?: 1f).coerceIn(0f, 1f)
+        val range = max - min
+        val deltaValue = (delta / 1000f) * range
+        val newValue = (value + deltaValue).coerceIn(min, max)
         onValueChange(newValue)
     }
 
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .draggable(
-                orientation = Orientation.Horizontal,
-                state = dragState
+        modifier = modifier.fillMaxWidth().draggable(
+                orientation = Orientation.Horizontal, state = dragState
             )
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize().height(40.dp)) {
             val thumbRadius = 12.dp.toPx()
             val width = size.width
             val centerY = size.height / 2
             val trackHeight = 3.dp.toPx()  // We use 2 px in Bisq 2 but seems to small here
 
-            val maxPos = (max ?: 1f).coerceIn(0f, 1f) * width
-            val thumbPos = value.coerceIn(0f, 1f) * width
+            val thumbPos = normalizedValue * width
+            val leftPos = (normalizedLeftMarker ?: 0f) * width
+            val rightPos = (normalizedRightMarker ?: max.normalized()) * width
 
             // Track
             drawLine(
-                color = BisqTheme.colors.mid_grey10, // We use mid_grey20 in Bisq 2 but seems to bright here
+                color = BisqTheme.colors.mid_grey10,  // We use mid_grey20 in Bisq 2 but seems to bright here
                 start = Offset(thumbRadius / 2, centerY),
                 end = Offset(width - thumbRadius / 2, centerY),
                 strokeWidth = trackHeight
             )
 
             // Marker range
-            drawLine(
-                color = BisqTheme.colors.primary,
-                start = Offset((leftMarker ?: 0f).coerceIn(0f, 1f) * width, centerY),
-                end = Offset(((max ?: rightMarker) ?: 0f).coerceIn(0f, 1f) * width, centerY),
-                strokeWidth = trackHeight
-            )
+            if (leftMarker != null || rightMarker != null) {
+                drawLine(
+                    color = BisqTheme.colors.primary,
+                    start = Offset(leftPos, centerY),
+                    end = Offset(rightPos, centerY),
+                    strokeWidth = trackHeight
+                )
+            }
 
             // Thumb
             drawCircle(
-                color = BisqTheme.colors.primary,
-                radius = thumbRadius,
-                center = Offset(thumbPos.coerceAtMost(maxPos), centerY)
+                color = BisqTheme.colors.primary, radius = thumbRadius, center = Offset(
+                    thumbPos.coerceIn(thumbRadius / 2, width - thumbRadius / 2), centerY
+                )
             )
         }
     }
 }
-

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AmountSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AmountSlider.kt
@@ -11,9 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
@@ -56,7 +53,7 @@ fun AmountSlider(
 
             val thumbPos = normalizedValue * width
             val leftPos = (normalizedLeftMarker ?: 0f) * width
-            val rightPos = (normalizedRightMarker ?: max.normalized()) * width
+            val rightPos = (normalizedRightMarker ?: 1f) * width
 
             // Track
             drawLine(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/RangeAmountSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/RangeAmountSlider.kt
@@ -18,7 +18,7 @@ fun RangeAmountSlider(
     Column(verticalArrangement = Arrangement.spacedBy(32.dp)) {
         AmountSlider(
             value = minRangeValue,
-            max= maxValue,
+            max= maxValue ?: 1f,
             leftMarker= leftMarkerValue,
             rightMarker= rightMarkerValue,
             onValueChange = { value ->
@@ -31,7 +31,7 @@ fun RangeAmountSlider(
 
         AmountSlider(
             value = maxRangeValue,
-            max= maxValue,
+            max= maxValue ?: 1f,
             leftMarker= leftMarkerValue,
             rightMarker= rightMarkerValue,
             onValueChange = { value ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -117,14 +117,14 @@ fun BisqTextField(
     }
 
     val whiteColor = BisqTheme.colors.white
-    val finalLabelColor by remember(disabled) {
-        mutableStateOf(
-            if (disabled) {
-                BisqTheme.colors.mid_grey20
-            } else {
-                whiteColor
+    val finalLabelColor by remember(disabled, validationError, hasInteracted) {
+        derivedStateOf {
+            when {
+                disabled -> BisqTheme.colors.dark_grey50
+                validationError?.isNotEmpty() == true && hasInteracted -> BisqTheme.colors.danger
+                else -> whiteColor
             }
-        )
+        }
     }
 
     val finalTextStyle by remember(disabled) {
@@ -171,11 +171,21 @@ fun BisqTextField(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                BisqText.baseLight(
-                    text = label,
-                    color = finalLabelColor,
-                    modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 2.dp)
-                )
+                val isError = validationError?.isNotEmpty() == true && hasInteracted
+                if (isError) {
+                    BisqText.baseRegular(
+                        text = label,
+                        color = finalLabelColor,
+                        modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 2.dp)
+                    )
+                } else {
+                    BisqText.baseLight(
+                        text = label,
+                        color = finalLabelColor,
+                        modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 2.dp)
+                    )
+                }
+
                 if (labelRightSuffix != null) {
                     labelRightSuffix()
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -215,31 +215,31 @@ fun BisqTextField(
                     if (numberWithTwoDecimals) {
                         val separator = getDecimalSeparator().toString()
                         val escapedSeparator = Regex.escape(separator)
-                        val loosePattern = Regex("^\\d*${escapedSeparator}?\\d*$")
+
+                        // Allow partial and complete decimal input
+                        val loosePattern = Regex("^[-]?\\d*(${escapedSeparator}\\d{0,})?\$")
 
                         if (loosePattern.matches(cleanValue)) {
-                            val trimmedValue = if (cleanValue.contains(separator)) {
-                                val parts = cleanValue.split(separator)
-                                if (parts.size == 2) {
-                                    val integer = parts[0]
-                                    val decimals = parts[1].take(2) // Trim to 2 decimal digits
-                                    "$integer$separator$decimals"
-                                } else {
-                                    cleanValue // malformed (multiple separators), leave as-is
+                            val parts = cleanValue.split(separator)
+                            val integerPart = parts[0]
+                            val decimalPart = if (parts.size == 2) parts[1] else ""
+
+                            val trimmedValue = when {
+                                parts.size == 2 && decimalPart.length > 2 -> {
+                                    "$integerPart$separator${decimalPart.take(2)}"
                                 }
-                            } else {
-                                cleanValue
+                                else -> cleanValue // let the user keep typing normally
                             }
 
                             validationError = validation?.invoke(trimmedValue)
-                            onValueChange?.invoke(
-                                trimmedValue,
-                                validationError == null || validationError?.isEmpty() == true
-                            )
+                            onValueChange?.invoke(trimmedValue, validationError == null || validationError?.isEmpty() == true)
                         }
                     } else {
                         validationError = validation?.invoke(cleanValue)
-                        onValueChange?.invoke(cleanValue, validationError == null || validationError?.isEmpty() == true)
+                        onValueChange?.invoke(
+                            cleanValue,
+                            validationError == null || validationError?.isEmpty() == true
+                        )
                     }
                 },
                 modifier = Modifier

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
@@ -114,7 +114,7 @@ fun CheckCircleIcon(modifier: Modifier = Modifier.size(24.dp)) {
 }
 
 @Composable
-fun RemoveOfferIcon(modifier: Modifier = Modifier) {
+fun RemoveOfferIcon(modifier: Modifier = Modifier.size(24.dp)) {
     Image(painterResource(Res.drawable.remove_offer), "Remove offer icon", modifier = modifier)
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Icons.kt
@@ -114,7 +114,7 @@ fun CheckCircleIcon(modifier: Modifier = Modifier.size(24.dp)) {
 }
 
 @Composable
-fun RemoveOfferIcon(modifier: Modifier = Modifier.size(24.dp)) {
+fun RemoveOfferIcon(modifier: Modifier = Modifier.size(20.dp)) {
     Image(painterResource(Res.drawable.remove_offer), "Remove offer icon", modifier = modifier)
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/AmountSelector.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/AmountSelector.kt
@@ -61,7 +61,7 @@ fun BisqAmountSelector(
 
             AmountSlider(
                 value = sliderPosition,
-                max = maxSliderValue,
+                max = maxSliderValue ?: 1f,
                 leftMarker = leftMarkerSliderValue,
                 rightMarker = rightMarkerSliderValue,
                 onValueChange = { onSliderValueChange(it) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/AmountWithCurrency.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/AmountWithCurrency.kt
@@ -1,0 +1,28 @@
+package network.bisq.mobile.presentation.ui.components.molecules
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
+
+@Composable
+fun AmountWithCurrency(
+    formattedPrice: String,
+) {
+    val priceFragments = formattedPrice.split(" ")
+        val value = priceFragments[0]
+
+    Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            BisqText.largeRegular(text = value)
+
+            if(priceFragments.size == 2) {
+                BisqGap.HHalf()
+                BisqText.baseRegularGrey(priceFragments[1])
+            }
+        }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/info/InfoBoxCurrency.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/info/InfoBoxCurrency.kt
@@ -1,0 +1,19 @@
+package network.bisq.mobile.presentation.ui.components.molecules.info
+
+import androidx.compose.runtime.Composable
+import network.bisq.mobile.presentation.ui.components.molecules.AmountWithCurrency
+
+@Composable
+fun InfoBoxCurrency(
+    label: String,
+    value: String,
+    rightAlign: Boolean = false,
+) {
+    InfoBox(
+        label = label,
+        rightAlign = rightAlign,
+        valueComposable = {
+            AmountWithCurrency(value)
+        }
+    )
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/Dashboard.kt
@@ -24,6 +24,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
+import network.bisq.mobile.presentation.ui.components.molecules.AmountWithCurrency
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -135,12 +136,9 @@ fun WelcomeCard(
 fun PriceProfileCard(price: String, priceText: String) {
     BisqCard(
         borderRadius = BisqUIConstants.ScreenPaddingQuarter,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        BisqText.largeRegular(
-            text = price,
-            textAlign = TextAlign.Center,
-        )
+        AmountWithCurrency(price)
 
         BisqGap.V1()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBox
+import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxCurrency
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxSats
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoRowContainer
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
@@ -53,7 +54,7 @@ fun CreateOfferReviewOfferScreen() {
             )
             if (presenter.isRangeOffer) {
                 if (presenter.direction == DirectionEnum.BUY) {
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                         value = presenter.amountToPay
                     )
@@ -72,7 +73,7 @@ fun CreateOfferReviewOfferScreen() {
                         }
                     )
                 } else {
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                         value = presenter.amountToReceive
                     )
@@ -94,7 +95,7 @@ fun CreateOfferReviewOfferScreen() {
             } else {
                 if (presenter.direction == DirectionEnum.BUY) {
                     InfoRowContainer {
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                             value = presenter.amountToPay,
                         )
@@ -109,7 +110,7 @@ fun CreateOfferReviewOfferScreen() {
                             label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                             value = presenter.amountToPay
                         )
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                             value = presenter.amountToReceive,
                         )
@@ -127,6 +128,7 @@ fun CreateOfferReviewOfferScreen() {
                         horizontalArrangement = Arrangement.spacedBy(2.dp)
                     ) {
                         BisqText.h6Regular(presenter.formattedPrice)
+                        BisqGap.HQuarter()
                         BisqText.baseRegularGrey(presenter.marketCodes)
                     }
                 },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
@@ -3,12 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.offerbook
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -26,6 +21,7 @@ import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferIt
 import network.bisq.mobile.domain.utils.StringUtils.truncate
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.components.atoms.icons.RemoveOfferIcon
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqVDivider
 import network.bisq.mobile.presentation.ui.components.molecules.PaymentMethods
@@ -136,7 +132,16 @@ fun OfferCard(
 
             BisqGap.V1()
 
-            PaymentMethods(item.baseSidePaymentMethods, item.quoteSidePaymentMethods)
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                PaymentMethods(item.baseSidePaymentMethods, item.quoteSidePaymentMethods)
+
+                if (isMyOffer) {
+                    RemoveOfferIcon()
+                }
+            }
             
             if (isInvalidDueToReputation) {
                 BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -117,13 +117,13 @@ fun TradeDetailsHeader() {
                 if (isSell) {
                     InfoBoxSats(label = presenter.leftAmountDescription, value = leftAmount)
                 } else {
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = presenter.leftAmountDescription,
                         value = "$leftAmount $leftCode"
                     )
                 }
                 if (isSell) {
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = presenter.rightAmountDescription,
                         value = "$rightAmount $rightCode"
                     )
@@ -135,13 +135,13 @@ fun TradeDetailsHeader() {
                     if (isSell) {
                         InfoBoxSats(label = presenter.leftAmountDescription, value = leftAmount)
                     } else {
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = presenter.leftAmountDescription,
                             value = "$leftAmount $leftCode"
                         )
                     }
                     if (isSell) {
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = presenter.rightAmountDescription,
                             value = "$rightAmount $rightCode",
                             rightAlign = true

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowItem.kt
@@ -87,11 +87,11 @@ fun TradeFlowItem(
                 )
 
             } else if (isActive) {
-                BisqText.baseBold(
+                BisqText.baseRegular(
                     textAlign = TextAlign.Center,
                     text = text,
                     color = textColor,
-                    modifier = Modifier.padding(start = 8.dp, top = 2.dp)
+                    modifier = Modifier.padding(start = 7.dp, top = 1.dp)
                 )
 
             } else {
@@ -99,7 +99,7 @@ fun TradeFlowItem(
                     textAlign = TextAlign.Center,
                     text = text,
                     color = textColor,
-                    modifier = Modifier.padding(start = 8.dp, top = 2.dp)
+                    modifier = Modifier.padding(start = 7.dp, top = 1.dp)
                 )
             }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewScreen.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBox
+import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxCurrency
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxSats
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoRowContainer
 import network.bisq.mobile.presentation.ui.components.organisms.offer.TakeOfferProgressDialog
@@ -55,7 +56,7 @@ fun TakeOfferReviewTradeScreen() {
             )
             if (presenter.takersDirection.isBuy) {
                 if (presenter.isSmallScreen()) {
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                         value = presenter.amountToPay,
                     )
@@ -66,7 +67,7 @@ fun TakeOfferReviewTradeScreen() {
                     )
                 } else {
                     InfoRowContainer {
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                             value = presenter.amountToPay,
                         )
@@ -83,7 +84,7 @@ fun TakeOfferReviewTradeScreen() {
                         label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                         value = presenter.amountToPay,
                     )
-                    InfoBox(
+                    InfoBoxCurrency(
                         label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                         value = presenter.amountToReceive,
                         rightAlign = true
@@ -94,7 +95,7 @@ fun TakeOfferReviewTradeScreen() {
                             label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                             value = presenter.amountToPay,
                         )
-                        InfoBox(
+                        InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                             value = presenter.amountToReceive,
                             rightAlign = true
@@ -118,6 +119,7 @@ fun TakeOfferReviewTradeScreen() {
                             horizontalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
                             BisqText.h6Regular(presenter.price)
+                            BisqGap.HQuarter()
                             BisqText.baseRegularGrey(presenter.marketCodes)
                         }
                         BisqText.smallRegularGrey(presenter.priceDetails)


### PR DESCRIPTION
 * Fixes #402 Allowing negative % in Create offer price screen. Also added a slider to set the percentage.
 * Fixes #411 Step number: Centering
 * Fixes #412 Text Field: Label in red on error state
 * Fixes #438 Added remove icon in my own cards in offer list
 * Fixes #440 Trade price spacing, between price value and currency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a slider control for selecting percentage price in the offer creation screen.
  * Introduced a new component to display amounts with currency formatting.
  * Added a new info box component specifically for currency values.

* **Enhancements**
  * Improved slider components to support configurable minimum and maximum values.
  * Enhanced text field validation and error display for better user feedback.
  * Updated icons to have consistent default sizing.
  * Refined styling for trade flow items and improved padding.

* **UI Improvements**
  * Replaced generic info boxes with currency-specific info boxes in review and trade detail screens for clearer currency display.
  * Added a remove offer icon for user-owned offers in the offer card list.
  * Improved layout and spacing in various UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->