### PR TITLE
missing_i18n_pr_trading

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/I18nSupport.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/I18nSupport.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.i18n
 
+import network.bisq.mobile.client.shared.BuildConfig
+
 // We use non-printing characters as separator. See: https://en.wikipedia.org/wiki/Delimiter#ASCII_delimited_text
 const val ARGS_SEPARATOR: Char = 0x1f.toChar()
 const val PARAM_SEPARATOR: Char = 0x1e.toChar()
@@ -84,8 +86,18 @@ fun has(key: String): Boolean {
 fun String.i18n(): String {
     val result = bundles
         .firstOrNull { it.containsKey(this) }
-        ?.getString(this) ?: "MISSING: [$this]"
+        ?.getString(this) ?: missingI18NPlaceholder(this)
     return result
+}
+
+private fun missingI18NPlaceholder(key: String): String {
+    val missingPlaceholderForKey = "MISSING: [${key.split(PARAM_SEPARATOR).first()}]"
+    val defaultBundles = GeneratedResourceBundles_en.bundles.values
+    return when {
+        // is safe to relay only on this one because all BuildConfig debug are generated equal
+        BuildConfig.IS_DEBUG -> missingPlaceholderForKey
+        else -> defaultBundles.firstOrNull { it.containsKey(key) }?.get(key) ?: missingPlaceholderForKey
+    }
 }
 
 fun String.i18nEncode(vararg arguments: Any): String {

--- a/shared/domain/src/commonMain/resources/mobile/bisq_easy_pt_BR.properties
+++ b/shared/domain/src/commonMain/resources/mobile/bisq_easy_pt_BR.properties
@@ -548,3 +548,337 @@ bisqEasy.openTrades.failed.popup=A negocia\u00e7\u00e3o falhou: ''{0}''\n\n\
 bisqEasy.openTrades.failedAtPeer=A negocia\u00e7\u00e3o falhou no seu par: ''{0}''
 bisqEasy.openTrades.failedAtPeer.popup=A negocia\u00e7\u00e3o falhou no seu par: ''{0}''\n\n\
   Stack trace: {1}
+
+bisqEasy.openTrades.table.tradePeer=Par
+bisqEasy.openTrades.table.me=Eu
+bisqEasy.openTrades.table.mediator=Mediador
+bisqEasy.openTrades.table.tradeId=ID da Negocia\u00e7\u00e3o
+bisqEasy.openTrades.table.price=Pre\u00e7o
+bisqEasy.openTrades.table.baseAmount=Quantia em BTC
+bisqEasy.openTrades.table.quoteAmount=Quantia
+bisqEasy.openTrades.table.paymentMethod=Pagamento
+bisqEasy.openTrades.table.paymentMethod.tooltip=M\u00e9todo de pagamento fiat: {0}
+bisqEasy.openTrades.table.settlementMethod=Liquida\u00e7\u00e3o
+bisqEasy.openTrades.table.settlementMethod.tooltip=M\u00e9todo de liquida\u00e7\u00e3o Bitcoin: {0}
+bisqEasy.openTrades.table.makerTakerRole=Meu papel
+bisqEasy.openTrades.table.direction.buyer=Comprando de:
+bisqEasy.openTrades.table.direction.seller=Vendendo para:
+bisqEasy.openTrades.table.makerTakerRole.maker=Criador
+bisqEasy.openTrades.table.makerTakerRole.taker=Aceitador
+bisqEasy.openTrades.csv.quoteAmount=Quantia em {0}
+bisqEasy.openTrades.csv.txIdOrPreimage=ID da Transa\u00e7\u00e3o/Preimage
+bisqEasy.openTrades.csv.receiverAddressOrInvoice=Endere\u00e7o do destinat\u00e1rio/Fatura
+bisqEasy.openTrades.csv.paymentMethod=M\u00e9todo de pagamento
+bisqEasy.openTrades.chat.peer.description=Par do chat
+bisqEasy.openTrades.chat.detach=Destacar
+bisqEasy.openTrades.chat.detach.tooltip=Abrir chat em nova janela
+bisqEasy.openTrades.chat.attach=Restaurar
+bisqEasy.openTrades.chat.attach.tooltip=Restaurar chat de volta \u00e0 janela principal
+bisqEasy.openTrades.chat.window.title={0} - Chat com {1} / ID da Negocia\u00e7\u00e3o: {2}
+bisqEasy.openTrades.chat.peerLeft.headline={0} saiu da negocia\u00e7\u00e3o
+bisqEasy.openTrades.chat.peerLeft.subHeadline=Se a negocia\u00e7\u00e3o n\u00e3o foi conclu\u00edda do seu lado e voc\u00ea precisa de assist\u00eancia, entre em contato com o mediador ou visite o chat de suporte.
+bisqEasy.openTrades.tradeDetails.button=Mostrar detalhes
+bisqEasy.openTrades.tradeDetails.headline=Detalhes da negocia\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.overview=Vis\u00e3o geral
+bisqEasy.openTrades.tradeDetails.details=Detalhes
+bisqEasy.openTrades.tradeDetails.tradeDate=Data da negocia\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.tradeDuration=Dura\u00e7\u00e3o da negocia\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.tradersAndRole=Negociadores / Papel
+bisqEasy.openTrades.tradeDetails.tradersAndRole.me=Eu:
+bisqEasy.openTrades.tradeDetails.tradersAndRole.peer=Par:
+bisqEasy.openTrades.tradeDetails.tradersAndRole.copy=Copiar nome de usu\u00e1rio do par
+bisqEasy.openTrades.tradeDetails.offerTypeAndMarket=Tipo de oferta / Mercado
+bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.buyOffer=Oferta de compra
+bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.sellOffer=Oferta de venda
+bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.fiatMarket=Mercado {0}
+bisqEasy.openTrades.tradeDetails.amountAndPrice=Quantia @ Pre\u00e7o
+bisqEasy.openTrades.tradeDetails.paymentAndSettlementMethods=M\u00e9todos de pagamento
+bisqEasy.openTrades.tradeDetails.tradeId=ID da Negocia\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.tradeId.copy=Copiar ID da negocia\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.peerNetworkAddress=Endere\u00e7o de rede do par
+bisqEasy.openTrades.tradeDetails.peerNetworkAddress.copy=Copiar endere\u00e7o de rede do par
+bisqEasy.openTrades.tradeDetails.btcPaymentAddress=Endere\u00e7o de pagamento BTC
+bisqEasy.openTrades.tradeDetails.lightningInvoice=Fatura Lightning
+bisqEasy.openTrades.tradeDetails.txId=ID da Transa\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.lightningPreImage=Preimage Lightning
+bisqEasy.openTrades.tradeDetails.txId.copy=Copiar ID da transa\u00e7\u00e3o
+bisqEasy.openTrades.tradeDetails.lightningPreImage.copy=Copiar preimage Lightning
+bisqEasy.openTrades.tradeDetails.btcPaymentAddress.copy=Copiar endere\u00e7o de pagamento BTC
+bisqEasy.openTrades.tradeDetails.lightningInvoice.copy=Copiar fatura Lightning
+bisqEasy.openTrades.tradeDetails.paymentAccountData=Dados da conta de pagamento
+bisqEasy.openTrades.tradeDetails.paymentAccountData.copy=Copiar dados da conta de pagamento
+bisqEasy.openTrades.tradeDetails.assignedMediator=Mediador designado
+bisqEasy.openTrades.tradeDetails.dataNotYetProvided=Dados ainda n\u00e3o fornecidos
+######################################################
+# Private chat
+######################################################
+bisqEasy.privateChats.leave=Sair do chat
+bisqEasy.privateChats.table.myUser=Meu perfil
+######################################################
+# Top pane
+######################################################
+# Commented out in code
+# suppress inspection "UnusedProperty"
+bisqEasy.topPane.filter=Filtrar livro de ofertas
+# Commented out in code
+# suppress inspection "UnusedProperty"
+bisqEasy.topPane.closeFilter=Fechar filtro
+################################################################################
+#
+# BisqEasyOfferDetails
+#
+################################################################################
+bisqEasy.offerDetails.headline=Detalhes da oferta
+bisqEasy.offerDetails.buy=Oferta para comprar Bitcoin
+bisqEasy.offerDetails.sell=Oferta para vender Bitcoin
+bisqEasy.offerDetails.direction=Tipo de oferta
+bisqEasy.offerDetails.baseSideAmount=Quantia de Bitcoin
+bisqEasy.offerDetails.quoteSideAmount=Quantia em {0}
+bisqEasy.offerDetails.price=Pre\u00e7o da oferta em {0}
+bisqEasy.offerDetails.priceValue={0} (pr\u00eamio: {1})
+bisqEasy.offerDetails.paymentMethods=M\u00e9todo(s) de pagamento suportado(s)
+bisqEasy.offerDetails.id=ID da Oferta
+bisqEasy.offerDetails.date=Data de cria\u00e7\u00e3o
+bisqEasy.offerDetails.makersTradeTerms=Termos de negocia\u00e7\u00e3o do criador
+################################################################################
+#
+# OpenTradesWelcome
+#
+################################################################################
+bisqEasy.openTrades.welcome.headline=Bem-vindo \u00e0 sua primeira negocia\u00e7\u00e3o no Bisq Easy!
+bisqEasy.openTrades.welcome.info=Por favor, familiarize-se com o conceito, processo e regras para negociar no Bisq Easy.\n\
+  Depois de ler e aceitar as regras de negocia\u00e7\u00e3o, voc\u00ea pode iniciar a negocia\u00e7\u00e3o.
+bisqEasy.openTrades.welcome.line1=Aprenda sobre o modelo de seguran\u00e7a do Bisq Easy
+bisqEasy.openTrades.welcome.line2=Veja como funciona o processo de negocia\u00e7\u00e3o
+bisqEasy.openTrades.welcome.line3=Familiarize-se com as regras de negocia\u00e7\u00e3o
+################################################################################
+#
+# TradeState
+#
+################################################################################
+bisqEasy.tradeState.requestMediation=Solicitar media\u00e7\u00e3o
+bisqEasy.tradeState.reportToMediator=Reportar ao mediador
+bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Aten\u00e7\u00e3o \u00e0 Mudan\u00e7a de Pre\u00e7o!
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice=Seu pre\u00e7o de oferta para comprar Bitcoin era {0}.
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice=No entanto, o vendedor est\u00e1 oferecendo um pre\u00e7o diferente: {0}.
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question=Voc\u00ea quer aceitar este novo pre\u00e7o ou quer rejeitar/cancelar* a negocia\u00e7\u00e3o?
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.disclaimer=(*Note que neste caso espec\u00edfico, cancelar a negocia\u00e7\u00e3o N\u00c3O ser\u00e1 considerado uma viola\u00e7\u00e3o das regras de negocia\u00e7\u00e3o.)
+bisqEasy.tradeState.acceptOrRejectSellersPrice.button.accept=Aceitar pre\u00e7o
+# Trade State: Header
+bisqEasy.tradeState.header.peer=Par da negocia\u00e7\u00e3o
+bisqEasy.tradeState.header.direction=Eu quero
+bisqEasy.tradeState.header.send=Quantia a enviar
+bisqEasy.tradeState.header.pay=Quantia a pagar
+bisqEasy.tradeState.header.receive=Quantia a receber
+bisqEasy.tradeState.header.tradeId=ID da Negocia\u00e7\u00e3o
+# Trade State: Phase (left side)
+bisqEasy.tradeState.phase1=Detalhes da conta
+bisqEasy.tradeState.phase2=Pagamento fiat
+bisqEasy.tradeState.phase3=Transfer\u00eancia Bitcoin
+bisqEasy.tradeState.phase4=Negocia\u00e7\u00e3o conclu\u00edda
+# Trade State: Info (right side)
+bisqEasy.tradeState.info.phase3b.balance.help.explorerLookup=Consultando transa\u00e7\u00e3o no explorador de blocos ''{0}''
+bisqEasy.tradeState.info.phase3b.balance.help.notConfirmed=Transa\u00e7\u00e3o vista no mempool mas ainda n\u00e3o confirmada
+bisqEasy.tradeState.info.phase3b.balance.help.confirmed=Transa\u00e7\u00e3o confirmada
+bisqEasy.tradeState.info.phase3b.txId.failed=Consulta da transa\u00e7\u00e3o em ''{0}'' falhou com {1}: ''{2}''
+bisqEasy.tradeState.info.phase3b.button.skip=Pular espera pela confirma\u00e7\u00e3o do bloco
+bisqEasy.tradeState.info.phase3b.balance.invalid.noOutputsForAddress=Nenhuma sa\u00edda correspondente encontrada na transa\u00e7\u00e3o
+bisqEasy.tradeState.info.phase3b.balance.invalid.multipleOutputsForAddress=M\u00faltiplas sa\u00eddas correspondentes encontradas na transa\u00e7\u00e3o
+bisqEasy.tradeState.info.phase3b.balance.invalid.amountNotMatching=Quantia de sa\u00edda da transa\u00e7\u00e3o n\u00e3o corresponde \u00e0 quantia da negocia\u00e7\u00e3o
+bisqEasy.tradeState.info.phase3b.button.next=Pr\u00f3ximo
+bisqEasy.tradeState.info.phase3b.button.next.amountNotMatching=A quantia de sa\u00edda para o endere\u00e7o ''{0}'' na transa\u00e7\u00e3o ''{1}'' \u00e9 ''{2}'', que n\u00e3o corresponde \u00e0 quantia da negocia\u00e7\u00e3o de ''{3}''.\n\n\
+  Voc\u00ea conseguiu resolver este problema com seu par de negocia\u00e7\u00e3o?\n\
+  Se n\u00e3o, voc\u00ea pode considerar solicitar media\u00e7\u00e3o para ajudar a resolver a quest\u00e3o.
+bisqEasy.tradeState.info.phase3b.button.next.noOutputForAddress=Nenhuma sa\u00edda correspondente ao endere\u00e7o ''{0}'' na transa\u00e7\u00e3o ''{1}'' foi encontrada.\n\n\
+  Voc\u00ea conseguiu resolver este problema com seu par de negocia\u00e7\u00e3o?\n\
+  Se n\u00e3o, voc\u00ea pode considerar solicitar media\u00e7\u00e3o para ajudar a resolver a quest\u00e3o.
+bisqEasy.tradeState.info.phase3b.button.next.amountNotMatching.resolved=Eu resolvi
+bisqEasy.tradeState.info.phase3b.txId=ID da Transa\u00e7\u00e3o
+bisqEasy.tradeState.info.phase3b.txId.tooltip=Abrir transa\u00e7\u00e3o no explorador de blocos
+bisqEasy.tradeState.info.phase3b.lightning.preimage=Preimage
+bisqEasy.tradeState.info.phase4.txId.tooltip=Abrir transa\u00e7\u00e3o no explorador de blocos
+bisqEasy.tradeState.info.phase4.showDetails=Mostrar detalhes
+bisqEasy.tradeState.info.phase4.exportTrade=Exportar dados da negocia\u00e7\u00e3o
+bisqEasy.tradeState.info.phase4.leaveChannel=Fechar negocia\u00e7\u00e3o
+####################################################################
+# Dynamically created from BitcoinPaymentRail enum name
+####################################################################
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.bitcoinPaymentData.MAIN_CHAIN=Endere\u00e7o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.bitcoinPaymentData.LN=Fatura Lightning
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.paymentProof.MAIN_CHAIN=ID da Transa\u00e7\u00e3o
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.paymentProof.LN=Preimage
+# Trade State Info: Buyer
+####################################################################
+# Dynamically created from BitcoinPaymentRail enum name
+####################################################################
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.headline.MAIN_CHAIN=Preencha seu endere\u00e7o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.description.MAIN_CHAIN=Endere\u00e7o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.prompt.MAIN_CHAIN=Preencha seu endere\u00e7o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage.MAIN_CHAIN={0} enviou o endere\u00e7o Bitcoin ''{1}''
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.headline.LN=Preencha sua fatura Lightning
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.description.LN=Fatura Lightning
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.prompt.LN=Preencha sua fatura Lightning
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage.LN={0} enviou a fatura Lightning ''{1}''
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.walletHelp=Se voc\u00ea ainda n\u00e3o configurou uma carteira, pode encontrar ajuda no guia da carteira
+bisqEasy.tradeState.info.buyer.phase1a.walletHelpButton=Abrir guia da carteira
+bisqEasy.tradeState.info.buyer.phase1a.send=Enviar para o vendedor
+bisqEasy.tradeState.info.buyer.phase1a.scanQrCode.tooltip=Escanear c\u00f3digo QR usando sua webcam
+bisqEasy.tradeState.info.buyer.phase1a.scanQrCode.webcamState.description=Estado da conex\u00e3o da webcam
+bisqEasy.tradeState.info.buyer.phase1a.scanQrCode.webcamState.connecting=Conectando \u00e0 webcam...
+bisqEasy.tradeState.info.buyer.phase1a.scanQrCode.webcamState.imageRecognized=Webcam conectada
+bisqEasy.tradeState.info.buyer.phase1a.scanQrCode.webcamState.failed=Falha ao conectar \u00e0 webcam
+bisqEasy.tradeState.info.buyer.phase1b.headline=Aguarde os dados da conta de pagamento do vendedor
+bisqEasy.tradeState.info.buyer.phase1b.info=Voc\u00ea pode usar o chat abaixo para entrar em contato com o vendedor.
+bisqEasy.tradeState.info.buyer.phase2a.headline=Envie {0} para a conta de pagamento do vendedor
+bisqEasy.tradeState.info.buyer.phase2a.quoteAmount=Quantia a transferir
+bisqEasy.tradeState.info.buyer.phase2a.paymentReason=Motivo do pagamento
+bisqEasy.tradeState.info.buyer.phase2a.sellersAccount=Conta de pagamento do vendedor
+bisqEasy.tradeState.info.buyer.phase2a.confirmFiatSent=Confirmar pagamento de {0}
+bisqEasy.tradeState.info.buyer.phase2a.tradeLogMessage={0} iniciou o pagamento de {1}
+bisqEasy.tradeState.info.buyer.phase2a.accountDataBannedError=Os dados da conta do vendedor foram usados em atividades fraudulentas
+bisqEasy.tradeState.info.buyer.phase2a.accountDataBanned.popup.warning=Os dados da conta do vendedor foram banidos devido a atividades fraudulentas.\n\n\
+  N\u00e3o envie dinheiro para esta conta!\n\n\
+  O par foi reportado ao moderador e em breve ser\u00e1 banido da rede.\n\n\
+  Para sua prote\u00e7\u00e3o, esta negocia\u00e7\u00e3o foi marcada como cancelada. Voc\u00ea pode agora fechar a negocia\u00e7\u00e3o com seguran\u00e7a.\n\n\
+  Se voc\u00ea tiver alguma pergunta ou precisar de assist\u00eancia adicional, por favor visite o chat de suporte.
+
+bisqEasy.tradeState.info.buyer.phase2b.headline=Aguarde o vendedor confirmar o recebimento do pagamento
+bisqEasy.tradeState.info.buyer.phase2b.info=Assim que o vendedor receber seu pagamento de {0}, ele iniciar\u00e1 a transfer\u00eancia Bitcoin para seu {1} fornecido.
+bisqEasy.tradeState.info.buyer.phase3a.headline=Aguarde a liquida\u00e7\u00e3o Bitcoin do vendedor
+bisqEasy.tradeState.info.buyer.phase3a.info=O vendedor precisa iniciar a transfer\u00eancia Bitcoin para seu {0} fornecido.
+bisqEasy.tradeState.info.buyer.phase3b.headline.ln=O vendedor enviou o Bitcoin via rede Lightning
+bisqEasy.tradeState.info.buyer.phase3b.info.ln=Transfer\u00eancias via Lightning Network s\u00e3o tipicamente quase instant\u00e2neas. \
+  Se voc\u00ea n\u00e3o recebeu o pagamento em um minuto, por favor entre em contato com o vendedor no chat da negocia\u00e7\u00e3o. \
+  Ocasionalmente, pagamentos podem falhar e precisar ser repetidos.
+bisqEasy.tradeState.info.buyer.phase3b.confirmButton.ln=Confirmar recebimento
+# The key of this string is used for simulating a protocol state change. Do not change it as we expect the exact key!
+# This is a bit of a hack, but we did not want to alter the trade protocol for this relative small feature.
+bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln={0} confirmou ter recebido o pagamento Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase3b.headline.MAIN_CHAIN=O vendedor iniciou o pagamento Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase3b.info.MAIN_CHAIN=Assim que a transa\u00e7\u00e3o Bitcoin estiver vis\u00edvel na rede Bitcoin, voc\u00ea ver\u00e1 o pagamento. \
+  Ap\u00f3s 1 confirma\u00e7\u00e3o da blockchain, o pagamento pode ser considerado conclu\u00eddo.
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase3b.balance=Bitcoin recebido
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase3b.balance.prompt=Aguardando dados da blockchain...
+# Trade State Info: Seller
+bisqEasy.tradeState.info.seller.phase1.headline=Envie os dados da sua conta de pagamento para o comprador
+bisqEasy.tradeState.info.seller.phase1.accountData=Dados da minha conta de pagamento
+bisqEasy.tradeState.info.seller.phase1.accountData.prompt=Preencha os dados da sua conta de pagamento. Ex: IBAN, BIC e nome do titular da conta
+bisqEasy.tradeState.info.seller.phase1.buttonText=Enviar dados da conta
+bisqEasy.tradeState.info.seller.phase1.note=Nota: Voc\u00ea pode usar o chat abaixo para entrar em contato com o comprador antes de revelar os dados da sua conta.
+bisqEasy.tradeState.info.seller.phase1.tradeLogMessage={0} enviou os dados da conta de pagamento:\n{1}
+bisqEasy.tradeState.info.seller.phase2a.waitForPayment.headline=Aguarde o pagamento de {0} do comprador
+bisqEasy.tradeState.info.seller.phase2a.waitForPayment.info=Assim que o comprador iniciar o pagamento de {0}, voc\u00ea ser\u00e1 notificado.
+bisqEasy.tradeState.info.seller.phase2b.headline=Verifique se voc\u00ea recebeu {0} com motivo de pagamento ''{1}''
+bisqEasy.tradeState.info.seller.phase2b.info=Visite sua conta banc\u00e1ria ou aplicativo do provedor de pagamento para confirmar o recebimento do pagamento do comprador.
+bisqEasy.tradeState.info.seller.phase2b.fiatReceivedButton=Confirmar recebimento de {0}
+bisqEasy.tradeState.info.seller.phase2b.tradeLogMessage={0} confirmou o recebimento de {1}
+bisqEasy.tradeState.info.seller.phase3a.fiatPaymentReceivedCheckBox=Eu confirmei ter recebido {0}
+bisqEasy.tradeState.info.seller.phase3a.sendBtc=Enviar {0} para o comprador
+bisqEasy.tradeState.info.seller.phase3a.baseAmount=Quantia a enviar
+bisqEasy.tradeState.info.seller.phase3a.qrCodeDisplay.openWindow=Abrir exibi\u00e7\u00e3o maior
+bisqEasy.tradeState.info.seller.phase3a.qrCodeDisplay.window.title=Escanear C\u00f3digo QR para negocia\u00e7\u00e3o ''{0}''
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3b.headline.MAIN_CHAIN=Aguardando confirma\u00e7\u00e3o da blockchain
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3b.info.MAIN_CHAIN=O pagamento Bitcoin requer pelo menos 1 confirma\u00e7\u00e3o da blockchain para ser considerado completo.
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3b.balance=Pagamento Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3b.balance.prompt=Aguardando dados da blockchain...
+####################################################################
+# Dynamically created from BitcoinPaymentRail enum name
+####################################################################
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.bitcoinPayment.description.MAIN_CHAIN=Endere\u00e7o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.description.MAIN_CHAIN=ID da Transa\u00e7\u00e3o
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.prompt.MAIN_CHAIN=Preencha o ID da transa\u00e7\u00e3o Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.paymentProof.MAIN_CHAIN=ID da Transa\u00e7\u00e3o
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.bitcoinPayment.description.LN=Fatura Lightning
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.description.LN=Preimage (opcional)
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.prompt.LN=Preencha o preimage se dispon\u00edvel
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.paymentProof.LN=Preimage
+bisqEasy.tradeState.info.seller.phase3a.btcSentButton=Eu confirmo ter enviado {0}
+bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage={0} iniciou a transfer\u00eancia Bitcoin. {1}: ''{2}''
+bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.noProofProvided={0} iniciou a transfer\u00eancia Bitcoin.
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.warning.MAIN_CHAIN=O ID da Transa\u00e7\u00e3o que voc\u00ea inseriu parece ser inv\u00e1lido.\n\n\
+  Se voc\u00ea tem certeza de que o ID da Transa\u00e7\u00e3o \u00e9 v\u00e1lido, pode ignorar este aviso e prosseguir.
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.warning.LN=O preimage que voc\u00ea inseriu parece ser inv\u00e1lido.\n\n\
+  Se voc\u00ea tem certeza de que o preimage \u00e9 v\u00e1lido, pode ignorar este aviso e prosseguir.
+bisqEasy.tradeState.info.seller.phase3a.paymentProof.warning.proceed=Ignorar aviso
+bisqEasy.tradeState.info.seller.phase3b.headline.ln=Aguarde o comprador confirmar o recebimento do Bitcoin
+bisqEasy.tradeState.info.seller.phase3b.info.ln=Transfer\u00eancias via Lightning Network s\u00e3o geralmente quase instant\u00e2neas e confi\u00e1veis. \
+  No entanto, em alguns casos, pagamentos podem falhar e precisar ser repetidos.\n\n\
+  Para evitar problemas, por favor aguarde o comprador confirmar o recebimento.
+bisqEasy.tradeState.info.seller.phase3b.confirmButton.skipWaitForConfirmation.ln=Pular espera pela confirma\u00e7\u00e3o do comprador
+bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.ln=O comprador confirmou o recebimento do Bitcoin
+bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.headline.ln=Sua transfer\u00eancia Bitcoin foi confirmada
+bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.info.ln=Voc\u00ea pode agora prosseguir para finalizar sua negocia\u00e7\u00e3o e ver um resumo completo da transa\u00e7\u00e3o.
+bisqEasy.tradeState.info.seller.phase3b.confirmButton.ln=Concluir negocia\u00e7\u00e3o
+######################################################
+# Trade Completed Table
+#####################################################
+bisqEasy.tradeCompleted.title=Parab\u00e9ns por concluir sua negocia\u00e7\u00e3o no Bisq Easy!
+bisqEasy.tradeCompleted.info=We hope your experience was smooth and enjoyable. We’d love to hear your thoughts!\n\
+  Compartilhar suas impress\u00f5es no chat de discuss\u00e3o ajuda a equipe Bisq a melhorar o Bisq Easy.
+bisqEasy.tradeCompleted.tableTitle=Resumo
+bisqEasy.tradeCompleted.header.tradeWith=Negociar com
+bisqEasy.tradeCompleted.header.myDirection.seller=Eu vendi
+bisqEasy.tradeCompleted.header.myDirection.buyer=Eu comprei
+bisqEasy.tradeCompleted.header.myDirection.btc=btc
+bisqEasy.tradeCompleted.header.myOutcome.seller=Eu recebi
+bisqEasy.tradeCompleted.header.myOutcome.buyer=Eu paguei
+bisqEasy.tradeCompleted.header.paymentMethod=M\u00e9todo de pagamento
+bisqEasy.tradeCompleted.body.tradeId=ID da Negocia\u00e7\u00e3o
+bisqEasy.tradeCompleted.body.date=Data de aceita\u00e7\u00e3o da oferta
+bisqEasy.tradeCompleted.body.tradeDuration=Dura\u00e7\u00e3o da negocia\u00e7\u00e3o
+bisqEasy.tradeCompleted.header.tradePrice=Pre\u00e7o da negocia\u00e7\u00e3o
+bisqEasy.tradeCompleted.body.tradeFee=Taxa de negocia\u00e7\u00e3o
+bisqEasy.tradeCompleted.body.tradeFee.value=Sem taxas de negocia\u00e7\u00e3o no Bisq Easy
+bisqEasy.tradeCompleted.body.copy.txId.tooltip=Copiar ID da transa\u00e7\u00e3o para a \u00e1rea de transfer\u00eancia
+bisqEasy.tradeCompleted.body.copy.explorerLink.tooltip=Copiar link da transa\u00e7\u00e3o do explorador de blocos
+bisqEasy.tradeCompleted.body.txId.tooltip=Abrir transa\u00e7\u00e3o no explorador de blocos
+################################################################################
+#
+# Mediation
+#
+################################################################################
+bisqEasy.mediation.request.confirm.headline=Solicitar media\u00e7\u00e3o
+bisqEasy.mediation.request.confirm.msg=Se voc\u00ea tem problemas que n\u00e3o consegue resolver com seu parceiro de negocia\u00e7\u00e3o, pode solicitar assist\u00eancia de um mediador.\n\n\
+  Por favor, n\u00e3o solicite media\u00e7\u00e3o para perguntas gerais. Na se\u00e7\u00e3o de suporte h\u00e1 salas de chat onde voc\u00ea pode obter conselhos gerais e ajuda.
+bisqEasy.mediation.request.confirm.openMediation=Abrir media\u00e7\u00e3o
+bisqEasy.mediation.request.feedback.headline=Media\u00e7\u00e3o solicitada
+bisqEasy.mediation.request.feedback.msg=Uma solicita\u00e7\u00e3o aos mediadores registrados foi enviada.\n\n\
+  Por favor, tenha paci\u00eancia at\u00e9 que um mediador esteja online para se juntar ao chat da negocia\u00e7\u00e3o e ajudar a resolver quaisquer problemas.
+bisqEasy.mediation.request.feedback.noMediatorAvailable=N\u00e3o h\u00e1 mediador dispon\u00edvel. Por favor, use o chat de suporte em vez disso.
+bisqEasy.mediation.requester.tradeLogMessage={0} solicitou media\u00e7\u00e3o
+
+mobile.bisqEasy.createOffer.mediatorWaiting.title=Publicando oferta
+mobile.bisqEasy.createOffer.mediatorWaiting.message=A rede ainda est\u00e1 sincronizando, isso levar\u00e1 um pouco mais de tempo que o normal. Por favor, aguarde...
+mobile.bisqEasy.createOffer.mediatorTimeout=Falha ao publicar oferta: Nenhum mediador dispon\u00edvel. Por favor, tente novamente mais tarde.
+mobile.bisqEasy.createOffer.failed=Falha ao criar oferta. Por favor, tente novamente.
+


### PR DESCRIPTION
 - contribs #150 
 - missing pr_BR trading translations
 - change fallback to only print missing placeholder on debug builds and use default english translation in prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extensive Brazilian Portuguese (pt-BR) translations across Bisq Easy: Open Trades, Offer Details, Private Chats, Top Pane controls, Trade States (buyer/seller, BTC/LN), Mediation flows, and completion messages.

* **Bug Fixes**
  * Improved missing-translation handling: production now falls back to English when a locale string is unavailable; debug builds show clear placeholders to surface gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->