### PR TITLE
Only show num connections in node

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.android.node.di
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.NodeApplicationLifecycleService
 import network.bisq.mobile.android.node.presentation.NodeAboutPresenter
+import network.bisq.mobile.android.node.presentation.NodeDashboardPresenter
 import network.bisq.mobile.android.node.presentation.NodeGeneralSettingsPresenter
 import network.bisq.mobile.android.node.presentation.NodeMainPresenter
 import network.bisq.mobile.android.node.presentation.NodeOnBoardingPresenter
@@ -43,6 +44,7 @@ import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.AppPresenter
+import network.bisq.mobile.presentation.ui.uicases.DashboardPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.AboutPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.GeneralSettingsPresenter
 import network.bisq.mobile.presentation.ui.uicases.settings.IAboutPresenter
@@ -138,6 +140,19 @@ val androidNodeModule = module {
     single<SplashPresenter> {
         NodeSplashPresenter(
             get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+        )
+    }
+
+    single<DashboardPresenter> {
+        NodeDashboardPresenter(
             get(),
             get(),
             get(),

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeDashboardPresenter.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeDashboardPresenter.kt
@@ -1,0 +1,33 @@
+package network.bisq.mobile.android.node.presentation
+
+import network.bisq.mobile.domain.data.repository.SettingsRepository
+import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.service.network.NetworkServiceFacade
+import network.bisq.mobile.domain.service.notifications.controller.NotificationServiceController
+import network.bisq.mobile.domain.service.offers.OffersServiceFacade
+import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
+import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.presentation.MainPresenter
+import network.bisq.mobile.presentation.ui.uicases.DashboardPresenter
+
+class NodeDashboardPresenter(
+    mainPresenter: MainPresenter,
+    userProfileServiceFacade: UserProfileServiceFacade,
+    marketPriceServiceFacade: MarketPriceServiceFacade,
+    offersServiceFacade: OffersServiceFacade,
+    settingsServiceFacade: SettingsServiceFacade,
+    networkServiceFacade: NetworkServiceFacade,
+    settingsRepository: SettingsRepository,
+    notificationServiceController: NotificationServiceController,
+) : DashboardPresenter(
+    mainPresenter,
+    userProfileServiceFacade,
+    marketPriceServiceFacade,
+    offersServiceFacade,
+    settingsServiceFacade,
+    networkServiceFacade,
+    settingsRepository,
+    notificationServiceController,
+) {
+    override val showNumConnections: Boolean = true
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardPresenter.kt
@@ -39,6 +39,8 @@ open class DashboardPresenter(
     val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
     val marketPrice: StateFlow<String> get() = marketPriceServiceFacade.selectedFormattedMarketPrice
 
+    open val showNumConnections: Boolean = false
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val savedNotifPermissionState: StateFlow<NotificationPermissionState?> =
         settingsRepository.data.mapLatest { it.notificationPermissionState }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/DashboardScreen.kt
@@ -65,6 +65,8 @@ fun DashboardScreen() {
     val tradeRulesConfirmed by presenter.tradeRulesConfirmed.collectAsState()
     val notifPermissionState by presenter.savedNotifPermissionState.collectAsState()
     var isPermissionRequestDialogVisible by remember { mutableStateOf(false) }
+    val showNumConnections = presenter.showNumConnections
+
     val notifPermLauncher = rememberNotificationPermissionLauncher { granted ->
         if (granted) {
             presenter.saveNotificationPermissionState(NotificationPermissionState.GRANTED)
@@ -115,6 +117,7 @@ fun DashboardScreen() {
     DashboardContent(
         offersOnline = offersOnline,
         publishedProfiles = publishedProfiles,
+        showNumConnections = showNumConnections,
         numConnections = numConnections,
         isInteractive = isInteractive,
         marketPrice = marketPrice,
@@ -145,6 +148,7 @@ fun DashboardScreen() {
 private fun DashboardContent(
     offersOnline: Number,
     publishedProfiles: Number,
+    showNumConnections: Boolean,
     numConnections: Number,
     isInteractive: Boolean,
     marketPrice: String,
@@ -179,11 +183,19 @@ private fun DashboardContent(
                     price = offersOnline.toString(),
                     text = "dashboard.offersOnline".i18n()
                 )
-                HomeInfoCard(
-                    modifier = Modifier.weight(1f).fillMaxHeight(),
-                    price = numConnections.toString(),
-                    text = "mobile.dashboard.numConnections".i18n()
-                )
+                if (showNumConnections) {
+                    HomeInfoCard(
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        price = numConnections.toString(),
+                        text = "mobile.dashboard.numConnections".i18n()
+                    )
+                } else {
+                    HomeInfoCard(
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        price = publishedProfiles.toString(),
+                        text = "dashboard.activeUsers".i18n()
+                    )
+                }
             }
         }
 
@@ -292,6 +304,7 @@ private fun DashboardContentPreview(
         DashboardContent(
             offersOnline = 1,
             publishedProfiles = 2,
+            showNumConnections = true,
             numConnections = 8,
             isInteractive = true,
             marketPrice = "111247.40 BTC/USD",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now conditionally shows either the network connections count or an Active Users metric for more relevant info.
  * Android defaults to displaying the connections count for greater network visibility.
  * Labels and values update accordingly so dashboard cards remain clear and accurate.
  * Behavior is automatic with no user setup required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->