### PR TITLE
Update LocalClipboardManager implementation due to deprecation

### DIFF
--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.android.kt
@@ -1,0 +1,22 @@
+package network.bisq.mobile.presentation.ui.helpers
+
+import android.content.ClipData
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.text.AnnotatedString
+
+actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
+    if (this == null) return null
+    return ClipEntry(ClipData.newPlainText(this.text, this.text))
+}
+
+actual suspend fun ClipEntry.readText(): String? {
+    val clipData = this.clipData
+    val stringBuilder = StringBuilder()
+    for (i in 0 until clipData.itemCount) {
+        val item = clipData.getItemAt(i)
+        item.text?.let {
+            stringBuilder.append(it)
+        }
+    }
+    return stringBuilder.toString().ifEmpty { null }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/NoteText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/NoteText.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -15,7 +17,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
+import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.WebLinkConfirmationDialog
+import network.bisq.mobile.presentation.ui.helpers.toClipEntry
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 // Pass either uri or onLinkClick. Not both
@@ -29,7 +33,8 @@ fun NoteText(
     onLinkClick: (() -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     var showConfirmDialog by remember { mutableStateOf(false) }
 
     val annotatedString = buildAnnotatedString {
@@ -123,7 +128,9 @@ fun NoteText(
                 showConfirmDialog = false
             },
             onDismiss = {
-                clipboardManager.setText(buildAnnotatedString { append(uri ?: linkText) })
+                scope.launch {
+                    clipboard.setClipEntry(AnnotatedString(uri ?: linkText).toClipEntry())
+                }
                 showConfirmDialog = false
             }
         )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/CopyIconButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/CopyIconButton.kt
@@ -2,20 +2,27 @@ package network.bisq.mobile.presentation.ui.components.atoms.button
 
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.icons.CopyIcon
+import network.bisq.mobile.presentation.ui.helpers.toClipEntry
 import org.koin.compose.koinInject
 
 @Composable
 fun CopyIconButton(value: String, showToast: Boolean = true) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+
     val presenter: MainPresenter = koinInject()
     IconButton(
         onClick = {
-            clipboardManager.setText(buildAnnotatedString { append(value) })
+            scope.launch {
+                clipboard.setClipEntry(AnnotatedString(value).toClipEntry())
+            }
             if (showToast) {
                 presenter.showSnackbar("mobile.components.copyIconButton.copied".i18n())
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/PasteIconButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/PasteIconButton.kt
@@ -2,19 +2,24 @@ package network.bisq.mobile.presentation.ui.components.atoms.button
 
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalClipboard
+import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.ui.components.atoms.icons.PasteIcon
+import network.bisq.mobile.presentation.ui.helpers.readText
 
 @Composable
 fun PasteIconButton(
     onPaste: (String) -> Unit,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     IconButton(
         onClick = {
-            val value = clipboardManager.getText()
-            if (value != null) {
-                onPaste(value.text)
+            scope.launch {
+                clipboard.getClipEntry()?.readText()?.let { text ->
+                    onPaste(text)
+                }
             }
         }
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
@@ -1,13 +1,16 @@
 package network.bisq.mobile.presentation.ui.components.molecules.dialog
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.icons.InfoGreenIcon
+import network.bisq.mobile.presentation.ui.helpers.toClipEntry
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 
 @Composable
@@ -22,7 +25,8 @@ fun WebLinkConfirmationDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
     ConfirmationDialog(
         headline = headline,
@@ -37,7 +41,9 @@ fun WebLinkConfirmationDialog(
         },
         onDismiss = { toCopy ->
             if (toCopy) {
-                clipboardManager.setText(buildAnnotatedString { append(link) })
+                scope.launch {
+                    clipboard.setClipEntry(AnnotatedString(link).toClipEntry())
+                }
             }
             onDismiss()
         },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/ReportBugPanel.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/ReportBugPanel.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.AppPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.BisqButton
@@ -24,6 +26,7 @@ import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.ExclamationRedIcon
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.molecules.dialog.BisqDialog
+import network.bisq.mobile.presentation.ui.helpers.toClipEntry
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
@@ -35,7 +38,8 @@ fun ReportBugPanel(
     onClose: () -> Unit,
 ) {
     val presenter: AppPresenter = koinInject()
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
 
     BisqDialog(
@@ -95,7 +99,9 @@ fun ReportBugPanel(
             BisqButton(
                 text = "support.reports.title".i18n(),
                 onClick = {
-                    clipboardManager.setText(buildAnnotatedString { append(errorMessage) })
+                    scope.launch {
+                        clipboard.setClipEntry(AnnotatedString(errorMessage).toClipEntry())
+                    }
                     presenter.navigateToReportError()
                     if (!isUncaughtException)
                         onClose.invoke()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.kt
@@ -1,0 +1,8 @@
+package network.bisq.mobile.presentation.ui.helpers
+
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.text.AnnotatedString
+
+expect fun AnnotatedString?.toClipEntry(): ClipEntry?
+
+expect suspend fun ClipEntry.readText(): String?

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/ui/helpers/ClipboardUtils.ios.kt
@@ -1,0 +1,14 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package network.bisq.mobile.presentation.ui.helpers
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.text.AnnotatedString
+
+actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
+    if (this == null) return null
+    return ClipEntry.withPlainText(this.text)
+}
+
+actual suspend fun ClipEntry.readText(): String? = getPlainText()


### PR DESCRIPTION
- Fixes https://github.com/bisq-network/bisq-mobile/issues/636
Update LocalClipboardManager implementation due to deprecation.
Implementation tested on both platforms Android and iOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Cross-platform clipboard helpers added for Android and iOS.

- Improvements
  - Clipboard actions migrated to an asynchronous coroutine-based API for non-blocking copy/paste.
  - Clipboard usage unified across dialogs, buttons, report-bug flow, and trade chat for consistent UX.

- Bug Fixes
  - More reliable copy and paste behavior; paste now consistently reads and inserts available clipboard content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->