### PR TITLE
Improve reputation service facade

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/reputation/NodeReputationServiceFacade.kt
@@ -1,13 +1,7 @@
 package network.bisq.mobile.android.node.service.reputation
 
-import bisq.common.application.DevMode
-import bisq.common.observable.Pin
+import bisq.user.reputation.ReputationScore
 import bisq.user.reputation.ReputationService
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
@@ -18,36 +12,22 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
     ReputationServiceFacade {
     private val reputationService: ReputationService by lazy { applicationService.reputationService.get() }
 
-    // Properties
-    private val _reputationByUserProfileId: MutableStateFlow<Map<String, ReputationScoreVO>> =
-        MutableStateFlow(emptyMap())
-    override val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>> get() = _reputationByUserProfileId.asStateFlow()
-
-    // Misc
-    private var reputationChangePin: Pin? = null
+    override val scoreByUserProfileId: Map<String, Long> get() = reputationService.scoreByUserProfileId
 
     // Life cycle
     override fun activate() {
         super<ServiceFacade>.activate()
-        serviceScope.launch {
-            observeReputation()
-        }
     }
 
     override fun deactivate() {
-        reputationChangePin?.unbind()
-        reputationChangePin = null
         super<ServiceFacade>.deactivate()
     }
 
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
-        val score = when {
-            useDevModeReputationScore() -> provideDevModeReputationScore(userProfileId)
-            else -> reputationByUserProfileId.value[userProfileId]
-        }
-        return score?.let { Result.success(it) }
-            ?: Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not found"))
+        val score: ReputationScore = reputationService.getReputationScore(userProfileId)
+        val scoreVO = Mappings.ReputationScoreMapping.fromBisq2Model(score)
+        return Result.success(scoreVO)
     }
 
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> {
@@ -72,45 +52,6 @@ class NodeReputationServiceFacade(private val applicationService: AndroidApplica
         } catch (e: Exception) {
             log.e(e) { "Failed to get profile age for userId=$userProfileId" }
             Result.failure(e)
-        }
-    }
-
-    private fun useDevModeReputationScore() = DevMode.isDevMode() && DevMode.devModeReputationScore() > 0L
-
-    // If we have set devModeReputationScore and if we are in dev mode we override the real reputation score.
-    // This code would get provided by reputationService.findReputationScore but as we use the observer and the MutableStateFlow
-    // We do not get not existing reputation values, thus we make the call here and provide the result to the MutableStateFlow field.
-    private fun provideDevModeReputationScore(userProfileId: String): ReputationScoreVO? {
-        return reputationService.findReputationScore(userProfileId)?.get()?.let {
-            Mappings.ReputationScoreMapping.fromBisq2Model(it)
-        }?.also {
-            _reputationByUserProfileId.update { current ->
-                current + (userProfileId to it)
-            }
-        }
-    }
-
-    // Private
-    private fun observeReputation() {
-        reputationChangePin?.unbind()
-        reputationChangePin = reputationService.userProfileIdWithScoreChange.addObserver { userProfileId ->
-            try {
-                if (userProfileId != null) {
-                    updateUserReputation(userProfileId)
-                }
-            } catch (e: Exception) {
-                log.e("Failed to update user reputation", e)
-            }
-        }
-    }
-
-    private fun updateUserReputation(userProfileId: String) {
-        val reputation = reputationService.getReputationScore(userProfileId).let {
-            Mappings.ReputationScoreMapping.fromBisq2Model(it)
-        }
-
-        _reputationByUserProfileId.update { current ->
-            current + (userProfileId to reputation)
         }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/reputation/ReputationServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/reputation/ReputationServiceFacade.kt
@@ -1,12 +1,11 @@
 package network.bisq.mobile.domain.service.reputation
 
-import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
 
 interface ReputationServiceFacade : LifeCycleAware {
 
-    val reputationByUserProfileId: StateFlow<Map<String, ReputationScoreVO>>
+    val scoreByUserProfileId: Map<String, Long>
 
     suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO>
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferAmountPresenter.kt
@@ -8,11 +8,10 @@ import network.bisq.mobile.domain.data.IODispatcher
 import network.bisq.mobile.domain.data.replicated.common.monetary.CoinVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVO
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory
+import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory.faceValueToLong
 import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory.from
 import network.bisq.mobile.domain.data.replicated.common.monetary.MonetaryVOExtensions.asDouble
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVO
-import network.bisq.mobile.domain.data.replicated.common.monetary.FiatVOFactory.faceValueToLong
-
 import network.bisq.mobile.domain.data.replicated.common.monetary.PriceQuoteVOExtensions.toBaseSideMonetary
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
@@ -30,9 +29,8 @@ import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.MAX_USD_TRADE_
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.findRequiredReputationScoreByFiatAmount
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.getReputationBasedQuoteSideAmount
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.withTolerance
-import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.domain.utils.MonetarySlider
-
+import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
 import network.bisq.mobile.presentation.BasePresenter
 import network.bisq.mobile.presentation.MainPresenter
@@ -40,7 +38,6 @@ import network.bisq.mobile.presentation.ui.BisqLinks
 import network.bisq.mobile.presentation.ui.helpers.AmountValidator
 import network.bisq.mobile.presentation.ui.navigation.Routes
 import network.bisq.mobile.presentation.ui.uicases.create_offer.CreateOfferPresenter.AmountType
-import kotlin.math.roundToLong
 
 // TODO Create/Take offer amount preseenters are very similar a base class could be extracted
 class CreateOfferAmountPresenter(
@@ -442,10 +439,9 @@ class CreateOfferAmountPresenter(
 
     private suspend fun getPeersScoreByUserProfileId(): Map<String, Long> {
         val myProfileIds: Set<String> = userProfileServiceFacade.getUserIdentityIds().toSet()
-        val scoreByUserProfileId = reputationServiceFacade.reputationByUserProfileId.value
-        return scoreByUserProfileId
+        return reputationServiceFacade.scoreByUserProfileId
             .filterKeys { it !in myProfileIds }
-            .mapValues { it.value.totalScore }
+            .mapValues { it.value }
     }
 
     private fun applyRangeAmountSliderValue(rangeSliderPosition: ClosedFloatingPointRange<Float>) {


### PR DESCRIPTION
Some minor improvements. No need to get it into release...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined reputation handling by fetching scores directly from the service for more consistent display.
  - Replaced reactive reputation stream with a direct scores map used across the app, including Create Offer flows.
  - Removed development-mode reputation behavior and background observers to reduce overhead.
  - No visible UI changes; reputation values continue to display as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->