### PR TITLE
bugfix/missing_ios_imports

### DIFF
--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.ios.kt
@@ -45,8 +45,12 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.languageCode
 import platform.Foundation.localeWithLocaleIdentifier
 import platform.Foundation.stringByAddingPercentEncodingWithAllowedCharacters
+import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDevice
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
 import platform.UIKit.UIImage
 import platform.UIKit.UIImagePNGRepresentation
 import platform.darwin.dispatch_async
@@ -285,6 +289,7 @@ actual class PlatformImage(val image: UIImage) {
     }
 }
 
+@OptIn(ExperimentalForeignApi::class)
 actual fun createEmptyImage(): PlatformImage {
     // Create a 1x1 transparent image
     val size = CGSizeMake(1.0, 1.0)


### PR DESCRIPTION
 - fix missing imports causing iOS build to fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for generating a minimal placeholder image on iOS to ensure consistent rendering wherever an image is required.
- Bug Fixes
  - Improved stability on iOS by providing a safe fallback image when no image data is available, reducing visual glitches and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->