### PR TITLE
bugfix/localhost_support_lost

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -342,7 +342,7 @@ class WebSocketClient(
                         //todo add input validation
                         log.d { "Received raw text $message" }
                         val webSocketMessage: WebSocketMessage =
-                            json.decodeFromString(WebSocketMessage.serializer(), message)
+                            json.decodeFromString<WebSocketMessage>(message)
                         log.i { "Received webSocketMessage $webSocketMessage" }
                         if (webSocketMessage is WebSocketResponse) {
                             onWebSocketResponse(webSocketMessage)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/WebSocketClient.kt
@@ -342,7 +342,11 @@ class WebSocketClient(
                         //todo add input validation
                         log.d { "Received raw text $message" }
                         val webSocketMessage: WebSocketMessage =
-                            json.decodeFromString<WebSocketMessage>(message)
+                            runCatching {
+                                json.decodeFromString<WebSocketMessage>(message)
+                            }.onFailure {
+                                log.w(it) { "Failed to decode WS message; dropping frame. Raw=$message" }
+                            }.getOrNull() ?: continue
                         log.i { "Received webSocketMessage $webSocketMessage" }
                         if (webSocketMessage is WebSocketResponse) {
                             onWebSocketResponse(webSocketMessage)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/messages/WebSocketMessage.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/websocket/messages/WebSocketMessage.kt
@@ -3,5 +3,4 @@ package network.bisq.mobile.client.websocket.messages
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed interface WebSocketMessage {
-}
+sealed interface WebSocketMessage

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -35,6 +35,8 @@ class TrustedNodeSetupPresenter(
 
     companion object {
         const val SAFEGUARD_TEST_TIMEOUT = 10000L
+        const val LOCALHOST = "localhost"
+        const val ANDROID_LOCALHOST = "10.0.2.2"
     }
 
     enum class NetworkType(private val i18nKey: String) {
@@ -55,7 +57,7 @@ class TrustedNodeSetupPresenter(
     private val _port = MutableStateFlow("8090")
     val port: StateFlow<String> get() = _port.asStateFlow()
 
-    private val _hostPrompt = MutableStateFlow("10.0.2.2")
+    private val _hostPrompt = MutableStateFlow(localHost())
     val hostPrompt: StateFlow<String> get() = _hostPrompt.asStateFlow()
 
     private val _trustedNodeVersion = MutableStateFlow("")
@@ -85,7 +87,7 @@ class TrustedNodeSetupPresenter(
 
         updateHostPrompt()
         if (BuildConfig.IS_DEBUG) {
-            _host.value = "10.0.2.2"
+            _host.value = localHost()
             validateApiUrl()
         }
 
@@ -289,7 +291,7 @@ class TrustedNodeSetupPresenter(
     private fun updateHostPrompt() {
         if (selectedNetworkType.value == NetworkType.LAN) {
             if (BuildConfig.IS_DEBUG) {
-                _hostPrompt.value = "10.0.2.2"
+                _hostPrompt.value = localHost()
             } else {
                 _hostPrompt.value = "192.168.1.10"
             }
@@ -304,6 +306,7 @@ class TrustedNodeSetupPresenter(
         }
         if (selectedNetworkType.value == NetworkType.LAN) {
             // We only support IPv4 as we only support LAN addresses
+            if (value == localHost()) return null
             if (!value.isValidIpv4()) {
                 return "mobile.trustedNodeSetup.host.ip.invalid".i18n()
             }
@@ -327,5 +330,9 @@ class TrustedNodeSetupPresenter(
     private fun validateApiUrl() {
         _isApiUrlValid.value = validateHost(host.value) == null &&
                 validatePort(port.value) == null
+    }
+
+    private fun localHost(): String {
+        return if (isIOS()) LOCALHOST else ANDROID_LOCALHOST
     }
 }


### PR DESCRIPTION
 - fix missing localhost host support on trusted node setup screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Trusted Node setup now auto-selects the appropriate local host per platform (Android emulator vs iOS) and uses that as the default in debug, streamlining initial setup prompts.
* **Bug Fixes**
  * Removes false validation errors for local node addresses and accepts the platform-specific local host during LAN validation to reduce emulator/simulator setup friction.
* **Chores**
  * More robust WebSocket handling: malformed frames are now caught and dropped without crashing; minor serialization syntax cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->