### PR TITLE
lastUserActivity update as in bisq2

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -72,11 +72,11 @@ val androidNodeModule = module {
 
     single<UserProfileServiceFacade> { NodeUserProfileServiceFacade(get()) }
 
-    single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get(), get()) }
+    single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get()) }
 
     single<ExplorerServiceFacade> { NodeExplorerServiceFacade(get()) }
 
-    single<TradesServiceFacade> { NodeTradesServiceFacade(get(), get()) }
+    single<TradesServiceFacade> { NodeTradesServiceFacade(get()) }
 
     single<TradeChatMessagesServiceFacade> { NodeTradeChatMessagesServiceFacade(get(), get()) }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeMainPresenter.kt
@@ -41,7 +41,7 @@ class NodeMainPresenter(
     private val reputationServiceFacade: ReputationServiceFacade,
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
-    private val userProfileServiceFacade: UserProfileServiceFacade,
+    userProfileServiceFacade: UserProfileServiceFacade,
     private val tradeReadStateRepository: TradeReadStateRepository,
     private val provider: AndroidApplicationService.Provider,
     private val androidMemoryReportService: AndroidMemoryReportService,
@@ -50,6 +50,7 @@ class NodeMainPresenter(
     openTradesNotificationService,
     settingsServiceFacade,
     tradesServiceFacade,
+    userProfileServiceFacade,
     tradeReadStateRepository,
     urlLauncher
 ) {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -43,7 +43,6 @@ import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.PriceSpecVO
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationDto
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationModel
-import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.MediatorNotAvailableException
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
@@ -57,7 +56,6 @@ import kotlin.time.Duration.Companion.seconds
 class NodeOffersServiceFacade(
     private val applicationService: AndroidApplicationService.Provider,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
-    private val userRepository: UserRepository
 ) : OffersServiceFacade() {
 
     companion object {
@@ -166,7 +164,6 @@ class NodeOffersServiceFacade(
             if (!broadcastResultNotEmpty) {
                 log.w { "Delete offer message was not broadcast to network. Maybe there are no peers connected." }
             }
-            userRepository.updateLastActivity()
             return Result.success(broadcastResultNotEmpty)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -192,7 +189,6 @@ class NodeOffersServiceFacade(
                 Mappings.PriceSpecMapping.toBisq2Model(priceSpec),
                 ArrayList<String>(supportedLanguageCodes)
             )
-            userRepository.updateLastActivity()
             Result.success(offerId)
         } catch (e: Exception) {
             log.e(e) { "Failed to create offer: ${e.message}" }
@@ -219,7 +215,6 @@ class NodeOffersServiceFacade(
                 Mappings.PriceSpecMapping.toBisq2Model(priceSpec),
                 ArrayList<String>(supportedLanguageCodes)
             )
-            userRepository.updateLastActivity()
             Result.success(offerId)
         } catch (e: Exception) {
             log.e(e) { "Failed to create offer with mediator wait: ${e.message}" }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
@@ -39,7 +39,6 @@ import network.bisq.mobile.android.node.mapping.TradeItemPresentationDtoFactory
 import network.bisq.mobile.domain.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
-import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.trades.TakeOfferStatus
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -72,7 +71,6 @@ import kotlin.time.Duration.Companion.seconds
  * - Maintains backward compatibility with existing trade flow
  */
 class NodeTradesServiceFacade(
-    private val userRepository: UserRepository,
     applicationService: AndroidApplicationService.Provider
 ) : ServiceFacade(), TradesServiceFacade {
 
@@ -175,7 +173,6 @@ class NodeTradesServiceFacade(
                 takeOfferStatus,
                 takeOfferErrorMessage
             )
-            userRepository.updateLastActivity()
             return Result.success(tradeId)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -193,7 +190,6 @@ class NodeTradesServiceFacade(
             val encoded: String = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName)
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).join()
             bisqEasyTradeService.rejectTrade(trade)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -206,7 +202,6 @@ class NodeTradesServiceFacade(
             val encoded: String = Res.encode("bisqEasy.openTrades.tradeLogMessage.cancelled", userName)
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).join()
             bisqEasyTradeService.cancelTrade(trade)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -219,7 +214,6 @@ class NodeTradesServiceFacade(
             bisqEasyTradeService.removeTrade(trade)
             leavePrivateChatManager.leaveChannel(channel)
             _selectedTrade.value = null
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -237,7 +231,6 @@ class NodeTradesServiceFacade(
             )
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             bisqEasyTradeService.sellerSendsPaymentAccount(trade, paymentAccountData)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -256,7 +249,6 @@ class NodeTradesServiceFacade(
             )
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             bisqEasyTradeService.buyerSendBitcoinPaymentData(trade, bitcoinPaymentData)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -274,7 +266,6 @@ class NodeTradesServiceFacade(
             )
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             bisqEasyTradeService.sellerConfirmFiatReceipt(trade)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -291,7 +282,6 @@ class NodeTradesServiceFacade(
             )
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             bisqEasyTradeService.buyerConfirmFiatSent(trade)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -322,7 +312,6 @@ class NodeTradesServiceFacade(
 
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             bisqEasyTradeService.sellerConfirmBtcSent(trade, Optional.ofNullable(paymentProof))
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)
@@ -341,7 +330,6 @@ class NodeTradesServiceFacade(
                 bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
             }
             bisqEasyTradeService.btcConfirmed(trade)
-            userRepository.updateLastActivity()
             return Result.success(Unit)
         } catch (e: Exception) {
             return Result.failure(e)

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -88,6 +88,7 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
                 }
             }
         }
+
     }
 
     override fun deactivate() {
@@ -192,6 +193,14 @@ class NodeUserProfileServiceFacade(private val applicationService: AndroidApplic
         val key = "${userProfile.id}-v${userProfile.avatarVersion}"
         avatarMap[key]?.let { return it }
         return generateCatHash(key, userProfile)
+    }
+
+    override suspend fun getUserPublishDate(): Long {
+        return userService.userIdentityService.selectedUserIdentity.userProfile.publishDate
+    }
+
+    override suspend fun userActivityDetected() {
+        userService.republishUserProfileService.userActivityDetected()
     }
 
     private suspend fun generateCatHash(

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -184,10 +184,10 @@ val clientModule = module {
     single<UserProfileServiceFacade> { ClientUserProfileServiceFacade(get(), get(), get()) }
 
     single { OfferbookApiGateway(get(), get()) }
-    single<OffersServiceFacade> { ClientOffersServiceFacade(get(), get(), get(), get()) }
+    single<OffersServiceFacade> { ClientOffersServiceFacade(get(), get(), get()) }
 
     single { TradesApiGateway(get(), get()) }
-    single<TradesServiceFacade> { ClientTradesServiceFacade(get(), get(), get(), get()) }
+    single<TradesServiceFacade> { ClientTradesServiceFacade(get(), get(), get()) }
 
     single { TradeChatMessagesApiGateway(get(), get()) }
     single<TradeChatMessagesServiceFacade> { ClientTradeChatMessagesServiceFacade(get(), get(), get(), get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
@@ -18,13 +18,11 @@ import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.PriceSpecVO
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationDto
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationModel
-import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 
 class ClientOffersServiceFacade(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
-    private val userRepository: UserRepository,
     private val apiGateway: OfferbookApiGateway,
     private val json: Json
 ) : OffersServiceFacade() {
@@ -69,7 +67,6 @@ class ClientOffersServiceFacade(
     override suspend fun deleteOffer(offerId: String): Result<Boolean> {
         val result: Result<Unit> = apiGateway.deleteOffer(offerId)
         if (result.isSuccess) {
-            userRepository.updateLastActivity()
             return Result.success(true)
         } else {
             throw result.exceptionOrNull() ?: IllegalStateException("No Exception is set in result failure")
@@ -89,7 +86,6 @@ class ClientOffersServiceFacade(
             direction, market, bitcoinPaymentMethods, fiatPaymentMethods, amountSpec, priceSpec, supportedLanguageCodes
         )
         if (apiResult.isSuccess) {
-            userRepository.updateLastActivity()
             return Result.success(apiResult.getOrThrow().offerId)
         } else {
             return Result.failure(apiResult.exceptionOrNull()!!)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/trades/ClientTradesServiceFacade.kt
@@ -14,7 +14,6 @@ import network.bisq.mobile.domain.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.domain.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationDto
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
-import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.trades.TakeOfferStatus
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -39,7 +38,6 @@ import network.bisq.mobile.domain.service.trades.TradesServiceFacade
  * 4. Monitors TRADE_PROPERTIES subscription for automatic state updates
  */
 class ClientTradesServiceFacade(
-    private val userRepository: UserRepository,
     private val apiGateway: TradesApiGateway,
     webSocketClientProvider: WebSocketClientProvider,
     json: Json
@@ -101,7 +99,6 @@ class ClientTradesServiceFacade(
         )
         if (apiResult.isSuccess) {
             takeOfferStatus.value = TakeOfferStatus.SUCCESS
-            userRepository.updateLastActivity()
             return Result.success(apiResult.getOrThrow().tradeId)
         } else {
             return Result.failure(apiResult.exceptionOrNull()!!)
@@ -114,24 +111,17 @@ class ClientTradesServiceFacade(
 
     override suspend fun rejectTrade(): Result<Unit> {
         val result = apiGateway.rejectTrade(requireNotNull(tradeId))
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun cancelTrade(): Result<Unit> {
         val result = apiGateway.cancelTrade(requireNotNull(tradeId))
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun closeTrade(): Result<Unit> {
         val result = apiGateway.closeTrade(requireNotNull(tradeId))
         if (result.isSuccess) {
-            userRepository.updateLastActivity()
             _selectedTrade.value = null
         }
         return result
@@ -139,49 +129,31 @@ class ClientTradesServiceFacade(
 
     override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> {
         val result = apiGateway.sellerSendsPaymentAccount(requireNotNull(tradeId), paymentAccountData)
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> {
         val result = apiGateway.buyerSendBitcoinPaymentData(requireNotNull(tradeId), bitcoinPaymentData)
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun sellerConfirmFiatReceipt(): Result<Unit> {
         val result = apiGateway.sellerConfirmFiatReceipt(requireNotNull(tradeId))
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun buyerConfirmFiatSent(): Result<Unit> {
         val result = apiGateway.buyerConfirmFiatSent(requireNotNull(tradeId))
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> {
         val result = apiGateway.sellerConfirmBtcSent(requireNotNull(tradeId), paymentProof)
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 
     override suspend fun btcConfirmed(): Result<Unit> {
         val result = apiGateway.btcConfirmed(requireNotNull(tradeId))
-        if (result.isSuccess) {
-            userRepository.updateLastActivity()
-        }
         return result
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -231,6 +231,14 @@ class ClientUserProfileServiceFacade(
             return avatarMap[userProfile.nym]
         }
 
+    override suspend fun getUserPublishDate(): Long {
+        return selectedUserProfile.value?.publishDate ?: 0L
+    }
+
+    override suspend fun userActivityDetected() {
+        // TODO: Call to userActivityDetected endpoint
+    }
+
     override suspend fun ignoreUserProfile(profileId: String) {
         try {
             apiGateway.ignoreUser(profileId).getOrThrow()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/User.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/model/User.kt
@@ -7,6 +7,5 @@ import network.bisq.mobile.domain.PlatformImage
 data class User(
     val tradeTerms: String? = null,
     val statement: String? = null,
-    val lastActivity: Long? = null,
     val uniqueAvatar: PlatformImage? = null
 )

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/UserRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/UserRepository.kt
@@ -10,8 +10,6 @@ interface UserRepository {
 
     suspend fun fetch() = data.first()
 
-    suspend fun updateLastActivity()
-
     suspend fun updateTerms(value: String)
 
     suspend fun updateStatement(value: String)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/UserRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/repository/UserRepositoryImpl.kt
@@ -23,12 +23,6 @@ class UserRepositoryImpl(
                 }
             }
 
-    override suspend fun updateLastActivity() {
-        userStore.updateData {
-            it.copy(lastActivity = Clock.System.now().toEpochMilliseconds())
-        }
-    }
-
     override suspend fun updateTerms(value: String) {
         userStore.updateData {
             it.copy(tradeTerms = value)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/user_profile/UserProfileServiceFacade.kt
@@ -84,6 +84,10 @@ interface UserProfileServiceFacade : LifeCycleAware {
      */
     suspend fun getUserAvatar(userProfile: UserProfileVO): PlatformImage?
 
+    suspend fun getUserPublishDate(): Long
+
+    suspend fun userActivityDetected()
+
     /**
      * Marks the given profile as ignored. Implementations must persist this update.
      * Idempotent: calling this for an already-ignored profile is a no-op.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/TimeUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/TimeUtils.kt
@@ -1,0 +1,15 @@
+package network.bisq.mobile.domain.utils
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+
+object TimeUtils {
+    fun tickerFlow(periodMillis: Long = 1000L) = flow {
+        while (currentCoroutineContext().isActive) {
+            emit(Unit)
+            delay(periodMillis)
+        }
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/I18nSupport.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/i18n/I18nSupport.kt
@@ -9,6 +9,8 @@ const val PARAM_SEPARATOR: Char = 0x1e.toChar()
 class I18nSupport {
     companion object {
 
+        var isReady: Boolean = false
+
         fun initialize(languageCode: String = "en") {
             // bundles = BUNDLE_NAMES.map { ResourceBundle.getBundle(it, languageCode) }
             val bundleMapsByName: Map<String, Map<String, String>> = when (languageCode) {
@@ -25,6 +27,7 @@ class I18nSupport {
             }
             val maps: Collection<Map<String, String>> = bundleMapsByName.values
             bundles = maps.map { ResourceBundle(it) }
+            isReady = true
         }
 
         fun has(key: String): Boolean {

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/migration/DataStoreMigrationTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/migration/DataStoreMigrationTest.kt
@@ -26,7 +26,6 @@ class DataStoreMigrationTest {
         {
             "tradeTerms": "Legacy terms",
             "statement": "Legacy statement", 
-            "lastActivity": 1234567890,
             "legacyField": "should be ignored",
             "anotherLegacyField": 42
         }
@@ -38,7 +37,6 @@ class DataStoreMigrationTest {
         // Then - should parse successfully and ignore unknown fields
         assertEquals("Legacy terms", user.tradeTerms)
         assertEquals("Legacy statement", user.statement)
-        assertEquals(1234567890L, user.lastActivity)
     }
 
     @Test
@@ -59,31 +57,6 @@ class DataStoreMigrationTest {
         assertEquals(true, settings.firstLaunch)
         assertEquals(Settings().showChatRulesWarnBox, settings.showChatRulesWarnBox) // default
         assertEquals(Settings().selectedMarketCode, settings.selectedMarketCode) // default
-    }
-
-    @Test
-    fun `should handle different number formats for lastActivity`() {
-        // Given - different ways lastActivity might have been stored
-        val testCases = listOf(
-            """{"lastActivity": 1234567890}""", // Int
-            """{"lastActivity": 1234567890123}""", // Long
-            """{"lastActivity": "1234567890123"}""", // String (shouldn't happen but test anyway)
-        )
-
-        // When & Then
-        testCases.forEachIndexed { index, json ->
-            try {
-                val user = this.json.decodeFromString(User.serializer(), json)
-                when (index) {
-                    0 -> assertEquals(1234567890L, user.lastActivity)
-                    1 -> assertEquals(1234567890123L, user.lastActivity)
-                    // String case might fail, which is acceptable
-                }
-            } catch (e: Exception) {
-                // String parsing failure is acceptable
-                if (index != 2) throw e
-            }
-        }
     }
 
     @Test
@@ -138,7 +111,6 @@ class DataStoreMigrationTest {
         {
             "tradeTerms": null,
             "statement": null,
-            "lastActivity": null
         }
         """.trimIndent()
 
@@ -153,7 +125,6 @@ class DataStoreMigrationTest {
         val user = json.decodeFromString(User.serializer(), userWithNulls)
         assertEquals(null, user.tradeTerms) // User model allows null
         assertEquals(null, user.statement) // User model allows null
-        assertEquals(null, user.lastActivity) // User model allows null
 
         val settings = json.decodeFromString(Settings.serializer(), settingsWithMissingFields)
         assertEquals(Settings().bisqApiUrl, settings.bisqApiUrl) // default
@@ -166,7 +137,6 @@ class DataStoreMigrationTest {
         // Given - various malformed JSON scenarios
         val malformedJsonCases = listOf(
             """{"tradeTerms": "unclosed string""",
-            """{"lastActivity": "not-a-number"}""",
             """{"firstLaunch": "not-a-boolean"}""",
             """{"extraComma": true,}""",
             """{"missingQuotes": value}"""
@@ -192,7 +162,6 @@ class DataStoreMigrationTest {
         val originalUser = User(
             tradeTerms = "My trading terms",
             statement = "My statement",
-            lastActivity = getTimeMillis()
         )
 
         val originalSettings = Settings(

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/UserRepositoryImplTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/repository/UserRepositoryImplTest.kt
@@ -28,7 +28,6 @@ class UserRepositoryImplTest {
         val expectedUser = User(
             tradeTerms = "Test terms",
             statement = "Test statement",
-            lastActivity = 123456789L
         )
         every { mockDataStore.data } returns flowOf(expectedUser)
 
@@ -72,42 +71,12 @@ class UserRepositoryImplTest {
     }
 
     @Test
-    fun `updateLastActivity should update user with current timestamp`() = runTest {
-        // Given
-        val updateSlot = slot<suspend (User) -> User>()
-        coEvery { mockDataStore.updateData(capture(updateSlot)) } returns User()
-        
-        val originalUser = User(tradeTerms = "existing terms")
-        val beforeUpdate = Clock.System.now().toEpochMilliseconds()
-
-        // When
-        repository.updateLastActivity()
-
-        // Then
-        coVerify { mockDataStore.updateData(any()) }
-
-        // Verify the update function sets lastActivity to current time
-        val updatedUser = updateSlot.captured(originalUser)
-        assertNotNull(updatedUser.lastActivity)
-        val afterUpdate = Clock.System.now().toEpochMilliseconds()
-
-        // Allow for small time difference due to test execution
-         assertTrue(
-                    updatedUser.lastActivity!! in beforeUpdate..afterUpdate,
-                    "lastActivity should be set to the current timestamp range"
-         )
-
-        // Verify other fields are preserved
-        assertEquals("existing terms", updatedUser.tradeTerms)
-    }
-
-    @Test
     fun `updateTerms should update user trade terms`() = runTest {
         // Given
         val updateSlot = slot<suspend (User) -> User>()
         coEvery { mockDataStore.updateData(capture(updateSlot)) } returns User()
         
-        val originalUser = User(statement = "existing statement", lastActivity = 123L)
+        val originalUser = User(statement = "existing statement")
         val newTerms = "New trade terms"
 
         // When
@@ -120,7 +89,6 @@ class UserRepositoryImplTest {
         assertEquals(newTerms, updatedUser.tradeTerms)
         // Verify other fields are preserved
         assertEquals("existing statement", updatedUser.statement)
-        assertEquals(123L, updatedUser.lastActivity)
     }
 
     @Test
@@ -129,7 +97,7 @@ class UserRepositoryImplTest {
         val updateSlot = slot<suspend (User) -> User>()
         coEvery { mockDataStore.updateData(capture(updateSlot)) } returns User()
         
-        val originalUser = User(tradeTerms = "existing terms", lastActivity = 456L)
+        val originalUser = User(tradeTerms = "existing terms")
         val newStatement = "New statement"
 
         // When
@@ -142,7 +110,6 @@ class UserRepositoryImplTest {
         assertEquals(newStatement, updatedUser.statement)
         // Verify other fields are preserved
         assertEquals("existing terms", updatedUser.tradeTerms)
-        assertEquals(456L, updatedUser.lastActivity)
     }
 
     @Test
@@ -155,7 +122,6 @@ class UserRepositoryImplTest {
         val newUser = User(
             tradeTerms = "new terms",
             statement = "new statement",
-            lastActivity = 789L
         )
 
         // When
@@ -177,7 +143,6 @@ class UserRepositoryImplTest {
         val originalUser = User(
             tradeTerms = "some terms",
             statement = "some statement",
-            lastActivity = 999L
         )
 
         // When

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/serialization/DataStoreSerializationTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/data/serialization/DataStoreSerializationTest.kt
@@ -20,7 +20,6 @@ class DataStoreSerializationTest {
         val user = User(
             tradeTerms = "Test terms with special chars: àáâãäåæçèéêë",
             statement = "Test statement with emojis: 🚀💰📈",
-            lastActivity = 1234567890123L
         )
 
         // When - serialize and deserialize
@@ -31,7 +30,6 @@ class DataStoreSerializationTest {
         assertEquals(user, deserialized)
         assertEquals(user.tradeTerms, deserialized.tradeTerms)
         assertEquals(user.statement, deserialized.statement)
-        assertEquals(user.lastActivity, deserialized.lastActivity)
     }
 
     @Test
@@ -45,7 +43,6 @@ class DataStoreSerializationTest {
         // Then - should use default values (null for User model)
         assertEquals("test", deserialized.tradeTerms)
         assertEquals(null, deserialized.statement) // User model defaults to null
-        assertEquals(null, deserialized.lastActivity)
     }
 
     @Test
@@ -118,7 +115,7 @@ class DataStoreSerializationTest {
     @Test
     fun `Serialization should be deterministic`() {
         // Given
-        val user = User(tradeTerms = "test", statement = "statement", lastActivity = 123L)
+        val user = User(tradeTerms = "test", statement = "statement")
 
         // When - serialize multiple times
         val serialized1 = json.encodeToString(User.serializer(), user)
@@ -135,7 +132,6 @@ class DataStoreSerializationTest {
         val largeUser = User(
             tradeTerms = "Large terms: $largeStatement",
             statement = largeStatement,
-            lastActivity = Long.MAX_VALUE
         )
 
         val largeTradeMap = TradeReadStateMap(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -39,12 +39,12 @@ open class ClientMainPresenter(
     private val reputationServiceFacade: ReputationServiceFacade,
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
-    private val userProfileServiceFacade: UserProfileServiceFacade,
+    userProfileServiceFacade: UserProfileServiceFacade,
     openTradesNotificationService: OpenTradesNotificationService,
     private val tradeReadStateRepository: TradeReadStateRepository,
     private val webSocketClientProvider: WebSocketClientProvider,
     urlLauncher: UrlLauncher
-) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, tradeReadStateRepository, urlLauncher) {
+) : MainPresenter(connectivityService, openTradesNotificationService, settingsServiceFacade, tradesServiceFacade, userProfileServiceFacade, tradeReadStateRepository, urlLauncher, ) {
 
     private var lastConnectedStatus: Boolean? = null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,7 @@ import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
@@ -360,6 +362,15 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) : ViewPr
     override fun onViewAttached() {
         log.i { "Lifecycle: View ${if (view != null) view!!::class.simpleName else ""} attached to presenter ${this::class.simpleName}" }
         enableInteractive()
+
+        // In bisq2, UserActivityDetected is triggered on mouse move and key press events
+        // In bisq-mobile, userActivityDetected is triggered on every screen navigation,
+        // which helps to reset user.publishDate.
+        launchUI {
+            if (I18nSupport.isReady) { // Makes sure bundles are loaded. This fails for Splash
+                rootPresenter?.userProfileServiceFacade?.userActivityDetected()
+            }
+        }
     }
 
     @CallSuper

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -24,6 +24,7 @@ import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.presentation.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.ui.navigation.Routes
@@ -37,8 +38,9 @@ open class MainPresenter(
     private val openTradesNotificationService: OpenTradesNotificationService,
     private val settingsService: SettingsServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
+    val userProfileServiceFacade: UserProfileServiceFacade,
     private val tradeReadStateRepository: TradeReadStateRepository,
-    private val urlLauncher: UrlLauncher
+    private val urlLauncher: UrlLauncher,
 ) : BasePresenter(null), AppPresenter {
 
     override lateinit var navController: NavHostController

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -128,7 +128,7 @@ val presentationModule = module {
         )
     } bind IUserProfileSettingsPresenter::class
 
-    single<DashboardPresenter> { DashboardPresenter(get(), get(), get(), get(), get()) }
+    single<DashboardPresenter> { DashboardPresenter(get(), get(), get(), get(), get(), get()) }
 
     single {
         CreateProfilePresenter(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.ui.uicases
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.domain.data.repository.UserRepository
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
@@ -17,7 +18,8 @@ open class DashboardPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val offersServiceFacade: OffersServiceFacade,
-    private val settingsServiceFacade: SettingsServiceFacade
+    private val settingsServiceFacade: SettingsServiceFacade,
+    private val userRepository: UserRepository,
 ) : BasePresenter(mainPresenter) {
     private val _offersOnline = MutableStateFlow(0)
     val offersOnline: StateFlow<Int> get() = _offersOnline.asStateFlow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/UserProfileSettingsPresenter.kt
@@ -7,10 +7,12 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.domain.PlatformImage
@@ -22,6 +24,7 @@ import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.DateUtils
+import network.bisq.mobile.domain.utils.TimeUtils
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -71,11 +74,16 @@ class UserProfileSettingsPresenter(
         )
 
     override val lastUserActivity: StateFlow<String> =
-        userRepository.data.map { it.lastActivity?.let { ts -> DateUtils.lastSeen(ts) } }
-            .map { it ?: getLocalizedNA() }.stateIn(
-                presenterScope,
-                SharingStarted.Lazily,
-                getLocalizedNA(),
+        TimeUtils.tickerFlow(1_000L)
+            .onStart { emit(Unit) }
+            .map {
+                val ts: Long = userProfileServiceFacade.getUserPublishDate()
+                if (ts <= 0L) getLocalizedNA() else DateUtils.lastSeen(ts)
+            }
+            .stateIn(
+                scope = presenterScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = getLocalizedNA()
             )
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -160,13 +168,7 @@ class UserProfileSettingsPresenter(
                     )
                 }
                 if (result.isSuccess) {
-                    val updatedLastActivity = withContext(IODispatcher) {
-                        runCatching { userRepository.updateLastActivity() }.isSuccess
-                    }
                     showSnackbar("mobile.settings.userProfile.saveSuccess".i18n(), isError = false)
-                    if (!updatedLastActivity) {
-                        log.w { "updateLastActivity failed after successful profile save" }
-                    }
                 } else {
                     showSnackbar("mobile.settings.userProfile.saveFailure".i18n(), isError = true)
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/CreateProfilePresenter.kt
@@ -154,7 +154,6 @@ open class CreateProfilePresenter(
                     userRepository.update(
                         User().copy(
                             uniqueAvatar = profileIcon.value,
-                            lastActivity = Clock.System.now().toEpochMilliseconds()
                         )
                     )
                 }


### PR DESCRIPTION
User.publishDate is set to current time on 
 - App launch
 - Updating statement, trade terms user profile
 - Every 5 mins, on active app usage.

Tested if the same is reflected in bisq2, for this user's Last seen activity.

Notes:
 - User profile screen - Last user activity is now updated every second
 - Removed User :: lastUserActivity, UserRepository :: updateLastActivity() calls. lastUserActivity is a UI level variable, derived from User.publishDate. Updated the same in UserProfileSettingsPresenter.
 - RepublishUserProfileService takes care of updating User.publishDate. We don’t do it manually in our code. Just need to call `RepublishUserProfileService.userActivityDetected()`, on user actions in app. In bisq2, it’s done in move move, key press events. In mobile, I added `userActivityDetected()` to BasePresenter.onViewUnattaching(), so it happens on every screen navigation.