### PR TITLE
Improve splash screen

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -43,7 +43,7 @@ class ClientApplicationBootstrapFacade(
                 setState("bootstrap.connectedToTrustedNode".i18n())
                 setProgress(1.0f)
             } else if (url == null) {
-                // fresh install escenario, let it proceed to onboarding
+                // fresh install scenario, let it proceed to onboarding
                 setState("bootstrap.connectedToTrustedNode".i18n())
                 setProgress(1.0f)
             } else {

--- a/shared/domain/src/commonMain/resources/mobile/application.properties
+++ b/shared/domain/src/commonMain/resources/mobile/application.properties
@@ -30,7 +30,7 @@ bootstrap.timeout.title=Bootstrap
 bootstrap.timeout.message=It looks like {0} is taking longer than usual. Would you like to stop and restart the app?
 bootstrap.timeout.stop=Stop Bootstrap
 bootstrap.timeout.continue=Continue Waiting
-bootstrap.retry=Restart App
+bootstrap.restart=Restart
 bootstrap.progress.continuing=Bootstrap is continuing normally
 
 # Dynamic values using DefaultApplicationService.State.name()

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -1,5 +1,4 @@
-
-bootstrap.connectedToTrustedNode=Connected to trusted node
+bootstrap.connectedToTrustedNode=Connected to remote node
 error.exception=Exception
 error.warning=Warning
 mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo=Use the trade ID {0} for the ''Reason for payment'' field

--- a/shared/domain/src/commonMain/resources/mobile/mobile_es.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile_es.properties
@@ -30,25 +30,25 @@ mobile.components.marketFilter.showMarkets.all=Todos
 ################################################################################
 # Mobile others - TODO: Categorize
 ################################################################################
-mobile.reputation.buildReputation=Aprende m�¡s sobre cómo construir reputación en la Wiki de Bisq.
-mobile.reputation.learnMore=Aprende m�¡s sobre el sistema de reputación en la Wiki de Bisq.
+mobile.reputation.buildReputation=Aprende m�¡s sobre cómo construir reputación en la Wiki de Bisq.
+mobile.reputation.learnMore=Aprende m�¡s sobre el sistema de reputación en la Wiki de Bisq.
 offers=Ofertas
 mobile.organisms.trustednodeApiIncompatiblePopup.fixTrustedNode=Arreglar nodo de confianza
-mobile.validations.amountValidator.invalidNumber=Número inv�¡lido
+mobile.validations.amountValidator.invalidNumber=Número inv�¡lido
 mobile.validations.amountValidator.shouldBeGreaterThan=Debe ser mayor que
 mobile.validations.amountValidator.shouldBeLessThan=Debe ser menor que
 mobile.offerbook.title=Libro de Ofertas - {0}
 mobile.offerBookScreen.noOffersSection.thereAreNoOffers=No hay ofertas
 
-mobile.bisqEasy.tradeWizard.direction.buy.helpText=La forma m�¡s f�¡cil de obtener tu primer Bitcoin
+mobile.bisqEasy.tradeWizard.direction.buy.helpText=La forma m�¡s f�¡cil de obtener tu primer Bitcoin
 mobile.bisqEasy.tradeWizard.direction.sell.helpText=Usuarios experimentados de Bisq con reputación pueden actuar como vendedores
 
-mobile.bisqEasy.tradeWizard.market.headline.buyer=�¿En qué moneda quieres pagar?
-mobile.bisqEasy.tradeWizard.market.headline.seller=�¿En qué moneda quieres que te paguen?
+mobile.bisqEasy.tradeWizard.market.headline.buyer=�¿En qué moneda quieres pagar?
+mobile.bisqEasy.tradeWizard.market.headline.seller=�¿En qué moneda quieres que te paguen?
 mobile.bisqEasy.tradeWizard.market.title=Moneda
 mobile.bisqEasy.tradeWizard.market.subTitle=Elige tu moneda de intercambio
 
-mobile.bisqEasy.tradeWizard.price.title=�¿Cu�¡l es tu precio de intercambio?
+mobile.bisqEasy.tradeWizard.price.title=�¿Cu�¡l es tu precio de intercambio?
 mobile.bisqEasy.tradeWizard.price.subTitle=Esto puede definirse como un precio porcentual que fluctúa con el precio de mercado o un precio fijo.
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage=Porcentaje
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.fixed=Fijo
@@ -58,8 +58,8 @@ mobile.bisqEasy.tradeWizard.price.tradePrice.type.fixed.validation.shouldBeLessT
 
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.cannotBeEmpty=El valor no puede estar vacío
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeGreaterThanMarketPrice=Mín: -10%
-mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeLessThanMarketPrice=M�¡x: 50%
-mobile.bisqEasy.tradeWizard.amount.range.validation.minShouldBeLessThanMax=El mínimo debe ser menor que el m�¡ximo
+mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage.validation.shouldBeLessThanMarketPrice=M�¡x: 50%
+mobile.bisqEasy.tradeWizard.amount.range.validation.minShouldBeLessThanMax=El mínimo debe ser menor que el m�¡ximo
 
 mobile.bisqEasy.openTrades.title=ID de Intercambio: {0}
 mobile.bisqEasy.openTrades.failed=El intercambio falló con el mensaje de error: {0}
@@ -68,7 +68,7 @@ mobile.bisqEasy.openTrades.warnIgnoredUser=Cuidado: Este intercambio involucra a
 
 mobile.bisqEasy.tradeState.mediationFailed=El reporte de mediación falló, por favor contacta al soporte
 mobile.bisqEasy.tradeState.info.seller.phase1.accountData.validations.minLength=Longitud mínima: 3 caracteres
-mobile.bisqEasy.tradeState.info.seller.phase1.accountData.validations.maxLength=Longitud m�¡xima: 1024 caracteres
+mobile.bisqEasy.tradeState.info.seller.phase1.accountData.validations.maxLength=Longitud m�¡xima: 1024 caracteres
 mobile.bisqEasy.tradeState.info.seller.phase3a.send=Enviar
 mobile.bisqEasy.tradeState.info.seller.phase3a.toTheBuyer=al comprador
 
@@ -76,9 +76,9 @@ mobile.bisqEasy.tradeState.info.seller.phase3a.toTheBuyer=al comprador
 mobile.bisqEasy.offerbook.failedToDeleteOffer=Error al eliminar la oferta {0}, por favor inténtalo de nuevo
 mobile.bisqEasy.offerbook.unableToDeleteOffer=No se puede eliminar la oferta {0}
 mobile.bisqEasy.offerbook.unableToTakeOffer=No se puede tomar la oferta {0}
-mobile.bisqEasy.offerbook.createOfferDisabledInDemoMode=Crear oferta est�¡ deshabilitado en modo demo
-mobile.bisqEasy.offerbook.createOfferDisabledInDemonstrationMode=Crear oferta est�¡ deshabilitado en modo demostración
-mobile.bisqEasy.offerbook.cannotCreateOffer=No se puede crear la oferta en este momento, por favor inténtalo m�¡s tarde
+mobile.bisqEasy.offerbook.createOfferDisabledInDemoMode=Crear oferta est�¡ deshabilitado en modo demo
+mobile.bisqEasy.offerbook.createOfferDisabledInDemonstrationMode=Crear oferta est�¡ deshabilitado en modo demostración
+mobile.bisqEasy.offerbook.cannotCreateOffer=No se puede crear la oferta en este momento, por favor inténtalo m�¡s tarde
 mobile.bisqEasy.offerbook.offerCard.offerToBTC=Mi oferta para {0} Bitcoin
 mobile.bisqEasy.offerbook.offerCard.BuyBitcoinFrom={0} Bitcoin de
 mobile.bisqEasy.offerbook.offerCard.SellBitcoinTo={0} Bitcoin a
@@ -231,7 +231,7 @@ mobile.bottomNavigation.settings=Ajustes
 mobile.bottomNavigation.myOpenTrades=Abiertos
 mobile.bottomNavigation.app=App
 
-mobile.base.swipeBackToExit=Presiona/Desliza hacia atr�¡s de nuevo para salir
+mobile.base.swipeBackToExit=Presiona/Desliza hacia atr�¡s de nuevo para salir
 
 mobile.profile.generatingKeyPairFailed=La generaci\u00f3n del par de claves fall\u00f3. La generaci\u00f3n del perfil no funcionar\u00e1
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Logo.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/icons/Logo.kt
@@ -30,7 +30,7 @@ fun BisqLogoCircle(modifier: Modifier = Modifier) {
 
 @Composable
 fun BisqLogoMarkGrey(modifier: Modifier = Modifier.size(50.dp)) {
-    Image(painterResource(Res.drawable.bisq_logo_mark_grey), "Bisq Logo mark midsize", modifier = modifier)
+    Image(painterResource(Res.drawable.bisq_logo_mark_grey), "Bisq Logo mark", modifier = modifier)
 }
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingPresenter.kt
@@ -70,11 +70,8 @@ abstract class OnBoardingPresenter(
                 settingsRepository.fetch()
                 val deviceSettings: Settings? = settingsRepository.data.value
 
-                // to ensure event propagation, probably need to change settings equals definition to avoid this
-                val updatedSettings = Settings().apply {
-                    bisqApiUrl = deviceSettings?.bisqApiUrl ?: ""
-                    firstLaunch = false
-                }
+                val updatedSettings = deviceSettings?.copy(firstLaunch = false)
+                    ?: Settings().apply { firstLaunch = false }
                 settingsRepository.update(updatedSettings)
 
                 val remoteBisqUrl = deviceSettings?.bisqApiUrl ?: ""

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/OnBoardingScreen.kt
@@ -23,7 +23,7 @@ import org.koin.compose.koinInject
 
 interface IOnboardingPresenter : ViewPresenter {
     val headline: String
-    
+
     val buttonText: StateFlow<String>
 
     val filteredPages: List<PagerViewItem>

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashPresenter.kt
@@ -162,7 +162,7 @@ open class SplashPresenter(
         applicationBootstrapFacade.extendTimeout()
     }
 
-    open fun onBootstrapFailedRetry() {
+    open fun onRestart() {
         log.i { "User requested app restart from failed state" }
         restartApp()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
@@ -23,7 +22,8 @@ import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogoCircle
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
-import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants.ScreenPadding4X
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants.ScreenPaddingHalfQuarter
 import org.koin.compose.koinInject
 
 @Composable
@@ -60,8 +60,10 @@ fun SplashScreen() {
                     BisqButton(
                         text = "bootstrap.restart".i18n(),
                         onClick = { presenter.onRestart() },
-                        modifier = Modifier.padding(BisqUIConstants.ScreenPadding4X)
-                            .scale(1.2f)
+                        modifier = Modifier.padding(
+                            horizontal = ScreenPadding4X,
+                            vertical = ScreenPaddingHalfQuarter
+                        )
                     )
                 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/SplashScreen.kt
@@ -6,17 +6,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqProgressBar
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogo
+import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogoCircle
 import network.bisq.mobile.presentation.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
@@ -39,29 +42,35 @@ fun SplashScreen() {
             verticalArrangement = Arrangement.SpaceBetween,
             snackbarHostState = presenter.getSnackState()
         ) {
-            BisqLogo()
+            Box(
+                modifier = Modifier.fillMaxSize().weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                BisqLogoCircle(modifier = Modifier.size(140.dp))
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
 
-            Column {
+                // Restart button when bootstrap fails
+                if (isBootstrapFailed && !isTimeoutDialogVisible) {
+                    BisqButton(
+                        text = "bootstrap.restart".i18n(),
+                        onClick = { presenter.onRestart() },
+                        modifier = Modifier.padding(BisqUIConstants.ScreenPadding4X)
+                            .scale(1.2f)
+                    )
+                }
+
                 BisqProgressBar(progress)
 
                 BisqText.baseRegularGrey(
                     text = state,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
-
-        // Retry button overlay for failed bootstrap
-        if (isBootstrapFailed && !isTimeoutDialogVisible) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                BisqButton(
-                    text = "bootstrap.retry".i18n(),
-                    onClick = { presenter.onBootstrapFailedRetry() },
-                    modifier = Modifier.padding(BisqUIConstants.ScreenPadding2X)
                 )
             }
         }


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq-mobile/pull/532

<img width="250"  alt="Screenshot 2025-08-15 at 12 25 37" src="https://github.com/user-attachments/assets/95883fc4-b125-461d-97dc-df4fdc69a7f2" />
<img width="250"  alt="Screenshot 2025-08-15 at 12 25 58" src="https://github.com/user-attachments/assets/e87504d2-475c-4de0-aa3d-71bfd6878924" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Splash screen: inline Restart control replaces overlay button; centered circular logo (140dp).
  - Copy updates: “Restart App” → “Restart”; “Connected to trusted node” → “Connected to remote node”.

- Translations
  - Spanish locale refreshed: encoding fixes, percentage-based pricing validation messages, added demo-mode offerbook notices, removed obsolete peer-failure message.

- Accessibility
  - Improved logo description for screen readers.

- Refactor
  - Restart action naming streamlined in startup flow (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->