### PR TITLE
Bugfix/open trade header showing wrong direction

### DIFF
--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModelDirectionTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModelDirectionTest.kt
@@ -1,0 +1,58 @@
+package network.bisq.mobile.domain.data.replicated.presentation.open_trades
+
+import io.mockk.every
+import io.mockk.mockk
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelModel
+import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.BisqEasyTradeModel
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TradeItemPresentationModelDirectionTest {
+
+    @BeforeTest
+    fun initI18n() {
+        I18nSupport.initialize("en")
+    }
+
+    @Test
+    fun directionalTitle_usesIsSeller_whenSeller() {
+        val dto = mockk<TradeItemPresentationDto>(relaxed = true)
+        val channelModel = mockk<BisqEasyOpenTradeChannelModel>(relaxed = true)
+        val tradeModel = mockk<BisqEasyTradeModel>(relaxed = true)
+        every { tradeModel.isSeller } returns true
+
+        val model = TradeItemPresentationModel(
+            tradeItemPresentationDto = dto,
+            bisqEasyOpenTradeChannelModel = channelModel,
+            bisqEasyTradeModel = tradeModel,
+        )
+
+        assertEquals(
+            "bisqEasy.openTrades.table.direction.seller".i18n().uppercase(),
+            model.directionalTitle
+        )
+    }
+
+    @Test
+    fun directionalTitle_usesIsSeller_whenBuyer() {
+        val dto = mockk<TradeItemPresentationDto>(relaxed = true)
+        val channelModel = mockk<BisqEasyOpenTradeChannelModel>(relaxed = true)
+        val tradeModel = mockk<BisqEasyTradeModel>(relaxed = true)
+        every { tradeModel.isSeller } returns false
+
+        val model = TradeItemPresentationModel(
+            tradeItemPresentationDto = dto,
+            bisqEasyOpenTradeChannelModel = channelModel,
+            bisqEasyTradeModel = tradeModel,
+        )
+
+        assertEquals(
+            "bisqEasy.openTrades.table.direction.buyer".i18n().uppercase(),
+            model.directionalTitle
+        )
+    }
+}
+

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
@@ -22,10 +22,12 @@ data class TradeItemPresentationModel(
     val makerUserProfile: UserProfileVO get() = tradeItemPresentationDto.makerUserProfile
     val takerUserProfile: UserProfileVO get() = tradeItemPresentationDto.takerUserProfile
 
-    val directionalTitle: String get() = when {
-        tradeItemPresentationDto.directionalTitle.uppercase().contains("SELLING") -> "bisqEasy.openTrades.table.direction.seller"
-        else -> "bisqEasy.openTrades.table.direction.buyer"
-    }.i18n().uppercase()
+    // Determine direction from the actual trade role instead of parsing a formatted string
+    // This avoids mismatches like showing 'BUYING FROM' while amounts reflect the seller role.
+    val directionalTitle: String get() = if (bisqEasyTradeModel.isSeller)
+        "bisqEasy.openTrades.table.direction.seller".i18n().uppercase()
+    else
+        "bisqEasy.openTrades.table.direction.buyer".i18n().uppercase()
 
     val formattedDate: String get() = tradeItemPresentationDto.formattedDate
     val formattedTime: String get() = tradeItemPresentationDto.formattedTime

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
@@ -22,8 +22,6 @@ data class TradeItemPresentationModel(
     val makerUserProfile: UserProfileVO get() = tradeItemPresentationDto.makerUserProfile
     val takerUserProfile: UserProfileVO get() = tradeItemPresentationDto.takerUserProfile
 
-    // Determine direction from the actual trade role instead of parsing a formatted string
-    // This avoids mismatches like showing 'BUYING FROM' while amounts reflect the seller role.
     val directionalTitle: String get() = if (bisqEasyTradeModel.isSeller)
         "bisqEasy.openTrades.table.direction.seller".i18n().uppercase()
     else

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
@@ -287,3 +287,4 @@ class MainPresenterUnreadBadgeTest {
         assertFalse(unread.containsKey("t1"))
     }
 }
+

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/TradeDirectionPresentationTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/TradeDirectionPresentationTest.kt
@@ -1,0 +1,155 @@
+package network.bisq.mobile.presentation.ui.uicases.open_trades
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelModel
+import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.BisqEasyTradeModel
+import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import network.bisq.mobile.domain.service.mediation.MediationServiceFacade
+import network.bisq.mobile.domain.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.uicases.open_trades.selected.TradeDetailsHeaderPresenter
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TradeDirectionPresentationTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    // Minimal Koin module for BasePresenter jobsManager injection
+    private val testKoinModule = module {
+        single { CoroutineExceptionHandlerSetup() }
+        factory<CoroutineJobsManager> {
+            DefaultCoroutineJobsManager().apply {
+                get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
+            }
+        }
+    }
+
+    @BeforeTest
+    fun setup() {
+        // Coroutine Main dispatcher for presenters
+        Dispatchers.setMain(testDispatcher)
+        // Minimal Koin context for CoroutineJobsManager used by BasePresenter
+        startKoin { modules(testKoinModule) }
+        // Ensure i18n bundles are loaded
+        I18nSupport.initialize("en")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+    @Test
+    fun seller_seesSellingTo_and_amountsMappedBaseThenQuote() = runTest {
+        // Main presenter only used for languageCode
+        val mainPresenter = mockk<MainPresenter>(relaxed = true)
+        every { mainPresenter.languageCode } returns MutableStateFlow("en")
+
+        // Trade item model and nested flows
+        val tradeModel = mockk<BisqEasyTradeModel>(relaxed = true)
+        every { tradeModel.isSeller } returns true
+        every { tradeModel.tradeState } returns MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+        val channelModel = mockk<BisqEasyOpenTradeChannelModel>(relaxed = true)
+        every { channelModel.isInMediation } returns MutableStateFlow(false)
+
+        val tradeItem = mockk<network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel>(relaxed = true)
+        every { tradeItem.bisqEasyTradeModel } returns tradeModel
+        every { tradeItem.bisqEasyOpenTradeChannelModel } returns channelModel
+        every { tradeItem.formattedBaseAmount } returns "0.00433161"
+        every { tradeItem.baseCurrencyCode } returns "BTC"
+        every { tradeItem.formattedQuoteAmount } returns "500.00"
+        every { tradeItem.quoteCurrencyCode } returns "USD"
+
+        // Services
+        val tradesServiceFacade = mockk<TradesServiceFacade>()
+        every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(tradeItem)
+
+        val mediationServiceFacade = mockk<MediationServiceFacade>(relaxed = true)
+        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
+
+        val presenter = TradeDetailsHeaderPresenter(
+            mainPresenter = mainPresenter,
+            tradesServiceFacade = tradesServiceFacade,
+            mediationServiceFacade = mediationServiceFacade,
+            userProfileServiceFacade = userProfileServiceFacade,
+        )
+
+        presenter.onViewAttached()
+
+        assertEquals("offer.sell".i18n().uppercase(), presenter.direction)
+        assertEquals("bisqEasy.tradeState.header.send".i18n(), presenter.leftAmountDescription)
+        assertEquals("bisqEasy.tradeState.header.receive".i18n(), presenter.rightAmountDescription)
+        assertEquals("0.00433161", presenter.leftAmount.value)
+        assertEquals("BTC", presenter.leftCode.value)
+        assertEquals("500.00", presenter.rightAmount.value)
+        assertEquals("USD", presenter.rightCode.value)
+    }
+
+    @Test
+    fun buyer_seesBuyingFrom_and_amountsMappedQuoteThenBase() = runTest {
+        val mainPresenter = mockk<MainPresenter>(relaxed = true)
+        every { mainPresenter.languageCode } returns MutableStateFlow("en")
+
+        val tradeModel = mockk<BisqEasyTradeModel>(relaxed = true)
+        every { tradeModel.isSeller } returns false
+        every { tradeModel.tradeState } returns MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+        val channelModel = mockk<BisqEasyOpenTradeChannelModel>(relaxed = true)
+        every { channelModel.isInMediation } returns MutableStateFlow(false)
+
+        val tradeItem = mockk<network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel>(relaxed = true)
+        every { tradeItem.bisqEasyTradeModel } returns tradeModel
+        every { tradeItem.bisqEasyOpenTradeChannelModel } returns channelModel
+        every { tradeItem.formattedBaseAmount } returns "0.00433161"
+        every { tradeItem.baseCurrencyCode } returns "BTC"
+        every { tradeItem.formattedQuoteAmount } returns "500.00"
+        every { tradeItem.quoteCurrencyCode } returns "USD"
+
+        val tradesServiceFacade = mockk<TradesServiceFacade>()
+        every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(tradeItem)
+
+        val mediationServiceFacade = mockk<MediationServiceFacade>(relaxed = true)
+        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
+
+        val presenter = TradeDetailsHeaderPresenter(
+            mainPresenter = mainPresenter,
+            tradesServiceFacade = tradesServiceFacade,
+            mediationServiceFacade = mediationServiceFacade,
+            userProfileServiceFacade = userProfileServiceFacade,
+        )
+
+        presenter.onViewAttached()
+
+        assertEquals("offer.buy".i18n().uppercase(), presenter.direction)
+        assertEquals("bisqEasy.tradeState.header.pay".i18n(), presenter.leftAmountDescription)
+        assertEquals("bisqEasy.tradeState.header.receive".i18n(), presenter.rightAmountDescription)
+        assertEquals("500.00", presenter.leftAmount.value)
+        assertEquals("USD", presenter.leftCode.value)
+        assertEquals("0.00433161", presenter.rightAmount.value)
+        assertEquals("BTC", presenter.rightCode.value)
+    }
+}
+

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/di/PresentationModule.kt
@@ -187,7 +187,7 @@ val presentationModule = module {
     // Trade General process
     factory { TradeStatesProvider(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { OpenTradeListPresenter(get(), get(), get(), get()) }
-    single { TradeDetailsHeaderPresenter(get(), get(), get(), get()) }
+    factory { TradeDetailsHeaderPresenter(get(), get(), get(), get()) }
     factory { InterruptedTradePresenter(get(), get(), get(), get()) }
     factory { TradeFlowPresenter(get(), get(), get()) }
     factory { OpenTradePresenter(get(), get(), get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/PreviewEnvironment.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/helpers/PreviewEnvironment.kt
@@ -16,13 +16,21 @@ import org.koin.dsl.module
  *   BisqTheme.Preview {
  *     PreviewEnvironment { YourContent() }
  *   }
+ *
+ * TODO: WORKAROUND - This is a temporary environment for previewing complex UI Composables
+ *  that depend on navigation and DI.
+ *  **The Long-Term Goal:** Refactor the underlying Composables to be **stateless**.
+ *  A stateless Composable should receive all its data as parameters and expose events
+ *  through lambda functions (e.g., `onClick: () -> Unit`). This makes them easy to
+ *  preview by simply passing static data, eliminating the need for this wrapper.
+ *
  */
 @Composable
 fun PreviewEnvironment(content: @Composable () -> Unit) {
     val root = rememberNavController()
     val tab = rememberNavController()
 
-    // TODO add more modules as needed for different UI Previews
+    // Add more modules as needed for different UI Previews
     KoinApplication(application = {
         modules(
             module {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -104,14 +104,11 @@ class OpenTradeListPresenter(
 
     private fun navigateToOpenTrade(openTradeItem: TradeItemPresentationModel) {
         try {
-            disableInteractive()
             tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
             navigateTo(Routes.OpenTrade)
         } catch (e: Exception) {
             log.e(e) { "Failed to open trade ${openTradeItem.tradeId}" }
             showSnackbar("mobile.bisqEasy.openTrades.failed".i18n(e.message ?: "unknown"))
-        } finally {
-            enableInteractive()
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -13,6 +13,8 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.navigation.Routes
+import network.bisq.mobile.i18n.i18n
+
 
 class OpenTradeListPresenter(
     private val mainPresenter: MainPresenter,
@@ -72,8 +74,7 @@ class OpenTradeListPresenter(
 
     fun onSelect(openTradeItem: TradeItemPresentationModel) {
         if (tradeRulesConfirmed.value) {
-            tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
-            navigateTo(Routes.OpenTrade)
+            navigateToOpenTrade(openTradeItem)
         } else {
             log.w { "User hasn't accepted trade rules yet, showing dialog" }
             _tradeGuideVisible.value = true
@@ -98,6 +99,19 @@ class OpenTradeListPresenter(
                     }
                 }
             }
+        }
+    }
+
+    private fun navigateToOpenTrade(openTradeItem: TradeItemPresentationModel) {
+        try {
+            disableInteractive()
+            tradesServiceFacade.selectOpenTrade(openTradeItem.tradeId)
+            navigateTo(Routes.OpenTrade)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to open trade ${openTradeItem.tradeId}" }
+            showSnackbar("mobile.bisqEasy.openTrades.failed".i18n(e.message ?: "unknown"))
+        } finally {
+            enableInteractive()
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/OpenTradeScreen.kt
@@ -117,7 +117,7 @@ fun OpenTradeScreen() {
                     .fillMaxSize()
             ) {
                 if (selectedTrade != null) {
-                    TradeDetailsHeader()
+                    TradeDetailsHeader(presenter = headerPresenter)
 
                     if (isIgnoredUser) {
                         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeader.kt
@@ -51,8 +51,7 @@ import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.koin.compose.koinInject
 
 @Composable
-fun TradeDetailsHeader() {
-    val presenter: TradeDetailsHeaderPresenter = koinInject()
+fun TradeDetailsHeader(presenter: TradeDetailsHeaderPresenter = koinInject()) {
     RememberPresenterLifecycle(presenter)
 
     val isInteractive by presenter.isInteractive.collectAsState()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/selected/TradeDetailsHeaderPresenter.kt
@@ -46,9 +46,7 @@ class TradeDetailsHeaderPresenter(
         COMPLETED
     }
 
-    private val _selectedTrade: MutableStateFlow<TradeItemPresentationModel?> =
-        MutableStateFlow(tradesServiceFacade.selectedTrade.value)
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     var direction: String = ""
     var directionEnum: DirectionEnum = DirectionEnum.BUY


### PR DESCRIPTION
 - fix #667 
 - use same direction condition for all data + use factory for Header DI to avoid data retention
 - added unit tests for long term direction validations QA
 - added missing enable/disable interactive pattern for open trades navigation
 - added missing header comment suggestion from previous merged PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Safer trade opening: UI disables interactions during open and shows a translated error snackbar on failure.
- Bug Fixes
  - Trade direction labels reliably display SELL or BUY based on the trade role.
- Tests
  - Added unit tests validating direction label logic and trade header UI mappings for seller/buyer scenarios.
- Refactor
  - Trade header observes live selected-trade updates; presenter provisioning changed to per-use factory and header now accepts an injectable presenter.
- Documentation
  - Added notes/workaround to aid UI previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->