### PR TITLE
fix: make verifyControlPortAccessible suspend

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
@@ -286,6 +286,7 @@ class KmpTorService : ServiceFacade(), Logging {
             }
 
             val configFile = File(getTorDir(), "external_tor.config")
+            @Suppress("BlockingMethodInNonBlockingContext") // already called from IO context
             FileOutputStream(configFile).use { fos ->
                 fos.write(configContent.toByteArray())
                 fos.fd.sync() // ensures data is flushed to disk
@@ -296,7 +297,7 @@ class KmpTorService : ServiceFacade(), Logging {
             verifyControlPortAccessible(controlPort)
 
         } catch (error: Exception) {
-            handleError("Failed to write external_tor.config. {$error}")
+            handleError("Failed to write external_tor.config: $error")
         }
     }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
@@ -274,7 +274,7 @@ class KmpTorService : ServiceFacade(), Logging {
         }
     }
 
-    private fun writeExternalTorConfig(socksPort: Int, controlPort: Int) {
+    private suspend fun writeExternalTorConfig(socksPort: Int, controlPort: Int) {
         try {
             val cookieFile = File(getTorDir(), "control_auth_cookie")
             val configContent = buildString {
@@ -300,10 +300,10 @@ class KmpTorService : ServiceFacade(), Logging {
         }
     }
 
-    private fun verifyControlPortAccessible(controlPort: Int) {
+    private suspend fun verifyControlPortAccessible(controlPort: Int) {
         try {
             // Give Tor a moment to fully initialize the control port
-            Thread.sleep(500)
+            delay(500)
 
             java.net.Socket().use { socket ->
                 socket.connect(java.net.InetSocketAddress("127.0.0.1", controlPort), 5000)


### PR DESCRIPTION
as discussed on matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tor startup flow converted to coroutine-friendly, non-blocking sequencing for improved app responsiveness during initialization.

* **Bug Fixes**
  * Replaced blocking waits with non-blocking delays and background IO to prevent UI stalls.
  * Added retrying, progressive port-access checks with clearer success/warning logs.
  * Improved error message when writing the external Tor configuration fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->