### PR TITLE
fix ci test command pre merge to run all modules but node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
           echo "KEY_PASSWORD=yourKeyPassword" >> local.properties
           echo "CLI_KEY_PASSWORD=yourCliKeyPassword" >> local.properties
 
-      - name: Run androidClient Tests
+      - name: Run Tests
         env:
           CI: true
-        run: ./gradlew androidClient:clean androidClient:assembleDebug androidClient:testDebugUnitTest --info
+        run: ./gradlew clean test -x :androidNode:testDebugUnitTest -x :androidNode:testReleaseUnitTest -x :androidNode:test --info
 
 #      TODO seems GH default ci doesn't have support for this
 #      - name: Headless Android emulator and run instrumentation tests
@@ -141,4 +141,4 @@ jobs:
       - name: Build Node Project with Maven Secrets
         run: |
           ./gradlew androidNode:clean androidNode:bundleDebug --refresh-dependencies --info
-          ./gradlew test
+          ./gradlew androidNode:test


### PR DESCRIPTION
 - make sure all modules tests run pre merge not only the androidClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI test step naming for consistency.
  * Consolidated Android test commands into a single sequence.
  * Updated workflow to run clean test executions with appropriate exclusions.
  * Simplified previously separate module invocations.

* **Tests**
  * Adjusted Android test execution to use a unified task.
  * Switched Node build path to run module-specific tests for better alignment with the project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->