### PR TITLE
fix: correct edge-to-edge window inset handling

### DIFF
--- a/androidClient/src/androidMain/AndroidManifest.xml
+++ b/androidClient/src/androidMain/AndroidManifest.xml
@@ -2,9 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />  
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
     <application
         android:name=".MainApplication"
@@ -15,12 +15,12 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.App.Starting">
         <activity
-            android:exported="true"
+            android:name="network.bisq.mobile.client.MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:name="network.bisq.mobile.client.MainActivity">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -29,9 +29,8 @@
         <service
             android:name="network.bisq.mobile.domain.service.BisqForegroundService"
             android:exported="false"
-            android:permission="android.permission.FOREGROUND_SERVICE"
-            android:foregroundServiceType="remoteMessaging">
-        </service>
+            android:foregroundServiceType="remoteMessaging"
+            android:permission="android.permission.FOREGROUND_SERVICE" />
     </application>
 
 </manifest>

--- a/androidNode/src/androidMain/AndroidManifest.xml
+++ b/androidNode/src/androidMain/AndroidManifest.xml
@@ -3,26 +3,27 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
+    <!-- android:largeHeap: Request larger heap for P2P sync GC pressure reduction caused by bisq2 jars -->
     <application
         android:name="network.bisq.mobile.android.node.MainApplication"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
-        android:supportsRtl="true"
+        android:largeHeap="${largeHeap}"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:theme="@style/Theme.App.Starting"
-        android:largeHeap="${largeHeap}"> <!-- Request larger heap for P2P sync GC pressure reduction caused by bisq2 jars -->
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.App.Starting">
         <activity
-            android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:name="network.bisq.mobile.android.node.MainActivity"
-            android:launchMode="singleTop">
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -31,9 +32,8 @@
         <service
             android:name="network.bisq.mobile.domain.service.BisqForegroundService"
             android:exported="false"
-            android:permission="android.permission.FOREGROUND_SERVICE"
-            android:foregroundServiceType="remoteMessaging">
-        </service>
+            android:foregroundServiceType="remoteMessaging"
+            android:permission="android.permission.FOREGROUND_SERVICE" />
     </application>
 
 </manifest>

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/BisqMainActivity.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/BisqMainActivity.kt
@@ -45,8 +45,7 @@ abstract class BisqMainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-
-        intent?.getStringExtra(NotificationServiceController.EXTRA_DESTINATION)?.let { destination ->
+        intent.getStringExtra(NotificationServiceController.EXTRA_DESTINATION)?.let { destination ->
             Routes.fromString(destination)?.let { presenter.navigateToTab(it) }
         }
     }
@@ -61,8 +60,6 @@ abstract class BisqMainActivity : ComponentActivity() {
         GenericErrorHandler.setupCoroutineExceptionHandler(exceptionHandlerSetup)
 
         presenter.attachView(this)
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         val bgColor = Color(BACKGROUND_COLOR_CODE).adjustGamma().toArgb()
         enableEdgeToEdge(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/MultiScreenWizardScaffold.kt
@@ -76,7 +76,6 @@ fun MultiScreenWizardScaffold(
         } else null
 
     val scaffold: @Composable (
-        padding: PaddingValues,
         topBar: @Composable (() -> Unit)?,
         bottomBar: @Composable (() -> Unit)?,
         hAlignment: Alignment.Horizontal,
@@ -86,9 +85,8 @@ fun MultiScreenWizardScaffold(
         shouldBlurBg: Boolean,
         content: @Composable ColumnScope.() -> Unit
     ) -> Unit =
-        if (useStaticScaffold) { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, _shouldBlurBg, innerContent ->
+        if (useStaticScaffold) { topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, _shouldBlurBg, innerContent ->
             BisqStaticScaffold(
-                padding = padding,
                 topBar = topBar,
                 bottomBar = bottomBar,
                 horizontalAlignment = hAlignment,
@@ -98,9 +96,8 @@ fun MultiScreenWizardScaffold(
                 shouldBlurBg = _shouldBlurBg || confirmClose.visible,
                 content = innerContent
             )
-        } else { padding, topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, _shouldBlurBg, innerContent ->
+        } else { topBar, bottomBar, hAlignment, verticalArrangement, snackState, _showJumpToBottom, _shouldBlurBg, innerContent ->
             BisqScrollScaffold(
-                padding = padding,
                 topBar = topBar,
                 bottomBar = bottomBar,
                 horizontalAlignment = hAlignment,
@@ -114,7 +111,6 @@ fun MultiScreenWizardScaffold(
         }
 
     scaffold(
-        PaddingValues(all = 0.dp),
         {
             Column {
                 TopBar(
@@ -126,7 +122,8 @@ fun MultiScreenWizardScaffold(
                 )
                 BisqProgressBar(
                     stepIndex.toFloat() / stepsLength.toFloat(),
-                    modifier = Modifier.fillMaxWidth().padding(top = BisqUIConstants.ScreenPaddingHalf)
+                    modifier = Modifier.fillMaxWidth()
+                        .padding(top = BisqUIConstants.ScreenPaddingHalf)
                 )
             }
         },
@@ -134,7 +131,10 @@ fun MultiScreenWizardScaffold(
             if (showNextPrevButtons) {
                 BottomAppBar(
                     containerColor = BisqTheme.colors.backgroundColor,
-                    contentPadding = PaddingValues(horizontal = BisqUIConstants.ScreenPadding2X, vertical = 0.dp),
+                    contentPadding = PaddingValues(
+                        horizontal = BisqUIConstants.ScreenPadding2X,
+                        vertical = 0.dp
+                    ),
                     windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp)
                 ) {
                     Row(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -28,7 +29,8 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqScrollLayout(
-    padding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
+    contentPadding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
+    scaffoldPadding: PaddingValues? = null,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     onModifier: ((Modifier) -> Modifier)? = null, // allows to customize modifier settings
@@ -47,8 +49,17 @@ fun BisqScrollLayout(
 
     Box(
         modifier = Modifier
+            .let {
+                if (scaffoldPadding != null) {
+                    it.padding(scaffoldPadding)
+                } else {
+                    it
+                }
+            }
             .fillMaxSize()
             .background(BisqTheme.colors.backgroundColor)
+            .imePadding()
+
     ) {
         Column(
             horizontalAlignment = horizontalAlignment,
@@ -56,7 +67,7 @@ fun BisqScrollLayout(
             modifier = Modifier
                 .fillMaxSize()
                 // .background(color = BisqTheme.colors.backgroundColor)
-                .padding(padding)
+                .padding(contentPadding)
                 .verticalScroll(scrollState)
                 .run { onModifier?.invoke(this) ?: this }
         ) {
@@ -85,7 +96,8 @@ fun BisqScrollLayout(
             JumpToBottomFloatingButton(
                 visible = jumpToBottomVisible,
                 onClicked = { scope.launch { scrollState.animateScrollTo(scrollState.maxValue) } },
-                modifier = Modifier.align(Alignment.BottomEnd).offset(x = -BisqUIConstants.ScreenPadding),
+                modifier = Modifier.align(Alignment.BottomEnd)
+                    .offset(x = -BisqUIConstants.ScreenPadding),
                 jumpOffset = 90,
             )
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollScaffold.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.presentation.ui.components.layout
 
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
@@ -24,7 +23,6 @@ fun BisqScrollScaffold(
     topBar: @Composable (() -> Unit)? = null,
     bottomBar: @Composable (() -> Unit)? = null,
     snackbarHostState: SnackbarHostState? = null,
-    scrollState: ScrollState? = null,
     fab: @Composable (() -> Unit)? = null,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
@@ -33,7 +31,6 @@ fun BisqScrollScaffold(
     shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
-
     Scaffold(
         modifier = Modifier.blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero),
         containerColor = BisqTheme.colors.backgroundColor,
@@ -45,28 +42,17 @@ fun BisqScrollScaffold(
             }
         },
         floatingActionButton = fab ?: {},
-        content = {
+        content = { scaffoldPadding ->
             BisqScrollLayout(
-                padding = if (topBar != null) it else padding,
+                scaffoldPadding = scaffoldPadding,
+                contentPadding = padding,
                 verticalArrangement = verticalArrangement,
                 isInteractive = isInteractive,
                 showJumpToBottom = showJumpToBottom,
+                horizontalAlignment = horizontalAlignment
             ) {
-                // Padding logic:
-                // when topBar is set, Scaffold.content.it provides the padding
-                // to offset topBar height, which is passed to BisqStaticLayout
-                // But then the content()'s get attached to the screen edges.
-                // So in that case, we add another column to provde ScreenPadding on all sides.
-                if (topBar != null)
-                    Column(
-                        modifier = Modifier.padding(all = BisqUIConstants.ScreenPadding),
-                        horizontalAlignment = horizontalAlignment
-                    ) {
-                        content()
-                    }
-                else
-                    content()
+                content()
             }
-        },
+        }
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticLayout.kt
@@ -13,7 +13,8 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqStaticLayout(
-    padding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
+    contentPadding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPadding),
+    scaffoldPadding: PaddingValues? = null,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalArrangement: Arrangement.Vertical = Arrangement.SpaceBetween,
     isInteractive: Boolean = true,
@@ -22,7 +23,15 @@ fun BisqStaticLayout(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .let {
+                if (scaffoldPadding != null) {
+                    it.padding(scaffoldPadding)
+                } else {
+                    it
+                }
+            }
             .background(BisqTheme.colors.backgroundColor)
+            .imePadding()
     ) {
         Column(
             horizontalAlignment = horizontalAlignment,
@@ -30,7 +39,7 @@ fun BisqStaticLayout(
             modifier = Modifier
                 .fillMaxSize()
                 .background(color = BisqTheme.colors.backgroundColor)
-                .padding(padding)
+                .padding(contentPadding)
         ) {
             content()
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/StaticScaffold.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
@@ -19,7 +20,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 @Composable
 fun BisqStaticScaffold(
     padding: PaddingValues = PaddingValues(
-        top = BisqUIConstants.StaticTopPadding,
+        top = BisqUIConstants.ScreenPadding,
         bottom = BisqUIConstants.ScreenPadding,
         start = BisqUIConstants.ScreenPadding,
         end = BisqUIConstants.ScreenPadding
@@ -34,7 +35,6 @@ fun BisqStaticScaffold(
     shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
-
     Scaffold(
         modifier = Modifier.blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero),
         containerColor = BisqTheme.colors.backgroundColor,
@@ -46,27 +46,15 @@ fun BisqStaticScaffold(
             }
         },
         floatingActionButton = floatingButton ?: {},
-        content = {
+        content = { scaffoldPadding ->
             BisqStaticLayout(
-                padding = if (topBar != null) it else padding,
+                contentPadding = padding,
+                scaffoldPadding = scaffoldPadding,
                 horizontalAlignment = horizontalAlignment,
                 verticalArrangement = verticalArrangement,
                 isInteractive = isInteractive
             ) {
-                // Padding logic:
-                // when topBar is set, Scaffold.content.it provides the padding
-                // to offset topBar height, which is passed to BisqStaticLayout
-                // But then the content()'s get attached to the screen edges.
-                // So in that case, we add another column to provde ScreenPadding on all sides.
-                if (topBar != null)
-                    Column(
-                        modifier = Modifier.padding(all = BisqUIConstants.ScreenPadding),
-                        horizontalAlignment = horizontalAlignment
-                    ) {
-                        content()
-                    }
-                else
-                    content()
+                content()
             }
         }
     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
@@ -75,7 +75,7 @@ private fun DashboardContent(
 ) {
     val padding = BisqUIConstants.ScreenPadding
     BisqScrollLayout(
-        padding = PaddingValues(all = BisqUIConstants.Zero),
+        contentPadding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.spacedBy(padding),
         isInteractive = isInteractive,
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookMarketScreen.kt
@@ -79,7 +79,7 @@ private fun OfferbookMarketScreenContent(
     onDismissFilterDialog: () -> Unit,
 ) {
     BisqStaticLayout(
-        padding = PaddingValues(all = BisqUIConstants.Zero),
+        contentPadding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.Top,
         isInteractive = isInteractive,
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
@@ -74,7 +74,7 @@ fun OpenTradeListScreen() {
     }
 
     BisqStaticLayout(
-        padding = PaddingValues(all = BisqUIConstants.Zero),
+        contentPadding = PaddingValues(all = BisqUIConstants.Zero),
         isInteractive = isInteractive,
     ) {
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/IgnoredUsersScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/IgnoredUsersScreen.kt
@@ -52,7 +52,6 @@ fun IgnoredUsersScreen() {
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.settings.ignoredUsers".i18n()) },
-        padding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.SpaceBetween,
         isInteractive = isInteractive,
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -30,7 +30,7 @@ fun SettingsScreen(isTabSelected: Boolean) {
     val menuTree by presenter.menuItems.collectAsState()
 
     BisqStaticLayout(
-        padding = PaddingValues(all = BisqUIConstants.Zero),
+        contentPadding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.Top,
         isInteractive = isInteractive,
     ) {


### PR DESCRIPTION
 - Fixes #629 
 - Fixes #637 

This pull request addresses a UI bug where the screen content was not correctly accounting for system window insets. This caused UI elements of the screen to be drawn underneath the system status, making them difficult to see and interact with.


**Before**

https://github.com/user-attachments/assets/9df927c5-4bda-4eb6-9f27-335fe16ea926

**After**

https://github.com/user-attachments/assets/75f65006-2cd0-4cfc-bddb-05a1b6457e8e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Keyboard/input now resizes screens correctly and accounts for on-screen keyboard in layouts.

- Refactor
  - Unified padding model across static and scrollable layouts for more consistent spacing and alignment.

- Chores
  - Android manifest adjustments: enabled large-heap for stability and refined activity/service declarations for improved app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->