### PR TITLE
Remove use-animations from settings

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/SettingsScreen.kt
@@ -167,18 +167,6 @@ fun SettingsScreen() {
             }
         )
 
-        BisqHDivider()
-
-        BisqText.h4Light("settings.display.headline".i18n())
-
-        BisqGap.V1()
-
-        BisqSwitch(
-            label = "settings.display.useAnimations".i18n(),
-            checked = useAnimations,
-            onSwitch = { presenter.setUseAnimations(it) }
-        )
-
         if (shouldShowPoWAdjustmentFactor) {
             BisqHDivider()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Simplified Settings by removing the Display/Animations section, including its header, divider, spacing, and the “Use animations” switch. The animations preference can no longer be changed from within the app, and the toggle is no longer visible. Other settings remain unaffected, with no additional functional changes beyond this UI cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->