### PR TITLE
chore: refactor StateFlows to use get & asStateFlow

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGeneralSettingsPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeGeneralSettingsPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.android.node.presentation
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
@@ -13,6 +14,6 @@ class NodeGeneralSettingsPresenter(
     mainPresenter: MainPresenter
 ) : GeneralSettingsPresenter(settingsServiceFacade, languageServiceFacade, mainPresenter) {
 
-    override val shouldShowPoWAdjustmentFactor: StateFlow<Boolean> = MutableStateFlow(true)
+    override val shouldShowPoWAdjustmentFactor: StateFlow<Boolean> = MutableStateFlow(true).asStateFlow()
 
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/accounts/NodeAccountsServiceFacade.kt
@@ -4,6 +4,7 @@ import bisq.account.AccountService
 import bisq.account.accounts.UserDefinedFiatAccount
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.UserDefinedFiatAccountMapping
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
@@ -14,10 +15,10 @@ class NodeAccountsServiceFacade(applicationService: AndroidApplicationService.Pr
     private val accountService: AccountService by lazy { applicationService.accountService.get() }
 
     private val _accounts = MutableStateFlow<List<UserDefinedFiatAccountVO>>(emptyList())
-    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = _accounts
+    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = _accounts.asStateFlow()
 
     private val _selectedAccount = MutableStateFlow<UserDefinedFiatAccountVO?>(null)
-    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount
+    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount.asStateFlow()
 
     override fun activate() {
         super<ServiceFacade>.activate()

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/common/NodeLanguageServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/common/NodeLanguageServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.android.node.service.common
 import bisq.common.locale.LanguageRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
 
@@ -10,10 +11,10 @@ class NodeLanguageServiceFacade : ServiceFacade(), LanguageServiceFacade {
 
     // Properties
     private val _i18nPairs: MutableStateFlow<List<Pair<String, String>>> = MutableStateFlow(emptyList())
-    override val i18nPairs: StateFlow<List<Pair<String, String>>> = _i18nPairs
+    override val i18nPairs: StateFlow<List<Pair<String, String>>> get() = _i18nPairs.asStateFlow()
 
     private val _allPairs: MutableStateFlow<List<Pair<String, String>>> = MutableStateFlow(emptyList())
-    override val allPairs: StateFlow<List<Pair<String, String>>> = _allPairs
+    override val allPairs: StateFlow<List<Pair<String, String>>> get() = _allPairs.asStateFlow()
 
     // Life cycle
     override fun activate() {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
@@ -45,7 +45,7 @@ class KmpTorService : ServiceFacade(), Logging {
     private var controlPortFileObserverJob: Job? = null
 
     private val _startupFailure: MutableStateFlow<KmpTorException?> = MutableStateFlow(null)
-    val startupFailure: StateFlow<KmpTorException?> = _startupFailure.asStateFlow()
+    val startupFailure: StateFlow<KmpTorException?> get() = _startupFailure.asStateFlow()
 
     fun startTor(baseDir: Path): CompletableDeferred<Boolean> {
         this.baseDir = baseDir

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
@@ -5,6 +5,7 @@ import bisq.common.observable.Pin
 import bisq.user.reputation.ReputationService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.AndroidApplicationService
@@ -20,7 +21,7 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
     // Properties
     private val _reputationByUserProfileId: MutableStateFlow<Map<String, ReputationScoreVO>> =
         MutableStateFlow(emptyMap())
-    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId
+    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId.asStateFlow()
 
     // Misc
     private var reputationChangePin: Pin? = null

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/settings/NodeSettingsServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/settings/NodeSettingsServiceFacade.kt
@@ -6,13 +6,14 @@ import bisq.settings.ChatNotificationType
 import bisq.settings.SettingsService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
 import network.bisq.mobile.domain.data.replicated.chat.notifications.ChatChannelNotificationTypeEnum
 import network.bisq.mobile.domain.data.replicated.settings.SettingsVO
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
-import java.util.*
+import java.util.Locale
 
 class NodeSettingsServiceFacade(applicationService: AndroidApplicationService.Provider) : ServiceFacade(), SettingsServiceFacade {
     private val languageToLocaleMap = mapOf(
@@ -32,19 +33,19 @@ class NodeSettingsServiceFacade(applicationService: AndroidApplicationService.Pr
 
     // Properties
     private val _isTacAccepted: MutableStateFlow<Boolean?> = MutableStateFlow(null)
-    override val isTacAccepted: StateFlow<Boolean?> get() = _isTacAccepted
+    override val isTacAccepted: StateFlow<Boolean?> get() = _isTacAccepted.asStateFlow()
     override suspend fun confirmTacAccepted(value: Boolean) {
         settingsService.setIsTacAccepted(value)
     }
 
     private val _tradeRulesConfirmed = MutableStateFlow(false)
-    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed
+    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed.asStateFlow()
     override suspend fun confirmTradeRules(value: Boolean) {
         settingsService.setTradeRulesConfirmed(value)
     }
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
-    override val languageCode: StateFlow<String> get() = _languageCode
+    override val languageCode: StateFlow<String> get() = _languageCode.asStateFlow()
     override suspend fun setLanguageCode(value: String) {
         settingsService.setLanguageCode(value)
         val locale = languageToLocaleMap[value] ?: Locale("en", "US")
@@ -53,14 +54,14 @@ class NodeSettingsServiceFacade(applicationService: AndroidApplicationService.Pr
     }
 
     private val _supportedLanguageCodes: MutableStateFlow<Set<String>> = MutableStateFlow(emptySet())
-    override val supportedLanguageCodes: StateFlow<Set<String>> get() = _supportedLanguageCodes
+    override val supportedLanguageCodes: StateFlow<Set<String>> get() = _supportedLanguageCodes.asStateFlow()
     override suspend fun setSupportedLanguageCodes(value: Set<String>) {
         settingsService.supportedLanguageCodes.setAll(value)
     }
 
     private val _chatNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =
         MutableStateFlow(ChatChannelNotificationTypeEnum.ALL)
-    override val chatNotificationType: StateFlow<ChatChannelNotificationTypeEnum> get() = _chatNotificationType
+    override val chatNotificationType: StateFlow<ChatChannelNotificationTypeEnum> get() = _chatNotificationType.asStateFlow()
     override suspend fun setChatNotificationType(value: ChatChannelNotificationTypeEnum) {
         settingsService.setChatNotificationType(
             when (value) {
@@ -73,37 +74,37 @@ class NodeSettingsServiceFacade(applicationService: AndroidApplicationService.Pr
     }
 
     private val _closeMyOfferWhenTaken = MutableStateFlow(true)
-    override val closeMyOfferWhenTaken: StateFlow<Boolean> get() = _closeMyOfferWhenTaken
+    override val closeMyOfferWhenTaken: StateFlow<Boolean> get() = _closeMyOfferWhenTaken.asStateFlow()
     override suspend fun setCloseMyOfferWhenTaken(value: Boolean) {
         settingsService.setCloseMyOfferWhenTaken(value)
     }
 
     private val _maxTradePriceDeviation = MutableStateFlow(5.0)
-    override val maxTradePriceDeviation: StateFlow<Double> get() = _maxTradePriceDeviation
+    override val maxTradePriceDeviation: StateFlow<Double> get() = _maxTradePriceDeviation.asStateFlow()
     override suspend fun setMaxTradePriceDeviation(value: Double) {
         settingsService.setMaxTradePriceDeviation(value)
     }
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val useAnimations: StateFlow<Boolean> get() = _useAnimations
+    override val useAnimations: StateFlow<Boolean> get() = _useAnimations.asStateFlow()
     override suspend fun setUseAnimations(value: Boolean) {
         settingsService.setUseAnimations(value)
     }
 
     private val _difficultyAdjustmentFactor: MutableStateFlow<Double> = MutableStateFlow(1.0)
-    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor
+    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor.asStateFlow()
     override suspend fun setDifficultyAdjustmentFactor(value: Double) {
         settingsService.setDifficultyAdjustmentFactor(value)
     }
 
     private val _numDaysAfterRedactingTradeData = MutableStateFlow(90)
-    override val numDaysAfterRedactingTradeData: StateFlow<Int> = _numDaysAfterRedactingTradeData
+    override val numDaysAfterRedactingTradeData: StateFlow<Int> get() = _numDaysAfterRedactingTradeData.asStateFlow()
     override suspend fun setNumDaysAfterRedactingTradeData(days: Int) {
         settingsService.setNumDaysAfterRedactingTradeData(days)
     }
 
     private val _ignoreDiffAdjustmentFromSecManager: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager
+    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
     override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean) {
         settingsService.setIgnoreDiffAdjustmentFromSecManager(value)
     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
@@ -28,9 +28,9 @@ import bisq.user.identity.UserIdentityService
 import bisq.user.profile.UserProfile
 import bisq.user.profile.UserProfileService
 import bisq.user.reputation.ReputationService
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeout
 import network.bisq.mobile.android.node.AndroidApplicationService
@@ -93,10 +93,10 @@ class NodeTradesServiceFacade(
 
     // Properties
     private val _openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
-    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems
+    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems.asStateFlow()
 
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade
+    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
 
     // Misc
     private var tradesPin: Pin? = null

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,7 +49,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
 
     // Properties
     private val _selectedUserProfile: MutableStateFlow<UserProfileVO?> = MutableStateFlow(null)
-    override val selectedUserProfile: StateFlow<UserProfileVO?> = _selectedUserProfile
+    override val selectedUserProfile: StateFlow<UserProfileVO?> get() = _selectedUserProfile.asStateFlow()
 
     // TODO: Performance test for 100s of users and 1000s of offers
     private val avatarMap: MutableMap<String, PlatformImage?> = mutableMapOf<String, PlatformImage?>()

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.android.kt
@@ -6,12 +6,13 @@ import android.content.Context
 import android.os.Bundle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.utils.Logging
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class AppForegroundController(val context: Context) : ForegroundDetector, Logging {
     private val _isForeground = MutableStateFlow(false)
-    override val isForeground: StateFlow<Boolean> = _isForeground
+    override val isForeground: StateFlow<Boolean> get() = _isForeground.asStateFlow()
 
     init {
         (context.applicationContext as Application).registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/accounts/ClientAccountsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/accounts/ClientAccountsServiceFacade.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client.service.accounts
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.accounts.AccountsServiceFacade
@@ -11,10 +12,10 @@ class ClientAccountsServiceFacade(
 ) : ServiceFacade(), AccountsServiceFacade {
 
     private val _accounts = MutableStateFlow<List<UserDefinedFiatAccountVO>>(emptyList())
-    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = _accounts
+    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = _accounts.asStateFlow()
 
     private val _selectedAccount = MutableStateFlow<UserDefinedFiatAccountVO?>(null)
-    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount
+    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = _selectedAccount.asStateFlow()
 
     override fun activate() {
         super<ServiceFacade>.activate()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -34,12 +35,12 @@ class ClientTradeChatMessagesServiceFacade(
 
     private val _allBisqEasyOpenTradeMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessageDto>> =
         MutableStateFlow(emptySet())
-    private val allBisqEasyOpenTradeMessages: StateFlow<Set<BisqEasyOpenTradeMessageDto>> =
-        _allBisqEasyOpenTradeMessages
+    private val allBisqEasyOpenTradeMessages: StateFlow<Set<BisqEasyOpenTradeMessageDto>> get() =
+        _allBisqEasyOpenTradeMessages.asStateFlow()
 
     private val _allChatReactions: MutableStateFlow<Set<BisqEasyOpenTradeMessageReactionVO>> =
         MutableStateFlow(emptySet())
-    private val allChatReactions: StateFlow<Set<BisqEasyOpenTradeMessageReactionVO>> = _allChatReactions
+    private val allChatReactions: StateFlow<Set<BisqEasyOpenTradeMessageReactionVO>> get() = _allChatReactions.asStateFlow()
 
     private var jobs: MutableSet<Job> = mutableSetOf()
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/common/ClientLanguageServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.service.common
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.common.LanguageServiceFacade
@@ -11,10 +12,10 @@ class ClientLanguageServiceFacade : ServiceFacade(), LanguageServiceFacade {
 
     // Properties
     private val _i18nPairs: MutableStateFlow<List<Pair<String, String>>> = MutableStateFlow(emptyList())
-    override val i18nPairs: StateFlow<List<Pair<String, String>>> = _i18nPairs
+    override val i18nPairs: StateFlow<List<Pair<String, String>>> get() = _i18nPairs.asStateFlow()
 
     private val _allPairs: MutableStateFlow<List<Pair<String, String>>> = MutableStateFlow(emptyList())
-    override val allPairs: StateFlow<List<Pair<String, String>>> = _allPairs
+    override val allPairs: StateFlow<List<Pair<String, String>>> get() = _allPairs.asStateFlow()
 
     private val _defaultLanguage: MutableStateFlow<String> = MutableStateFlow("en")
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/reputation/ClientReputationServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.service.reputation
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.shared.BuildConfig
@@ -18,7 +19,7 @@ class ClientReputationServiceFacade(
 
     // Properties
     private val _reputationByUserProfileId = MutableStateFlow<Map<String, ReputationScoreVO>>(emptyMap())
-    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId
+    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId.asStateFlow()
 
     // Misc
     private var reputationSequenceNumber = atomic(-1)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/settings/ClientSettingsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/settings/ClientSettingsServiceFacade.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client.service.settings
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.data.replicated.chat.notifications.ChatChannelNotificationTypeEnum
 import network.bisq.mobile.domain.data.replicated.settings.SettingsVO
@@ -12,7 +13,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     // Properties
 
     private val _isTacAccepted: MutableStateFlow<Boolean?> = MutableStateFlow(null)
-    override val isTacAccepted: StateFlow<Boolean?> get() = _isTacAccepted
+    override val isTacAccepted: StateFlow<Boolean?> get() = _isTacAccepted.asStateFlow()
     override suspend fun confirmTacAccepted(value: Boolean) {
         val result = apiGateway.confirmTacAccepted(value)
         if (result.isSuccess) {
@@ -21,7 +22,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _tradeRulesConfirmed: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed
+    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed.asStateFlow()
     override suspend fun confirmTradeRules(value: Boolean) {
         val result = apiGateway.confirmTradeRules(value)
         if (result.isSuccess) {
@@ -30,7 +31,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
-    override val languageCode: StateFlow<String> get() = _languageCode
+    override val languageCode: StateFlow<String> get() = _languageCode.asStateFlow()
     override suspend fun setLanguageCode(value: String) {
         val result = apiGateway.setLanguageCode(value)
         if (result.isSuccess) {
@@ -39,7 +40,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _supportedLanguageCodes: MutableStateFlow<Set<String>> = MutableStateFlow(emptySet())
-    override val supportedLanguageCodes: StateFlow<Set<String>> get() = _supportedLanguageCodes
+    override val supportedLanguageCodes: StateFlow<Set<String>> get() = _supportedLanguageCodes.asStateFlow()
 
     override suspend fun setSupportedLanguageCodes(value: Set<String>) {
         val result = apiGateway.setSupportedLanguageCodes(value)
@@ -50,13 +51,13 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
 
     private val _chatNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =
         MutableStateFlow(ChatChannelNotificationTypeEnum.ALL)
-    override val chatNotificationType: StateFlow<ChatChannelNotificationTypeEnum> get() = _chatNotificationType
+    override val chatNotificationType: StateFlow<ChatChannelNotificationTypeEnum> get() = _chatNotificationType.asStateFlow()
     override suspend fun setChatNotificationType(value: ChatChannelNotificationTypeEnum) {
         TODO()
     }
 
     private val _closeMyOfferWhenTaken = MutableStateFlow(true)
-    override val closeMyOfferWhenTaken: StateFlow<Boolean> get() = _closeMyOfferWhenTaken
+    override val closeMyOfferWhenTaken: StateFlow<Boolean> get() = _closeMyOfferWhenTaken.asStateFlow()
     override suspend fun setCloseMyOfferWhenTaken(value: Boolean) {
         val result = apiGateway.setCloseMyOfferWhenTaken(value)
         if (result.isSuccess) {
@@ -65,7 +66,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _maxTradePriceDeviation = MutableStateFlow(5.0)
-    override val maxTradePriceDeviation: StateFlow<Double> get() = _maxTradePriceDeviation
+    override val maxTradePriceDeviation: StateFlow<Double> get() = _maxTradePriceDeviation.asStateFlow()
     override suspend fun setMaxTradePriceDeviation(value: Double) {
         val result = apiGateway.setMaxTradePriceDeviation(value)
         if (result.isSuccess) {
@@ -74,7 +75,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val useAnimations: StateFlow<Boolean> get() = _useAnimations
+    override val useAnimations: StateFlow<Boolean> get() = _useAnimations.asStateFlow()
     override suspend fun setUseAnimations(value: Boolean) {
         val result = apiGateway.setUseAnimations(value)
         if (result.isSuccess) {
@@ -83,13 +84,13 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _difficultyAdjustmentFactor: MutableStateFlow<Double> = MutableStateFlow(1.0)
-    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor
+    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor.asStateFlow()
     override suspend fun setDifficultyAdjustmentFactor(value: Double) {
         // Not applicable for xClients
     }
 
     private val _numDaysAfterRedactingTradeData: MutableStateFlow<Int> = MutableStateFlow(90)
-    override val numDaysAfterRedactingTradeData: StateFlow<Int> get() = _numDaysAfterRedactingTradeData
+    override val numDaysAfterRedactingTradeData: StateFlow<Int> get() = _numDaysAfterRedactingTradeData.asStateFlow()
     override suspend fun setNumDaysAfterRedactingTradeData(days: Int) {
         val result = apiGateway.setNumDaysAfterRedactingTradeData(days)
         if (result.isSuccess) {
@@ -98,7 +99,7 @@ class ClientSettingsServiceFacade(private val apiGateway: SettingsApiGateway) : 
     }
 
     private val _ignoreDiffAdjustmentFromSecManager: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager
+    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
     override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean) {
         // Not applicable for xClients
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.service.trades
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.WebSocketClientProvider
@@ -54,10 +55,10 @@ class ClientTradesServiceFacade(
 
     // Properties
     private val _openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
-    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems
+    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems.asStateFlow()
 
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade
+    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
 
     // Misc
     private val tradeId get() = selectedTrade.value?.tradeId

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,7 +32,7 @@ class ClientUserProfileServiceFacade(
 
     // Properties
     private val _selectedUserProfile: MutableStateFlow<UserProfileVO?> = MutableStateFlow(null)
-    override val selectedUserProfile: StateFlow<UserProfileVO?> = _selectedUserProfile
+    override val selectedUserProfile: StateFlow<UserProfileVO?> get() = _selectedUserProfile.asStateFlow()
 
     private val avatarMap: MutableMap<String, PlatformImage?> = mutableMapOf<String, PlatformImage?>()
     private val avatarMapMutex = Mutex()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -97,7 +97,7 @@ class WebSocketClient(
         CONNECTED
     }
 
-    val _webSocketClientStatus = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
+    private val _webSocketClientStatus = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
     val webSocketClientStatus: StateFlow<WebSocketClientStatus> get() = _webSocketClientStatus.asStateFlow()
 
     private var listenerJob: Job? = null

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -8,11 +8,18 @@ import io.ktor.util.collections.ConcurrentMap
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.websocket.messages.SubscriptionRequest
@@ -91,7 +98,7 @@ class WebSocketClient(
     }
 
     val _webSocketClientStatus = MutableStateFlow(WebSocketClientStatus.DISCONNECTED)
-    val webSocketClientStatus: StateFlow<WebSocketClientStatus> = _webSocketClientStatus
+    val webSocketClientStatus: StateFlow<WebSocketClientStatus> get() = _webSocketClientStatus.asStateFlow()
 
     private var listenerJob: Job? = null
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/WebSocketEventObserver.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/subscription/WebSocketEventObserver.kt
@@ -2,11 +2,12 @@ package network.bisq.mobile.client.websocket.subscription
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.client.websocket.messages.WebSocketEvent
 
 class WebSocketEventObserver {
     private val _webSocketEvent = MutableStateFlow<WebSocketEvent?>(null)
-    val webSocketEvent: StateFlow<WebSocketEvent?> = _webSocketEvent
+    val webSocketEvent: StateFlow<WebSocketEvent?> get() = _webSocketEvent.asStateFlow()
     fun setEvent(value: WebSocketEvent) {
         _webSocketEvent.value = value
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/offerbook/OfferbookMarket.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/offerbook/OfferbookMarket.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.data.model.offerbook
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVOFactory
 
@@ -11,7 +12,7 @@ import network.bisq.mobile.domain.data.replicated.common.currency.MarketVOFactor
 // todo Not used yet, maybe we can remove it later
 data class OfferbookMarket(val market: MarketVO) {
     private val _formattedPrice = MutableStateFlow("")
-    val formattedPrice: StateFlow<String> get() = _formattedPrice
+    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
 
     fun setFormattedPrice(value: String) {
         _formattedPrice.value = value

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import network.bisq.mobile.domain.data.replicated.chat.notifications.ChatChannelNotificationTypeEnum
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
@@ -23,9 +24,9 @@ class BisqEasyOpenTradeChannelModel(bisqEasyOpenTradeChannelDto: BisqEasyOpenTra
 
     // Mutable properties
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> = _isInMediation
+    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
     val _chatMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(emptySet())
-    val chatMessages: StateFlow<Set<BisqEasyOpenTradeMessageModel>> = _chatMessages
+    val chatMessages: StateFlow<Set<BisqEasyOpenTradeMessageModel>> get() = _chatMessages.asStateFlow()
     val chatChannelNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =
         MutableStateFlow(ChatChannelNotificationTypeEnum.ALL)
     val userProfileIdsOfActiveParticipants: MutableSet<String> = mutableSetOf()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
@@ -25,7 +25,7 @@ class BisqEasyOpenTradeChannelModel(bisqEasyOpenTradeChannelDto: BisqEasyOpenTra
     // Mutable properties
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
-    val _chatMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(emptySet())
+    private val _chatMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(emptySet())
     val chatMessages: StateFlow<Set<BisqEasyOpenTradeMessageModel>> get() = _chatMessages.asStateFlow()
     val chatChannelNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =
         MutableStateFlow(ChatChannelNotificationTypeEnum.ALL)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessageModel.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.CitationVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
@@ -22,7 +23,7 @@ class BisqEasyOpenTradeMessageModel(
     private val _chatReactions: MutableStateFlow<List<BisqEasyOpenTradeMessageReactionVO>> = MutableStateFlow(
         chatReactions
     )
-    val chatReactions: StateFlow<List<BisqEasyOpenTradeMessageReactionVO>> = _chatReactions
+    val chatReactions: StateFlow<List<BisqEasyOpenTradeMessageReactionVO>> get() = _chatReactions.asStateFlow()
 
     // Delegates of BisqEasyOpenTradeMessageDto
     val id: String = bisqEasyOpenTradeMessage.messageId

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
@@ -18,6 +18,7 @@ package network.bisq.mobile.domain.data.replicated.presentation.offerbook
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 
 /**
@@ -39,19 +40,19 @@ class OfferItemPresentationModel(offerItemPresentationDto: OfferItemPresentation
 
     // In case of market price or float is used, the price and the base amount need to be updated at market price updates.
     private val _formattedPrice = MutableStateFlow(offerItemPresentationDto.formattedPrice)
-    val formattedPrice: StateFlow<String> get() = _formattedPrice
+    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
 
     private val _formattedBaseAmount = MutableStateFlow(offerItemPresentationDto.formattedBaseAmount)
-    val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount
+    val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount.asStateFlow()
 
     // The user name is the nickname and the nym in case there are multiple nicknames in the network.
     // We get that set by the backend in the makersUserProfile but we need to update it after initial retrieval by websocket events.
     // At Bisq Easy the UserNameLookup class handles that.
     private val _userName = MutableStateFlow(offerItemPresentationDto.userProfile.userName)
-    val userName: StateFlow<String> get() = _userName
+    val userName: StateFlow<String> get() = _userName.asStateFlow()
 
     private val _makersReputationScore = MutableStateFlow(offerItemPresentationDto.reputationScore)
-    val makersReputationScore: StateFlow<ReputationScoreVO> get() = _makersReputationScore
+    val makersReputationScore: StateFlow<ReputationScoreVO> get() = _makersReputationScore.asStateFlow()
 
     var isInvalidDueToReputation: Boolean = false
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/MultiObjectRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.data.persistance.PersistenceSource
@@ -24,7 +25,7 @@ abstract class MultiObjectRepository<out T : BaseModel>(
 ) : Logging {
 
     private val _dataMap = MutableStateFlow<Map<String, T>>(emptyMap())
-    val dataMap: StateFlow<Map<String, T>> = _dataMap
+    val dataMap: StateFlow<Map<String, T>> get() = _dataMap.asStateFlow()
 
     private val job = Job()
     private val scope = CoroutineScope(job + IODispatcher)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/SingleObjectRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.data.persistance.PersistenceSource
@@ -24,7 +25,7 @@ abstract class SingleObjectRepository<out T : BaseModel>(
 ) : Repository<T>, Logging {
 
     private val _data = MutableStateFlow<T?>(null)
-    override val data: StateFlow<T?> = _data
+    override val data: StateFlow<T?> get() = _data.asStateFlow()
 
     private val job = Job()
     private val scope = CoroutineScope(job + IODispatcher)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.service.bootstrap
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.ServiceFacade
 
 @Suppress("RedundantOverride")
@@ -11,13 +12,13 @@ abstract class ApplicationBootstrapFacade : ServiceFacade() {
     }
 
     private val _state = MutableStateFlow("")
-    val state: StateFlow<String> = _state
+    val state: StateFlow<String> get() = _state.asStateFlow()
     fun setState(value: String) {
         _state.value = value
     }
 
     private val _progress = MutableStateFlow(0f)
-    val progress: StateFlow<Float> = _progress
+    val progress: StateFlow<Float> get() = _progress.asStateFlow()
     fun setProgress(value: Float) {
         _progress.value = value
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/market_price/MarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/market_price/MarketPriceServiceFacade.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.service.market_price
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.datetime.Clock
 import network.bisq.mobile.domain.data.model.MarketPriceItem
 import network.bisq.mobile.domain.data.model.Settings
@@ -15,11 +16,11 @@ abstract class MarketPriceServiceFacade(private val settingsRepository: Settings
     val selectedMarketPriceItem: StateFlow<MarketPriceItem?> get() = _selectedMarketPriceItem
 
     protected val _selectedFormattedMarketPrice = MutableStateFlow("N/A")
-    val selectedFormattedMarketPrice: StateFlow<String> = _selectedFormattedMarketPrice
+    val selectedFormattedMarketPrice: StateFlow<String> get() = _selectedFormattedMarketPrice.asStateFlow()
 
     // Global price update trigger - emits when any market price changes
     private val _globalPriceUpdate = MutableStateFlow(0L)
-    val globalPriceUpdate: StateFlow<Long> get() = _globalPriceUpdate
+    val globalPriceUpdate: StateFlow<Long> get() = _globalPriceUpdate.asStateFlow()
 
     // Abstract methods that must be implemented by concrete classes
     abstract fun findMarketPriceItem(marketVO: MarketVO): MarketPriceItem?

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -55,7 +56,7 @@ abstract class ConnectivityService : ServiceFacade() {
 
     private var job: Job? = null
     private val _status = MutableStateFlow(ConnectivityStatus.DISCONNECTED)
-    val status: StateFlow<ConnectivityStatus> = _status
+    val status: StateFlow<ConnectivityStatus> get() = _status.asStateFlow()
 
     /**
      * Starts monitoring connectivity every given period (ms). Default is 10 seconds.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network_stats/ProfileStatsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network_stats/ProfileStatsServiceFacade.kt
@@ -2,9 +2,10 @@ package network.bisq.mobile.domain.service.network_stats
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.ServiceFacade
 
 abstract class ProfileStatsServiceFacade : ServiceFacade() {
     protected val _publishedProfilesCount = MutableStateFlow(0)
-    val publishedProfilesCount: StateFlow<Int> = _publishedProfilesCount
+    val publishedProfilesCount: StateFlow<Int> get() = _publishedProfilesCount.asStateFlow()
 }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/service/AppForegroundController.ios.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.domain.service
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.utils.Logging
 import platform.Foundation.NSNotificationCenter
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
@@ -10,7 +11,7 @@ import platform.UIKit.UIApplicationWillEnterForegroundNotification
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class AppForegroundController : ForegroundDetector, Logging {
     private val _isForeground = MutableStateFlow(true)
-    override val isForeground: StateFlow<Boolean> = _isForeground
+    override val isForeground: StateFlow<Boolean> get() = _isForeground.asStateFlow()
 
     init {
         val notificationCenter = NSNotificationCenter.defaultCenter

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -22,8 +23,8 @@ import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
-import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import org.koin.core.component.KoinComponent
@@ -137,7 +138,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
 
     // Presenter is interactive by default
     private val _isInteractive = MutableStateFlow(true)
-    override val isInteractive: StateFlow<Boolean> = _isInteractive
+    override val isInteractive: StateFlow<Boolean> get() = _isInteractive.asStateFlow()
     private val snackbarHostState: SnackbarHostState = SnackbarHostState()
 
     override fun getSnackState(): SnackbarHostState {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -3,7 +3,17 @@ package network.bisq.mobile.presentation
 import androidx.annotation.CallSuper
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.domain.UrlLauncher
@@ -36,18 +46,18 @@ open class MainPresenter(
 
     // Observable state
     private val _isContentVisible = MutableStateFlow(false)
-    override val isContentVisible: StateFlow<Boolean> = _isContentVisible
+    override val isContentVisible: StateFlow<Boolean> get() = _isContentVisible.asStateFlow()
 
     private val _isSmallScreen = MutableStateFlow(false)
-    override val isSmallScreen: StateFlow<Boolean> = _isSmallScreen
+    override val isSmallScreen: StateFlow<Boolean> get() = _isSmallScreen.asStateFlow()
 
-    final override val languageCode: StateFlow<String> = settingsService.languageCode
+    final override val languageCode: StateFlow<String> get() = settingsService.languageCode
 
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
-    override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
+    override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> get() = _tradesWithUnreadMessages.asStateFlow()
 
     private val _readMessageCountsByTrade = MutableStateFlow(emptyMap<String, Int>())
-    override val readMessageCountsByTrade: StateFlow<Map<String, Int>> = _readMessageCountsByTrade
+    override val readMessageCountsByTrade: StateFlow<Map<String, Int>> get() = _readMessageCountsByTrade.asStateFlow()
 
     override val showAnimation: StateFlow<Boolean> get() = settingsService.useAnimations
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -91,21 +91,20 @@ fun SafeInsetsContainer(
 @Composable
 @Preview
 fun App() {
-
+    val presenter: AppPresenter = koinInject()
     val rootNavController = rememberNavController()
     val tabNavController = rememberNavController()
     var isNavControllerSet by remember { mutableStateOf(false) }
-    val presenter: AppPresenter = koinInject()
-    val languageCode by presenter.languageCode.collectAsState()
-    val showAnimation by presenter.showAnimation.collectAsState()
-
-    I18nSupport.initialize(languageCode)
-
     RememberPresenterLifecycle(presenter, {
         presenter.navController = rootNavController
         presenter.tabNavController = tabNavController
         isNavControllerSet = true
     })
+
+    val languageCode by presenter.languageCode.collectAsState()
+    val showAnimation by presenter.showAnimation.collectAsState()
+
+    I18nSupport.initialize(languageCode)
 
     SafeInsetsContainer {
         BisqTheme(darkTheme = true) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBarPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.components.molecules
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.IODispatcher
@@ -15,12 +16,12 @@ import network.bisq.mobile.presentation.ui.navigation.Routes
 open class TopBarPresenter(
     private val userRepository: UserRepository,
     private val settingsServiceFacade: SettingsServiceFacade,
-    connectivityService: ConnectivityService,
+    private val connectivityService: ConnectivityService,
     mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), ITopBarPresenter {
 
     private val _uniqueAvatar = MutableStateFlow(userRepository.data.value?.uniqueAvatar)
-    override val uniqueAvatar: StateFlow<PlatformImage?> get() = _uniqueAvatar
+    override val uniqueAvatar: StateFlow<PlatformImage?> get() = _uniqueAvatar.asStateFlow()
 
     private fun setUniqueAvatar(value: PlatformImage?) {
         _uniqueAvatar.value = value
@@ -28,7 +29,7 @@ open class TopBarPresenter(
 
     override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
 
-    override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> = connectivityService.status
+    override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> get() = connectivityService.status
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/error/GenericErrorHandler.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/error/GenericErrorHandler.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.error
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.setupUncaughtExceptionHandler
 import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
@@ -13,10 +14,10 @@ import kotlin.jvm.JvmStatic
 class GenericErrorHandler : Logging {
     companion object {
         private val _isUncaughtException: MutableStateFlow<Boolean> = MutableStateFlow(false)
-        val isUncaughtException: StateFlow<Boolean> get() = _isUncaughtException
+        val isUncaughtException: StateFlow<Boolean> get() = _isUncaughtException.asStateFlow()
 
         private val _genericErrorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
-        val genericErrorMessage: StateFlow<String?> get() = _genericErrorMessage
+        val genericErrorMessage: StateFlow<String?> get() = _genericErrorMessage.asStateFlow()
 
         fun clearGenericError() {
             _isUncaughtException.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.network_stats.ProfileStatsServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
@@ -25,12 +26,12 @@ open class DashboardPresenter(
     )
 
     private val _offersOnline = MutableStateFlow(0)
-    override val offersOnline: StateFlow<Int> = _offersOnline
+    override val offersOnline: StateFlow<Int> get() = _offersOnline.asStateFlow()
 
     private val _publishedProfiles = MutableStateFlow(0)
-    override val publishedProfiles: StateFlow<Int> = _publishedProfiles
+    override val publishedProfiles: StateFlow<Int> get() = _publishedProfiles.asStateFlow()
 
-    val formattedMarketPrice: StateFlow<String> = marketPriceServiceFacade.selectedFormattedMarketPrice
+    val formattedMarketPrice: StateFlow<String> get() = marketPriceServiceFacade.selectedFormattedMarketPrice
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -18,7 +19,7 @@ class TabContainerPresenter(
 ) : BasePresenter(mainPresenter), ITabContainerPresenter {
 
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
-    override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
+    override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> get() = _tradesWithUnreadMessages.asStateFlow()
     override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
     private var forceServicesReactivation = false
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -50,7 +50,7 @@ class CreateOfferAmountPresenter(
     lateinit var quoteCurrencyCode: String
     lateinit var formattedMinAmount: String
 
-    val _amountType: MutableStateFlow<AmountType> = MutableStateFlow(AmountType.FIXED_AMOUNT)
+    private val _amountType: MutableStateFlow<AmountType> = MutableStateFlow(AmountType.FIXED_AMOUNT)
     val amountType: StateFlow<AmountType> get() = _amountType.asStateFlow()
 
     // FIXED_AMOUNT

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -2,8 +2,8 @@ package network.bisq.mobile.presentation.ui.uicases.create_offer
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
-import network.bisq.mobile.domain.toDoubleOrNullLocaleAware
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVO
@@ -21,6 +21,7 @@ import network.bisq.mobile.domain.getGroupingSeparator
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.toDoubleOrNullLocaleAware
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.DEFAULT_MIN_USD_TRADE_AMOUNT
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.MAX_USD_TRADE_AMOUNT
@@ -50,51 +51,51 @@ class CreateOfferAmountPresenter(
     lateinit var formattedMinAmount: String
 
     val _amountType: MutableStateFlow<AmountType> = MutableStateFlow(AmountType.FIXED_AMOUNT)
-    val amountType: StateFlow<AmountType> = _amountType
+    val amountType: StateFlow<AmountType> get() = _amountType.asStateFlow()
 
     // FIXED_AMOUNT
     private val _fixedAmountSliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
-    val fixedAmountSliderPosition: StateFlow<Float> = _fixedAmountSliderPosition
+    val fixedAmountSliderPosition: StateFlow<Float> get() = _fixedAmountSliderPosition.asStateFlow()
 
     private val _reputationBasedMaxSliderValue: MutableStateFlow<Float?> = MutableStateFlow(null)
-    val reputationBasedMaxSliderValue: StateFlow<Float?> = _reputationBasedMaxSliderValue
+    val reputationBasedMaxSliderValue: StateFlow<Float?> get() = _reputationBasedMaxSliderValue.asStateFlow()
 
     private val _rightMarkerValue: MutableStateFlow<Float?> = MutableStateFlow(null)
-    val rightMarkerSliderValue: StateFlow<Float?> = _rightMarkerValue
+    val rightMarkerSliderValue: StateFlow<Float?> get() = _rightMarkerValue.asStateFlow()
 
     var formattedMinAmountWithCode: String = ""
     var formattedMaxAmountWithCode: String = ""
     private val _formattedQuoteSideFixedAmount = MutableStateFlow("")
-    val formattedQuoteSideFixedAmount: StateFlow<String> = _formattedQuoteSideFixedAmount
+    val formattedQuoteSideFixedAmount: StateFlow<String> get() = _formattedQuoteSideFixedAmount.asStateFlow()
     private val _formattedBaseSideFixedAmount = MutableStateFlow("")
-    val formattedBaseSideFixedAmount: StateFlow<String> = _formattedBaseSideFixedAmount
+    val formattedBaseSideFixedAmount: StateFlow<String> get() = _formattedBaseSideFixedAmount.asStateFlow()
 
     // RANGE_AMOUNT
     private val _minRangeSliderValue: MutableStateFlow<Float> = MutableStateFlow(0.1f)
-    var minRangeSliderValue: StateFlow<Float> = _minRangeSliderValue
+    val minRangeSliderValue: StateFlow<Float> get() = _minRangeSliderValue.asStateFlow()
     private val _maxRangeSliderValue: MutableStateFlow<Float> = MutableStateFlow(0.9f)
-    var maxRangeSliderValue: StateFlow<Float> = _maxRangeSliderValue
+    val maxRangeSliderValue: StateFlow<Float> get() = _maxRangeSliderValue.asStateFlow()
     private var rangeSliderPosition: ClosedFloatingPointRange<Float> = 0.0f..1.0f
     private val _formattedQuoteSideMinRangeAmount = MutableStateFlow("")
-    val formattedQuoteSideMinRangeAmount: StateFlow<String> = _formattedQuoteSideMinRangeAmount
+    val formattedQuoteSideMinRangeAmount: StateFlow<String> get() = _formattedQuoteSideMinRangeAmount.asStateFlow()
     private val _formattedBaseSideMinRangeAmount = MutableStateFlow("")
-    val formattedBaseSideMinRangeAmount: StateFlow<String> = _formattedBaseSideMinRangeAmount
+    val formattedBaseSideMinRangeAmount: StateFlow<String> get() = _formattedBaseSideMinRangeAmount.asStateFlow()
 
     private val _formattedQuoteSideMaxRangeAmount = MutableStateFlow("")
-    val formattedQuoteSideMaxRangeAmount: StateFlow<String> = _formattedQuoteSideMaxRangeAmount
+    val formattedQuoteSideMaxRangeAmount: StateFlow<String> get() = _formattedQuoteSideMaxRangeAmount.asStateFlow()
     private val _formattedBaseSideMaxRangeAmount = MutableStateFlow("")
-    val formattedBaseSideMaxRangeAmount: StateFlow<String> = _formattedBaseSideMaxRangeAmount
+    val formattedBaseSideMaxRangeAmount: StateFlow<String> get() = _formattedBaseSideMaxRangeAmount.asStateFlow()
     private val _requiredReputation = MutableStateFlow<Long>(0L)
-    val requiredReputation: StateFlow<Long> = _requiredReputation
+    val requiredReputation: StateFlow<Long> get() = _requiredReputation.asStateFlow()
 
     private val _amountLimitInfo = MutableStateFlow("")
-    val amountLimitInfo: StateFlow<String> = _amountLimitInfo
+    val amountLimitInfo: StateFlow<String> get() = _amountLimitInfo.asStateFlow()
 
     private val _amountLimitInfoOverlayInfo = MutableStateFlow("")
-    val amountLimitInfoOverlayInfo: StateFlow<String> = _amountLimitInfoOverlayInfo
+    val amountLimitInfoOverlayInfo: StateFlow<String> get() = _amountLimitInfoOverlayInfo.asStateFlow()
 
     private val _shouldShowWarningIcon = MutableStateFlow(false)
-    val shouldShowWarningIcon: StateFlow<Boolean> = _shouldShowWarningIcon
+    val shouldShowWarningIcon: StateFlow<Boolean> get() = _shouldShowWarningIcon.asStateFlow()
 
     private lateinit var createOfferModel: CreateOfferPresenter.CreateOfferModel
     private var minAmount: Long = DEFAULT_MIN_USD_TRADE_AMOUNT.value
@@ -106,20 +107,20 @@ class CreateOfferAmountPresenter(
     private lateinit var baseSideMinRangeAmount: CoinVO
     private lateinit var quoteSideMaxRangeAmount: FiatVO
     private lateinit var baseSideMaxRangeAmount: CoinVO
-    private var _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    var isBuy: StateFlow<Boolean> = _isBuy
+    private val _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val isBuy: StateFlow<Boolean> get() = _isBuy.asStateFlow()
 
-    private var _formattedReputationBasedMaxAmount: MutableStateFlow<String> = MutableStateFlow("")
-    val formattedReputationBasedMaxAmount: StateFlow<String> = _formattedReputationBasedMaxAmount
+    private val _formattedReputationBasedMaxAmount: MutableStateFlow<String> = MutableStateFlow("")
+    val formattedReputationBasedMaxAmount: StateFlow<String> get() = _formattedReputationBasedMaxAmount.asStateFlow()
 
-    private var _showLimitPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showLimitPopup: StateFlow<Boolean> = _showLimitPopup
+    private val _showLimitPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val showLimitPopup: StateFlow<Boolean> get() = _showLimitPopup.asStateFlow()
     fun setShowLimitPopup(newValue: Boolean) {
         _showLimitPopup.value = newValue
     }
 
-    private var _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val amountValid: StateFlow<Boolean> = _amountValid
+    private val _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val amountValid: StateFlow<Boolean> get() = _amountValid.asStateFlow()
 
     // Life cycle
     init {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferDirectionPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.create_offer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
@@ -27,7 +28,7 @@ class CreateOfferDirectionPresenter(
     private val _reputation = MutableStateFlow<ReputationScoreVO?>(null)
 
     private val _showSellerReputationWarning = MutableStateFlow(false)
-    val showSellerReputationWarning: StateFlow<Boolean> get() = _showSellerReputationWarning
+    val showSellerReputationWarning: StateFlow<Boolean> get() = _showSellerReputationWarning.asStateFlow()
     fun setShowSellerReputationWarning(value: Boolean) {
         _showSellerReputationWarning.value = value
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferMarketPresenter.kt
@@ -3,17 +3,18 @@ package network.bisq.mobile.presentation.ui.uicases.create_offer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isBuy
+import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
-import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.presentation.ui.uicases.market.MarketFilterUtil
 
 class CreateOfferMarketPresenter(
@@ -28,7 +29,7 @@ class CreateOfferMarketPresenter(
     private var marketListItem: MarketListItem? = null
 
     private var _searchText = MutableStateFlow("")
-    val searchText: StateFlow<String> = _searchText
+    val searchText: StateFlow<String> get() = _searchText.asStateFlow()
     fun setSearchText(newValue: String) {
         _searchText.value = newValue
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPricePresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.create_offer
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVOExtensions.marketCodes
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVOFactory
@@ -32,26 +33,26 @@ class CreateOfferPricePresenter(
     var priceQuote: PriceQuoteVO
     var percentagePriceValue: Double = 0.0
     private val _formattedPercentagePrice = MutableStateFlow("")
-    val formattedPercentagePrice: StateFlow<String> = _formattedPercentagePrice
+    val formattedPercentagePrice: StateFlow<String> get() = _formattedPercentagePrice.asStateFlow()
     private val _formattedPercentagePriceValid = MutableStateFlow(true)
-    val formattedPercentagePriceValid: StateFlow<Boolean> = _formattedPercentagePriceValid
+    val formattedPercentagePriceValid: StateFlow<Boolean> get() = _formattedPercentagePriceValid.asStateFlow()
 
     private val _formattedPrice = MutableStateFlow("")
-    val formattedPrice: StateFlow<String> = _formattedPrice
+    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
     private val _formattedPriceValid = MutableStateFlow(true)
 
     private val _priceType = MutableStateFlow(PriceType.PERCENTAGE)
-    val priceType: StateFlow<PriceType> = _priceType
+    val priceType: StateFlow<PriceType> get() = _priceType.asStateFlow()
 
-    private var _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    var isBuy: StateFlow<Boolean> = _isBuy
+    private val _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val isBuy: StateFlow<Boolean> get() = _isBuy.asStateFlow()
     private val _hintText = MutableStateFlow("")
-    val hintText: StateFlow<String> = _hintText
+    val hintText: StateFlow<String> get() = _hintText.asStateFlow()
 
     private var createOfferModel: CreateOfferPresenter.CreateOfferModel
 
-    private var _showWhyPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showWhyPopup: StateFlow<Boolean> = _showWhyPopup
+    private val _showWhyPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val showWhyPopup: StateFlow<Boolean> get() = _showWhyPopup.asStateFlow()
     fun setShowWhyPopup(newValue: Boolean) {
         _showWhyPopup.value = newValue
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.create_offer
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
@@ -40,7 +41,7 @@ class CreateOfferReviewPresenter(
     var isRangeOffer: Boolean = false
 
     private val _showMediatorWaitingDialog = MutableStateFlow(false)
-    val showMediatorWaitingDialog: StateFlow<Boolean> get() = _showMediatorWaitingDialog
+    val showMediatorWaitingDialog: StateFlow<Boolean> get() = _showMediatorWaitingDialog.asStateFlow()
 
     private var mediatorWaitJob: Job? = null
     private lateinit var createOfferModel: CreateOfferPresenter.CreateOfferModel

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
@@ -21,6 +21,7 @@ import org.koin.compose.koinInject
 fun TradeGuideTradeRules() {
     val presenter: TradeGuideTradeRulesPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
+
     val userAgreed by presenter.tradeRulesConfirmed.collectAsState()
     var localUserAgreed by remember(userAgreed) { mutableStateOf(userAgreed) }
     val isInteractive by presenter.isInteractive.collectAsState()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRulesPresenter.kt
@@ -13,7 +13,7 @@ class TradeGuideTradeRulesPresenter(
     private val settingsServiceFacade: SettingsServiceFacade
 ) : BasePresenter(mainPresenter) {
 
-    val tradeRulesConfirmed: StateFlow<Boolean> = settingsServiceFacade.tradeRulesConfirmed
+    val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
 
     fun prevClick() {
         navigateBack()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/WalletGuideReceiving.kt
@@ -32,9 +32,7 @@ fun WalletGuideReceiving() {
     RememberPresenterLifecycle(presenter)
 
     val isInteractive by presenter.isInteractive.collectAsState()
-
     val title = "bisqEasy.walletGuide.receive".i18n() + " - " + "bisqEasy.walletGuide.tabs.headline".i18n()
-
     var showSecondImage by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.offerbook
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
@@ -27,19 +28,19 @@ class OfferbookMarketPresenter(
     private val _marketPriceUpdated = MutableStateFlow(false)
 
     private val _sortBy = MutableStateFlow(MarketSortBy.MostOffers)
-    var sortBy: StateFlow<MarketSortBy> = _sortBy
+    val sortBy: StateFlow<MarketSortBy> get() = _sortBy.asStateFlow()
     fun setSortBy(newValue: MarketSortBy) {
         _sortBy.value = newValue
     }
 
-    private var _filter = MutableStateFlow(MarketFilter.All)
-    var filter: StateFlow<MarketFilter> = _filter
+    private val _filter = MutableStateFlow(MarketFilter.All)
+    val filter: StateFlow<MarketFilter> get() = _filter.asStateFlow()
     fun setFilter(newValue: MarketFilter) {
         _filter.value = newValue
     }
 
-    private var _searchText = MutableStateFlow("")
-    val searchText: StateFlow<String> = _searchText
+    private val _searchText = MutableStateFlow("")
+    val searchText: StateFlow<String> get() = _searchText.asStateFlow()
     fun setSearchText(newValue: String) {
         _searchText.value = newValue
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.offerbook
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
@@ -13,17 +14,17 @@ import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory.from
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.mirror
+import network.bisq.mobile.domain.data.replicated.offer.amount.spec.FixedAmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.RangeAmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMaxAmount
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMinAmount
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.domain.formatters.AmountFormatter
-import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
-import network.bisq.mobile.domain.data.replicated.offer.amount.spec.FixedAmountSpecVO
-import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.formatters.PriceSpecFormatter
+import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
@@ -48,16 +49,16 @@ class OfferbookPresenter(
 
     //todo for dev testing its more convenient
     private val _selectedDirection = MutableStateFlow(DirectionEnum.SELL)
-    val selectedDirection: StateFlow<DirectionEnum> = _selectedDirection
+    val selectedDirection: StateFlow<DirectionEnum> get() = _selectedDirection.asStateFlow()
 
     private val _sortedFilteredOffers = MutableStateFlow<List<OfferItemPresentationModel>>(emptyList())
-    val sortedFilteredOffers: StateFlow<List<OfferItemPresentationModel>> = _sortedFilteredOffers
+    val sortedFilteredOffers: StateFlow<List<OfferItemPresentationModel>> get() = _sortedFilteredOffers.asStateFlow()
 
     private val _showDeleteConfirmation = MutableStateFlow(false)
-    val showDeleteConfirmation: StateFlow<Boolean> = _showDeleteConfirmation
+    val showDeleteConfirmation: StateFlow<Boolean> get() = _showDeleteConfirmation.asStateFlow()
 
     private val _showNotEnoughReputationDialog = MutableStateFlow(false)
-    val showNotEnoughReputationDialog: StateFlow<Boolean> = _showNotEnoughReputationDialog
+    val showNotEnoughReputationDialog: StateFlow<Boolean> get() = _showNotEnoughReputationDialog.asStateFlow()
 
     var notEnoughReputationHeadline: String = ""
     var notEnoughReputationMessage: String = ""
@@ -69,7 +70,7 @@ class OfferbookPresenter(
     private val _avatarMap: MutableStateFlow<Map<String, PlatformImage?>> = MutableStateFlow(
         emptyMap()
     )
-    val avatarMap: StateFlow<Map<String, PlatformImage?>> = _avatarMap
+    val avatarMap: StateFlow<Map<String, PlatformImage?>> get() = _avatarMap.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import network.bisq.mobile.domain.PlatformImage
@@ -23,18 +24,18 @@ class OpenTradeListPresenter(
 ) : BasePresenter(mainPresenter) {
 
     private val _sortedOpenTradeItems: MutableStateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
-    val sortedOpenTradeItems: StateFlow<List<TradeItemPresentationModel>> = _sortedOpenTradeItems
+    val sortedOpenTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _sortedOpenTradeItems.asStateFlow()
 
-    val tradeRulesConfirmed: StateFlow<Boolean> = settingsServiceFacade.tradeRulesConfirmed
+    val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
 
     private val _tradeGuideVisible = MutableStateFlow(false)
-    val tradeGuideVisible: StateFlow<Boolean> get() = _tradeGuideVisible
+    val tradeGuideVisible: StateFlow<Boolean> get() = _tradeGuideVisible.asStateFlow()
 
     private val _tradesWithUnreadMessages: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
-    val tradesWithUnreadMessages: StateFlow<Map<String, Int>> = _tradesWithUnreadMessages
+    val tradesWithUnreadMessages: StateFlow<Map<String, Int>> get() = _tradesWithUnreadMessages.asStateFlow()
 
     private val _avatarMap: MutableStateFlow<Map<String, PlatformImage?>> = MutableStateFlow(emptyMap())
-    val avatarMap: StateFlow<Map<String, PlatformImage?>> = _avatarMap
+    val avatarMap: StateFlow<Map<String, PlatformImage?>> get() = _avatarMap.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/InterruptedTradePresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.TradeReadState
@@ -14,8 +15,6 @@ import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
-import kotlin.collections.orEmpty
-import kotlin.collections.toMutableMap
 
 class InterruptedTradePresenter(
     mainPresenter: MainPresenter,
@@ -24,23 +23,23 @@ class InterruptedTradePresenter(
     private val tradeReadStateRepository: TradeReadStateRepository,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
-    private var _interruptedTradeInfo: MutableStateFlow<String> = MutableStateFlow("")
-    val interruptedTradeInfo: StateFlow<String> = _interruptedTradeInfo
+    private val _interruptedTradeInfo: MutableStateFlow<String> = MutableStateFlow("")
+    val interruptedTradeInfo: StateFlow<String> get() = _interruptedTradeInfo.asStateFlow()
 
-    private var _interruptionInfoVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val interruptionInfoVisible: StateFlow<Boolean> = _interruptionInfoVisible
+    private val _interruptionInfoVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val interruptionInfoVisible: StateFlow<Boolean> get() = _interruptionInfoVisible.asStateFlow()
 
     var errorMessage: String = ""
-    private var _errorMessageVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val errorMessageVisible: StateFlow<Boolean> = _errorMessageVisible
+    private val _errorMessageVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val errorMessageVisible: StateFlow<Boolean> get() = _errorMessageVisible.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> = _isInMediation
+    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
 
     private val _reportToMediatorButtonVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val reportToMediatorButtonVisible: StateFlow<Boolean> = _reportToMediatorButtonVisible
+    val reportToMediatorButtonVisible: StateFlow<Boolean> get() = _reportToMediatorButtonVisible.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradePresenter.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.update
@@ -37,24 +38,24 @@ class OpenTradePresenter(
 ) : BasePresenter(mainPresenter) {
 
     private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade // tradesServiceFacade.selectedTrade //
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow() // tradesServiceFacade.selectedTrade //
 
     private val _tradeAbortedBoxVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val tradeAbortedBoxVisible: StateFlow<Boolean> = _tradeAbortedBoxVisible
+    val tradeAbortedBoxVisible: StateFlow<Boolean> get() = _tradeAbortedBoxVisible.asStateFlow()
 
     private val _tradeProcessBoxVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val tradeProcessBoxVisible: StateFlow<Boolean> = _tradeProcessBoxVisible
+    val tradeProcessBoxVisible: StateFlow<Boolean> get() = _tradeProcessBoxVisible.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> = _isInMediation
+    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
 
     private val _newMsgCount: MutableStateFlow<Int> = MutableStateFlow(0)
-    val newMsgCount: StateFlow<Int> = _newMsgCount
+    val newMsgCount: StateFlow<Int> get() = _newMsgCount.asStateFlow()
 
     private val _lastChatMsg: MutableStateFlow<BisqEasyOpenTradeMessageModel?> = MutableStateFlow(null)
-    val lastChatMsg: StateFlow<BisqEasyOpenTradeMessageModel?> = _lastChatMsg
+    val lastChatMsg: StateFlow<BisqEasyOpenTradeMessageModel?> get() = _lastChatMsg.asStateFlow()
 
-    private var _tradePaneScrollState: MutableStateFlow<ScrollState?> = MutableStateFlow(null)
+    private val _tradePaneScrollState: MutableStateFlow<ScrollState?> = MutableStateFlow(null)
     private var _coroutineScope: CoroutineScope? = null
 
     private var languageJob: Job? = null

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -42,15 +42,19 @@ fun OpenTradeScreen() {
     val buyerState4Presenter: BuyerState4Presenter = koinInject()
     val sellerState4Presenter: SellerState4Presenter = koinInject()
 
+    val scrollState = rememberScrollState()
+    val scope = rememberCoroutineScope()
+    RememberPresenterLifecycle(presenter, {
+        presenter.setTradePaneScrollState(scrollState)
+        presenter.setUIScope(scope)
+    })
+
     val focusManager = LocalFocusManager.current
 
     val selectedTrade by presenter.selectedTrade.collectAsState()
     val tradeAbortedBoxVisible by presenter.tradeAbortedBoxVisible.collectAsState()
     val tradeProcessBoxVisible by presenter.tradeProcessBoxVisible.collectAsState()
     val isInMediation by presenter.isInMediation.collectAsState()
-    val scrollState = rememberScrollState()
-    val scope = rememberCoroutineScope()
-
     val tradeCloseType by headerPresenter.tradeCloseType.collectAsState()
     val showInterruptionConfirmationDialog by headerPresenter.showInterruptionConfirmationDialog.collectAsState()
     val showMediationConfirmationDialog by headerPresenter.showMediationConfirmationDialog.collectAsState()
@@ -75,11 +79,6 @@ fun OpenTradeScreen() {
                     sellerState4ShowCloseTradeDialog
         }
     }
-
-    RememberPresenterLifecycle(presenter, {
-        presenter.setTradePaneScrollState(scrollState)
-        presenter.setUIScope(scope)
-    })
 
     BisqStaticScaffold(
         topBar = { TopBar("mobile.bisqEasy.openTrades.title".i18n(selectedTrade?.shortTradeId ?: "")) },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.withContext
@@ -34,44 +35,44 @@ class TradeDetailsHeaderPresenter(
 
     private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> =
         MutableStateFlow(tradesServiceFacade.selectedTrade.value)
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
 
     var direction: String = ""
     var directionEnum: DirectionEnum = DirectionEnum.BUY
     var leftAmountDescription: String = ""
-    private var _leftAmount: MutableStateFlow<String> = MutableStateFlow("")
-    var leftAmount: StateFlow<String> = _leftAmount
-    private var _leftCode: MutableStateFlow<String> = MutableStateFlow("")
-    var leftCode: StateFlow<String> = _leftCode
+    private val _leftAmount: MutableStateFlow<String> = MutableStateFlow("")
+    val leftAmount: StateFlow<String> get() = _leftAmount.asStateFlow()
+    private val _leftCode: MutableStateFlow<String> = MutableStateFlow("")
+    val leftCode: StateFlow<String> get() = _leftCode.asStateFlow()
     var rightAmountDescription: String = ""
-    private var _rightAmount: MutableStateFlow<String> = MutableStateFlow("")
-    var rightAmount: StateFlow<String> = _rightAmount
-    private var _rightCode: MutableStateFlow<String> = MutableStateFlow("")
-    var rightCode: StateFlow<String> = _rightCode
+    private val _rightAmount: MutableStateFlow<String> = MutableStateFlow("")
+    val rightAmount: StateFlow<String> get() = _rightAmount.asStateFlow()
+    private val _rightCode: MutableStateFlow<String> = MutableStateFlow("")
+    val rightCode: StateFlow<String> get() = _rightCode.asStateFlow()
 
-    private var _tradeCloseType: MutableStateFlow<TradeCloseType?> = MutableStateFlow(null)
-    val tradeCloseType: StateFlow<TradeCloseType?> = _tradeCloseType
+    private val _tradeCloseType: MutableStateFlow<TradeCloseType?> = MutableStateFlow(null)
+    val tradeCloseType: StateFlow<TradeCloseType?> get() = _tradeCloseType.asStateFlow()
 
-    private var _interruptTradeButtonText: MutableStateFlow<String> = MutableStateFlow("")
-    val interruptTradeButtonText: StateFlow<String> = _interruptTradeButtonText
+    private val _interruptTradeButtonText: MutableStateFlow<String> = MutableStateFlow("")
+    val interruptTradeButtonText: StateFlow<String> get() = _interruptTradeButtonText.asStateFlow()
 
-    private var _openMediationButtonText: MutableStateFlow<String> = MutableStateFlow("")
-    val openMediationButtonText: StateFlow<String> = _openMediationButtonText
+    private val _openMediationButtonText: MutableStateFlow<String> = MutableStateFlow("")
+    val openMediationButtonText: StateFlow<String> get() = _openMediationButtonText.asStateFlow()
 
     private val _showInterruptionConfirmationDialog = MutableStateFlow(false)
-    val showInterruptionConfirmationDialog: StateFlow<Boolean> get() = _showInterruptionConfirmationDialog
+    val showInterruptionConfirmationDialog: StateFlow<Boolean> get() = _showInterruptionConfirmationDialog.asStateFlow()
 
     private val _showMediationConfirmationDialog = MutableStateFlow(false)
-    val showMediationConfirmationDialog: StateFlow<Boolean> get() = _showMediationConfirmationDialog
+    val showMediationConfirmationDialog: StateFlow<Boolean> get() = _showMediationConfirmationDialog.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> = this._isInMediation
+    val isInMediation: StateFlow<Boolean> get() = this._isInMediation.asStateFlow()
 
     private val _peerAvatar: MutableStateFlow<PlatformImage?> = MutableStateFlow(null)
-    val peerAvatar: StateFlow<PlatformImage?> = _peerAvatar
+    val peerAvatar: StateFlow<PlatformImage?> get() = _peerAvatar.asStateFlow()
 
     private val _isShowDetails: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isShowDetails: StateFlow<Boolean> = this._isShowDetails
+    val isShowDetails: StateFlow<Boolean> get() = this._isShowDetails.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeFlowPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.trade.TradeRoleEnumExtensions.isSeller
 import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
@@ -74,7 +75,7 @@ class TradeFlowPresenter(
     val buyerState4Presenter = tradeStatesProvider.buyerState4Presenter
     val sellerState4Presenter = tradeStatesProvider.sellerState4Presenter
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
     val steps = listOf(
         TradeFlowStep.ACCOUNT_DETAILS,
         TradeFlowStep.FIAT_PAYMENT,
@@ -82,8 +83,8 @@ class TradeFlowPresenter(
         TradeFlowStep.TRADE_COMPLETED
     )
 
-    private var _tradePhaseState: MutableStateFlow<TradePhaseState> = MutableStateFlow(TradePhaseState.INIT)
-    val tradePhaseState: StateFlow<TradePhaseState> = _tradePhaseState
+    private val _tradePhaseState: MutableStateFlow<TradePhaseState> = MutableStateFlow(TradePhaseState.INIT)
+    val tradePhaseState: StateFlow<TradePhaseState> get() = _tradePhaseState.asStateFlow()
 
     private var isSeller: Boolean = false
     private var isMainChain: Boolean = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState1aPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -17,22 +18,22 @@ class BuyerState1aPresenter(
 ) : BasePresenter(mainPresenter) {
 
     private var _headline = MutableStateFlow("")
-    val headline: StateFlow<String> get() = _headline
+    val headline: StateFlow<String> get() = _headline.asStateFlow()
 
     private var _description = MutableStateFlow("")
-    val description: StateFlow<String> get() = _description
+    val description: StateFlow<String> get() = _description.asStateFlow()
 
     private var _bitcoinPaymentData = MutableStateFlow("")
-    val bitcoinPaymentData: StateFlow<String> get() = _bitcoinPaymentData
+    val bitcoinPaymentData: StateFlow<String> get() = _bitcoinPaymentData.asStateFlow()
 
     private var _bitcoinPaymentDataValid = MutableStateFlow(false)
-    val bitcoinPaymentDataValid: StateFlow<Boolean> get() = _bitcoinPaymentDataValid
+    val bitcoinPaymentDataValid: StateFlow<Boolean> get() = _bitcoinPaymentDataValid.asStateFlow()
 
     private var _bitcoinAddressFieldType = MutableStateFlow(BitcoinLnAddressFieldType.Bitcoin)
-    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType
+    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType.asStateFlow()
 
     private val _showInvalidAddressDialog = MutableStateFlow(false)
-    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog
+    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog.asStateFlow()
     fun setShowInvalidAddressDialog(value: Boolean) {
         _showInvalidAddressDialog.value = value
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2aPresenter.kt
@@ -12,7 +12,7 @@ class BuyerState2aPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     override fun onViewUnattaching() {
         super.onViewUnattaching()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState2bPresenter.kt
@@ -9,8 +9,8 @@ import network.bisq.mobile.presentation.MainPresenter
 
 class BuyerState2bPresenter(
     mainPresenter: MainPresenter,
-    tradesServiceFacade: TradesServiceFacade,
+    private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerState3aPresenter.kt
@@ -8,8 +8,8 @@ import network.bisq.mobile.presentation.MainPresenter
 
 class BuyerState3aPresenter(
     mainPresenter: MainPresenter,
-    tradesServiceFacade: TradesServiceFacade,
+    private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateLightning3bPresenter.kt
@@ -11,7 +11,7 @@ class BuyerStateLightning3bPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     fun onCompleteTrade() {
         launchIO {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/BuyerStateMainChain3bPresenter.kt
@@ -1,9 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory
@@ -26,25 +26,25 @@ class BuyerStateMainChain3bPresenter(
     private val explorerServiceFacade: ExplorerServiceFacade
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _buttonText: MutableStateFlow<String> = MutableStateFlow("")
-    val buttonText: StateFlow<String> = _buttonText
+    val buttonText: StateFlow<String> get() = _buttonText.asStateFlow()
 
     private val _txConfirmationState: MutableStateFlow<TxConfirmationState> = MutableStateFlow(IDLE)
-    val txConfirmationState: StateFlow<TxConfirmationState> = _txConfirmationState
+    val txConfirmationState: StateFlow<TxConfirmationState> get() = _txConfirmationState.asStateFlow()
 
     private val _blockExplorer: MutableStateFlow<String> = MutableStateFlow("")
-    val blockExplorer: StateFlow<String> = _blockExplorer
+    val blockExplorer: StateFlow<String> get() = _blockExplorer.asStateFlow()
 
     private val _balanceFromTx: MutableStateFlow<String> = MutableStateFlow("")
-    val balanceFromTx: StateFlow<String> = _balanceFromTx
+    val balanceFromTx: StateFlow<String> get() = _balanceFromTx.asStateFlow()
 
     private val _errorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
-    val errorMessage: StateFlow<String?> = _errorMessage
+    val errorMessage: StateFlow<String?> get() = _errorMessage.asStateFlow()
 
     private val _skip: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val skip: StateFlow<Boolean> = _skip
+    val skip: StateFlow<Boolean> get() = _skip.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState1Presenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.account.UserDefinedFiatAccountVO
@@ -16,16 +17,16 @@ class SellerState1Presenter(
     private val accountsServiceFacade: AccountsServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val accounts: StateFlow<List<UserDefinedFiatAccountVO>> = accountsServiceFacade.accounts
+    val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = accountsServiceFacade.accounts
 
     private var _paymentAccountData = MutableStateFlow("")
-    val paymentAccountData: StateFlow<String> get() = _paymentAccountData
+    val paymentAccountData: StateFlow<String> get() = _paymentAccountData.asStateFlow()
 
     private var _paymentAccountDataValid = MutableStateFlow(false)
-    val paymentAccountDataValid: StateFlow<Boolean> get() = _paymentAccountDataValid
+    val paymentAccountDataValid: StateFlow<Boolean> get() = _paymentAccountDataValid.asStateFlow()
 
     private var _paymentAccountName = MutableStateFlow("")
-    val paymentAccountName: StateFlow<String> get() = _paymentAccountName
+    val paymentAccountName: StateFlow<String> get() = _paymentAccountName.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2aPresenter.kt
@@ -8,7 +8,7 @@ import network.bisq.mobile.presentation.MainPresenter
 
 class SellerState2aPresenter(
     mainPresenter: MainPresenter,
-    tradesServiceFacade: TradesServiceFacade,
+    private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState2bPresenter.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -11,7 +10,7 @@ class SellerState2bPresenter(
     mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     override fun onViewUnattaching() {
         super.onViewUnattaching()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3aPresenter.kt
@@ -1,8 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
@@ -16,28 +16,28 @@ class SellerState3aPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
-    private var _paymentProof: MutableStateFlow<String?> = MutableStateFlow(null)
-    val paymentProof: StateFlow<String?> get() = _paymentProof
+    private val _paymentProof: MutableStateFlow<String?> = MutableStateFlow(null)
+    val paymentProof: StateFlow<String?> get() = _paymentProof.asStateFlow()
 
-    private var _paymentProofValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val paymentProofValid: StateFlow<Boolean> get() = _paymentProofValid
+    private val _paymentProofValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val paymentProofValid: StateFlow<Boolean> get() = _paymentProofValid.asStateFlow()
 
     private val _showInvalidAddressDialog = MutableStateFlow(false)
-    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog
+    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog.asStateFlow()
     fun setShowInvalidAddressDialog(value: Boolean) {
         _showInvalidAddressDialog.value = value
     }
 
-    private var _buttonEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val buttonEnabled: StateFlow<Boolean> get() = _buttonEnabled
+    private val _buttonEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val buttonEnabled: StateFlow<Boolean> get() = _buttonEnabled.asStateFlow()
 
     private var _bitcoinAddressFieldType = MutableStateFlow(BitcoinLnAddressFieldType.Bitcoin)
-    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType
+    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType.asStateFlow()
 
-    private var _isLightning: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isLightning: StateFlow<Boolean> get() = _isLightning
+    private val _isLightning: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isLightning: StateFlow<Boolean> get() = _isLightning.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateLightning3bPresenter.kt
@@ -1,8 +1,8 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelModel
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -15,8 +15,8 @@ class SellerStateLightning3bPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
 
-    private var _buyerHasConfirmedBitcoinReceipt: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    var buyerHasConfirmedBitcoinReceipt: StateFlow<Boolean> = _buyerHasConfirmedBitcoinReceipt
+    private val _buyerHasConfirmedBitcoinReceipt: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val buyerHasConfirmedBitcoinReceipt: StateFlow<Boolean> get() = _buyerHasConfirmedBitcoinReceipt.asStateFlow()
     fun setBuyerHasConfirmedBitcoinReceipt(value: Boolean) {
         _buyerHasConfirmedBitcoinReceipt.value = value
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerStateMainChain3bPresenter.kt
@@ -1,9 +1,9 @@
 package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVOFactory
@@ -27,25 +27,25 @@ class SellerStateMainChain3bPresenter(
     private val explorerServiceFacade: ExplorerServiceFacade
 ) : BasePresenter(mainPresenter) {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _buttonText: MutableStateFlow<String> = MutableStateFlow("")
-    val buttonText: StateFlow<String> = _buttonText
+    val buttonText: StateFlow<String> get() = _buttonText.asStateFlow()
 
     private val _txConfirmationState: MutableStateFlow<TxConfirmationState> = MutableStateFlow(IDLE)
-    val txConfirmationState: StateFlow<TxConfirmationState> = _txConfirmationState
+    val txConfirmationState: StateFlow<TxConfirmationState> get() = _txConfirmationState.asStateFlow()
 
     private val _blockExplorer: MutableStateFlow<String> = MutableStateFlow("")
-    val blockExplorer: StateFlow<String> = _blockExplorer
+    val blockExplorer: StateFlow<String> get() = _blockExplorer.asStateFlow()
 
     private val _balanceFromTx: MutableStateFlow<String> = MutableStateFlow("")
-    val balanceFromTx: StateFlow<String> = _balanceFromTx
+    val balanceFromTx: StateFlow<String> get() = _balanceFromTx.asStateFlow()
 
     private val _errorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
-    val errorMessage: StateFlow<String?> = _errorMessage
+    val errorMessage: StateFlow<String?> get() = _errorMessage.asStateFlow()
 
     private val _skip: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val skip: StateFlow<Boolean> = _skip
+    val skip: StateFlow<Boolean> get() = _skip.asStateFlow()
 
 
     override fun onViewAttached() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/State4Presenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.open_trades.selected.states
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.model.TradeReadState
@@ -11,18 +12,16 @@ import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
-import kotlin.collections.orEmpty
-import kotlin.collections.toMutableMap
 
 abstract class State4Presenter(
     mainPresenter: MainPresenter,
     private val tradesServiceFacade: TradesServiceFacade,
     private val tradeReadStateRepository: TradeReadStateRepository,
 ) : BasePresenter(mainPresenter) {
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _showCloseTradeDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showCloseTradeDialog: StateFlow<Boolean> = _showCloseTradeDialog
+    val showCloseTradeDialog: StateFlow<Boolean> get() = _showCloseTradeDialog.asStateFlow()
 
     override fun onViewUnattaching() {
         _showCloseTradeDialog.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/trade_chat/TradeChatPresenter.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -34,19 +35,19 @@ class TradeChatPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
 ) : BasePresenter(mainPresenter), Logging {
 
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> = tradesServiceFacade.selectedTrade
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _chatMessages: MutableStateFlow<List<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(listOf())
-    val chatMessages: StateFlow<List<BisqEasyOpenTradeMessageModel>> = _chatMessages
+    val chatMessages: StateFlow<List<BisqEasyOpenTradeMessageModel>> get() = _chatMessages.asStateFlow()
 
     private val _quotedMessage: MutableStateFlow<BisqEasyOpenTradeMessageModel?> = MutableStateFlow(null)
-    val quotedMessage: StateFlow<BisqEasyOpenTradeMessageModel?> = _quotedMessage
+    val quotedMessage: StateFlow<BisqEasyOpenTradeMessageModel?> get() = _quotedMessage.asStateFlow()
 
     private val _showChatRulesWarnBox: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val showChatRulesWarnBox: StateFlow<Boolean> = _showChatRulesWarnBox
+    val showChatRulesWarnBox: StateFlow<Boolean> get() = _showChatRulesWarnBox.asStateFlow()
 
     private val _avatarMap: MutableStateFlow<Map<String, PlatformImage?>> = MutableStateFlow(emptyMap())
-    val avatarMap: StateFlow<Map<String, PlatformImage?>> = _avatarMap
+    val avatarMap: StateFlow<Map<String, PlatformImage?>> get() = _avatarMap.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases.settings
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import network.bisq.mobile.domain.data.replicated.settings.SettingsVO
 import network.bisq.mobile.domain.formatters.NumberFormatter
@@ -21,8 +22,8 @@ open class GeneralSettingsPresenter(
     private val mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), IGeneralSettingsPresenter {
 
-    override val i18nPairs: StateFlow<List<Pair<String, String>>> = languageServiceFacade.i18nPairs
-    override val allLanguagePairs: StateFlow<List<Pair<String, String>>> = languageServiceFacade.allPairs
+    override val i18nPairs: StateFlow<List<Pair<String, String>>> get() = languageServiceFacade.i18nPairs
+    override val allLanguagePairs: StateFlow<List<Pair<String, String>>> get() = languageServiceFacade.allPairs
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("en")
     override val languageCode: MutableStateFlow<String> = _languageCode
@@ -64,7 +65,7 @@ open class GeneralSettingsPresenter(
 
     private val _chatNotification: MutableStateFlow<String> =
         MutableStateFlow("chat.notificationsSettingsMenu.all".i18n())
-    override val chatNotification: StateFlow<String> = _chatNotification
+    override val chatNotification: StateFlow<String> get() = _chatNotification.asStateFlow()
     override fun setChatNotification(value: String) {
         disableInteractive()
         launchUI {
@@ -78,7 +79,7 @@ open class GeneralSettingsPresenter(
     }
 
     private val _closeOfferWhenTradeTaken: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val closeOfferWhenTradeTaken: StateFlow<Boolean> = _closeOfferWhenTradeTaken
+    override val closeOfferWhenTradeTaken: StateFlow<Boolean> get() = _closeOfferWhenTradeTaken.asStateFlow()
     override fun setCloseOfferWhenTradeTaken(value: Boolean) {
         disableInteractive()
         launchUI {
@@ -94,7 +95,7 @@ open class GeneralSettingsPresenter(
     // This is internally represented as ratio. So 100% is saved as 1.0, 5% as 0.05.
     // Hence the 100 multiplier and divider
     private val _tradePriceTolerance: MutableStateFlow<String> = MutableStateFlow("5")
-    override val tradePriceTolerance: StateFlow<String> = _tradePriceTolerance
+    override val tradePriceTolerance: StateFlow<String> get() = _tradePriceTolerance.asStateFlow()
     override fun setTradePriceTolerance(value: String, isValid: Boolean) {
         disableInteractive()
         launchUI {
@@ -113,7 +114,7 @@ open class GeneralSettingsPresenter(
     }
 
     private val _numDaysAfterRedactingTradeData = MutableStateFlow("90")
-    override val numDaysAfterRedactingTradeData: StateFlow<String> = _numDaysAfterRedactingTradeData
+    override val numDaysAfterRedactingTradeData: StateFlow<String> get() = _numDaysAfterRedactingTradeData.asStateFlow()
     override fun setNumDaysAfterRedactingTradeData(value: String, isValid: Boolean) {
         disableInteractive()
         launchUI {
@@ -132,7 +133,7 @@ open class GeneralSettingsPresenter(
     }
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val useAnimations: StateFlow<Boolean> = _useAnimations
+    override val useAnimations: StateFlow<Boolean> get() = _useAnimations.asStateFlow()
     override fun setUseAnimations(value: Boolean) {
         disableInteractive()
         launchUI {
@@ -146,7 +147,7 @@ open class GeneralSettingsPresenter(
     }
 
     private val _powFactor: MutableStateFlow<String> = MutableStateFlow("1")
-    override val powFactor: StateFlow<String> = _powFactor
+    override val powFactor: StateFlow<String> get() = _powFactor.asStateFlow()
     override fun setPowFactor(value: String, isValid: Boolean) {
         disableInteractive()
         launchUI {
@@ -163,7 +164,7 @@ open class GeneralSettingsPresenter(
     }
 
     private val _ignorePow: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val ignorePow: StateFlow<Boolean> = _ignorePow
+    override val ignorePow: StateFlow<Boolean> get() = _ignorePow.asStateFlow()
     override fun setIgnorePow(value: Boolean) {
         disableInteractive()
         launchUI {
@@ -176,7 +177,7 @@ open class GeneralSettingsPresenter(
         }
     }
 
-    override val shouldShowPoWAdjustmentFactor: StateFlow<Boolean> = MutableStateFlow(false)
+    override val shouldShowPoWAdjustmentFactor: StateFlow<Boolean> = MutableStateFlow(false).asStateFlow()
 
     private var jobs: MutableSet<Job> = mutableSetOf()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/GeneralSettingsScreen.kt
@@ -65,6 +65,12 @@ fun GeneralSettingsScreen() {
     val presenter: IGeneralSettingsPresenter = koinInject()
     val settingsPresenter: ISettingsPresenter = koinInject()
 
+    val menuTree: MenuItem = settingsPresenter.menuTree()
+    val menuPath = remember { mutableStateListOf(menuTree) }
+    RememberPresenterLifecycle(presenter, {
+        menuPath.add((menuTree as MenuItem.Parent).children[0])
+    })
+
     val isInteractive by presenter.isInteractive.collectAsState()
     val i18nPairs by presenter.i18nPairs.collectAsState()
     val allLanguagePairs by presenter.allLanguagePairs.collectAsState()
@@ -77,13 +83,6 @@ fun GeneralSettingsScreen() {
     val powFactor by presenter.powFactor.collectAsState()
     val ignorePow by presenter.ignorePow.collectAsState()
     val shouldShowPoWAdjustmentFactor by presenter.shouldShowPoWAdjustmentFactor.collectAsState()
-
-    val menuTree: MenuItem = settingsPresenter.menuTree()
-    val menuPath = remember { mutableStateListOf(menuTree) }
-
-    RememberPresenterLifecycle(presenter, {
-        menuPath.add((menuTree as MenuItem.Parent).children[0])
-    })
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.settings.title".i18n()) },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountPresenter.kt
@@ -15,9 +15,9 @@ open class PaymentAccountPresenter(
     mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), IPaymentAccountSettingsPresenter {
 
-    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> = accountsServiceFacade.accounts
+    override val accounts: StateFlow<List<UserDefinedFiatAccountVO>> get() = accountsServiceFacade.accounts
 
-    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> = accountsServiceFacade.selectedAccount
+    override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = accountsServiceFacade.selectedAccount
 
 
     override fun selectAccount(account: UserDefinedFiatAccountVO) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountSettingsScreen.kt
@@ -51,9 +51,14 @@ interface IPaymentAccountSettingsPresenter : ViewPresenter {
 
 @Composable
 fun PaymentAccountSettingsScreen() {
-
     val presenter: IPaymentAccountSettingsPresenter = koinInject()
     val settingsPresenter: ISettingsPresenter = koinInject()
+
+    val menuTree: MenuItem = settingsPresenter.menuTree()
+    val menuPath = remember { mutableStateListOf(menuTree) }
+    RememberPresenterLifecycle(presenter, {
+        menuPath.add((menuTree as MenuItem.Parent).children[2])
+    })
 
     val isInteractive by presenter.isInteractive.collectAsState()
     val accounts by presenter.accounts.collectAsState()
@@ -66,13 +71,6 @@ fun PaymentAccountSettingsScreen() {
 
     var showConfirmationDialog by remember { mutableStateOf(false) }
     var showBottomSheet by remember { mutableStateOf(false) }
-
-    val menuTree: MenuItem = settingsPresenter.menuTree()
-    val menuPath = remember { mutableStateListOf(menuTree) }
-
-    RememberPresenterLifecycle(presenter, {
-        menuPath.add((menuTree as MenuItem.Parent).children[2])
-    })
 
     LaunchedEffect(selectedAccount) {
         accountName = selectedAccount?.accountName ?: ""

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.settings
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.IODispatcher
@@ -22,7 +23,7 @@ class UserProfileSettingsPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val reputationServiceFacade: ReputationServiceFacade,
     private val userRepository: UserRepository,
-    connectivityService: ConnectivityService,
+    private val connectivityService: ConnectivityService,
     mainPresenter: MainPresenter
 ) : BasePresenter(mainPresenter), IUserProfileSettingsPresenter {
 
@@ -31,35 +32,35 @@ class UserProfileSettingsPresenter(
     }
 
     private val _uniqueAvatar = MutableStateFlow(userRepository.data.value?.uniqueAvatar)
-    override val uniqueAvatar: StateFlow<PlatformImage?> get() = _uniqueAvatar
+    override val uniqueAvatar: StateFlow<PlatformImage?> get() = _uniqueAvatar.asStateFlow()
 
     private val _reputation = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val reputation: StateFlow<String> = _reputation
+    override val reputation: StateFlow<String> get() = _reputation.asStateFlow()
     private val _lastUserActivity = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val lastUserActivity: StateFlow<String> = _lastUserActivity
+    override val lastUserActivity: StateFlow<String> get() = _lastUserActivity.asStateFlow()
     private val _profileAge = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val profileAge: StateFlow<String> = _profileAge
+    override val profileAge: StateFlow<String> get() = _profileAge.asStateFlow()
     private val _profileId = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val profileId: StateFlow<String> = _profileId
+    override val profileId: StateFlow<String> get() = _profileId.asStateFlow()
     private val _nickname = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val nickname: StateFlow<String> = _nickname
+    override val nickname: StateFlow<String> get() = _nickname.asStateFlow()
     private val _botId = MutableStateFlow(DEFAULT_UNKNOWN_VALUE)
-    override val botId: StateFlow<String> = _botId
+    override val botId: StateFlow<String> get() = _botId.asStateFlow()
     private val _tradeTerms = MutableStateFlow("")
-    override val tradeTerms: StateFlow<String> = _tradeTerms
+    override val tradeTerms: StateFlow<String> get() = _tradeTerms.asStateFlow()
     private val _statement = MutableStateFlow("")
-    override val statement: StateFlow<String> = _statement
+    override val statement: StateFlow<String> get() = _statement.asStateFlow()
 
     private val _showLoading = MutableStateFlow(false)
-    override val showLoading: StateFlow<Boolean> = _showLoading
+    override val showLoading: StateFlow<Boolean> get() = _showLoading.asStateFlow()
 
     private val _showDeleteOfferConfirmation = MutableStateFlow(false)
-    override val showDeleteProfileConfirmation: StateFlow<Boolean> get() = _showDeleteOfferConfirmation
+    override val showDeleteProfileConfirmation: StateFlow<Boolean> get() = _showDeleteOfferConfirmation.asStateFlow()
     override fun setShowDeleteProfileConfirmation(value: Boolean) {
         _showDeleteOfferConfirmation.value = value
     }
 
-    override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> = connectivityService.status
+    override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> get() = connectivityService.status
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsScreen.kt
@@ -66,6 +66,12 @@ interface IUserProfileSettingsPresenter : ViewPresenter {
 fun UserProfileSettingsScreen() {
     val presenter: IUserProfileSettingsPresenter = koinInject()
     val settingsPresenter: ISettingsPresenter = koinInject()
+    
+    val menuTree: MenuItem = settingsPresenter.menuTree()
+    val menuPath = remember { mutableStateListOf(menuTree) }
+    RememberPresenterLifecycle(presenter, {
+        menuPath.add((menuTree as MenuItem.Parent).children[1])
+    })
 
     val isInteractive by presenter.isInteractive.collectAsState()
     val botId by presenter.botId.collectAsState()
@@ -79,13 +85,6 @@ fun UserProfileSettingsScreen() {
 
     val showLoading by presenter.showLoading.collectAsState()
     val showDeleteConfirmation by presenter.showDeleteProfileConfirmation.collectAsState()
-
-    val menuTree: MenuItem = settingsPresenter.menuTree()
-    val menuPath = remember { mutableStateListOf(menuTree) }
-
-    RememberPresenterLifecycle(presenter, {
-        menuPath.add((menuTree as MenuItem.Parent).children[1])
-    })
 
     BisqScrollScaffold(
         topBar = { TopBar("user.userProfile".i18n(), showUserAvatar = false) },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/AgreementPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/AgreementPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.startup
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
@@ -14,7 +15,7 @@ open class AgreementPresenter(
 ) : BasePresenter(mainPresenter), IAgreementPresenter {
 
     private val _accepted = MutableStateFlow(false)
-    override val isAccepted: StateFlow<Boolean> = _accepted
+    override val isAccepted: StateFlow<Boolean> get() = _accepted.asStateFlow()
 
 
     override fun onAccept(accepted: Boolean) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import network.bisq.mobile.domain.PlatformImage
@@ -25,37 +26,37 @@ open class CreateProfilePresenter(
 
     // Properties
     private val _id = MutableStateFlow("")
-    val id: StateFlow<String> get() = _id
+    val id: StateFlow<String> get() = _id.asStateFlow()
     private fun setId(value: String) {
         _id.value = value
     }
 
     private val _nym = MutableStateFlow("")
-    val nym: StateFlow<String> get() = _nym
+    val nym: StateFlow<String> get() = _nym.asStateFlow()
     private fun setNym(value: String) {
         _nym.value = value
     }
 
     private val _profileIcon = MutableStateFlow<PlatformImage?>(null)
-    val profileIcon: StateFlow<PlatformImage?> get() = _profileIcon
+    val profileIcon: StateFlow<PlatformImage?> get() = _profileIcon.asStateFlow()
     private fun setProfileIcon(value: PlatformImage?) {
         _profileIcon.value = value
     }
 
     private val _nickName = MutableStateFlow("")
-    val nickName: StateFlow<String> get() = _nickName
+    val nickName: StateFlow<String> get() = _nickName.asStateFlow()
     fun setNickname(value: String) {
         _nickName.value = value
     }
 
     private val _nickNameValid = MutableStateFlow(false)
-    val nickNameValid: StateFlow<Boolean> get() = _nickNameValid
+    val nickNameValid: StateFlow<Boolean> get() = _nickNameValid.asStateFlow()
 
     private val _generateKeyPairInProgress = MutableStateFlow(false)
-    val generateKeyPairInProgress: StateFlow<Boolean> get() = _generateKeyPairInProgress
+    val generateKeyPairInProgress: StateFlow<Boolean> get() = _generateKeyPairInProgress.asStateFlow()
 
     private val _createAndPublishInProgress = MutableStateFlow(false)
-    val createAndPublishInProgress: StateFlow<Boolean> get() = _createAndPublishInProgress
+    val createAndPublishInProgress: StateFlow<Boolean> get() = _createAndPublishInProgress.asStateFlow()
 
     // Misc
     private var job: Job? = null

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
@@ -2,12 +2,14 @@ package network.bisq.mobile.presentation.ui.uicases.startup
 
 import androidx.compose.foundation.pager.PagerState
 import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.*
+import bisqapps.shared.presentation.generated.resources.img_bisq_Easy
+import bisqapps.shared.presentation.generated.resources.img_fiat_btc
+import bisqapps.shared.presentation.generated.resources.img_learn_and_discover
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.data.model.Settings
 import network.bisq.mobile.domain.data.repository.SettingsRepository
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
@@ -33,7 +35,7 @@ open class OnBoardingPresenter(
     override val indexesToShow = listOf(0)
 
     private val _buttonText = MutableStateFlow(CREATE_PROFILE_TEXT)
-    override val buttonText: StateFlow<String> = _buttonText
+    override val buttonText: StateFlow<String> get() = _buttonText.asStateFlow()
 
     override val onBoardingData = listOf(
         PagerViewItem(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.cancellation.CancellationException
 
 open class SplashPresenter(
     mainPresenter: MainPresenter,
-    applicationBootstrapFacade: ApplicationBootstrapFacade,
+    private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val userProfileService: UserProfileServiceFacade,
     private val userRepository: UserRepository,
     private val settingsRepository: SettingsRepository,
@@ -27,8 +27,8 @@ open class SplashPresenter(
     private val webSocketClientProvider: WebSocketClientProvider?,
 ) : BasePresenter(mainPresenter) {
 
-    val state: StateFlow<String> = applicationBootstrapFacade.state
-    val progress: StateFlow<Float> = applicationBootstrapFacade.progress
+    val state: StateFlow<String> get() = applicationBootstrapFacade.state
+    val progress: StateFlow<Float> get() = applicationBootstrapFacade.progress
 
     private var hasNavigatedAway = false
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -31,22 +32,22 @@ class TrustedNodeSetupPresenter(
     }
 
     private val _isBisqApiUrlValid = MutableStateFlow(true)
-    override val isBisqApiUrlValid: StateFlow<Boolean> get() = _isBisqApiUrlValid
+    override val isBisqApiUrlValid: StateFlow<Boolean> get() = _isBisqApiUrlValid.asStateFlow()
 
     private val _isBisqApiVersionValid = MutableStateFlow(true)
-    override val isBisqApiVersionValid: StateFlow<Boolean> get() = _isBisqApiVersionValid
+    override val isBisqApiVersionValid: StateFlow<Boolean> get() = _isBisqApiVersionValid.asStateFlow()
 
     private val _bisqApiUrl = MutableStateFlow("ws://10.0.2.2:8090")
-    override val bisqApiUrl: StateFlow<String> get() = _bisqApiUrl
+    override val bisqApiUrl: StateFlow<String> get() = _bisqApiUrl.asStateFlow()
 
     private val _trustedNodeVersion = MutableStateFlow("")
-    override val trustedNodeVersion: StateFlow<String> get() = _trustedNodeVersion
+    override val trustedNodeVersion: StateFlow<String> get() = _trustedNodeVersion.asStateFlow()
 
     private val _isConnected = MutableStateFlow(false)
-    override val isConnected: StateFlow<Boolean> get() = _isConnected
+    override val isConnected: StateFlow<Boolean> get() = _isConnected.asStateFlow()
 
     private val _isLoading = MutableStateFlow(false)
-    override val isLoading: StateFlow<Boolean> get() = _isLoading
+    override val isLoading: StateFlow<Boolean> get() = _isLoading.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -86,6 +86,14 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
     val presenter: ITrustedNodeSetupPresenter = koinInject()
     val settingsPresenter: ISettingsPresenter = koinInject()
 
+    val menuTree: MenuItem = settingsPresenter.menuTree()
+    val menuPath = remember { mutableStateListOf(menuTree) }
+    RememberPresenterLifecycle(presenter, {
+        if (!isWorkflow) {
+            menuPath.add((menuTree as MenuItem.Parent).children[3])
+        }
+    })
+
     val bisqApiUrl by presenter.bisqApiUrl.collectAsState()
     val isConnected by presenter.isConnected.collectAsState()
     val isVersionValid by presenter.isBisqApiVersionValid.collectAsState()
@@ -144,15 +152,6 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
             }
         }
     }
-
-    val menuTree: MenuItem = settingsPresenter.menuTree()
-    val menuPath = remember { mutableStateListOf(menuTree) }
-
-    RememberPresenterLifecycle(presenter, {
-        if (!isWorkflow) {
-            menuPath.add((menuTree as MenuItem.Parent).children[3])
-        }
-    })
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.trustedNodeSetup.title".i18n()) },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
@@ -27,7 +27,7 @@ class TakeOfferAmountPresenter(
     private val takeOfferPresenter: TakeOfferPresenter
 ) : BasePresenter(mainPresenter) {
 
-    val _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
+    private val _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
     val sliderPosition: StateFlow<Float> = _sliderPosition
 
     lateinit var quoteCurrencyCode: String

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.take_offer
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import network.bisq.mobile.domain.toDoubleOrNullLocaleAware
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory
@@ -13,6 +13,7 @@ import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVOEx
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.RangeAmountSpecVO
 import network.bisq.mobile.domain.formatters.AmountFormatter
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.toDoubleOrNullLocaleAware
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -26,17 +27,17 @@ class TakeOfferAmountPresenter(
     private val takeOfferPresenter: TakeOfferPresenter
 ) : BasePresenter(mainPresenter) {
 
-    var _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
-    var sliderPosition: StateFlow<Float> = _sliderPosition
+    val _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
+    val sliderPosition: StateFlow<Float> = _sliderPosition
 
     lateinit var quoteCurrencyCode: String
     lateinit var formattedMinAmount: String
     lateinit var formattedMinAmountWithCode: String
     lateinit var formattedMaxAmountWithCode: String
     private val _formattedQuoteAmount = MutableStateFlow("")
-    val formattedQuoteAmount: StateFlow<String> = _formattedQuoteAmount
+    val formattedQuoteAmount: StateFlow<String> get() = _formattedQuoteAmount.asStateFlow()
     private val _formattedBaseAmount = MutableStateFlow("")
-    val formattedBaseAmount: StateFlow<String> = _formattedBaseAmount
+    val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount.asStateFlow()
 
     private lateinit var takeOfferModel: TakeOfferPresenter.TakeOfferModel
     private var minAmount: Long = 0L
@@ -46,8 +47,8 @@ class TakeOfferAmountPresenter(
     private lateinit var quoteAmount: FiatVO
     private lateinit var baseAmount: CoinVO
 
-    private var _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val amountValid: StateFlow<Boolean> = _amountValid
+    private val _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val amountValid: StateFlow<Boolean> get() = _amountValid.asStateFlow()
 
     init {
         runCatching {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferAmountPresenter.kt
@@ -28,7 +28,7 @@ class TakeOfferAmountPresenter(
 ) : BasePresenter(mainPresenter) {
 
     private val _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
-    val sliderPosition: StateFlow<Float> = _sliderPosition
+    val sliderPosition: StateFlow<Float> get() = _sliderPosition.asStateFlow()
 
     lateinit var quoteCurrencyCode: String
     lateinit var formattedMinAmount: String

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/take_offer/TakeOfferReviewPresenter.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.ui.uicases.take_offer
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVOExtensions.marketCodes
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
@@ -49,13 +50,13 @@ class TakeOfferReviewPresenter(
     private val takeOfferErrorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
 
     private val _showTakeOfferProgressDialog = MutableStateFlow(false)
-    val showTakeOfferProgressDialog: StateFlow<Boolean> get() = _showTakeOfferProgressDialog
+    val showTakeOfferProgressDialog: StateFlow<Boolean> get() = _showTakeOfferProgressDialog.asStateFlow()
     private fun setShowTakeOfferProgressDialog(value: Boolean) {
         _showTakeOfferProgressDialog.value = value
     }
 
     private val _showTakeOfferSuccessDialog = MutableStateFlow(false)
-    val showTakeOfferSuccessDialog: StateFlow<Boolean> get() = _showTakeOfferSuccessDialog
+    val showTakeOfferSuccessDialog: StateFlow<Boolean> get() = _showTakeOfferSuccessDialog.asStateFlow()
     private fun setShowTakeOfferSuccessDialog(value: Boolean) {
         _showTakeOfferSuccessDialog.value = value
     }


### PR DESCRIPTION
based on #514 
towards resolving #512 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Exposed many internal mutable streams as read-only StateFlow getters across settings, accounts, language, connectivity, market price, trades, chats, offer flows, profiles, onboarding, and startup — improving encapsulation without changing UI behavior.
- Chores
  - Converted several public fields/constructor params to private/getter-backed properties and removed duplicate initializations to streamline lifecycle wiring.
- Style
  - Cleaned and tightened imports (removed wildcards/unused, added explicit ones) for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->