### PR TITLE
fix: search bar clear & btn weights

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -52,6 +52,7 @@ fun BisqTextField(
     leftSuffix: (@Composable () -> Unit)? = null,
     rightSuffix: (@Composable () -> Unit)? = null,
     rightSuffixModifier: Modifier = Modifier.width(50.dp),
+    rightSuffixContentAlignment: Alignment = Alignment.CenterEnd,
     isSearch: Boolean = false,
     helperText: String = "",
     indicatorColor: Color = BisqTheme.colors.primary,
@@ -304,7 +305,10 @@ fun BisqTextField(
                         }
 
                         if (rightSuffix != null) {
-                            Box(modifier = rightSuffixModifier) {
+                            Box(
+                                modifier = rightSuffixModifier,
+                                contentAlignment = rightSuffixContentAlignment,
+                            ) {
                                 rightSuffix()
                             }
                         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/inputfield/SearchField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/inputfield/SearchField.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.presentation.ui.components.molecules.inputfield
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -35,26 +37,28 @@ fun BisqSearchField(
         else
             Modifier.width(80.dp),
         rightSuffix = {
-            if (rightSuffix != null) {
-                Row {
+            Row(horizontalArrangement = Arrangement.End) {
+                if (value.isNotEmpty()) {
                     BisqButton(
                         iconOnly = {
                             CloseIcon(color = BisqTheme.colors.mid_grey20)
                         },
                         onClick = { onValueChanged("", true) },
-                        type = BisqButtonType.Clear
+                        type = BisqButtonType.Clear,
+                        modifier = Modifier.weight(1f),
                     )
+                } else if (rightSuffix != null) {
+                    // when we don't have a clear button, we still want to
+                    // have a spacer to fill in it's place, to push the
+                    // right suffix which is a button usually in our case
+                    // to the end of the row to look better and
+                    // also prevent it from moving when our clear button is added
+                    Spacer(Modifier.weight(1f))
+                }
+
+                if (rightSuffix != null) {
                     rightSuffix()
                 }
-            } else {
-
-                BisqButton(
-                    iconOnly = {
-                        CloseIcon(color = BisqTheme.colors.mid_grey20)
-                    },
-                    onClick = { onValueChanged("", true) },
-                    type = BisqButtonType.Clear
-                )
             }
         },
         isSearch = true,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.CurrencyCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
@@ -56,7 +57,8 @@ fun OfferbookMarketScreen() {
                         }
                     },
                     onClick = { showFilterDialog = true },
-                    type = BisqButtonType.Clear
+                    type = BisqButtonType.Clear,
+                    modifier = Modifier.weight(1f),
                 )
             }
         )


### PR DESCRIPTION
fix #423
the button were actually not in equal size and the filter button would move unnecessarily without the spacer when weights are adjusted, so I thought it would be better to fix those issues as well by aligning the content to the right and setting the weight modifiers equally

here's a video comparison:
old:

[old.webm](https://github.com/user-attachments/assets/3bced3ca-cf06-4a4d-b374-10f26ed310f8)

new:

[new.webm](https://github.com/user-attachments/assets/3eaa8770-de3a-4c81-8a38-4a18306be5af)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the layout stability of search and text fields, ensuring consistent alignment and spacing for suffix elements and clear buttons.
* **Style**
  * Enhanced alignment options for text field components, allowing for more precise control over suffix content positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->