### PR TITLE
fix: show ~ on offer counts when ignoring someone

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
@@ -3,7 +3,6 @@ package network.bisq.mobile.domain.service.user_profile
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.PlatformImage
-import network.bisq.mobile.domain.data.replicated.user.identity.UserIdentityVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 
 interface UserProfileServiceFacade : LifeCycleAware {
@@ -12,6 +11,7 @@ interface UserProfileServiceFacade : LifeCycleAware {
     }
 
     val selectedUserProfile: StateFlow<UserProfileVO?>
+    val hasIgnoredUsers: StateFlow<Boolean>
 
     /**
      * Returns true if there is a user identity already created.
@@ -108,5 +108,5 @@ interface UserProfileServiceFacade : LifeCycleAware {
     /**
      * Returns the current snapshot of ignored profile IDs.
      */
-    suspend fun getIgnoredUserProfileIds(): List<String>
+    suspend fun getIgnoredUserProfileIds(): Set<String>
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -53,10 +53,10 @@ import network.bisq.mobile.presentation.ui.uicases.settings.GeneralSettingsPrese
 import network.bisq.mobile.presentation.ui.uicases.settings.IAboutPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.IGeneralSettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.IIgnoredUsersPresenter
-import network.bisq.mobile.presentation.ui.uicases.settings.IgnoredUsersPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.IPaymentAccountSettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.ISettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.IUserProfileSettingsPresenter
+import network.bisq.mobile.presentation.ui.uicases.settings.IgnoredUsersPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.PaymentAccountPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.SettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.UserProfileSettingsPresenter
@@ -141,7 +141,7 @@ val presentationModule = module {
     single { PaymentAccountPresenter(get(), get()) } bind IPaymentAccountSettingsPresenter::class
 
     // Offerbook
-    single<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get()) }
+    single<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get(), get()) }
     single<OfferbookPresenter> { OfferbookPresenter(get(), get(), get(), get(), get(), get(), get()) }
 
     // Take offer

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/CurrencyCard.kt
@@ -32,6 +32,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 fun CurrencyCard(
     item: MarketListItem,
     isSelected: Boolean = false,
+    hasIgnoredUsers: Boolean = false,
     onClick: () -> Unit
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -94,7 +95,8 @@ fun CurrencyCard(
             }
         }
         BisqText.baseRegular(
-            text = "mobile.components.currencyCard.numberOfOffers".i18n(numOffers),
+            text = (if (hasIgnoredUsers && numOffers > 0) "~" else "") +
+                    "mobile.components.currencyCard.numberOfOffers".i18n(numOffers),
             color = BisqTheme.colors.primary,
             textAlign = TextAlign.End,
             modifier = Modifier.weight(1.0f),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/market/MarketFilterUtil.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/market/MarketFilterUtil.kt
@@ -24,9 +24,11 @@ object MarketFilterUtil : Logging {
     ): List<MarketListItem> {
         return markets.filter { marketListItem ->
             val hasPriceData = marketPriceServiceFacade.findMarketPriceItem(marketListItem.market) != null
-//            if (!hasPriceData) {
-//                log.v { "Filtering out market ${marketListItem.market.marketCodes} - no price data available" }
-//            }
+            if (!hasPriceData) {
+                log.d { "Filtering out market ${marketListItem.market.quoteCurrencyCode} (${marketListItem.market.quoteCurrencyName}) - no price data available" }
+            } else {
+                log.v { "Market ${marketListItem.market.quoteCurrencyCode} has price data - keeping" }
+            }
             hasPriceData
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketPresenter.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.CurrencyUtils
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -20,13 +21,16 @@ import network.bisq.mobile.presentation.ui.uicases.market.MarketFilterUtil
 class OfferbookMarketPresenter(
     mainPresenter: MainPresenter,
     private val offersServiceFacade: OffersServiceFacade,
-    private val marketPriceServiceFacade: MarketPriceServiceFacade
+    private val marketPriceServiceFacade: MarketPriceServiceFacade,
+    private val userProfileServiceFacade: UserProfileServiceFacade
 ) : BasePresenter(mainPresenter) {
 
     private var mainCurrencies = OffersServiceFacade.mainCurrencies
 
     // flag to force market update trigger when needed
     private val _marketPriceUpdated = MutableStateFlow(false)
+
+    val hasIgnoredUsers: StateFlow<Boolean> get() = userProfileServiceFacade.hasIgnoredUsers
 
     private val _sortBy = MutableStateFlow(MarketSortBy.MostOffers)
     val sortBy: StateFlow<MarketSortBy> get() = _sortBy.asStateFlow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
@@ -34,6 +34,7 @@ fun OfferbookMarketScreen() {
     var showFilterDialog by remember { mutableStateOf(false) }
     val searchText by presenter.searchText.collectAsState()
     val isInteractive by presenter.isInteractive.collectAsState()
+    val hasIgnoredUsers by presenter.hasIgnoredUsers.collectAsState()
 
     val marketItems by presenter.marketListItemWithNumOffers.collectAsState()
     val filter by presenter.filter.collectAsState()
@@ -69,7 +70,8 @@ fun OfferbookMarketScreen() {
         LazyColumn {
             items(marketItems) { item ->
                 CurrencyCard(
-                    item,
+                    item = item,
+                    hasIgnoredUsers = hasIgnoredUsers,
                     onClick = { presenter.onSelectMarket(item) }
                 )
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/IgnoredUsersPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/IgnoredUsersPresenter.kt
@@ -36,7 +36,7 @@ class IgnoredUsersPresenter(
     private fun loadIgnoredUsers() {
         launchIO {
             try {
-                val ignoredUserIds = userProfileService.getIgnoredUserProfileIds()
+                val ignoredUserIds = userProfileService.getIgnoredUserProfileIds().toList()
 
                 val userProfiles = userProfileService.findUserProfiles(ignoredUserIds)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market cards show a tilde (~) before offer counts when you have ignored users.
  * Offerbook exposes a real-time "has ignored users" indicator so UI updates reflect ignored-user state.

* **Refactor**
  * Ignored-user state is initialized at startup, kept in sync after changes, and exposed as an observable for consistent, timely UI behavior.

* **Diagnostics**
  * Additional logging and diagnostics improve visibility into market/offer filtering and ignored-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->