### PR TITLE
Release/anode 0.0.51

### DIFF
--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -324,3 +324,96 @@ tasks.withType<Test> {
 fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String {
     return "Bisq-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 }
+
+// Task to save ProGuard mapping files after successful release builds
+tasks.register("saveMappingFiles") {
+    group = "bisq"
+    description = "Save ProGuard mapping files to mappings/androidNode directory"
+
+    // Configuration cache compatible - capture values at configuration time
+    val mappingsDirPath = "${rootProject.projectDir}/mappings/androidNode"
+    val buildOutputsDirPath = "${layout.buildDirectory.get().asFile}/outputs"
+
+    doLast {
+        val mappingsDir = File(mappingsDirPath)
+        val buildOutputsDir = File(buildOutputsDirPath)
+
+        // Create mappings directory if it doesn't exist
+        mappingsDir.mkdirs()
+
+        // Copy configuration.txt
+        val configFile = File(buildOutputsDir, "mapping/release/configuration.txt")
+        if (configFile.exists()) {
+            configFile.copyTo(File(mappingsDir, "configuration.txt"), overwrite = true)
+            println("Saved configuration.txt to $mappingsDir")
+        } else {
+            println("configuration.txt not found at ${configFile.absolutePath}")
+        }
+
+        // Compress and copy mapping.txt as tar.gz
+        val mappingFile = File(buildOutputsDir, "mapping/release/mapping.txt")
+        if (mappingFile.exists()) {
+            val tarGzFile = File(mappingsDir, "mapping.txt.tar.gz")
+
+            // Use tar command to create compressed archive
+            val tarCommand = listOf(
+                "tar", "-czvf",
+                tarGzFile.absolutePath,
+                "-C", mappingFile.parent,
+                mappingFile.name
+            )
+
+            val process = ProcessBuilder(tarCommand)
+                .redirectErrorStream(true)
+                .start()
+
+            val exitCode = process.waitFor()
+            if (exitCode == 0) {
+                println("Saved mapping.txt.tar.gz to $mappingsDir")
+            } else {
+                val output = process.inputStream.bufferedReader().readText()
+                throw GradleException("Failed to create mapping.txt.tar.gz: $output")
+            }
+        } else {
+            println("mapping.txt not found at ${mappingFile.absolutePath}")
+        }
+    }
+}
+
+// Task to save output metadata after assembleRelease
+tasks.register("saveOutputMetadata") {
+    group = "bisq"
+    description = "Save output-metadata.json to mappings/androidNode directory"
+
+    // Configuration cache compatible - capture values at configuration time
+    val mappingsDirPath = "${rootProject.projectDir}/mappings/androidNode"
+    val buildOutputsDirPath = "${layout.buildDirectory.get().asFile}/outputs"
+
+    doLast {
+        val mappingsDir = File(mappingsDirPath)
+        val buildOutputsDir = File(buildOutputsDirPath)
+
+        // Create mappings directory if it doesn't exist
+        mappingsDir.mkdirs()
+
+        // Copy output-metadata.json
+        val metadataFile = File(buildOutputsDir, "apk/release/output-metadata.json")
+        if (metadataFile.exists()) {
+            metadataFile.copyTo(File(mappingsDir, "output-metadata.json"), overwrite = true)
+            println("Saved output-metadata.json to $mappingsDir")
+        } else {
+            println("output-metadata.json not found at ${metadataFile.absolutePath}")
+        }
+    }
+}
+
+// Hook the tasks to run after successful release builds
+afterEvaluate {
+    tasks.findByName("bundleRelease")?.let { task ->
+        task.finalizedBy("saveMappingFiles")
+    }
+
+    tasks.findByName("assembleRelease")?.let { task ->
+        task.finalizedBy("saveOutputMetadata")
+    }
+}

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -409,6 +409,7 @@ tasks.register("saveOutputMetadata") {
 
 // Hook the tasks to run after successful release builds
 afterEvaluate {
+    // TODO generalise to use also for android connect app
     tasks.findByName("bundleRelease")?.let { task ->
         task.finalizedBy("saveMappingFiles")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ client.ios.version=0.0.7
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=3
 client.android.version.code=7
-node.android.version.code=6
+node.android.version.code=7
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ android.enableR8.fullMode=true
 shared.version=0.1.0
 
 node.name=Bisq
-node.android.version=0.0.51
+node.android.version=0.0.52
 
 client.name=Bisq Connect
 client.android.version=0.0.37
@@ -38,7 +38,7 @@ client.ios.version=0.0.7
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=3
 client.android.version.code=7
-node.android.version.code=7
+node.android.version.code=8
 
 # Networking
 

--- a/mappings/androidNode/output-metadata.json
+++ b/mappings/androidNode/output-metadata.json
@@ -11,9 +11,9 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 6,
-      "versionName": "0.0.50",
-      "outputFile": "androidNode-0.0.50.apk"
+      "versionCode": 7,
+      "versionName": "0.0.51",
+      "outputFile": "androidNode-0.0.51.apk"
     }
   ],
   "elementType": "File",
@@ -22,14 +22,14 @@
       "minApi": 28,
       "maxApi": 30,
       "baselineProfiles": [
-        "baselineProfiles/1/androidNode-0.0.50.dm"
+        "baselineProfiles/1/androidNode-0.0.51.dm"
       ]
     },
     {
       "minApi": 31,
       "maxApi": 2147483647,
       "baselineProfiles": [
-        "baselineProfiles/0/androidNode-0.0.50.dm"
+        "baselineProfiles/0/androidNode-0.0.51.dm"
       ]
     }
   ],


### PR DESCRIPTION
 - contribts to #330 
 - added automated task to save mappings on each release (only for node now)
 - bump up versions for next iteration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Prepared a new Android release with updated app version and version code.
  - Improved release packaging to retain necessary build artifacts for post-release diagnostics.
  - Updated release metadata to reflect the latest build.

- Notes
  - No user-facing changes in this release; functionality and UI remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->