### PR TITLE
fix: simplify ignored offer check

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -96,16 +96,20 @@ class OfferbookPresenter(
                 mainPresenter.languageCode
             ) { offers, direction, _ ->
                 offers to direction
-                // offers.filter { it.bisqEasyOffer.direction.mirror == direction }
             }
-                .mapLatest { (offers, direction) ->
-                    offers
-                        .filter { it.bisqEasyOffer.direction.mirror == direction }
-                        .filter { offer -> !isOfferFromIgnoredUser(offer.bisqEasyOffer) }
+            .mapLatest { (offers, direction) ->
+                val filtered = mutableListOf<OfferItemPresentationModel>()
+                for (item in offers) {
+                    if (item.bisqEasyOffer.direction.mirror == direction &&
+                        !isOfferFromIgnoredUser(item.bisqEasyOffer)) {
+                        filtered += item
+                    }
                 }
-                .collectLatest { filtered ->
-                _sortedFilteredOffers.value = processAllOffers(filtered).sortedWith(
-                    compareByDescending<OfferItemPresentationModel> { it.bisqEasyOffer.date }.thenBy { it.bisqEasyOffer.id })
+                filtered
+            }
+            .collectLatest { filtered ->
+            _sortedFilteredOffers.value = processAllOffers(filtered).sortedWith(
+                compareByDescending<OfferItemPresentationModel> { it.bisqEasyOffer.date }.thenBy { it.bisqEasyOffer.id })
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.ui.uicases.offerbook
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -76,6 +77,7 @@ class OfferbookPresenter(
     )
     val avatarMap: StateFlow<Map<String, PlatformImage?>> get() = _avatarMap.asStateFlow()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun onViewAttached() {
         super.onViewAttached()
 
@@ -403,8 +405,12 @@ class OfferbookPresenter(
     }
 
     private suspend fun isOfferFromIgnoredUser(offer: BisqEasyOfferVO): Boolean {
-        val makersUserProfileId = offer.makerNetworkId.pubKey.id
-
-        return userProfileServiceFacade.isUserIgnored(makersUserProfileId)
+        val makerUserProfileId = offer.makerNetworkId.pubKey.id
+        return try {
+            userProfileServiceFacade.isUserIgnored(makerUserProfileId)
+        } catch (e: Exception) {
+            log.w("isUserIgnored failed for $makerUserProfileId", e)
+            false
+        }
     }
 }


### PR DESCRIPTION
 - fix #538 
 - fix #533 
 - because on first launch `findUserProfile` returns `null` so it doesn't show any offers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Offer Book now consistently excludes offers from users you’ve ignored, improving listing relevance.
  * Ignored-user determination is more reliable and resilient — failures are handled gracefully so listings remain stable.
  * Offer filtering pipeline simplified for better predictability and easier future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->