### PR TITLE
match_google_api_support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,8 @@ agp = "8.5.0"
 android-compileSdk = "35"
 android-targetSdk = "35"
 android-minSdk = "24"
-android-node-minSdk = "31"
+# TODO analyse lowering back to API 31 when Bisq2 full J17 support is returned and we can get rid of desugaring
+android-node-minSdk = "33"
 
 # AndroidX Core Libraries
 androidx-core = "1.13.1"


### PR DESCRIPTION
 - fixes #541 
 - upgrade min android SDK support for node to match Google min SDK support, avoiding String.lines() compatibility issue till we reassess J17 Jars supports + eliminating desugaring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased the minimum supported Android OS version to Android 13 (API 33).
  - Users on Android 12 and below will no longer be able to install or update to new releases.
  - Expect store listings and distribution to reflect the new minimum requirement.
  - No functional changes to features or UI; this update only affects device compatibility and installation targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->