### PR TITLE
enhancement/remove_bmap_in_ui_thread

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/KmpTorService.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
-import network.bisq.mobile.domain.service.ServiceFacade
+import network.bisq.mobile.domain.service.BaseService
 import network.bisq.mobile.domain.utils.Logging
 import java.io.File
 import java.io.FileOutputStream
@@ -39,7 +39,7 @@ import kotlin.io.path.absolutePathString
  *    The bisq 2 tor lib will detect the external tor and use that.
  *
  */
-class KmpTorService : ServiceFacade(), Logging {
+class KmpTorService : BaseService(), Logging {
 
     private lateinit var baseDir: Path
     private var torRuntime: TorRuntime? = null

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/network/NodeConnectivityService.kt
@@ -14,14 +14,6 @@ class NodeConnectivityService(private val applicationService: AndroidApplication
         const val SLOW_PEER_QUANTITY_THRESHOLD = 4
     }
 
-    override fun activate() {
-        super.activate()
-    }
-
-    override fun deactivate() {
-        super.deactivate()
-    }
-
     override fun isConnected(): Boolean {
         val connections = currentConnections()
         log.v { "Connected peers = $connections" }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -189,7 +189,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
     }
 
     override suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage? {
-        val key = userProfile.nym
+        val key = "${userProfile.id}-v${userProfile.avatarVersion}"
         avatarMap[key]?.let { return it }
         return generateCatHash(key, userProfile)
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/BaseService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/BaseService.kt
@@ -1,0 +1,31 @@
+package network.bisq.mobile.domain.service
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.Logging
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Base class for Bisq Android Services.
+ *
+ * Provide useful coroutines methods
+ */
+abstract class BaseService : KoinComponent, Logging {
+    // we use KoinCompoent inject to avoid having to pass the manager as parameter on every single service
+    protected val jobsManager: CoroutineJobsManager by inject()
+    
+    // Provide access to the IO scope from the jobsManager
+    protected val serviceScope: CoroutineScope
+        get() = jobsManager.getIOScope()
+
+    // Helper methods for launching coroutines with the jobsManager
+    protected fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
+        return jobsManager.launchIO(block)
+    }
+    
+    protected fun <T> collectIO(flow: Flow<T>, collector: suspend (T) -> Unit): Job {
+        return jobsManager.collectIO(flow, collector)
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ClientConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ClientConnectivityService.kt
@@ -7,14 +7,6 @@ import network.bisq.mobile.domain.utils.Logging
 class ClientConnectivityService(
     private val webSocketClientProvider: WebSocketClientProvider
 ) : ConnectivityService(), Logging {
-    override fun activate() {
-        super.activate()
-    }
-
-    override fun deactivate() {
-        super.deactivate()
-    }
-
     override fun isConnected(): Boolean {
         return webSocketClientProvider.get().isConnected()
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/network/ConnectivityService.kt
@@ -1,8 +1,6 @@
 package network.bisq.mobile.domain.service.network
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,14 +10,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
-import network.bisq.mobile.domain.data.IODispatcher
-import network.bisq.mobile.domain.service.ServiceFacade
+import network.bisq.mobile.domain.service.BaseService
 
 /**
  * Base definition for the connectivity service. Each app type should implement / override the default
  * based on its network type.
  */
-abstract class ConnectivityService : ServiceFacade() {
+abstract class ConnectivityService : BaseService() {
     companion object {
         const val TIMEOUT = 5000L
         const val PERIOD = 5000L // default check every 5 sec

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/utils/AndroidImageUtil.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/utils/AndroidImageUtil.kt
@@ -50,8 +50,11 @@ object AndroidImageUtil : Logging {
                 canvas.drawBitmap(scaledBitmap, 0f, 0f, paint)
 
                 // Recycle scaled bitmap if it's different from original to free memory
-                if (scaledBitmap != bitmap) {
+                if (scaledBitmap !== bitmap) {
                     scaledBitmap.recycle()
+                    bitmap.recycle()
+                } else {
+                    bitmap.recycle()
                 }
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/cathash/BaseClientCatHashService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/cathash/BaseClientCatHashService.kt
@@ -8,6 +8,7 @@ import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.pubKeyHashAsByteArray
+import network.bisq.mobile.domain.service.BaseService
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.domain.utils.base64ToByteArray
@@ -20,7 +21,7 @@ import okio.SYSTEM
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 abstract class BaseClientCatHashService(private val baseDirPath: String) :
-    ServiceFacade(), ClientCatHashService<PlatformImage?>, Logging {
+    BaseService(), ClientCatHashService<PlatformImage?>, Logging {
     companion object {
         const val SIZE_OF_CACHED_ICONS = 60
         const val MAX_CACHE_SIZE = 5000


### PR DESCRIPTION
 - found whilst working in #597 
 - contribs to #330 
 - fixes random skipped drawing frames (UI thread overload)
 - remove bitmap operations from main thread, add missing cache usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Performance
  - Faster, smoother avatar rendering by moving generation to background threads.
  - Reduced memory usage and avoided unnecessary image scaling for improved responsiveness.
  - Less log noise; only slow operations are reported.

- Refactor
  - Cleaner, more robust avatar fetching and caching flow with background generation and async disk writes.
  - Internal service layering standardized for consistency without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->