### PR TITLE
Rework BisqTextField structure to correctly handle keyboard

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/theme/UIConstants.kt
@@ -22,4 +22,5 @@ object BisqUIConstants {
     val ScrollTopPadding = 24.dp
 
     val topBarAvatarSize = 30.dp
+    val textFieldBorderRadius = 6.dp
 }


### PR DESCRIPTION
 - fixes #573 

This PR fixes a UI bug where the custom `BisqTextField` component was being obscured by the on-screen keyboard. The keyboard would overlap the component providing a poor user experience.
Investigation revealed that a standard Material `TextField` behaved correctly in the same layout, proving the issue was with the internal structure of our custom component.
The root cause was that `BisqTextField` was composed of multiple separate layout nodes (`Column`, `Box`, `Row`), which prevented the layout system from treating it as a single, cohesive unit during window resizing.
This PR refactors `BisqTextField` to align with Jetpack Compose best practices for creating custom input fields.

A comprehensive set of `@Preview` functions has been added to `BisqTextField.kt` to facilitate component-driven development and visual testing of its various states (empty, error, disabled, etc.).

<img width="1854" height="761" alt="Screenshot 2025-09-08 at 12 56 59" src="https://github.com/user-attachments/assets/8f71d6e6-95b9-478e-95c4-10e02de7609e" />


**Before:**

https://github.com/user-attachments/assets/5a4c616f-250e-46e2-885e-818133f7ee05

**After:**

https://github.com/user-attachments/assets/4ab80b20-9ddd-4d24-bdac-f33e70d906a7







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-field copy/paste controls.
  * Support for left and right suffix content inside inputs.
  * Text fields now expose a focus callback when a field gains focus.

* **Enhancements**
  * Centralized input rendering with smoother focus animations, animated borders, and consistent label/background styling.
  * Improved validation flow with clearer timing for error/help text display.
  * Updated default text field corner radius for more consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->