### PR TITLE
Enable compose previews and provide some samples

### DIFF
--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 dependencies {
     androidTestImplementation(libs.androidx.test.compose.junit4)
     androidTestImplementation(libs.androidx.test.compose.manifest)
+    debugImplementation(compose.uiTooling)
 }
 
 version = project.findProperty("shared.version") as String

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AutoResizeText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/AutoResizeText.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -33,6 +34,7 @@ fun AutoResizeText(
     minimumFontSize: TextUnit = 10.sp,
     modifier: Modifier = Modifier,
 ) {
+    val inPreview = LocalInspectionMode.current
     var readyToDraw by remember(text, textStyle.fontSize, maxLines, overflow) {
         mutableStateOf(false)
     }
@@ -52,7 +54,11 @@ fun AutoResizeText(
     Text(
         text = text,
         modifier = modifier.drawWithContent {
-            if (readyToDraw) drawContent()
+            // During previews, the `onTextLayout` recomposition loop may not complete,
+            // which would leave `readyToDraw` as false and result in an empty render.
+            // Bypassing the check in preview mode ensures the component is always visible
+            // for development, without affecting runtime behavior.
+            if (readyToDraw || inPreview) drawContent()
         },
         color = color,
         style = textStyle.copy(fontSize = determinedFontSize),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Text.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/Text.kt
@@ -34,7 +34,7 @@ object BisqText {
         modifier: Modifier = Modifier,
     ) {
 
-        return Text(
+        Text(
             text = text,
             color = color,
             style = style,
@@ -58,7 +58,7 @@ object BisqText {
         modifier: Modifier = Modifier,
     ) {
 
-        return Text(
+        Text(
             text = text,
             color = color,
             style = style,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/market/MarketFilters.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/market/MarketFilters.kt
@@ -3,15 +3,13 @@ package network.bisq.mobile.presentation.ui.components.organisms.market
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqSegmentButton
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
-import network.bisq.mobile.presentation.ui.uicases.offerbook.OfferbookMarketPresenter
-import org.koin.compose.koinInject
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class MarketSortBy {
     MostOffers,
@@ -39,36 +37,43 @@ fun MarketFilter.getDisplayName(): String {
     }
 }
 
-
 @Composable
-fun MarketFilters() {
-
-    val presenter: OfferbookMarketPresenter = koinInject()
-    val sortBy by presenter.sortBy.collectAsState()
-    val filter by presenter.filter.collectAsState()
-
+fun MarketFilters(
+    sortBy: MarketSortBy,
+    filter: MarketFilter,
+    onSortByChange: (MarketSortBy) -> Unit,
+    onFilterChange: (MarketFilter) -> Unit,
+) {
     Column(modifier = Modifier.padding(all = BisqUIConstants.ScreenPadding2X)) {
-
         BisqSegmentButton(
             label = "mobile.components.marketFilter.sortBy".i18n(),
             value = sortBy,
             items = MarketSortBy.entries.map { it to it.getDisplayName() },
             onValueChange = { pair ->
-                presenter.setSortBy(pair.first)
+                onSortByChange(pair.first)
             },
         )
-
         BisqGap.V2()
-
         BisqSegmentButton(
             label = "mobile.components.marketFilter.showMarkets".i18n(),
             items = MarketFilter.entries.map { it to it.getDisplayName() },
             value = filter,
             onValueChange = { pair ->
-                presenter.setFilter(pair.first)
+                onFilterChange(pair.first)
             },
         )
-
     }
+}
 
+@Preview
+@Composable
+private fun MarketFiltersPreview() {
+    BisqTheme.Preview {
+        MarketFilters(
+            sortBy = MarketSortBy.MostOffers,
+            filter = MarketFilter.WithOffers,
+            onSortByChange = {},
+            onFilterChange = {}
+        )
+    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTheme.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/BisqTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import network.bisq.mobile.i18n.I18nSupport
 
 object BisqTheme {
     private val LocalBisqTypography = staticCompositionLocalOf<BisqTypography> {
@@ -27,6 +28,29 @@ object BisqTheme {
 
         CompositionLocalProvider(LocalBisqTypography provides typography) {
             MaterialTheme(content = content)
+        }
+    }
+
+    /**
+     * A wrapper for Jetpack Compose `@Preview` annotations that provides the `BisqTheme`
+     * and initializes `I18nSupport` for the preview environment.
+     *
+     * This function is a convenience for ensuring that composable previews are rendered
+     * with the correct application theme and have access to localized strings. It should
+     * only be used for UI previews.
+     *
+     * @param language The code for the language to be used in the preview (e.g., "en", "es").
+     * Defaults to "en".
+     * @param content The composable lambda to be rendered within the theme.
+     */
+    @Composable
+    fun Preview(
+        language: String = "en",
+        content: @Composable () -> Unit
+    ) {
+        I18nSupport.initialize(language)
+        BisqTheme {
+            content()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
@@ -38,6 +38,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable
@@ -51,13 +52,33 @@ fun DashboardScreen() {
     val marketPrice by presenter.marketPrice.collectAsState()
     val tradeRulesConfirmed by presenter.tradeRulesConfirmed.collectAsState()
 
+    DashboardContent(
+        offersOnline = offersOnline,
+        publishedProfiles = publishedProfiles,
+        isInteractive = isInteractive,
+        marketPrice = marketPrice,
+        tradeRulesConfirmed = tradeRulesConfirmed,
+        onNavigateToMarkets = presenter::onNavigateToMarkets,
+        onOpenTradeGuide = presenter::onOpenTradeGuide
+    )
+}
+
+@Composable
+private fun DashboardContent(
+    offersOnline: Number,
+    publishedProfiles: Number,
+    isInteractive: Boolean,
+    marketPrice: String,
+    tradeRulesConfirmed: Boolean,
+    onNavigateToMarkets: () -> Unit,
+    onOpenTradeGuide: () -> Unit
+) {
     val padding = BisqUIConstants.ScreenPadding
     BisqScrollLayout(
         padding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.spacedBy(padding),
         isInteractive = isInteractive,
     ) {
-
         Column {
             PriceProfileCard(
                 price = marketPrice,
@@ -91,7 +112,7 @@ fun DashboardScreen() {
                     Pair("mobile.dashboard.main.content3".i18n(), Res.drawable.reputation)
                 ),
                 buttonText = "mobile.dashboard.startTrading.button".i18n(),
-                buttonHandler = { presenter.onNavigateToMarkets() }
+                buttonHandler = onNavigateToMarkets
             )
         } else {
             DashBoardCard(
@@ -102,12 +123,13 @@ fun DashboardScreen() {
                     Pair("bisqEasy.onboarding.top.content3".i18n(), Res.drawable.icon_chat)
                 ),
                 buttonText = "support.resources.guides.tradeGuide".i18n(),
-                buttonHandler = { presenter.onOpenTradeGuide() }
+                buttonHandler = onOpenTradeGuide
             )
         }
         Spacer(modifier = Modifier.fillMaxHeight().weight(0.2f))
     }
 }
+
 
 @Composable
 fun DashBoardCard(
@@ -120,15 +142,12 @@ fun DashBoardCard(
         padding = BisqUIConstants.ScreenPadding2X,
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)
     ) {
-//        BisqText.h1Light(title)
         AutoResizeText(
-            title, maxLines = 1,
+            text = title,
+            maxLines = 1,
             textStyle = BisqTheme.typography.h1Light,
             color = BisqTheme.colors.white,
             textAlign = TextAlign.Start,
-//            lineHeight = lineHeight,
-//            overflow = overflow,
-//            modifier = modifier
         )
 
         Column {
@@ -148,7 +167,7 @@ fun DashBoardCard(
         }
 
         BisqButton(
-            buttonText,
+            text = buttonText,
             fullWidth = true,
             onClick = buttonHandler,
         )
@@ -163,12 +182,47 @@ fun PriceProfileCard(modifier: Modifier = Modifier, price: String, priceText: St
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AmountWithCurrency(price)
-
         BisqGap.V1()
-
         BisqText.smallRegularGrey(
             text = priceText,
             textAlign = TextAlign.Center,
         )
     }
 }
+
+@Composable
+private fun DashboardContentPreview(
+    language: String = "en",
+    tradeRulesConfirmed: Boolean = true
+) {
+    BisqTheme.Preview(language = language) {
+        DashboardContent(
+            offersOnline = 1,
+            publishedProfiles = 2,
+            isInteractive = true,
+            marketPrice = "111247.40 BTC/USD",
+            tradeRulesConfirmed = tradeRulesConfirmed,
+            onNavigateToMarkets = {},
+            onOpenTradeGuide = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DashboardContentPreview_En() = DashboardContentPreview(tradeRulesConfirmed = true)
+
+@Preview
+@Composable
+private fun DashboardContentPreview_EnRulesNotConfirmed() =
+    DashboardContentPreview(tradeRulesConfirmed = false)
+
+@Preview
+@Composable
+private fun DashboardContentPreview_Ru() = DashboardContentPreview("ru", true)
+
+@Preview
+@Composable
+private fun DashboardContentPreview_RuRulesNotConfirmed() = DashboardContentPreview("ru", false)
+
+

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import network.bisq.mobile.domain.data.model.offerbook.MarketListItem
+import network.bisq.mobile.domain.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.domain.data.replicated.common.currency.MarketVOExtensions.marketCodes
 import network.bisq.mobile.presentation.ui.components.CurrencyCard
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
@@ -23,32 +25,67 @@ import network.bisq.mobile.presentation.ui.components.molecules.bottom_sheet.Bis
 import network.bisq.mobile.presentation.ui.components.molecules.inputfield.BisqSearchField
 import network.bisq.mobile.presentation.ui.components.organisms.market.MarketFilter
 import network.bisq.mobile.presentation.ui.components.organisms.market.MarketFilters
+import network.bisq.mobile.presentation.ui.components.organisms.market.MarketSortBy
 import network.bisq.mobile.presentation.ui.helpers.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable
 fun OfferbookMarketScreen() {
     val presenter: OfferbookMarketPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
-    
+
     var showFilterDialog by remember { mutableStateOf(false) }
     val searchText by presenter.searchText.collectAsState()
     val isInteractive by presenter.isInteractive.collectAsState()
     val hasIgnoredUsers by presenter.hasIgnoredUsers.collectAsState()
-
     val marketItems by presenter.marketListItemWithNumOffers.collectAsState()
     val filter by presenter.filter.collectAsState()
+    val sortBy by presenter.sortBy.collectAsState()
 
+    OfferbookMarketScreenContent(
+        searchText = searchText,
+        isInteractive = isInteractive,
+        hasIgnoredUsers = hasIgnoredUsers,
+        marketItems = marketItems,
+        filter = filter,
+        sortBy = sortBy,
+        showFilterDialog = showFilterDialog,
+        onFilterClick = { showFilterDialog = true },
+        onDismissFilterDialog = { showFilterDialog = false },
+        onSearchTextChange = presenter::setSearchText,
+        onMarketSelect = presenter::onSelectMarket,
+        onSortByFilterChange = presenter::setSortBy,
+        onFilterChange = presenter::setFilter
+    )
+}
+
+@Composable
+private fun OfferbookMarketScreenContent(
+    searchText: String,
+    isInteractive: Boolean,
+    hasIgnoredUsers: Boolean,
+    marketItems: List<MarketListItem>,
+    filter: MarketFilter,
+    sortBy: MarketSortBy,
+    showFilterDialog: Boolean,
+    onSortByFilterChange: (MarketSortBy) -> Unit,
+    onFilterChange: (MarketFilter) -> Unit,
+    onSearchTextChange: (String) -> Unit,
+    onFilterClick: () -> Unit,
+    onMarketSelect: (MarketListItem) -> Unit,
+    onDismissFilterDialog: () -> Unit,
+) {
     BisqStaticLayout(
         padding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.Top,
         isInteractive = isInteractive,
     ) {
-
         BisqSearchField(
             value = searchText,
-            onValueChanged = { it, isValid -> presenter.setSearchText(it) },
+            onValueChanged = { text, _ -> onSearchTextChange(text) },
             rightSuffix = {
                 // TODO: Height to be reduced with Icon only buttons
                 BisqButton(
@@ -59,7 +96,7 @@ fun OfferbookMarketScreen() {
                             SortIcon()
                         }
                     },
-                    onClick = { showFilterDialog = true },
+                    onClick = onFilterClick,
                     type = BisqButtonType.Clear,
                     modifier = Modifier.weight(1f),
                 )
@@ -73,15 +110,60 @@ fun OfferbookMarketScreen() {
                 CurrencyCard(
                     item = item,
                     hasIgnoredUsers = hasIgnoredUsers,
-                    onClick = { presenter.onSelectMarket(item) }
+                    onClick = { onMarketSelect(item) }
                 )
             }
         }
 
         if (showFilterDialog) {
-            BisqBottomSheet(onDismissRequest = { showFilterDialog = false }) {
-                MarketFilters()
+            BisqBottomSheet(onDismissRequest = onDismissFilterDialog) {
+                MarketFilters(
+                    sortBy = sortBy,
+                    filter = filter,
+                    onSortByChange = onSortByFilterChange,
+                    onFilterChange = onFilterChange
+                )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun OfferbookMarketScreenContentPreview() {
+    val mockMarketItems =
+        listOf(
+            MarketListItem(
+                market = MarketVO(baseCurrencyCode = "BTC", quoteCurrencyCode = "USD"),
+                localeFiatCurrencyName = "US Dollar",
+                numOffers = 12
+            ),
+            MarketListItem(
+                market = MarketVO(baseCurrencyCode = "BTC", quoteCurrencyCode = "EUR"),
+                localeFiatCurrencyName = "Euro",
+                numOffers = 8
+            ),
+            MarketListItem(
+                market = MarketVO(baseCurrencyCode = "BTC", quoteCurrencyCode = "BRL"),
+                localeFiatCurrencyName = "Brazilian Real",
+                numOffers = 0
+            )
+        )
+    BisqTheme.Preview {
+        OfferbookMarketScreenContent(
+            searchText = "",
+            isInteractive = true,
+            hasIgnoredUsers = false,
+            marketItems = mockMarketItems,
+            filter = MarketFilter.All,
+            sortBy = MarketSortBy.MostOffers,
+            showFilterDialog = false,
+            onSearchTextChange = {},
+            onFilterClick = {},
+            onMarketSelect = {},
+            onDismissFilterDialog = {},
+            onSortByFilterChange = {},
+            onFilterChange = {}
+        )
     }
 }


### PR DESCRIPTION
To improve UI development velocity and enable component-driven development, this PR configures our project to support Jetpack Compose @Preview. This allows developers to see their Composables in Android Studio without needing to build and run the app on an emulator or device.
Some @Preview samples are provided.

Screenshots:

<img width="1906" height="929" alt="Screenshot 2025-09-03 at 15 18 06" src="https://github.com/user-attachments/assets/7237beab-9108-4856-b643-cb2c2aacb84d" />


<img width="1510" height="408" alt="Screenshot 2025-09-03 at 15 21 07" src="https://github.com/user-attachments/assets/6e5d38c5-a228-4a97-ac4f-87b5c5bc82bd" />


<img width="1618" height="858" alt="Screenshot 2025-09-03 at 15 29 36" src="https://github.com/user-attachments/assets/a62b864a-6b7a-42f3-9b4a-afffbbc41eeb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Market screen: integrated sorting with filters and streamlined filter sheet interactions.

- UI
  - Dashboard: adjusted card layout and text rendering for consistency.
  - Offerbook and Dashboard: added multiple design previews demonstrating different languages and states.
  - Auto-resize text: previews now render in design mode for accurate layouts.

- Developer Experience
  - Enabled Compose UI tooling for debug builds.
  - Added theme preview helper for language-aware previews.

- Refactor
  - Decoupled screens from presenter/state wiring to callback-driven components.

- Style
  - Minor code-style cleanups with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->