### PR TITLE
Improve offers service facade

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainApplication.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainApplication.kt
@@ -1,7 +1,5 @@
 package network.bisq.mobile.android.node
 
-import android.annotation.SuppressLint
-import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Process
@@ -13,26 +11,19 @@ import bisq.common.network.clear_net_address_types.LANAddressTypeFacade
 import kotlinx.coroutines.runBlocking
 import network.bisq.mobile.android.node.di.androidNodeModule
 import network.bisq.mobile.android.node.di.serviceModule
-import network.bisq.mobile.android.node.service.offers.NodeOffersServiceFacade
 import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.di.domainModule
-import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.presentation.MainApplication
 import network.bisq.mobile.presentation.di.presentationModule
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.koin.android.ext.android.get
-import org.koin.android.ext.android.inject
 import org.koin.core.module.Module
 import java.security.Security
 
 /**
  * Bisq Android Node Application definition
- * TODO consider uplift ComponentCallbacks2 to shared app to use also in connect apps
  */
-class NodeMainApplication : MainApplication(), ComponentCallbacks2 {
-
-    // Lazy inject to avoid circular dependencies during app startup
-    private val nodeOffersServiceFacade: OffersServiceFacade? by inject()
+class NodeMainApplication : MainApplication() {
 
     override fun getKoinModules(): List<Module> {
         return listOf(domainModule, serviceModule, presentationModule, androidNodeModule)
@@ -56,36 +47,7 @@ class NodeMainApplication : MainApplication(), ComponentCallbacks2 {
         val nodeApplicationLifecycleService: NodeApplicationLifecycleService = get()
         nodeApplicationLifecycleService.initialize(filesDir.toPath(), applicationContext)
 
-        // Note: NodeMainApplication already implements ComponentCallbacks2, so onTrimMemory is automatically called
-        // No need to registerComponentCallbacks(this) - that would cause infinite recursion
-        // Note: Tor initialization is now handled in NodeApplicationBootstrapFacade
         log.i { "Bisq Easy Node Application Created" }
-    }
-
-    override fun onTrimMemory(level: Int) {
-        super.onTrimMemory(level)
-        log.i { "System memory trim requested (level: $level)" }
-        try {
-            // Memory cleanup of data-intensive facades. More to be added if needed
-            (nodeOffersServiceFacade as NodeOffersServiceFacade?).let {
-                if (it == null) {
-                    log.w { "Offers service not initialized, skipping memory trim" }
-                } else {
-                    log.i { "Trimming offers service memory" }
-                    it.onTrimMemory(level)
-                }
-            }
-        } catch (e: Exception) {
-            log.e(e) { "Error handling memory trim" }
-        }
-    }
-
-    @SuppressLint("WrongConstant")
-    @Deprecated("onLowMemory is deprecated in favor of onTrimMemory")
-    override fun onLowMemory() {
-        super.onLowMemory()
-        log.w { "System low memory callback" }
-        onTrimMemory(80) // TRIM_MEMORY_COMPLETE equivalent
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/AndroidNodeModule.kt
@@ -83,7 +83,7 @@ val androidNodeModule = module {
 
     single<UserProfileServiceFacade> { NodeUserProfileServiceFacade(get()) }
 
-    single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get()) }
+    single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get(), get()) }
 
     single<ExplorerServiceFacade> { NodeExplorerServiceFacade(get()) }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/mapping/OfferItemPresentationVOFactory.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/mapping/OfferItemPresentationVOFactory.kt
@@ -90,11 +90,11 @@ object OfferItemPresentationVOFactory {
         val formattedPriceSpec = PriceSpecFormatter.getFormattedPriceSpec(priceSpec, false)
         val quoteSidePaymentMethods: List<String> = PaymentMethodSpecUtil.getPaymentMethods(bisqEasyOffer.quoteSidePaymentMethodSpecs)
             .stream()
-            .map { obj: FiatPaymentMethod -> obj.name }
+            .map { method: FiatPaymentMethod -> method.name }
             .collect(Collectors.toList())
         val baseSidePaymentMethods = PaymentMethodSpecUtil.getPaymentMethods(bisqEasyOffer.baseSidePaymentMethodSpecs)
             .stream()
-            .map { obj: BitcoinPaymentMethod -> obj.name }
+            .map { method: BitcoinPaymentMethod -> method.name }
             .collect(Collectors.toList())
 
         val reputationScore = reputationService.getReputationScore(authorUserProfileId)

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -521,8 +521,6 @@ class NodeOffersServiceFacade(
         offersToProcess.chunked(5).forEach { chunk ->
             for (message in chunk) {
                 try {
-                    val offerId = message.bisqEasyOffer.get().id
-
                     if (!isValidOfferMessage(message)) {
                         continue
                     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -125,6 +125,7 @@ class NodeOffersServiceFacade(
         marketPricePin?.unbind()
         marketPricePin = null
         numOffersObservers.forEach { it.dispose() }
+        numOffersObservers.clear()
         log.d { "NodeOffersServiceFacade deactivated" }
 
         super.deactivate()
@@ -150,9 +151,11 @@ class NodeOffersServiceFacade(
 
     override suspend fun deleteOffer(offerId: String): Result<Boolean> {
         try {
-            val optionalOfferbookMessage = findBisqEasyOfferbookMessage(offerId)
-            check(optionalOfferbookMessage.isPresent) { "BisqEasyOfferbookMessage with offer ID $offerId not found" }
-            val offerbookMessage = optionalOfferbookMessage.get()
+            val optionalOfferbookMessage: Optional<BisqEasyOfferbookMessage> = bisqEasyOfferbookChannelService.findMessageByOfferId(offerId)
+            if (optionalOfferbookMessage.isEmpty) {
+                return Result.success(false)
+            }
+            val offerbookMessage: BisqEasyOfferbookMessage = optionalOfferbookMessage.get()
             val authorUserProfileId: String = offerbookMessage.authorUserProfileId
             val optionalUserIdentity = userIdentityService.findUserIdentity(authorUserProfileId)
             check(optionalUserIdentity.isPresent) { "UserIdentity for authorUserProfileId $authorUserProfileId not found" }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -68,6 +68,11 @@ class NodeOffersServiceFacade(
     override fun activate() {
         super.activate()
 
+        // We set channel to null to avoid that our _offerbookMarketItems gets filled initially
+        // to avoid memory and cpu pressure at startup.
+        // We only want to fill it when we select a market.
+        bisqEasyOfferbookChannelSelectionService.selectChannel(null)
+
         observeSelectedChannel()
         observeMarketPrice()
         observeMarketListItems(_offerbookMarketItems)

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -186,32 +186,6 @@ class NodeOffersServiceFacade(
         }
     }
 
-    override suspend fun createOfferWithMediatorWait(
-        direction: DirectionEnum,
-        market: MarketVO,
-        bitcoinPaymentMethods: Set<String>,
-        fiatPaymentMethods: Set<String>,
-        amountSpec: AmountSpecVO,
-        priceSpec: PriceSpecVO,
-        supportedLanguageCodes: Set<String>
-    ): Result<String> {
-        return try {
-            val offerId = createOfferWithMediatorWait(
-                Mappings.DirectionMapping.toBisq2Model(direction),
-                Mappings.MarketMapping.toBisq2Model(market),
-                bitcoinPaymentMethods.map { BitcoinPaymentMethodUtil.getPaymentMethod(it) },
-                fiatPaymentMethods.map { FiatPaymentMethodUtil.getPaymentMethod(it) },
-                Mappings.AmountSpecMapping.toBisq2Model(amountSpec),
-                Mappings.PriceSpecMapping.toBisq2Model(priceSpec),
-                ArrayList<String>(supportedLanguageCodes)
-            )
-            Result.success(offerId)
-        } catch (e: Exception) {
-            log.e(e) { "Failed to create offer with mediator wait: ${e.message}" }
-            Result.failure(e)
-        }
-    }
-
     // Private
     private fun createOffer(
         direction: Direction,
@@ -264,26 +238,6 @@ class NodeOffersServiceFacade(
         // blocking call
         bisqEasyOfferbookChannelService.publishChatMessage(myOfferMessage, userIdentity).join()
         return bisqEasyOffer.id
-    }
-
-    private fun createOfferWithMediatorWait(
-        direction: Direction,
-        market: Market,
-        bitcoinPaymentMethods: List<BitcoinPaymentMethod>,
-        fiatPaymentMethods: List<FiatPaymentMethod>,
-        amountSpec: AmountSpec,
-        priceSpec: PriceSpec,
-        supportedLanguageCodes: List<String>
-    ): String {
-        return createOffer(
-            direction,
-            market,
-            bitcoinPaymentMethods,
-            fiatPaymentMethods,
-            amountSpec,
-            priceSpec,
-            supportedLanguageCodes
-        )
     }
 
     private fun observeSelectedChannel() {

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -99,11 +99,7 @@ class NodeOffersServiceFacade(
 
         observeSelectedChannel()
         observeMarketPrice()
-        if (numOffersObservers.isNotEmpty()) {
-            numOffersObservers.forEach { it.resume() }
-        } else {
-            observeMarketListItems(_offerbookMarketItems)
-        }
+        observeMarketListItems(_offerbookMarketItems)
         startMemoryMonitoring()
         log.d { "NodeOffersServiceFacade activated, numOffersObservers: ${numOffersObservers.size}" }
     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -66,7 +66,6 @@ class NodeOffersServiceFacade(
         // Higher threshold to avoid masking memory leaks - only suggest GC in critical situations
         private const val MEMORY_GC_THRESHOLD = 0.85
         private const val OFFER_BATCH_DELAY = 100L // milliseconds
-        private const val MAP_CLEAR_THRESHOLD = 50
         private const val MIN_GC_INTERVAL = 10000L
         private val MEDIATOR_WAIT_TIMEOUT = 1.minutes
         private val MEDIATOR_POLL_INTERVAL = 2.seconds
@@ -152,9 +151,7 @@ class NodeOffersServiceFacade(
     override suspend fun deleteOffer(offerId: String): Result<Boolean> {
         try {
             val optionalOfferbookMessage: Optional<BisqEasyOfferbookMessage> = bisqEasyOfferbookChannelService.findMessageByOfferId(offerId)
-            if (optionalOfferbookMessage.isEmpty) {
-                return Result.success(false)
-            }
+            check(optionalOfferbookMessage.isPresent) { "Could not find offer for offer ID $offerId" }
             val offerbookMessage: BisqEasyOfferbookMessage = optionalOfferbookMessage.get()
             val authorUserProfileId: String = offerbookMessage.authorUserProfileId
             val optionalUserIdentity = userIdentityService.findUserIdentity(authorUserProfileId)

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NodeOffersServiceFacade.kt
@@ -501,10 +501,6 @@ class NodeOffersServiceFacade(
         }
     }
 
-    private suspend fun findBisqEasyOfferbookMessage(offerId: String): Optional<BisqEasyOfferbookMessage> {
-        return Optional.ofNullable(getOfferMessage(offerId))
-    }
-
     private suspend fun putOfferMessage(offerId: String, message: BisqEasyOfferbookMessage) {
         offerMapMutex.withLock {
             bisqEasyOfferbookMessageByOfferId[offerId] = message
@@ -528,12 +524,6 @@ class NodeOffersServiceFacade(
                 log.w { "MEMORY: Cleared large offer map ($currentSize items), suggesting GC" }
                 suggestGCtoOS()
             }
-        }
-    }
-
-    private suspend fun getOfferMessage(offerId: String): BisqEasyOfferbookMessage? {
-        return offerMapMutex.withLock {
-            bisqEasyOfferbookMessageByOfferId[offerId]
         }
     }
 

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NumOffersObserver.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/offers/NumOffersObserver.kt
@@ -2,12 +2,14 @@ package network.bisq.mobile.android.node.service.offers
 
 
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage
+
 import bisq.common.observable.Pin
 import network.bisq.mobile.domain.utils.Logging
 
 class NumOffersObserver(
-    // TODO restore usage of bisqEasyOfferbookMessageService for v2.1.8
     private val channel: BisqEasyOfferbookChannel,
+    private val messageFilter: (BisqEasyOfferbookMessage) -> Boolean,
     val setNumOffers: (Int) -> Unit
 ) : Logging {
     private var channelPin: Pin? = null
@@ -31,10 +33,14 @@ class NumOffersObserver(
         channelPin?.unbind()
         channelPin = null
     }
+    fun refresh() {
+        updateNumOffers()
+    }
+
 
     private fun updateNumOffers() {
         try {
-            val count = channel.chatMessages.count { it.hasBisqEasyOffer() }
+            val count = channel.chatMessages.count { it.hasBisqEasyOffer() && messageFilter(it) }
 
             // Only update if count changed to reduce unnecessary updates
             if (count != cachedCount) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/offers/ClientOffersServiceFacade.kt
@@ -92,27 +92,6 @@ class ClientOffersServiceFacade(
         }
     }
 
-    override suspend fun createOfferWithMediatorWait(
-        direction: DirectionEnum,
-        market: MarketVO,
-        bitcoinPaymentMethods: Set<String>,
-        fiatPaymentMethods: Set<String>,
-        amountSpec: AmountSpecVO,
-        priceSpec: PriceSpecVO,
-        supportedLanguageCodes: Set<String>
-    ): Result<String> {
-        // For client mode, we delegate to the server which should handle mediator waiting
-        return createOffer(
-            direction,
-            market,
-            bitcoinPaymentMethods,
-            fiatPaymentMethods,
-            amountSpec,
-            priceSpec,
-            supportedLanguageCodes
-        )
-    }
-
     private fun observeAvailableMarkets() {
         launchIO {
             val result = apiGateway.getMarkets()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/bisq_easy/BisqEasyOfferVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/offer/bisq_easy/BisqEasyOfferVO.kt
@@ -41,4 +41,43 @@ data class BisqEasyOfferVO(
     val quoteSidePaymentMethodSpecs: List<FiatPaymentMethodSpecVO>,
     val offerOptions: List<OfferOptionVO>,
     val supportedLanguageCodes: List<String>
-)
+
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BisqEasyOfferVO
+
+        if (date != other.date) return false
+        if (id != other.id) return false
+        if (makerNetworkId != other.makerNetworkId) return false
+        if (direction != other.direction) return false
+        if (market != other.market) return false
+        if (amountSpec != other.amountSpec) return false
+        if (priceSpec != other.priceSpec) return false
+        if (protocolTypes != other.protocolTypes) return false
+        if (baseSidePaymentMethodSpecs != other.baseSidePaymentMethodSpecs) return false
+        if (quoteSidePaymentMethodSpecs != other.quoteSidePaymentMethodSpecs) return false
+        if (offerOptions != other.offerOptions) return false
+        if (supportedLanguageCodes != other.supportedLanguageCodes) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = date.hashCode()
+        result = 31 * result + id.hashCode()
+        result = 31 * result + makerNetworkId.hashCode()
+        result = 31 * result + direction.hashCode()
+        result = 31 * result + market.hashCode()
+        result = 31 * result + amountSpec.hashCode()
+        result = 31 * result + priceSpec.hashCode()
+        result = 31 * result + protocolTypes.hashCode()
+        result = 31 * result + baseSidePaymentMethodSpecs.hashCode()
+        result = 31 * result + quoteSidePaymentMethodSpecs.hashCode()
+        result = 31 * result + offerOptions.hashCode()
+        result = 31 * result + supportedLanguageCodes.hashCode()
+        return result
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
@@ -56,4 +56,16 @@ class OfferItemPresentationModel(offerItemPresentationDto: OfferItemPresentation
 
     var isInvalidDueToReputation: Boolean = false
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as OfferItemPresentationModel
+
+        return bisqEasyOffer == other.bisqEasyOffer
+    }
+
+    override fun hashCode(): Int {
+        return bisqEasyOffer.hashCode()
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
@@ -38,19 +38,23 @@ class OfferItemPresentationModel(offerItemPresentationDto: OfferItemPresentation
     // convenience fields
     val offerId = bisqEasyOffer.id
 
+    // TODO _formattedPrice is never updated from market price
     // In case of market price or float is used, the price and the base amount need to be updated at market price updates.
     private val _formattedPrice = MutableStateFlow(offerItemPresentationDto.formattedPrice)
     val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
 
+    // TODO _formattedBaseAmount is never updated when market/float price is used and has change
     private val _formattedBaseAmount = MutableStateFlow(offerItemPresentationDto.formattedBaseAmount)
     val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount.asStateFlow()
 
     // The user name is the nickname and the nym in case there are multiple nicknames in the network.
     // We get that set by the backend in the makersUserProfile but we need to update it after initial retrieval by websocket events.
     // At Bisq Easy the UserNameLookup class handles that.
+    // TODO not updated when there is a duplicated nickname, though rather rare moments that it gets updated
     private val _userName = MutableStateFlow(offerItemPresentationDto.userProfile.userName)
     val userName: StateFlow<String> get() = _userName.asStateFlow()
 
+    // TODO not updated, though rather rare moments that it gets updated
     private val _makersReputationScore = MutableStateFlow(offerItemPresentationDto.reputationScore)
     val makersReputationScore: StateFlow<ReputationScoreVO> get() = _makersReputationScore.asStateFlow()
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/offers/OffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/offers/OffersServiceFacade.kt
@@ -53,16 +53,6 @@ abstract class OffersServiceFacade : ServiceFacade(), LifeCycleAware {
         supportedLanguageCodes: Set<String>,
     ): Result<String>
 
-    abstract suspend fun createOfferWithMediatorWait(
-        direction: DirectionEnum,
-        market: MarketVO,
-        bitcoinPaymentMethods: Set<String>,
-        fiatPaymentMethods: Set<String>,
-        amountSpec: AmountSpecVO,
-        priceSpec: PriceSpecVO,
-        supportedLanguageCodes: Set<String>,
-    ): Result<String>
-
     abstract fun selectOfferbookMarket(marketListItem: MarketListItem)
 
 

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -417,7 +417,6 @@ mobile.chat.undoIgnoreUserWarn=Are you sure you want to unblock this user?
 mobile.chat.unreadMessages=Unread Messages
 mobile.bisqEasy.createOffer.failed=Failed to create offer
 mobile.bisqEasy.createOffer.mediatorTimeout=Mediator request timed out
-mobile.bisqEasy.createOffer.mediatorWaiting.message=Waiting for mediator to join...
 mobile.bisqEasy.createOffer.mediatorWaiting.title=Requesting Mediator
 mobile.error.exception=Exception
 mobile.error.warning=Warning

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferPresenter.kt
@@ -14,9 +14,9 @@ import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory.
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVOExtensions.toBaseSideMonetary
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.amount.spec.QuoteSideRangeAmountSpecVO
-import network.bisq.mobile.domain.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.FixPriceSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.FloatPriceSpecVO
 import network.bisq.mobile.domain.data.replicated.offer.price.spec.MarketPriceSpecVO
@@ -224,21 +224,6 @@ class CreateOfferPresenter(
             val params = prepareOfferParameters()
             withContext(IODispatcher) {
                 offersServiceFacade.createOffer(
-                    params.direction, params.market, params.bitcoinPaymentMethods,
-                    params.fiatPaymentMethods, params.amountSpec, params.priceSpec,
-                    params.supportedLanguageCodes
-                )
-            }
-        } catch (e: IllegalStateException) {
-            Result.failure(e)
-        }
-    }
-
-    suspend fun createOfferWithMediatorWait(): Result<String> {
-        return try {
-            val params = prepareOfferParameters()
-            withContext(IODispatcher) {
-                offersServiceFacade.createOfferWithMediatorWait(
                     params.direction, params.market, params.bitcoinPaymentMethods,
                     params.fiatPaymentMethods, params.amountSpec, params.priceSpec,
                     params.supportedLanguageCodes

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewScreen.kt
@@ -16,7 +16,6 @@ import network.bisq.mobile.presentation.ui.components.atoms.BtcSatsText
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.ui.components.layout.MultiScreenWizardScaffold
-import network.bisq.mobile.presentation.ui.components.molecules.dialog.InformationConfirmationDialog
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBox
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxCurrency
 import network.bisq.mobile.presentation.ui.components.molecules.info.InfoBoxSats
@@ -33,7 +32,6 @@ fun CreateOfferReviewOfferScreen() {
     RememberPresenterLifecycle(presenter)
 
     val isInteractive by presenter.isInteractive.collectAsState()
-    val showMediatorWaitingDialog by presenter.showMediatorWaitingDialog.collectAsState()
 
     MultiScreenWizardScaffold(
         "bisqEasy.tradeWizard.review.headline.maker".i18n(),
@@ -171,14 +169,5 @@ fun CreateOfferReviewOfferScreen() {
                 subvalue = presenter.feeDetails,
             )
         }
-    }
-
-    // Mediator waiting dialog
-    if (showMediatorWaitingDialog) {
-        InformationConfirmationDialog(
-            message = "mobile.bisqEasy.createOffer.mediatorWaiting.message".i18n(),
-            onConfirm = { presenter.onDismissMediatorWaitingDialog() },
-            onDismiss = { presenter.onDismissMediatorWaitingDialog() }
-        )
     }
 }


### PR DESCRIPTION
This will require latest Bisq 2 mobile branch to be published.

Some aspects handled here are discussed at https://github.com/bisq-network/bisq-mobile/discussions/780.

From memory monitoring I could not see any significant difference, but there was some spike at initialization. 
By not having any channel selected initially we can avoid that. Only when the user browse to offerbook and select a market the list gets filled. We do not set the channel to null when the user move away from the offerbook, as it seems not needed. The number of offers is low (about 50 for USD) and I could not see any signature in the memory logging when selecting a market.

The extra handling with a queue and delays is not needed as it is not much data, thus this was removed to reduce complexity.

There is though a memory spike at the very start of the application, caused likely we we load all persisted data. See https://github.com/bisq-network/bisq-mobile/issues/807.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed mediator-wait pathway and dialog; offer creation now uses a single streamlined flow with standard error notifications.
  - App startup initialization simplified for more consistent startup behavior.
  - Offer list/count updates moved to event-driven, per-message updates for faster UI refreshes and reduced batching.

- New Features
  - Chat/message validation plus ignore/ban checks applied to offers and market counts.

- Chores
  - Removed obsolete mediator-wait localization string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->