### PR TITLE
fix: change TextField label color

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/TextField.kt
@@ -15,7 +15,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -134,7 +140,7 @@ fun BisqTextField(
     val finalLabelColor by remember(disabled, validationError, hasInteracted) {
         derivedStateOf {
             when {
-                disabled -> BisqTheme.colors.dark_grey50
+                disabled -> BisqTheme.colors.mid_grey30
                 isFocused -> BisqTheme.colors.primary
                 validationError?.isNotEmpty() == true && hasInteracted -> BisqTheme.colors.danger
                 else -> whiteColor


### PR DESCRIPTION
I simply changed the default label color across the app to be brighter in general and it looks like it solves the problem
resolves #421
resolves #491

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6e844c52-fd49-42ca-9102-b76e691a2a5f" />

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/36c80922-c15c-40cd-bb32-1bceb02dcb95" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the color of the label in disabled text fields for improved visual appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->