### PR TITLE
fix: chat input & add padding to msg list end

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/SettingsTextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/SettingsTextField.kt
@@ -16,6 +16,7 @@ fun SettingsTextField(
         value = value,
         disabled = !editable,
         isTextArea = isTextArea,
+        minLines = if (isTextArea) 2 else 1,
         onValueChange = { newValue, isValid ->
             if (onValueChange != null) {
                 onValueChange(newValue, isValid)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -59,6 +59,7 @@ fun BisqTextField(
     isTextArea: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Unspecified,
     paddingValues: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
+    minLines: Int = 1,
     maxLength: Int = 0,
     disabled: Boolean = false,
     color: Color = BisqTheme.colors.light_grey20,
@@ -74,6 +75,7 @@ fun BisqTextField(
         fontSize = 18.sp,
         textDecoration = TextDecoration.None
     ),
+    textFieldAlignment: Alignment = Alignment.TopStart,
 ) {
     var hasInteracted by remember { mutableStateOf(false) }
     var isFocused by remember { mutableStateOf(false) }
@@ -266,7 +268,7 @@ fun BisqTextField(
                     },
                 singleLine = !isTextArea,
                 maxLines = if (isTextArea) 4 else 1,
-                minLines = if (isTextArea) 2 else 1,
+                minLines = minLines,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = keyboardType,
                     imeAction = imeAction
@@ -285,7 +287,10 @@ fun BisqTextField(
                             Spacer(modifier = Modifier.width(10.dp))
                         }
 
-                        Box(modifier = Modifier.weight(1f)) {
+                        Box(
+                            modifier = Modifier.weight(1f),
+                            contentAlignment = textFieldAlignment,
+                        ) {
                             if (value.isEmpty()) {
                                 BisqText.largeLightGrey(placeholder)
                             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatInputField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatInputField.kt
@@ -78,7 +78,9 @@ fun ChatInputField(
                     return@BisqTextField "mobile.tradeChat.chatInput.maxLength".i18n(maxChars)
                 }
                 return@BisqTextField null
-            }
+            },
+            minLines = 1,
+            textFieldAlignment = Alignment.CenterStart,
         )
 
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ProfileIconAndText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bot_image
 import network.bisq.mobile.domain.PlatformImage
@@ -36,7 +37,7 @@ fun ProfileIconAndText(
 
         val icon = @Composable {
             Image(
-                painter = painter, "", modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
+                painter = painter, "", modifier = Modifier.size(30.dp) // same size as top bar
             )
         }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/TrustedNodeAPIIncompatiblePopup.kt
@@ -34,6 +34,7 @@ fun TrustedNodeAPIIncompatiblePopup(
             value = errorMessage,
             indicatorColor = BisqTheme.colors.backgroundColor,
             isTextArea = true,
+            minLines = 2,
         )
 
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
@@ -87,7 +87,7 @@ fun ChatMessageList(
                         )
                     }
                 }
-                item { Spacer(Modifier.padding(bottom = BisqUIConstants.ScreenPadding)) }
+                item { }
             }
         }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
@@ -3,7 +3,9 @@ package network.bisq.mobile.presentation.ui.components.organisms.chat
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -85,6 +87,7 @@ fun ChatMessageList(
                         )
                     }
                 }
+                item { Spacer(Modifier.padding(bottom = BisqUIConstants.ScreenPadding)) }
             }
         }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/settings/AddPaymentAccountCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/settings/AddPaymentAccountCard.kt
@@ -80,6 +80,7 @@ fun AppPaymentAccountCard(
             placeholder = "user.paymentAccounts.createAccount.accountData.prompt".i18n(),
             label = "user.paymentAccounts.accountData".i18n(),
             isTextArea = true,
+            minLines = 2,
             validation = {
                 if (it.isEmpty()) {
                     return@BisqTextField "mobile.user.paymentAccounts.createAccount.validations.accountData.isMandatory".i18n()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1.kt
@@ -50,6 +50,7 @@ fun SellerState1(
             value = paymentAccountData,
             onValueChange = { it, isValid -> presenter.onPaymentDataInput(it, isValid) },
             isTextArea = true,
+            minLines = 2,
             showPaste = true,
             validation = {
                 // Same validation as PaymentAccountSettingsScreen.accountData field validation

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
@@ -162,6 +162,7 @@ fun PaymentAccountSettingsScreen() {
             },
             label = "user.paymentAccounts.accountData".i18n(),
             isTextArea = true,
+            minLines = 2,
             validation = {
 
                 if (it.length < 3) {


### PR DESCRIPTION
fixes #424

I added a small padding at the end of the message list because personally I find it annoying that the last message is so close to the input box,
I can remove it upon request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Text input fields now support configurable minimum visible lines, improving the display of multi-line text areas across various screens.
  * Added options to control text alignment within input fields.

* **Style**
  * Enhanced chat message list with additional bottom spacing for improved readability.
  * Standardized profile icon size for consistent UI appearance.

* **Bug Fixes**
  * Improved visibility of error messages and account descriptions by ensuring text areas display at least two lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->