### PR TITLE
feat: make all events count toward badge

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVO.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.domain.data.replicated.network.identity.NetworkIdVO
 import network.bisq.mobile.domain.data.replicated.security.keys.PubKeyVO
 import network.bisq.mobile.domain.data.replicated.security.keys.PublicKeyVO
 import network.bisq.mobile.domain.data.replicated.security.pow.ProofOfWorkVO
+import network.bisq.mobile.domain.utils.createUuid
 
 @Serializable
 data class UserProfileVO(
@@ -50,3 +51,19 @@ val userProfileDemoObj = UserProfileVO(
     userName = "demo",
     publishDate = 10342435345324L
 )
+
+/**
+ * a fast way to create a mock user profile
+ */
+fun createMockUserProfile(name: String = createUuid()): UserProfileVO {
+    return userProfileDemoObj.copy(
+        nickName = name,
+        networkId = userProfileDemoObj.networkId.copy(
+            pubKey = userProfileDemoObj.networkId.pubKey.copy(
+                id = name,
+                keyId = name
+            )
+        ),
+        nym = name,
+    )
+}

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -55,6 +55,7 @@ mobile.permissions.notifications.dismissed=We won't ask for permissions again, a
 
 mobile.action.grantPermission=Grant permission
 mobile.action.dontAskAgain=Don't ask again
+mobile.action.finish=Finish
 
 ################################################################################
 # Notifications

--- a/shared/domain/src/commonMain/resources/mobile/mobile_es.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile_es.properties
@@ -1,7 +1,7 @@
 mobile.bootstrap.connectedToTrustedNode=Conectado al nodo de confianza
 mobile.error.exception=Excepción
 mobile.error.warning=Advertencia
-mobile.mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo=Usa el ID de intercambio {0} para el campo ''Motivo del pago''
+mobile.tradeState.info.buyer.phase2a.reasonForPaymentInfo=Usa el ID de intercambio {0} para el campo ''Motivo del pago''
 mobile.confirmation.areYouSure=¿Estás seguro?
 mobile.openTrades.inMediation.banner=Un mediador se ha unido al chat del intercambio.\nPor favor, usa el chat del intercambio para obtener asistencia del mediador.
 mobile.genericError.headline=Ha ocurrido un error

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
@@ -69,7 +69,7 @@ class MainPresenterUnreadBadgeTest {
 
         // Mock ignored user IDs
         val ignoredUserIdsFlow = MutableStateFlow(setOf("ignoredUser1"))
-        every { userProfileServiceFacade.ignoredUserIds } returns ignoredUserIdsFlow
+        every { userProfileServiceFacade.ignoredProfileIds } returns ignoredUserIdsFlow
 
         // Mock read states
         val readStatesFlow = MutableStateFlow(TradeReadStateMap(mapOf("trade1" to 1, "trade2" to 0)))

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -13,13 +14,14 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.domain.UrlLauncher
 import network.bisq.mobile.domain.data.model.TradeReadStateMap
+import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelModel
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
-import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.BisqEasyTradeModel
-import network.bisq.mobile.domain.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import network.bisq.mobile.domain.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.domain.data.replicated.user.profile.userProfileDemoObj
 import network.bisq.mobile.domain.data.repository.TradeReadStateRepository
-import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.notifications.OpenTradesNotificationService
 import network.bisq.mobile.domain.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
@@ -27,8 +29,7 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 /**
  * Tests for the unread badge logic in MainPresenter.
@@ -51,237 +52,124 @@ class MainPresenterUnreadBadgeTest {
     }
 
     @Test
-    fun `trades in final states are excluded from unread badge map`() = runTest {
-        // Mock top-level android-specific function called from MainPresenter.init
-        mockkStatic("network.bisq.mobile.presentation.PlatformPresentationAbstractions_androidKt")
-        every { getScreenWidthDp() } returns 480
-        // Dependencies
-        val connectivity = mockk<ConnectivityService>(relaxed = true)
-        val notifications = mockk<OpenTradesNotificationService>(relaxed = true)
-        val settings = mockk<SettingsServiceFacade>()
-        every { settings.languageCode } returns MutableStateFlow("en")
-        every { settings.useAnimations } returns MutableStateFlow(false)
-        val tradesFacade = mockk<TradesServiceFacade>()
-        val readRepo = mockk<TradeReadStateRepository>()
-        val urlLauncher = mockk<UrlLauncher>(relaxed = true)
-
-        // Trade item with message and state flows
-        val chatMessagesFlow = MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>>(emptySet())
-        val tradeStateFlow = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
-
-        val channelModel = mockk<BisqEasyOpenTradeChannelModel>()
-        every { channelModel.chatMessages } returns chatMessagesFlow
-        val tradeModel = mockk<BisqEasyTradeModel>()
-        every { tradeModel.tradeState } returns tradeStateFlow
-
-        val tradeItem = mockk<TradeItemPresentationModel>()
-        every { tradeItem.tradeId } returns "t1"
-        every { tradeItem.bisqEasyOpenTradeChannelModel } returns channelModel
-        every { tradeItem.bisqEasyTradeModel } returns tradeModel
-
-        val openTradesFlow = MutableStateFlow(listOf(tradeItem))
-        every { tradesFacade.openTradeItems } returns openTradesFlow
-        every { tradesFacade.selectedTrade } returns MutableStateFlow<TradeItemPresentationModel?>(null)
-
-        val readMapFlow = MutableStateFlow(TradeReadStateMap(mapOf("t1" to 0)))
-        every { readRepo.data } returns readMapFlow
-
-        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
-        val presenter = MainPresenter(
-            openTradesNotificationService = notifications,
-            settingsService = settings,
-            tradesServiceFacade = tradesFacade,
-            userProfileServiceFacade = userProfileServiceFacade,
-            tradeReadStateRepository = readRepo,
-            urlLauncher = urlLauncher
-        )
-
-        // Initially no messages => no unread
-        var unread = presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        // Add some messages while readCount is 0 => unread present
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        // Transition trade to final state => it should be excluded from unread
-        tradeStateFlow.value = BisqEasyTradeStateEnum.CANCELLED
-
-        unread = presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    // Test fixture to avoid duplication across final-state tests
-    private data class Fixture(
-        val presenter: MainPresenter,
-        val chatMessagesFlow: MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>>,
-        val tradeStateFlow: MutableStateFlow<BisqEasyTradeStateEnum>
-    )
-
-    private fun buildFixture(): Fixture {
+    fun `unread badge count reflects the total unread chat messages exactly`() = runTest {
         // Mock top-level android-specific function called from MainPresenter.init
         mockkStatic("network.bisq.mobile.presentation.PlatformPresentationAbstractions_androidKt")
         every { getScreenWidthDp() } returns 480
 
-        val connectivity = mockk<ConnectivityService>(relaxed = true)
-        val notifications = mockk<OpenTradesNotificationService>(relaxed = true)
-        val settings = mockk<SettingsServiceFacade>()
-        every { settings.languageCode } returns MutableStateFlow("en")
-        every { settings.useAnimations } returns MutableStateFlow(false)
-        val tradesFacade = mockk<TradesServiceFacade>()
-        val readRepo = mockk<TradeReadStateRepository>()
+        // Mock dependencies
+        val tradesServiceFacade = mockk<TradesServiceFacade>()
+        val tradeReadStateRepository = mockk<TradeReadStateRepository>()
+        val userProfileServiceFacade = mockk<UserProfileServiceFacade>()
+        val openTradesNotificationService = mockk<OpenTradesNotificationService>()
+        val settingsService = mockk<SettingsServiceFacade>()
+        every { settingsService.languageCode } returns MutableStateFlow("en")
+        every { settingsService.useAnimations } returns MutableStateFlow(false)
         val urlLauncher = mockk<UrlLauncher>(relaxed = true)
 
-        val chatMessagesFlow = MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>>(emptySet())
-        val tradeStateFlow = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+        // Mock ignored user IDs
+        val ignoredUserIdsFlow = MutableStateFlow(setOf("ignoredUser1"))
+        every { userProfileServiceFacade.ignoredUserIds } returns ignoredUserIdsFlow
 
-        val channelModel = mockk<BisqEasyOpenTradeChannelModel>()
-        every { channelModel.chatMessages } returns chatMessagesFlow
-        val tradeModel = mockk<BisqEasyTradeModel>()
-        every { tradeModel.tradeState } returns tradeStateFlow
+        // Mock read states
+        val readStatesFlow = MutableStateFlow(TradeReadStateMap(mapOf("trade1" to 1, "trade2" to 0)))
+        every { tradeReadStateRepository.data } returns readStatesFlow
 
-        val tradeItem = mockk<TradeItemPresentationModel>()
-        every { tradeItem.tradeId } returns "t1"
-        every { tradeItem.bisqEasyOpenTradeChannelModel } returns channelModel
-        every { tradeItem.bisqEasyTradeModel } returns tradeModel
+        // Mock myUserProfile for models
+        val myUserProfile = createMockUserProfile("myUser")
 
-        val openTradesFlow = MutableStateFlow(listOf(tradeItem))
-        every { tradesFacade.openTradeItems } returns openTradesFlow
-        every { tradesFacade.selectedTrade } returns MutableStateFlow<TradeItemPresentationModel?>(null)
+        // Mock DTOs and create models for trade1
+        val dto1 = mockk<BisqEasyOpenTradeMessageDto>()
+        every { dto1.chatMessageType } returns ChatMessageTypeEnum.TEXT
+        every { dto1.senderUserProfile } returns createMockUserProfile("User1")
+        every { dto1.messageId } returns "msg1"
+        every { dto1.text } returns null
+        every { dto1.citation } returns null
+        every { dto1.date } returns 0L
+        every { dto1.tradeId } returns "trade1"
+        every { dto1.mediator } returns null
+        every { dto1.bisqEasyOffer } returns null
+        every { dto1.citationAuthorUserProfile } returns null
+        val model1 = BisqEasyOpenTradeMessageModel(dto1, myUserProfile, emptyList())
 
-        val readMapFlow = MutableStateFlow(TradeReadStateMap(mapOf("t1" to 0)))
-        every { readRepo.data } returns readMapFlow
+        val dto2 = mockk<BisqEasyOpenTradeMessageDto>()
+        every { dto2.chatMessageType } returns ChatMessageTypeEnum.TEXT
+        every { dto2.senderUserProfile } returns createMockUserProfile("User2")
+        every { dto2.messageId } returns "msg2"
+        every { dto2.text } returns null
+        every { dto2.citation } returns null
+        every { dto2.date } returns 0L
+        every { dto2.tradeId } returns "trade1"
+        every { dto2.mediator } returns null
+        every { dto2.bisqEasyOffer } returns null
+        every { dto2.citationAuthorUserProfile } returns null
+        val model2 = BisqEasyOpenTradeMessageModel(dto2, myUserProfile, emptyList())
 
-        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
+        val dto3 = mockk<BisqEasyOpenTradeMessageDto>()
+        every { dto3.chatMessageType } returns ChatMessageTypeEnum.TEXT
+        every { dto3.senderUserProfile } returns createMockUserProfile("ignoredUser1")
+        every { dto3.messageId } returns "msg3"
+        every { dto3.text } returns null
+        every { dto3.citation } returns null
+        every { dto3.date } returns 0L
+        every { dto3.tradeId } returns "trade1"
+        every { dto3.mediator } returns null
+        every { dto3.bisqEasyOffer } returns null
+        every { dto3.citationAuthorUserProfile } returns null
+        val model3 = BisqEasyOpenTradeMessageModel(dto3, myUserProfile, emptyList())
+
+        val trade1MessagesFlow: StateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(setOf(model1, model2, model3))
+
+        // Mock DTO and model for trade2
+        val dto4 = mockk<BisqEasyOpenTradeMessageDto>()
+        every { dto4.chatMessageType } returns ChatMessageTypeEnum.TEXT
+        every { dto4.senderUserProfile } returns userProfileDemoObj.copy(userName = "User3", nym = "User3")
+        every { dto4.messageId } returns "msg4"
+        every { dto4.text } returns null
+        every { dto4.citation } returns null
+        every { dto4.date } returns 0L
+        every { dto4.tradeId } returns "trade2"
+        every { dto4.mediator } returns null
+        every { dto4.bisqEasyOffer } returns null
+        every { dto4.citationAuthorUserProfile } returns null
+        val model4 = BisqEasyOpenTradeMessageModel(dto4, myUserProfile, emptyList())
+
+        val trade2MessagesFlow = MutableStateFlow(setOf(model4))
+
+        val channelModel1 = mockk<BisqEasyOpenTradeChannelModel>()
+        every { channelModel1.chatMessages } answers { trade1MessagesFlow }
+
+        val channelModel2 = mockk<BisqEasyOpenTradeChannelModel>()
+        every { channelModel2.chatMessages } answers { trade2MessagesFlow }
+
+        val trade1 = mockk<TradeItemPresentationModel>()
+        every { trade1.tradeId } returns "trade1"
+        every { trade1.bisqEasyOpenTradeChannelModel } returns channelModel1
+
+        val trade2 = mockk<TradeItemPresentationModel>()
+        every { trade2.tradeId } returns "trade2"
+        every { trade2.bisqEasyOpenTradeChannelModel } returns channelModel2
+
+        val openTradeItemsFlow = MutableStateFlow(listOf(trade1, trade2))
+        every { tradesServiceFacade.openTradeItems } returns openTradeItemsFlow
+
+        // Create presenter
         val presenter = MainPresenter(
-            openTradesNotificationService = notifications,
-            settingsService = settings,
-            tradesServiceFacade = tradesFacade,
-            userProfileServiceFacade = userProfileServiceFacade,
-            tradeReadStateRepository = readRepo,
-            urlLauncher = urlLauncher
+            openTradesNotificationService,
+            settingsService,
+            tradesServiceFacade,
+            userProfileServiceFacade,
+            tradeReadStateRepository,
+            urlLauncher
         )
 
-        return Fixture(presenter, chatMessagesFlow, tradeStateFlow)
-    }
+        // Collect the unread messages map
+        val unreadMap = presenter.tradesWithUnreadMessages.first()
 
-    @Test
-    fun `final state BTC_CONFIRMED is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.BTC_CONFIRMED
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    @Test
-    fun `final state REJECTED is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.REJECTED
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    @Test
-    fun `final state PEER_REJECTED is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.PEER_REJECTED
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    @Test
-    fun `final state PEER_CANCELLED is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.PEER_CANCELLED
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    @Test
-    fun `final state FAILED is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.FAILED
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
-    }
-
-    @Test
-    fun `final state FAILED_AT_PEER is excluded from unread badge map`() = runTest {
-        val f = buildFixture()
-        var unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.isEmpty())
-
-        val m1 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m2 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        val m3 = mockk<BisqEasyOpenTradeMessageModel>(relaxed = true)
-        f.chatMessagesFlow.value = setOf(m1, m2, m3)
-
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertTrue(unread.containsKey("t1"))
-
-        f.tradeStateFlow.value = BisqEasyTradeStateEnum.FAILED_AT_PEER
-        unread = f.presenter.tradesWithUnreadMessages.first()
-        assertFalse(unread.containsKey("t1"))
+        // Assertions
+        // Trade1: 3 messages - 1 ignored = 2 visible, read 1, unread 1
+        // Trade2: 1 message, read 0, unread 1
+        assertEquals(mapOf("trade1" to 1, "trade2" to 1), unreadMap)
     }
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -66,8 +66,7 @@ open class MainPresenter(
                         trade.bisqEasyOpenTradeChannelModel.chatMessages,
                         tradeReadStateRepository.data.map { it.map },
                         userProfileServiceFacade.ignoredUserIds,
-                        trade.bisqEasyTradeModel.tradeState,
-                    ) { messages, readStates, ignoredUserIds, tradeState ->
+                    ) { messages, readStates, ignoredUserIds ->
                         // TODO: refactor to filter visible messages based on ignore at trade.bisqEasyOpenTradeChannelModel.chatMessages for consistency
                         // this is a duplicated logic from OpenTradePresenter msgCount collection
                         val visibleMessages = messages.filter {
@@ -76,17 +75,14 @@ open class MainPresenter(
                                 else -> true
                             }
                         }
-                        trade.tradeId to Pair(
-                            visibleMessages.size - readStates.getOrElse(trade.tradeId) {0},
-                            tradeState.isFinalState
-                        )
+                        trade.tradeId to visibleMessages.size - readStates.getOrElse(trade.tradeId) {0}
                     }
                 }
             }
             .flatMapLatest { pairsList ->
                 combine(pairsList) { pairs ->
-                    pairs.filter { it.second.first > 0 && !it.second.second }
-                        .associate { it.first to it.second.first }
+                    pairs.filter { it.second > 0 }
+                        .associate { it.first to it.second }
                 }
             }
             .stateIn(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -60,8 +60,8 @@ open class MainPresenter(
     // TODO: refactor when TradeItemPresentationModel is completely immutable
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> =
         tradesServiceFacade.openTradeItems
-            .map { openTradeItems ->
-                openTradeItems.map { trade ->
+            .flatMapLatest { openTradeItems ->
+                val flowsList = openTradeItems.map { trade ->
                     combine(
                         trade.bisqEasyOpenTradeChannelModel.chatMessages,
                         tradeReadStateRepository.data.map { it.map },
@@ -78,9 +78,7 @@ open class MainPresenter(
                         trade.tradeId to visibleMessages.size - readStates.getOrElse(trade.tradeId) {0}
                     }
                 }
-            }
-            .flatMapLatest { pairsList ->
-                combine(pairsList) { pairs ->
+                combine(flowsList) { pairs ->
                     pairs.filter { it.second > 0 }
                         .associate { it.first to it.second }
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -75,13 +76,20 @@ open class MainPresenter(
                                 else -> true
                             }
                         }
-                        val unread = (visibleMessages.size - readStates.getOrElse(trade.tradeId) { 0 }).coerceAtLeast(0)
+                        val unread =
+                            (visibleMessages.size - readStates.getOrElse(trade.tradeId) { 0 }).coerceAtLeast(
+                                0
+                            )
                         trade.tradeId to unread
                     }
                 }
-                combine(flowsList) { pairs ->
-                    pairs.filter { it.second > 0 }
-                        .associate { it.first to it.second }
+                if (flowsList.isEmpty()) {
+                    flowOf(emptyMap())
+                } else {
+                    combine(flowsList) { pairs ->
+                        pairs.filter { it.second > 0 }
+                            .associate { it.first to it.second }
+                    }
                 }
             }
             .stateIn(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -75,7 +75,8 @@ open class MainPresenter(
                                 else -> true
                             }
                         }
-                        trade.tradeId to visibleMessages.size - readStates.getOrElse(trade.tradeId) {0}
+                        val unread = (visibleMessages.size - readStates.getOrElse(trade.tradeId) { 0 }).coerceAtLeast(0)
+                        trade.tradeId to unread
                     }
                 }
                 combine(flowsList) { pairs ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfileRow.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/UserProfileRow.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.BadgedBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bot_image
@@ -17,7 +20,9 @@ import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.StarRating
+import network.bisq.mobile.presentation.ui.components.atoms.animations.AnimatedBadge
 import network.bisq.mobile.presentation.ui.components.atoms.icons.rememberPlatformImagePainter
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import org.jetbrains.compose.resources.painterResource
 
@@ -26,8 +31,9 @@ fun UserProfileRow(
     user: UserProfileVO,
     reputation: ReputationScoreVO,
     showUserName: Boolean = true,
-    modifier: Modifier = Modifier,
     userAvatar: PlatformImage? = null,
+    badgeCount: Int = 0,
+    modifier: Modifier = Modifier,
 ) {
     val fiveSystemScore = reputation.fiveSystemScore
 
@@ -38,13 +44,27 @@ fun UserProfileRow(
     }
 
     Row(
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            painter, "",
-            modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
-        )
+        BadgedBox(
+            modifier = Modifier.graphicsLayer(clip = false),
+            badge = {
+                if (badgeCount > 0) {
+                    AnimatedBadge(showAnimation = true, xOffset = 2.dp, yOffset = 24.dp) {
+                        BisqText.xsmallMedium(
+                            badgeCount.toString(),
+                            textAlign = TextAlign.Center, color = BisqTheme.colors.dark_grey20
+                        )
+                    }
+                }
+            }) {
+            Image(
+                painter, "",
+                modifier = Modifier.size(BisqUIConstants.ScreenPadding3X)
+            )
+        }
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (showUserName) {
                 BisqText.baseLight(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/TabContainerScreen.kt
@@ -80,7 +80,7 @@ fun TabContainerScreen() {
             BottomNavigation(
                 items = navigationListItem,
                 currentRoute = currentRoute.orEmpty(),
-                unreadTradeCount = tradesWithUnreadMessages.size,
+                unreadTradeCount = tradesWithUnreadMessages.values.sum(),
                 showAnimation = showAnimation,
                 onItemClick = { currentNavigationItem ->
                     Routes.fromString(currentNavigationItem.route)?.let { presenter.navigateToTab(it) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/guide/TradeGuideTradeRules.kt
@@ -36,7 +36,7 @@ fun TradeGuideTradeRules() {
         stepsLength = 4,
         prevOnClick = presenter::prevClick,
         nextOnClick = presenter::tradeRulesNextClick,
-        nextButtonText = "action.finish".i18n(),
+        nextButtonText = "mobile.action.finish".i18n(),
         nextDisabled = !localUserAgreed,
         horizontalAlignment = Alignment.Start,
         isInteractive = isInteractive,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListItem.kt
@@ -27,11 +27,11 @@ import network.bisq.mobile.presentation.ui.theme.BisqTheme
 fun OpenTradeListItem(
     item: TradeItemPresentationModel,
     userAvatar: PlatformImage? = null,
-    isUnread: Boolean,
+    unreadCount: Int,
     onSelect: () -> Unit,
 ) {
-    val bgColor = if (isUnread)
-        BisqTheme.colors.warning.copy(alpha = 0.15f)
+    val bgColor = if (unreadCount > 0)
+        BisqTheme.colors.dark_grey40.copy(red=0.19f)
     else
         BisqTheme.colors.dark_grey40
 
@@ -60,6 +60,7 @@ fun OpenTradeListItem(
                         reputation =  item.peersReputationScore,
                         showUserName =  true,
                         userAvatar = userAvatar,
+                        badgeCount = unreadCount,
                     )
                 }
                 BisqText.smallLightGrey("${item.formattedDate} ${item.formattedTime}")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
@@ -56,10 +56,6 @@ fun OpenTradeListScreen() {
 
     val userAvatarMap by presenter.avatarMap.collectAsState()
 
-    fun isTradeUnread(tradeId: String): Boolean {
-        return tradeId in tradesWithUnreadMessages.keys
-    }
-
     if (tradeGuideVisible) {
         InformationConfirmationDialog(
             message = "bisqEasy.tradeGuide.notConfirmed.warn".i18n(),
@@ -112,10 +108,9 @@ fun OpenTradeListScreen() {
                     }
                 }
                 items(sortedOpenTradeItems, key = { it.tradeId }) { trade ->
-                    val isUnread = isTradeUnread(trade.tradeId)
                     OpenTradeListItem(
                         trade,
-                        isUnread = isUnread,
+                        unreadCount = tradesWithUnreadMessages.getOrElse(trade.tradeId) { 0 },
                         userAvatar = userAvatarMap[trade.peersUserProfile.nym],
                         onSelect = { presenter.onSelect(trade) }
                     )
@@ -129,10 +124,9 @@ fun OpenTradeListScreen() {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                 items(sortedOpenTradeItems, key = { it.tradeId }) { trade ->
-                    val isUnread = isTradeUnread(trade.tradeId)
                     OpenTradeListItem(
                         trade,
-                        isUnread = isUnread,
+                        unreadCount = tradesWithUnreadMessages.getOrElse(trade.tradeId) { 0 },
                         userAvatar = userAvatarMap[trade.peersUserProfile.nym],
                         onSelect = { presenter.onSelect(trade) }
                     )


### PR DESCRIPTION
this will make "My Trades" badge count up to the unread events
however the final state condition is causing different behaviors, I need to know why it was added, as comment in the code is not explaining it
so I will make this PR with old behavior (different from desktop) for final state
then make an additional commit that will make it aligned with desktop behavior

toward resolving #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Bottom navigation badge now shows the total number of unread chat messages across all trades.
  - Profile avatars and trade list items display per-trade numeric unread badges.

- Bug Fixes
  - Unread counts exclude ignored senders and only count visible message types.
  - Badge totals are computed as the sum of unread messages and update consistently in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->