### PR TITLE
Fix handling of devModeReputationScore

### DIFF
--- a/androidNode/src/main/resources/android.conf
+++ b/androidNode/src/main/resources/android.conf
@@ -1,7 +1,7 @@
 application {
     appName = "Bisq2_mobile"
     devMode = true
-    devModeReputationScore = 10000
+    devModeReputationScore = 100000
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -23,10 +23,10 @@ import network.bisq.mobile.client.service.mediation.ClientMediationServiceFacade
 import network.bisq.mobile.client.service.mediation.MediationApiGateway
 import network.bisq.mobile.client.service.network_stats.ClientProfileStatsServiceFacade
 import network.bisq.mobile.client.service.network_stats.UserProfileStats
-import network.bisq.mobile.client.service.reputation.ReputationApiGateway
 import network.bisq.mobile.client.service.offers.ClientOffersServiceFacade
 import network.bisq.mobile.client.service.offers.OfferbookApiGateway
 import network.bisq.mobile.client.service.reputation.ClientReputationServiceFacade
+import network.bisq.mobile.client.service.reputation.ReputationApiGateway
 import network.bisq.mobile.client.service.settings.ClientSettingsServiceFacade
 import network.bisq.mobile.client.service.settings.SettingsApiGateway
 import network.bisq.mobile.client.service.trades.ClientTradesServiceFacade

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.websocket.subscription.WebSocketEventPayload
-
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
@@ -40,16 +39,6 @@ class ClientReputationServiceFacade(
         super<ServiceFacade>.deactivate()
     }
 
-    // API
-    override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
-        val reputation = reputationByUserProfileId.value[userProfileId]
-        return when {
-            BuildConfig.IS_DEBUG -> reputationDevStub(userProfileId)
-            reputation == null -> Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not cached yet"))
-            else -> Result.success(reputation)
-        }
-    }
-
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> {
         return try {
             apiGateway.getProfileAge(userProfileId)
@@ -59,41 +48,17 @@ class ClientReputationServiceFacade(
         }
     }
 
-    private fun reputationDevStub(userProfileId: String): Result<ReputationScoreVO> {
-        val reputation = reputationByUserProfileId.value[userProfileId]
-        // Hardcoded rep for dev/testing
-        // val myId = "f346be"
-        val myId = "7730e" // replace with mobile User's ID
-        val bobId = "e35fe38" // replace with bisq2 user's ID
-        return when {
-            userProfileId.startsWith(myId) -> {
-                Result.success(
-                    ReputationScoreVO(
-                        totalScore = 7000,  // Default value will be 0, as bisq-mobile user wont have any rep to start with
-                        // Try with different values: 0, <1200, 1200, 1200+
-                        fiveSystemScore = 3.5, ranking = 10
-                    )
-                )
-            }
-
-            userProfileId.startsWith(bobId) -> {
-                Result.success(
-                    ReputationScoreVO(
-                        totalScore = 10000, // Default value is 0, as devModeReputationScore set is bisq2, is not propagating to mobile.
-                        fiveSystemScore = 4.2, ranking = 3
-                    )
-                )
-            }
-
-            reputation == null -> {
-                Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not cached yet"))
-            }
-
-            else -> {
-                log.w { "Dev stuff for $userProfileId not setup, returning current network reputation" }
-                Result.success(reputation)
-            }
+    // API
+    override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
+        // We do not have access to the config data, thus we check with BuildConfig.IS_DEBUG if we are in dev mode and if so,
+        // we request the reputation score from the API instead of looking up the MutableStateFlow field which would contain only
+        // scores of profiles which have real reputation. By calling the getReputationScore on the backend we will get the
+        // devModeReputationScore in case the user has set that at the backend apps config and is in devMode.
+        if (BuildConfig.IS_DEBUG) {
+            return apiGateway.getReputationScore(userProfileId)
         }
+        return reputationByUserProfileId.value[userProfileId]?.let { Result.success(it) }
+            ?: Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not found"))
     }
 
     // Private

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ReputationApiGateway.kt
@@ -8,13 +8,10 @@ import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScor
 import network.bisq.mobile.domain.utils.Logging
 
 class ReputationApiGateway(
+    private val webSocketApiClient: WebSocketApiClient,
     private val webSocketClientProvider: WebSocketClientProvider,
-    private val webSocketApiClient: WebSocketApiClient
 ) : Logging {
     private val basePath = "reputation"
-    suspend fun getReputationScore(userProfileId: String): Result<ReputationScoreVO> {
-        return webSocketApiClient.get("$basePath/score/$userProfileId")
-    }
 
     suspend fun getProfileAge(userProfileId: String): Result<Long?> {
         return webSocketApiClient.get("$basePath/profile-age/$userProfileId")
@@ -27,5 +24,9 @@ class ReputationApiGateway(
             log.e(e) { "Failed to subscribe to reputation events: ${e.message}" }
             throw e
         }
+    }
+
+    suspend fun getReputationScore(userProfileId: String): Result<ReputationScoreVO> {
+        return webSocketApiClient.get("$basePath/score/$userProfileId")
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and streamlined the logic for retrieving reputation scores, now based on a development mode flag and configuration value.
  * Removed legacy debug and network checks, consolidating the reputation retrieval process.
  * Enhanced reputation fetching by integrating a new backend API call for reputation scores.

* **Chores**
  * Updated the default development mode reputation score in the configuration from 10,000 to 100,000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->