### PR TITLE
Rearchitect font handling to be theme-driven

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/App.kt
@@ -2,9 +2,22 @@ package network.bisq.mobile.presentation.ui
 
 import ErrorOverlay
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -19,7 +32,6 @@ import network.bisq.mobile.presentation.ui.components.SwipeBackIOSNavigationHand
 import network.bisq.mobile.presentation.ui.components.context.LocalAnimationsEnabled
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.ui.navigation.graph.RootNavGraph
-import network.bisq.mobile.presentation.ui.navigation.graph.TabNavGraph
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
@@ -74,8 +86,9 @@ fun SafeInsetsContainer(
         // Inner container adds padding for content
         Box(
             modifier = Modifier.fillMaxSize().padding(
-                    top = WindowInsets.statusBars.topPaddingDp(), bottom = WindowInsets.navigationBars.bottomPaddingDp()
-                )
+                top = WindowInsets.statusBars.topPaddingDp(),
+                bottom = WindowInsets.navigationBars.bottomPaddingDp()
+            )
         ) {
             content()
         }
@@ -110,7 +123,7 @@ fun App() {
     }
 
     SafeInsetsContainer {
-        BisqTheme(darkTheme = true) {
+        BisqTheme {
             if (isNavControllerSet) {
                 SwipeBackIOSNavigationHandler(rootNavController) {
                     CompositionLocalProvider(LocalAnimationsEnabled provides showAnimation) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AutoResizeText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AutoResizeText.kt
@@ -2,7 +2,6 @@ package network.bisq.mobile.presentation.ui.components.atoms
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -10,14 +9,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-import network.bisq.mobile.presentation.ui.components.atoms.BisqText.fontFamilyBold
-import network.bisq.mobile.presentation.ui.components.atoms.BisqText.fontFamilyLight
-import network.bisq.mobile.presentation.ui.components.atoms.BisqText.fontFamilyMedium
-import network.bisq.mobile.presentation.ui.components.atoms.BisqText.fontFamilyRegular
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 /**
@@ -28,33 +24,16 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 fun AutoResizeText(
     text: String,
     color: Color = BisqTheme.colors.white,
-    fontSize: FontSize = FontSize.BASE,
-    fontWeight: FontWeight = FontWeight.REGULAR,
+    textStyle: TextStyle = BisqTheme.typography.baseRegular,
     textAlign: TextAlign = TextAlign.Start,
-    lineHeight: TextUnit = TextUnit.Unspecified,
+    lineHeight: TextUnit = BisqText.getDefaultLineHeight(textStyle.fontSize),
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Clip,
     minimumFontSize: TextUnit = 10.sp,
     modifier: Modifier = Modifier,
 ) {
+    var fontSize by remember { mutableStateOf(textStyle.fontSize) }
     var readyToDraw by remember(text, fontSize, maxLines, overflow) { mutableStateOf(false) }
-    var determinedFontSize by remember(text, fontSize)  { mutableStateOf(fontSize.size) }
-    val determinedLineHeight by remember {
-        derivedStateOf {
-            if (lineHeight == TextUnit.Unspecified) {
-                determinedFontSize * 1.15f
-            } else {
-                lineHeight
-            }
-        }
-    }
-
-    val fontFamily = when (fontWeight) {
-        FontWeight.LIGHT -> fontFamilyLight()
-        FontWeight.REGULAR -> fontFamilyRegular()
-        FontWeight.MEDIUM -> fontFamilyMedium()
-        FontWeight.BOLD -> fontFamilyBold()
-    }
 
     Text(
         text = text,
@@ -62,16 +41,15 @@ fun AutoResizeText(
             if (readyToDraw) drawContent()
         },
         color = color,
-        fontSize = determinedFontSize,
-        fontFamily = fontFamily,
+        style = textStyle,
         textAlign = textAlign,
-        lineHeight = determinedLineHeight,
+        lineHeight = lineHeight,
         maxLines = maxLines,
         overflow = overflow,
         onTextLayout = { textLayoutResult ->
-            if (textLayoutResult.hasVisualOverflow && determinedFontSize > minimumFontSize) {
-                val next = determinedFontSize * 0.9f
-                determinedFontSize = if (next < minimumFontSize) minimumFontSize else next
+            if (textLayoutResult.hasVisualOverflow && fontSize > minimumFontSize) {
+                val next = fontSize * 0.9f
+                fontSize = if (next < minimumFontSize) minimumFontSize else next
             } else {
                 readyToDraw = true
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/BtcSatsText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/BtcSatsText.kt
@@ -1,9 +1,11 @@
 package network.bisq.mobile.presentation.ui.components.atoms
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,10 +14,9 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.getDecimalSeparator
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
@@ -31,7 +32,7 @@ enum class BtcSatsStyle {
 fun BtcSatsText(
     formattedBtcAmountValue: String, // Expect this to be in btc format (Eg: 0.001112222)
     label: String? = null,
-    fontSize: FontSize = FontSize.BASE,
+    textStyle: TextStyle = BisqTheme.typography.baseRegular,
     style: BtcSatsStyle = BtcSatsStyle.Default,
     noCode: Boolean = false
 ) {
@@ -39,7 +40,6 @@ fun BtcSatsText(
         return
 
     val formattedValue = formatSatsToDisplay(formattedBtcAmountValue, noCode)
-    val finalFontSize = fontSize
 
     if (style == BtcSatsStyle.Default) {
         Row(
@@ -47,12 +47,10 @@ fun BtcSatsText(
             verticalAlignment = Alignment.CenterVertically
         ) {
             // BtcLogo()
-            Text(
+
+            BisqText.styledText(
                 text = formattedValue,
-                fontSize = finalFontSize.size,
-                fontFamily = BisqText.fontFamilyRegular(),
-                lineHeight = TextUnit(finalFontSize.size.times(1.15).value, TextUnitType.Sp),
-                color = BisqTheme.colors.white,
+                style = textStyle
             )
         }
     } else if (style == BtcSatsStyle.TextField) {
@@ -82,12 +80,9 @@ fun BtcSatsText(
                 .padding(BisqUIConstants.ScreenPadding),
         ) {
             // BtcLogo()
-            Text(
+            BisqText.styledText(
                 text = formattedValue,
-                fontSize = finalFontSize.size,
-                fontFamily = BisqText.fontFamilyRegular(),
-                lineHeight = TextUnit(finalFontSize.size.times(1.15).value, TextUnitType.Sp),
-                color = BisqTheme.colors.white,
+                style = textStyle
             )
         }
     }
@@ -106,7 +101,8 @@ private fun formatSatsToDisplay(formattedBtcAmountValue: String, noCode: Boolean
         val leadingZeros = formattedFractional.takeWhile { it == '0' || it == ' ' }
         val significantDigits = formattedFractional.dropWhile { it == '0' || it == ' ' }
 
-        val prefixColor = if (integerPart.toInt() > 0) BisqTheme.colors.white else BisqTheme.colors.mid_grey20
+        val prefixColor =
+            if (integerPart.toInt() > 0) BisqTheme.colors.white else BisqTheme.colors.mid_grey20
 
         withStyle(style = SpanStyle(color = prefixColor)) {
             append(integerPart)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/NoteText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/NoteText.kt
@@ -1,13 +1,16 @@
 package network.bisq.mobile.presentation.ui.components.atoms
 
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -61,9 +64,9 @@ fun NoteText(
                 LinkAnnotation.Clickable(
                     tag = "custom_action",
                     styles = TextLinkStyles(
-                    style = SpanStyle(
-                        color = BisqTheme.colors.primary,
-                        textDecoration = TextDecoration.Underline
+                        style = SpanStyle(
+                            color = BisqTheme.colors.primary,
+                            textDecoration = TextDecoration.Underline
                         )
                     )
                 ) {
@@ -102,9 +105,8 @@ fun NoteText(
 
     BasicText(
         text = annotatedString,
-        style = TextStyle(
+        style = BisqTheme.typography.smallRegular.copy(
             color = BisqTheme.colors.mid_grey20,
-            fontSize = FontSize.SMALL.size,
             textAlign = textAlign
         )
     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Text.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Text.kt
@@ -4,88 +4,64 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
-import androidx.compose.ui.unit.sp
-import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_bold
-import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_light
-import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_medium
-import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_regular
 import network.bisq.mobile.presentation.ui.theme.BisqModifier
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
-import org.jetbrains.compose.resources.Font
-
-enum class FontWeight {
-    LIGHT,
-    REGULAR,
-    MEDIUM,
-    BOLD,
-}
-
-enum class FontSize(val size: TextUnit) {
-    XSMALL(12.sp),
-    SMALL(14.sp),
-    BASE(16.sp),
-    LARGE(18.sp),
-    H6(20.sp),
-    H5(22.sp),
-    H4(24.sp),
-    H3(27.sp),
-    H2(30.sp),
-    H1(34.sp);
-}
 
 object BisqText {
 
-    @Composable
-    fun fontFamilyLight(): FontFamily {
-        return FontFamily(Font(Res.font.ibm_plex_sans_light))
-    }
+    fun getDefaultLineHeight(fontSize: TextUnit) =
+        TextUnit(fontSize.times(1.15).value, TextUnitType.Sp)
+
+    private val defaultColor = BisqTheme.colors.white
+    private val defaultTextAlign = TextAlign.Start
+    private val defaultTextOverflow = TextOverflow.Clip
 
     @Composable
-    fun fontFamilyRegular(): FontFamily {
-        return FontFamily(Font(Res.font.ibm_plex_sans_regular))
-    }
+    fun styledText(
+        text: AnnotatedString,
+        color: Color = defaultColor,
+        textAlign: TextAlign = defaultTextAlign,
+        style: TextStyle = BisqTheme.typography.baseRegular,
+        lineHeight: TextUnit = getDefaultLineHeight(style.fontSize),
+        maxLines: Int = Int.MAX_VALUE,
+        overflow: TextOverflow = defaultTextOverflow,
+        modifier: Modifier = Modifier,
+    ) {
 
-    @Composable
-    fun fontFamilyMedium(): FontFamily {
-        return FontFamily(Font(Res.font.ibm_plex_sans_medium))
-    }
-
-    @Composable
-    fun fontFamilyBold(): FontFamily {
-        return FontFamily(Font(Res.font.ibm_plex_sans_bold))
+        return Text(
+            text = text,
+            color = color,
+            style = style,
+            textAlign = textAlign,
+            lineHeight = lineHeight,
+            maxLines = maxLines,
+            overflow = overflow,
+            modifier = modifier,
+        )
     }
 
     @Composable
     fun styledText(
         text: String,
-        color: Color = BisqTheme.colors.white,
-        fontSize: FontSize = FontSize.BASE,
-        fontWeight: FontWeight = FontWeight.REGULAR,
-        textAlign: TextAlign = TextAlign.Start,
-        lineHeight: TextUnit = TextUnit(fontSize.size.times(1.15).value, TextUnitType.Sp),
+        color: Color = defaultColor,
+        textAlign: TextAlign = defaultTextAlign,
+        style: TextStyle = BisqTheme.typography.baseRegular,
+        lineHeight: TextUnit = getDefaultLineHeight(style.fontSize),
         maxLines: Int = Int.MAX_VALUE,
-        overflow: TextOverflow = TextOverflow.Clip,
+        overflow: TextOverflow = defaultTextOverflow,
         modifier: Modifier = Modifier,
     ) {
-
-        val fontFamily = when (fontWeight) {
-            FontWeight.LIGHT -> fontFamilyLight()
-            FontWeight.REGULAR -> fontFamilyRegular()
-            FontWeight.MEDIUM -> fontFamilyMedium()
-            FontWeight.BOLD -> fontFamilyBold()
-        }
 
         return Text(
             text = text,
             color = color,
-            fontSize = fontSize.size,
-            fontFamily = fontFamily,
+            style = style,
             textAlign = textAlign,
             lineHeight = lineHeight,
             maxLines = maxLines,
@@ -103,8 +79,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.XSMALL,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.xsmallLight,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -117,10 +92,8 @@ object BisqText {
         textAlign: TextAlign = TextAlign.Start,
         modifier: Modifier = Modifier,
     ) {
-        styledText(
+        xsmallLight(
             text = text,
-            fontSize = FontSize.XSMALL,
-            fontWeight = FontWeight.LIGHT,
             color = BisqTheme.colors.mid_grey20,
             textAlign = textAlign,
             modifier = modifier,
@@ -136,8 +109,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.XSMALL,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.xsmallRegular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -167,8 +139,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.XSMALL,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.xsmallMedium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -184,8 +155,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.XSMALL,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.xsmallBold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -202,8 +172,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.SMALL,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.smallLight,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -233,8 +202,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.SMALL,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.smallRegular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -264,8 +232,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.SMALL,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.smallMedium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -281,8 +248,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.SMALL,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.smallBold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -313,8 +279,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.BASE,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.baseLight,
             color = color,
             textAlign = textAlign,
             maxLines = if (singleLine) 1 else Int.MAX_VALUE,
@@ -333,8 +298,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.BASE,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.baseRegular,
             color = color,
             textAlign = textAlign,
             maxLines = if (singleLine) 1 else Int.MAX_VALUE,
@@ -388,8 +352,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.BASE,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.baseMedium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -404,7 +367,7 @@ object BisqText {
     ) {
         baseMedium(
             text = text,
-            color =  BisqTheme.colors.mid_grey20,
+            color = BisqTheme.colors.mid_grey20,
             textAlign = textAlign,
             modifier = modifier,
         )
@@ -419,8 +382,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.BASE,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.baseBold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -437,8 +399,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.LARGE,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.largeLight,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -469,8 +430,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.LARGE,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.largeRegular,
             color = color,
             textAlign = textAlign,
             maxLines = if (singleLine) 1 else Int.MAX_VALUE,
@@ -504,8 +464,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.LARGE,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.largeMedium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -521,8 +480,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.LARGE,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.largeBold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -539,8 +497,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H6,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h6Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -556,8 +513,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H6,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h6Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -573,8 +529,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H6,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h6Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -590,8 +545,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H6,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h6Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -608,8 +562,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H5,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h5Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -625,8 +578,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H5,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h5Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -656,8 +608,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H5,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h5Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -673,8 +624,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H5,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h5Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -691,8 +641,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H4,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h4Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -722,8 +671,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H4,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h4Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -739,8 +687,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H4,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h4Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -756,8 +703,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H4,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h4Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -774,8 +720,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H3,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h3Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -791,8 +736,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H3,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h3Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -808,8 +752,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H3,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h3Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -825,8 +768,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H3,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h3Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -843,8 +785,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H2,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h2Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -860,8 +801,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H2,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h2Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -877,8 +817,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H2,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h2Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -894,8 +833,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H2,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h2Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -911,8 +849,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H1,
-            fontWeight = FontWeight.LIGHT,
+            style = BisqTheme.typography.h1Light,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -942,8 +879,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H1,
-            fontWeight = FontWeight.REGULAR,
+            style = BisqTheme.typography.h1Regular,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -959,8 +895,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H1,
-            fontWeight = FontWeight.MEDIUM,
+            style = BisqTheme.typography.h1Medium,
             color = color,
             textAlign = textAlign,
             modifier = modifier,
@@ -976,8 +911,7 @@ object BisqText {
     ) {
         styledText(
             text = text,
-            fontSize = FontSize.H1,
-            fontWeight = FontWeight.BOLD,
+            style = BisqTheme.typography.h1Bold,
             color = color,
             textAlign = textAlign,
             modifier = modifier,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/TopBar.kt
@@ -38,8 +38,6 @@ import network.bisq.mobile.presentation.ViewPresenter
 import network.bisq.mobile.presentation.ui.components.BackHandler
 import network.bisq.mobile.presentation.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
-import network.bisq.mobile.presentation.ui.components.atoms.FontWeight
 import network.bisq.mobile.presentation.ui.components.atoms.animations.ShineOverlay
 import network.bisq.mobile.presentation.ui.components.atoms.icons.BisqLogoSmall
 import network.bisq.mobile.presentation.ui.components.atoms.icons.UserIcon
@@ -143,8 +141,7 @@ fun TopBar(
                         // because the rest will be clipped by TopBar
                         AutoResizeText(
                             text = title,
-                            fontSize = FontSize.H5,
-                            fontWeight = FontWeight.REGULAR,
+                            textStyle = BisqTheme.typography.h5Regular,
                             color = BisqTheme.colors.white,
                         )
                     }
@@ -152,8 +149,7 @@ fun TopBar(
                     // we will allow overflow to 2 lines here, for better accessibility
                     AutoResizeText(
                         text = title,
-                        fontSize = FontSize.H4,
-                        fontWeight = FontWeight.REGULAR,
+                        textStyle = BisqTheme.typography.h4Regular,
                         color = BisqTheme.colors.white,
                         maxLines = 2,
                     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/info/InfoBoxSats.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/info/InfoBoxSats.kt
@@ -1,21 +1,22 @@
 package network.bisq.mobile.presentation.ui.components.molecules.info
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
 import network.bisq.mobile.presentation.ui.components.atoms.BtcSatsText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
 fun InfoBoxSats(
     label: String,
     value: String,
-    fontSize: FontSize = FontSize.H6,
+    textStyle: TextStyle = BisqTheme.typography.h6Regular,
     rightAlign: Boolean = false,
 ) {
     InfoBox(
         label = label,
         rightAlign = rightAlign,
         valueComposable = {
-            BtcSatsText(value, fontSize = fontSize)
+            BtcSatsText(value, textStyle = textStyle)
         }
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/StringHelper.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/StringHelper.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
+import network.bisq.mobile.presentation.ui.theme.FontSize
 
 object StringHelper {
     @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/navigation/BottomNavigation.kt
@@ -3,7 +3,10 @@ package network.bisq.mobile.presentation.ui.navigation
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.*
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -15,8 +18,6 @@ import androidx.compose.ui.unit.sp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
-import network.bisq.mobile.presentation.ui.components.atoms.FontWeight
 import network.bisq.mobile.presentation.ui.components.atoms.animations.AnimatedBadge
 import network.bisq.mobile.presentation.ui.composeModels.BottomNavigationItem
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
@@ -85,8 +86,7 @@ fun BottomNavigation(
                     AutoResizeText(
                         text = navigationItem.title.i18n(),
                         color = if (navigationItem.route == currentRoute) BisqTheme.colors.primary else BisqTheme.colors.white,
-                        fontSize = FontSize.BASE,
-                        fontWeight = FontWeight.LIGHT,
+                        textStyle = BisqTheme.typography.baseLight,
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         minimumFontSize = 8.sp

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTheme.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTheme.kt
@@ -2,16 +2,33 @@ package network.bisq.mobile.presentation.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 
-@Composable
-fun BisqTheme(
-    darkTheme: Boolean = true,
-    content: @Composable () -> Unit
-) {
-    MaterialTheme(content = content)
+private val LocalBisqTypography = staticCompositionLocalOf<BisqTypography> {
+    error("BisqTypography not provided. Make sure to wrap your UI in BisqTheme { ... }")
 }
 
 object BisqTheme {
+
+    val typography: BisqTypography
+        @Composable
+        get() = LocalBisqTypography.current
+
     val colors: BisqColors
         get() = darkColors
+
+    @Composable
+    operator fun invoke(
+        content: @Composable () -> Unit
+    ) {
+        val fontFamily = bisqFontFamily()
+        val typography = remember(fontFamily) { BisqTypography(fontFamily) }
+
+        CompositionLocalProvider(LocalBisqTypography provides typography) {
+            MaterialTheme(content = content)
+        }
+    }
+
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTypography.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTypography.kt
@@ -1,0 +1,277 @@
+package network.bisq.mobile.presentation.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_bold
+import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_light
+import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_medium
+import bisqapps.shared.presentation.generated.resources.ibm_plex_sans_regular
+import org.jetbrains.compose.resources.Font
+
+@Composable
+fun bisqFontFamily(): FontFamily {
+    return FontFamily(
+        Font(Res.font.ibm_plex_sans_light, FontWeight.Light),
+        Font(Res.font.ibm_plex_sans_regular, FontWeight.Normal),
+        Font(Res.font.ibm_plex_sans_medium, FontWeight.Medium),
+        Font(Res.font.ibm_plex_sans_bold, FontWeight.Bold)
+    )
+}
+
+class BisqTypography(fontFamily: FontFamily) {
+
+    val xsmallLight: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.XSMALL.size,
+    )
+
+    val xsmallRegular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.XSMALL.size,
+    )
+
+    val xsmallMedium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.XSMALL.size,
+    )
+
+    val xsmallBold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.XSMALL.size,
+    )
+
+    val smallLight: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.SMALL.size,
+    )
+
+    val smallRegular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.SMALL.size,
+    )
+
+    val smallMedium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.SMALL.size,
+    )
+
+    val smallBold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.SMALL.size,
+    )
+
+    val baseLight: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.BASE.size,
+    )
+
+    val baseRegular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.BASE.size,
+    )
+
+    val baseMedium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.BASE.size,
+    )
+
+    val baseBold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.BASE.size,
+    )
+
+    val largeLight: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.LARGE.size,
+    )
+
+    val largeRegular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.LARGE.size,
+    )
+
+    val largeMedium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.LARGE.size,
+    )
+
+    val largeBold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.LARGE.size,
+
+        )
+
+    val h6Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H6.size,
+    )
+
+    val h6Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H6.size,
+    )
+
+    val h6Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H6.size,
+    )
+
+    val h6Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H6.size,
+    )
+
+    val h5Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H5.size,
+    )
+
+    val h5Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H5.size,
+    )
+
+    val h5Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H5.size,
+    )
+    val h5Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H5.size,
+    )
+    val h4Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H4.size,
+    )
+
+    val h4Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H4.size,
+    )
+
+    val h4Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H4.size,
+    )
+
+    val h4Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H4.size,
+    )
+
+    val h3Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H3.size,
+    )
+
+    val h3Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H3.size,
+    )
+
+    val h3Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H3.size,
+    )
+
+    val h3Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H3.size,
+    )
+
+    val h2Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H2.size,
+    )
+
+    val h2Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H2.size,
+    )
+
+    val h2Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H2.size,
+    )
+
+    val h2Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H2.size,
+    )
+
+    val h1Light: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Light,
+        fontSize = FontSize.H1.size,
+    )
+
+    val h1Regular: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = FontSize.H1.size,
+    )
+    val h1Medium: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = FontSize.H1.size,
+    )
+    val h1Bold: TextStyle = TextStyle(
+        fontFamily = fontFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = FontSize.H1.size,
+    )
+}
+
+enum class FontSize(val size: TextUnit) {
+    XSMALL(12.sp),
+    SMALL(14.sp),
+    BASE(16.sp),
+    LARGE(18.sp),
+    H6(20.sp),
+    H5(22.sp),
+    H4(24.sp),
+    H3(27.sp),
+    H2(30.sp),
+    H1(34.sp);
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
@@ -30,8 +30,6 @@ import network.bisq.mobile.presentation.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
-import network.bisq.mobile.presentation.ui.components.atoms.FontWeight
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.ui.components.molecules.AmountWithCurrency
@@ -123,9 +121,9 @@ fun DashBoardCard(
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)
     ) {
 //        BisqText.h1Light(title)
-        AutoResizeText(title, maxLines = 1,
-            fontSize = FontSize.H1,
-            fontWeight = FontWeight.LIGHT,
+        AutoResizeText(
+            title, maxLines = 1,
+            textStyle = BisqTheme.typography.h1Light,
             color = BisqTheme.colors.white,
             textAlign = TextAlign.Start,
 //            lineHeight = lineHeight,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -12,7 +12,6 @@ import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.BtcSatsText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.ui.components.layout.MultiScreenWizardScaffold
@@ -22,6 +21,7 @@ import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxCurr
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxSats
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoRowContainer
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
@@ -62,12 +62,15 @@ fun CreateOfferReviewOfferScreen() {
                         valueComposable = {
                             Row {
                                 BtcSatsText(
-                                    presenter.formattedBaseRangeMinAmount,
+                                    formattedBtcAmountValue = presenter.formattedBaseRangeMinAmount,
                                     noCode = true,
-                                    fontSize = FontSize.H6
+                                    textStyle = BisqTheme.typography.h6Regular,
                                 )
                                 BisqText.baseLight(" - ")
-                                BtcSatsText(presenter.formattedBaseRangeMaxAmount, fontSize = FontSize.H6)
+                                BtcSatsText(
+                                    formattedBtcAmountValue = presenter.formattedBaseRangeMaxAmount,
+                                    textStyle = BisqTheme.typography.h6Regular,
+                                )
                             }
                         }
                     )
@@ -83,10 +86,13 @@ fun CreateOfferReviewOfferScreen() {
                                 BtcSatsText(
                                     presenter.formattedBaseRangeMinAmount,
                                     noCode = true,
-                                    fontSize = FontSize.H6
+                                    textStyle = BisqTheme.typography.h6Regular,
                                 )
                                 BisqText.baseLight(" - ")
-                                BtcSatsText(presenter.formattedBaseRangeMaxAmount, fontSize = FontSize.H6)
+                                BtcSatsText(
+                                    presenter.formattedBaseRangeMaxAmount,
+                                    textStyle = BisqTheme.typography.h6Regular,
+                                )
                             }
                         }
                     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.displayString
@@ -31,8 +30,6 @@ import network.bisq.mobile.domain.utils.StringUtils.truncate
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
-import network.bisq.mobile.presentation.ui.components.atoms.FontWeight
 import network.bisq.mobile.presentation.ui.components.atoms.icons.RemoveOfferIcon
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqVDivider
@@ -140,8 +137,7 @@ fun OfferCard(
                     AutoResizeText(
                         userName.truncate(maxUsernameChars),
                         color = directionalLabelColor,
-                        fontSize = FontSize.SMALL,
-                        fontWeight = FontWeight.REGULAR,
+                        textStyle = BisqTheme.typography.smallRegular,
                         maxLines = 2,
                         modifier = BisqModifier
                             .textHighlight(BisqTheme.colors.dark_grey10
@@ -160,8 +156,7 @@ fun OfferCard(
 
             AutoResizeText(
                 text = "@ " + item.formattedPriceSpec,
-                fontSize = FontSize.SMALL,
-                fontWeight = FontWeight.LIGHT,
+                textStyle = BisqTheme.typography.smallLight,
                 maxLines = 1,
             )
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3a.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/states/SellerState3a.kt
@@ -20,12 +20,12 @@ import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.BisqTextField
 import network.bisq.mobile.presentation.ui.components.atoms.BtcSatsText
-import network.bisq.mobile.presentation.ui.components.atoms.FontSize
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.molecules.inputfield.BitcoinLnAddressField
 import network.bisq.mobile.presentation.ui.components.molecules.inputfield.PaymentProofField
 import network.bisq.mobile.presentation.ui.components.molecules.inputfield.PaymentProofType
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -45,7 +45,8 @@ fun SellerState3a(
         "bisqEasy.tradeState.info.seller.phase3a.bitcoinPayment.description.$paymentMethod".i18n()
     val paymentProofDescription =
         "bisqEasy.tradeState.info.seller.phase3a.paymentProof.description.$paymentMethod".i18n()
-    val paymentProofPrompt = "bisqEasy.tradeState.info.seller.phase3a.paymentProof.prompt.$paymentMethod".i18n()
+    val paymentProofPrompt =
+        "bisqEasy.tradeState.info.seller.phase3a.paymentProof.prompt.$paymentMethod".i18n()
 
     val bitcoinPaymentData by trade.bisqEasyTradeModel.bitcoinPaymentData.collectAsState()
     val isLightning by presenter.isLightning.collectAsState()
@@ -63,7 +64,9 @@ fun SellerState3a(
             )
             BisqText.baseRegularGrey(
                 // I confirmed to have received {0}
-                "bisqEasy.tradeState.info.seller.phase3a.fiatPaymentReceivedCheckBox".i18n(quoteAmount),
+                "bisqEasy.tradeState.info.seller.phase3a.fiatPaymentReceivedCheckBox".i18n(
+                    quoteAmount
+                ),
             )
         }
 
@@ -73,7 +76,7 @@ fun SellerState3a(
         // BisqText.h5Light("bisqEasy.tradeState.info.seller.phase3a.sendBtc".i18n(baseAmount))
         Row {
             BisqText.h5Light("mobile.bisqEasy.tradeState.info.seller.phase3a.send".i18n() + " ")
-            BtcSatsText(baseAmount, fontSize = FontSize.H5)
+            BtcSatsText(baseAmount, textStyle = BisqTheme.typography.h5Regular)
         }
         BisqText.h5Light("mobile.bisqEasy.tradeState.info.seller.phase3a.toTheBuyer".i18n())
 


### PR DESCRIPTION
### Summary

This PR refactors our font architecture to unblock the use of Jetpack Compose Previews. This is the foundational step in a larger initiative to enable previews and accelerate UI development.

### The Problem

Our `BisqText` component was hard-coding its font loading directly from KMP resources. This is incompatible with the Android Studio Preview environment and caused an immediate crash, making it impossible to use previews.

### The Solution: A Theme-Driven Architecture

This PR aligns our typography with standard Compose best practices by making our theme the single source of truth for all text styling.

* A new `BisqTypography` class now centrally defines all `TextStyle`s for the app.
* The `BisqTheme` is now responsible for loading the font and providing these styles to the UI.
* The `BisqText` component has been refactored to be a clean API that consumes styles directly from the theme, with no internal font-loading logic.

### Benefits

* **Unblocks Compose Previews:** The font-loading crash is resolved.
* **Improved Architecture:** Decouples text components from the font implementation.
* **Enhanced Maintainability:** All text styles are now managed in one central location.