### PR TITLE
bugfix/copy_paste_icon_raises_height

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/CopyIconButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/CopyIconButton.kt
@@ -1,14 +1,20 @@
+
 package network.bisq.mobile.presentation.ui.components.atoms.button
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.MainPresenter
 import network.bisq.mobile.presentation.ui.components.atoms.icons.CopyIcon
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.ui.helpers.toClipEntry
 import org.koin.compose.koinInject
 
@@ -18,16 +24,19 @@ fun CopyIconButton(value: String, showToast: Boolean = true) {
     val scope = rememberCoroutineScope()
 
     val presenter: MainPresenter = koinInject()
-    IconButton(
-        onClick = {
-            scope.launch {
-                clipboard.setClipEntry(AnnotatedString(value).toClipEntry())
+    CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides androidx.compose.ui.unit.Dp.Unspecified) {
+        IconButton(
+            modifier = Modifier.size(BisqUIConstants.ScreenPadding2X),
+            onClick = {
+                scope.launch {
+                    clipboard.setClipEntry(AnnotatedString(value).toClipEntry())
+                }
+                if (showToast) {
+                    presenter.showSnackbar("mobile.components.copyIconButton.copied".i18n())
+                }
             }
-            if (showToast) {
-                presenter.showSnackbar("mobile.components.copyIconButton.copied".i18n())
-            }
+        ) {
+            CopyIcon()
         }
-    ) {
-        CopyIcon()
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/PasteIconButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/atoms/button/PasteIconButton.kt
@@ -1,11 +1,17 @@
+
 package network.bisq.mobile.presentation.ui.components.atoms.button
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.ui.components.atoms.icons.PasteIcon
+import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.ui.helpers.readText
 
 @Composable
@@ -14,15 +20,18 @@ fun PasteIconButton(
 ) {
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
-    IconButton(
-        onClick = {
-            scope.launch {
-                clipboard.getClipEntry()?.readText()?.let { text ->
-                    onPaste(text)
+    CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides androidx.compose.ui.unit.Dp.Unspecified) {
+        IconButton(
+            modifier = Modifier.size(BisqUIConstants.ScreenPadding2X),
+            onClick = {
+                scope.launch {
+                    clipboard.getClipEntry()?.readText()?.let { text ->
+                        onPaste(text)
+                    }
                 }
             }
+        ) {
+            PasteIcon()
         }
-    ) {
-        PasteIcon()
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/offerbook/OfferbookPresenter.kt
@@ -168,8 +168,6 @@ class OfferbookPresenter(
                 )
                 AmountFormatter.formatRangeAmount(minFiatVO, maxFiatVO, true, true)
             }
-
-            else -> ""
         }
 
         val formattedPrice = PriceSpecFormatter.getFormattedPriceSpec(offer.priceSpec)


### PR DESCRIPTION
 - fix #728 
 - fix height push from copy/paste icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardizes icon button sizing for copy/paste actions, improving visual consistency and alignment.
  - Updates composition to render icons within buttons while preserving existing tap, clipboard, and notification behavior.

- **Refactor**
  - Streamlines offer amount formatting by removing a generic fallback, enforcing explicit handling of supported types.
  - No changes to public APIs; behavior remains consistent aside from visual refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->