### PR TITLE
chore: improve guidelines

### DIFF
--- a/docs/compose-guidelines/README.md
+++ b/docs/compose-guidelines/README.md
@@ -7,7 +7,6 @@ This document outlines the general best‑practice guidelines we expect contribu
 - Prefer stateless UI; hoist state to callers
 - Unidirectional data flow: pass state down, send events up
 - Favor immutable models; use `@Stable` and `@Immutable` on classes where appropriate
-- Prefer cold `Flow`s over hot `StateFlow`s unless continuous observation is required
 
 ## Tips
 


### PR DESCRIPTION
after reading the last bullet point of core principles a few more times, I find it unnecessary and maybe even confusing
if we follow immutability patterns it will happen as a result on it's own

sorry about the clutter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Revised Compose guidelines: removed the principle recommending preferring cold Flows over hot StateFlows unless continuous observation is required.
  - Core principles section updated; the rest of the guidelines remain intact.
  - This is a documentation-only update—no product behavior, APIs, or interfaces are affected, and no user action is required at this time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->