### PR TITLE
bugfix/node_debug_tor_bootstrap_fails_datastore

### DIFF
--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -154,7 +154,14 @@ android {
                 "lib/**/libcrypto.so",
                 "lib/**/libevent*.so",
                 "lib/**/libssl.so",
-                "lib/**/libsqlite*.so"
+                "lib/**/libsqlite*.so",
+                // Data store
+                "lib/**/libdatastore_shared_counter.so",
+            )
+            // Exclude problematic native libraries
+            excludes += listOf(
+                "**/libmagtsync.so",
+                "**/libMEOW*.so"
             )
             // Required for kmp-tor exec resources - helps prevent EOCD corruption
             useLegacyPackaging = true


### PR DESCRIPTION
 - fix debug pickfirst .so causing the conflict with tor and exclude problematic failing ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android app stability by avoiding conflicts with certain bundled native libraries, reducing installation and startup issues across devices.

* **Chores**
  * Updated Android packaging to refine how native libraries are selected and to globally exclude known problematic libraries while keeping legacy packaging compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->