### PR TITLE
bugfix/market_price_update_troubles_create_offer

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
@@ -1569,6 +1569,7 @@ object GeneratedResourceBundles_af_ZA {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_af_ZA.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_af_ZA {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
@@ -1571,6 +1571,7 @@ object GeneratedResourceBundles_cs {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_cs.kt
@@ -1544,6 +1544,7 @@ object GeneratedResourceBundles_cs {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_de {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_de.kt
@@ -1569,6 +1569,7 @@ object GeneratedResourceBundles_de {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
@@ -1568,6 +1568,7 @@ object GeneratedResourceBundles_en {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_en.kt
@@ -1595,6 +1595,7 @@ object GeneratedResourceBundles_en {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_es.kt
@@ -1580,6 +1580,7 @@ object GeneratedResourceBundles_es {
             "mobile.components.copyIconButton.copied" to "ES_Text copied",
             "mobile.components.marketFilter.showMarkets" to "ES_Show Markets",
             "mobile.bisqEasy.tradeWizard.price.subTitle" to "ES_This can be defined as a percentage price which floats with the market price or fixed price.",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "ES_Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeState.info.seller.phase1.accountData.validations.minLength" to "ES_Min length: 3 characters",
             "mobile.createProfile.nickname.minLength" to "Min length: 1 character",
             "mobile.reputation.learnMore" to "ES_Learn more about the reputation system at the Bisq Wiki.",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_it {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_it.kt
@@ -1569,6 +1569,7 @@ object GeneratedResourceBundles_it {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
@@ -1554,6 +1554,7 @@ object GeneratedResourceBundles_pcm {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pcm.kt
@@ -1527,6 +1527,7 @@ object GeneratedResourceBundles_pcm {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
@@ -1569,6 +1569,7 @@ object GeneratedResourceBundles_pt_BR {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_pt_BR.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_pt_BR {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
@@ -1569,6 +1569,7 @@ object GeneratedResourceBundles_ru {
             "mobile.settings.trustedNode" to "Trusted Node",
             "mobile.openTradeNotifications.tradeCompleted.message" to "Your trade with {0} has finished as {1}",
             "mobile.onboarding.bisq2.bisqP2PInMobile" to "Bisq p2p in mobile",
+            "mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange" to "Price adjusted due to market price change",
             "mobile.profile.generatingKeyPairFailed" to "Generating the key pair failed. Profile generation won't work",
             "mobile.user.paymentAccounts.createAccount.validations.name.isMandatory" to "Name is mandatory",
             "mobile.user.paymentAccounts.createAccount.validations.name.maxLength" to "Max length: 256 characters",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/GeneratedResourceBundles_ru.kt
@@ -1542,6 +1542,7 @@ object GeneratedResourceBundles_ru {
             "mobile.user.paymentAccounts.createAccount.paymentAccount.validations.minLength" to "Min length: 3 characters",
             "mobile.components.button.passEitherTextOrCustomTextorIcon" to "Error: Pass either text or customText or icon",
             "mobile.takeOffer.unexpectedError" to "Unexpected error occurred, please try again",
+            "mobile.bisqEasy.tradeWizard.price.updateError" to "Unable to update prices due to market price change",
             "mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice" to "Min: -10%",
             "mobile.bisqEasy.offerbook.unableToDeleteOffer" to "Unable to delete offer {0}",
             "mobile.dashboard.title" to "Bisq Easy Client",

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -57,6 +57,7 @@ mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.cannotBe
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice=Min: -10%
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeLessThanMarketPrice=Max: 50%
 mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange=Price adjusted due to market price change
+mobile.bisqEasy.tradeWizard.price.updateError=Unable to update prices due to market price change
 mobile.bisqEasy.tradeWizard.amount.range.validation.minShouldBeLessThanMax=Min should be lesser than Max
 
 mobile.bisqEasy.openTrades.title=Trade ID: {0}

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -56,6 +56,7 @@ mobile.bisqEasy.tradeWizard.price.tradePrice.type.fixed.validation.shouldBeLessT
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.cannotBeEmpty=Value cannot be empty
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice=Min: -10%
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeLessThanMarketPrice=Max: 50%
+mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange=Price adjusted due to market price change
 mobile.bisqEasy.tradeWizard.amount.range.validation.minShouldBeLessThanMax=Min should be lesser than Max
 
 mobile.bisqEasy.openTrades.title=Trade ID: {0}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
@@ -26,10 +26,10 @@ class CreateOfferPricePresenter(
     private val createOfferPresenter: CreateOfferPresenter
 ) : BasePresenter(mainPresenter) {
 
-    lateinit var priceTypeTitle: String
-    lateinit var fixPriceDescription: String
+    var priceTypeTitle: String
+    var fixPriceDescription: String
     var priceTypes: List<PriceType> = PriceType.entries.toList()
-    lateinit var priceQuote: PriceQuoteVO
+    var priceQuote: PriceQuoteVO
     var percentagePriceValue: Double = 0.0
     private val _formattedPercentagePrice = MutableStateFlow("")
     val formattedPercentagePrice: StateFlow<String> = _formattedPercentagePrice
@@ -39,7 +39,6 @@ class CreateOfferPricePresenter(
     private val _formattedPrice = MutableStateFlow("")
     val formattedPrice: StateFlow<String> = _formattedPrice
     private val _formattedPriceValid = MutableStateFlow(true)
-    val formattedPriceValid: StateFlow<Boolean> = _formattedPriceValid
 
     private val _priceType = MutableStateFlow(PriceType.PERCENTAGE)
     val priceType: StateFlow<PriceType> = _priceType
@@ -49,7 +48,7 @@ class CreateOfferPricePresenter(
     private val _hintText = MutableStateFlow("")
     val hintText: StateFlow<String> = _hintText
 
-    private lateinit var createOfferModel: CreateOfferPresenter.CreateOfferModel
+    private var createOfferModel: CreateOfferPresenter.CreateOfferModel
 
     private var _showWhyPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val showWhyPopup: StateFlow<Boolean> = _showWhyPopup
@@ -73,10 +72,54 @@ class CreateOfferPricePresenter(
         fixPriceDescription = "bisqEasy.price.tradePrice.inputBoxText".i18n(createOfferModel.market!!.marketCodes)
 
         _isBuy.value = createOfferModel.direction.isBuy
-        //onPercentagePriceChanged("10")
 
         if (isBuy.value) {
             updateHintText(percentagePriceValue)
+        }
+    }
+
+    override fun onViewAttached() {
+        super.onViewAttached()
+        observeMarketPriceChanges()
+    }
+
+    private fun observeMarketPriceChanges() {
+        collectIO(marketPriceServiceFacade.selectedMarketPriceItem) { marketPriceItem ->
+            if (marketPriceItem != null) {
+                revalidateCurrentPrices()
+            }
+        }
+    }
+
+    private fun revalidateCurrentPrices() {
+        try {
+            val isCurrentlyValid = isValid(percentagePriceValue)
+
+            if (!isCurrentlyValid) {
+                // Auto-adjust to valid range
+                val adjustedPercentage = percentagePriceValue.coerceIn(-0.1, 0.5)
+                log.i { "Auto-adjusting price from ${percentagePriceValue * 100}% to ${adjustedPercentage * 100}% due to market price change" }
+
+                // Reuse existing method to update both percentage and fixed price consistently
+                val adjustedPercentageString = PercentageFormatter.format(adjustedPercentage, false)
+                onPercentagePriceChanged(adjustedPercentageString, true)
+
+                showSnackbar("mobile.bisqEasy.tradeWizard.price.adjustedDueToMarketChange".i18n())
+            } else {
+                // Price is still valid, but we need to update the calculated values based on new market price
+                if (priceType.value == PriceType.PERCENTAGE) {
+                    // For percentage price, recalculate the fixed price with new market price
+                    val currentPercentageString = _formattedPercentagePrice.value
+                    onPercentagePriceChanged(currentPercentageString, true)
+                } else {
+                    // For fixed price, recalculate the percentage with new market price
+                    val currentFixedPriceString = _formattedPrice.value
+                    onFixPriceChanged(currentFixedPriceString, true)
+                }
+            }
+
+        } catch (e: Exception) {
+            log.e(e) { "Failed to revalidate prices after market price change: ${e.message}" }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
@@ -85,8 +85,13 @@ class CreateOfferPricePresenter(
 
     private fun observeMarketPriceChanges() {
         collectIO(marketPriceServiceFacade.selectedMarketPriceItem) { marketPriceItem ->
-            if (marketPriceItem != null) {
-                revalidateCurrentPrices()
+            runCatching {
+                if (marketPriceItem != null) {
+                    revalidateCurrentPrices()
+                }
+            }.onFailure { e ->
+                log.e(e) { "Failed to process market price change: ${e.message}" }
+                showSnackbar("mobile.bisqEasy.tradeWizard.price.updateError".i18n(), isError = true)
             }
         }
     }


### PR DESCRIPTION
- fix #403  
- fixed by observing price changes on the market related to the offer creation and adjusting automatically. Also let the user know this is happening with a toast translatable message. Run generateResourceBundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now automatically revalidates and adjusts offer prices in response to market price changes, with user notifications if price adjustments occur.

* **Localization**
  * Added new localized strings for "Unable to update prices due to market price change" and "Price adjusted due to market price change" in multiple languages, enhancing multi-language support for price update notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->