### PR TITLE
ci_to_run_ios_validations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,27 @@ jobs:
           distribution: 'zulu'
           cache: gradle
 
-      - name: Cache Gradle dependencies
+      - name: Cache Gradle dependencies (Mac only)
+        if: startsWith(matrix.os, 'macos')
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: macos-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/settings.gradle*', '**/build.gradle*', 'gradle/libs.versions.toml') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            macos-gradle-
+
+      - name: Cache Kotlin/Native (konan) (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan
+          key: macos-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/settings.gradle*', '**/build.gradle*', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            macos-konan-
+
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -98,15 +110,18 @@ jobs:
         working-directory: iosClient
         run: pod install
 
-      - name: Prebuild KMP frameworks (Intel runner)
-        if: startsWith(matrix.os, 'macos') && runner.arch == 'X64'
-        run: |
-          ./gradlew :shared:domain:linkPodReleaseFrameworkIosX64 :shared:presentation:linkPodReleaseFrameworkIosX64 --no-daemon
 
-      - name: Prebuild KMP frameworks (Apple Silicon runner)
+      - name: Warm KMP compile outputs (Apple Silicon)
         if: startsWith(matrix.os, 'macos') && runner.arch == 'ARM64'
         run: |
-          ./gradlew :shared:domain:linkPodReleaseFrameworkIosSimulatorArm64 :shared:presentation:linkPodReleaseFrameworkIosSimulatorArm64 --no-daemon
+          ./gradlew :shared:domain:compileKotlinIosSimulatorArm64 :shared:presentation:compileKotlinIosSimulatorArm64 --no-daemon
+
+      - name: Warm KMP compile outputs (Intel)
+        if: startsWith(matrix.os, 'macos') && runner.arch == 'X64'
+        run: |
+          ./gradlew :shared:domain:compileKotlinIosX64 :shared:presentation:compileKotlinIosX64 --no-daemon
+
+
 
 
       - name: Build iOS Client (Mac only)
@@ -121,9 +136,13 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
-      - name: Run iOS Tests (x64 simulator for Intel runners)
-        if: startsWith(runner.os, 'macOS')
+      - name: Run iOS Tests (Intel runner)
+        if: startsWith(runner.os, 'macOS') && runner.arch == 'X64'
         run: ./gradlew shared:presentation:iosX64Test
+
+      - name: Run iOS Tests (Apple Silicon runner)
+        if: startsWith(runner.os, 'macOS') && runner.arch == 'ARM64'
+        run: ./gradlew shared:presentation:iosSimulatorArm64Test
 
   # --- Node-specific Maven build (needs secrets) ---
   node-maven:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,25 @@ jobs:
 #          disable-animations: true
 #          script: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest
 
+      - name: Generate KMP dummy frameworks (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          ./gradlew :shared:domain:generateDummyFramework :shared:presentation:generateDummyFramework --no-daemon
       - name: Install CocoaPods dependencies (Mac only)
         if: startsWith(matrix.os, 'macos')
         working-directory: iosClient
         run: pod install
 
+      - name: Prebuild KMP CocoaPods frameworks (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          ./gradlew :shared:domain:podDebugIosSimulatorFatFramework :shared:presentation:podDebugIosSimulatorFatFramework --no-daemon
+
+
       - name: Build iOS Client (Mac only)
         if: startsWith(matrix.os, 'macos')
+        env:
+          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         run: |
           xcodebuild -workspace iosClient/iosClient.xcworkspace \
             -scheme "iosClient Release" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,16 @@ jobs:
 
       - name: Build iOS Client (Mac only)
         if: startsWith(matrix.os, 'macos')
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.configuration-cache=false -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false"
         run: |
           xcodebuild -workspace iosClient/iosClient.xcworkspace \
             -scheme "iosClient Release" \
             -configuration Release \
             -sdk iphonesimulator \
             -destination 'generic/platform=iOS Simulator' \
+            -parallelizeTargets NO \
+            -jobs 1 \
             clean build \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build & Test (No Secrets)
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -112,16 +112,16 @@ jobs:
 #        working-directory: iosClient
 #        run: pod install
 
-
-      - name: Warm KMP compile outputs (Apple Silicon)
-        if: startsWith(matrix.os, 'macos') && runner.arch == 'ARM64'
-        run: |
-          ./gradlew :shared:domain:compileKotlinIosSimulatorArm64 :shared:presentation:compileKotlinIosSimulatorArm64 --no-daemon
-
-      - name: Warm KMP compile outputs (Intel)
-        if: startsWith(matrix.os, 'macos') && runner.arch == 'X64'
-        run: |
-          ./gradlew :shared:domain:compileKotlinIosX64 :shared:presentation:compileKotlinIosX64 --no-daemon
+#     Not needed anymore since we are not using xcodebuild
+#      - name: Warm KMP compile outputs (Apple Silicon)
+#        if: startsWith(matrix.os, 'macos') && runner.arch == 'ARM64'
+#        run: |
+#          ./gradlew :shared:domain:compileKotlinIosSimulatorArm64 :shared:presentation:compileKotlinIosSimulatorArm64 --no-daemon
+#
+#      - name: Warm KMP compile outputs (Intel)
+#        if: startsWith(matrix.os, 'macos') && runner.arch == 'X64'
+#        run: |
+#          ./gradlew :shared:domain:compileKotlinIosX64 :shared:presentation:compileKotlinIosX64 --no-daemon
 
 #     Takes way too much time in GH CI Actions
 #      - name: Build iOS Client (Mac only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,12 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           ./gradlew :shared:domain:generateDummyFramework :shared:presentation:generateDummyFramework --no-daemon
-      - name: Install CocoaPods dependencies (Mac only)
-        if: startsWith(matrix.os, 'macos')
-        working-directory: iosClient
-        run: pod install
+
+#      If we figure out how to fix the Build iOS client task re-enable this
+#      - name: Install CocoaPods dependencies (Mac only)
+#        if: startsWith(matrix.os, 'macos')
+#        working-directory: iosClient
+#        run: pod install
 
 
       - name: Warm KMP compile outputs (Apple Silicon)
@@ -121,25 +123,25 @@ jobs:
         run: |
           ./gradlew :shared:domain:compileKotlinIosX64 :shared:presentation:compileKotlinIosX64 --no-daemon
 
+#     Takes way too much time in GH CI Actions
+#      - name: Build iOS Client (Mac only)
+#        if: startsWith(matrix.os, 'macos')
+#        env:
+#          GRADLE_OPTS: "-Dorg.gradle.configuration-cache=false -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false"
+#        run: |
+#          xcodebuild -workspace iosClient/iosClient.xcworkspace \
+#            -scheme "iosClient Release" \
+#            -configuration Release \
+#            -sdk iphonesimulator \
+#            -destination 'generic/platform=iOS Simulator' \
+#            -parallelizeTargets NO \
+#            -jobs 1 \
+#            clean build \
+#            CODE_SIGN_IDENTITY="" \
+#            CODE_SIGNING_REQUIRED=NO \
+#            CODE_SIGNING_ALLOWED=NO
 
 
-
-      - name: Build iOS Client (Mac only)
-        if: startsWith(matrix.os, 'macos')
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.configuration-cache=false -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false"
-        run: |
-          xcodebuild -workspace iosClient/iosClient.xcworkspace \
-            -scheme "iosClient Release" \
-            -configuration Release \
-            -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
-            -parallelizeTargets NO \
-            -jobs 1 \
-            clean build \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
       - name: Run iOS Tests (Intel runner)
         if: startsWith(runner.os, 'macOS') && runner.arch == 'X64'
         run: ./gradlew shared:presentation:iosX64Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,29 +98,32 @@ jobs:
         working-directory: iosClient
         run: pod install
 
-      - name: Prebuild KMP CocoaPods frameworks (Mac only)
-        if: startsWith(matrix.os, 'macos')
+      - name: Prebuild KMP frameworks (Intel runner)
+        if: startsWith(matrix.os, 'macos') && runner.arch == 'X64'
         run: |
-          ./gradlew :shared:domain:podDebugIosSimulatorFatFramework :shared:presentation:podDebugIosSimulatorFatFramework --no-daemon
+          ./gradlew :shared:domain:linkPodReleaseFrameworkIosX64 :shared:presentation:linkPodReleaseFrameworkIosX64 --no-daemon
+
+      - name: Prebuild KMP frameworks (Apple Silicon runner)
+        if: startsWith(matrix.os, 'macos') && runner.arch == 'ARM64'
+        run: |
+          ./gradlew :shared:domain:linkPodReleaseFrameworkIosSimulatorArm64 :shared:presentation:linkPodReleaseFrameworkIosSimulatorArm64 --no-daemon
 
 
       - name: Build iOS Client (Mac only)
         if: startsWith(matrix.os, 'macos')
-        env:
-          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         run: |
           xcodebuild -workspace iosClient/iosClient.xcworkspace \
             -scheme "iosClient Release" \
-            -configuration Debug \
+            -configuration Release \
             -sdk iphonesimulator \
             -destination 'generic/platform=iOS Simulator' \
             clean build \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
-      - name: Run iOS Tests
+      - name: Run iOS Tests (x64 simulator for Intel runners)
         if: startsWith(runner.os, 'macOS')
-        run: ./gradlew shared:presentation:iosSimulatorArm64Test
+        run: ./gradlew shared:presentation:iosX64Test
 
   # --- Node-specific Maven build (needs secrets) ---
   node-maven:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build & Test (No Secrets)
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Xcode (Mac only)
         if: startsWith(matrix.os, 'macos')
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.3.app
+          sudo xcode-select -s /Applications/Xcode.app || true
           xcodebuild -version
 
       - name: Create fake local.properties
@@ -65,10 +65,15 @@ jobs:
           echo "KEY_PASSWORD=yourKeyPassword" >> local.properties
           echo "CLI_KEY_PASSWORD=yourCliKeyPassword" >> local.properties
 
-      - name: Run Tests
+      - name: Run Android Tests (Ubuntu only)
+        if: startsWith(matrix.os, 'ubuntu')
         env:
           CI: true
         run: ./gradlew clean test -x :androidNode:testDebugUnitTest -x :androidNode:testReleaseUnitTest -x :androidNode:test --info
+
+      - name: Android compile-only (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        run: ./gradlew :androidClient:assembleDebug -x test -x lint
 
 #      TODO seems GH default ci doesn't have support for this
 #      - name: Headless Android emulator and run instrumentation tests
@@ -84,6 +89,23 @@ jobs:
 #          disable-animations: true
 #          script: ./gradlew androidClient:testDebugUnitTest androidClient:connectedDebugAndroidTest
 
+      - name: Install CocoaPods dependencies (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        working-directory: iosClient
+        run: pod install
+
+      - name: Build iOS Client (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          xcodebuild -workspace iosClient/iosClient.xcworkspace \
+            -scheme "iosClient Release" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            clean build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
       - name: Run iOS Tests
         if: startsWith(runner.os, 'macOS')
         run: ./gradlew shared:presentation:iosSimulatorArm64Test


### PR DESCRIPTION
 - add macos to hardware matrix to pre-merge actions
 - add minimalistic compilation check for iOS + run iOS tests
 - restrict android runs to linux machines to save time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs on macOS (macos-14) and Ubuntu, adding macOS-specific Gradle and Kotlin/Native caches, KMP dummy-framework generation, CocoaPods-related steps, and a more resilient Xcode setup with a fallback. Commented headless Android emulator section retained.
  * Split Android validation: full Android tests on Ubuntu and compile-only Android checks on macOS.

* **Tests**
  * Added OS- and runner-specific iOS test jobs for Intel (x64) and Apple Silicon (arm64), plus platform-scoped test orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->