### PR TITLE
bugfix/missing_i18n_key_values

### DIFF
--- a/shared/domain/src/commonMain/resources/mobile/settings.properties
+++ b/shared/domain/src/commonMain/resources/mobile/settings.properties
@@ -38,7 +38,7 @@ settings.trade.numDaysAfterRedactingTradeData=Days after which sensitive trade d
 settings.trade.numDaysAfterRedactingTradeData.help=Removes payment account data and trade chat messages after the specified days.
 settings.trade.numDaysAfterRedactingTradeData.invalid=Must be between {0} and {1} days
 
-settings.network.headline=Network settings
+settings.network.difficultyAdjustmentFactor.headline=Network settings
 settings.network.difficultyAdjustmentFactor.description.self=Custom PoW difficulty adjustment factor
 settings.network.difficultyAdjustmentFactor.description.fromSecManager=PoW difficulty adjustment factor by Bisq Security Manager
 settings.network.difficultyAdjustmentFactor.invalid=Must be a number between 0 and {0}


### PR DESCRIPTION
 - fix #698 
 - missing default key value for network settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed an internal configuration label related to the network settings headline to align with existing difficulty adjustment factor entries. The displayed headline text remains "Network settings," and there are no functional changes. This is a behind-the-scenes cleanup with no impact on user workflows, logic, or error handling. No updates required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->