### PR TITLE
bugfix/ci_node_broken_after_lifecycle_pr_merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,12 @@ jobs:
         run: chmod +x gradlew
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 33
-          build-tools: 33.0.0
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK components
+        run: |
+          yes | sdkmanager --licenses || true
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;26.1.10909125"
 
       - name: Set up Xcode (Mac only)
         if: startsWith(matrix.os, 'macos')
@@ -124,10 +126,12 @@ jobs:
         run: chmod +x gradlew
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 33
-          build-tools: 33.0.0
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK components
+        run: |
+          yes | sdkmanager --licenses || true
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;26.1.10909125"
 
       - name: Create fake local.properties
         run: |

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -63,6 +63,8 @@ localProperties.load(File(rootDir, "local.properties").inputStream())
 android {
     namespace = "network.bisq.mobile.node"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
+    // pin ndk version for deterministic builds
+    ndkVersion = libs.versions.android.ndk.get()
 
     signingConfigs {
         create("release") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ ksp = "2.2.10-2.0.2"
 # -------------------- Android --------------------
 #noinspection AndroidGradlePluginVersion - we need to stick to it based on https://developer.android.com/build/kotlin-support
 agp = "8.10.1"
+android-ndk = "26.1.10909125"
 android-compileSdk = "35"
 android-targetSdk = "35"
 android-minSdk = "24"


### PR DESCRIPTION
  - pin ndk version for deterministic builds
 - upgrade android setup for CI considering ndk pinning