### PR TITLE
fix: improve message delivery state

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/mapping/Mappings.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/mapping/Mappings.kt
@@ -144,7 +144,6 @@ import network.bisq.mobile.domain.data.replicated.user.identity.UserIdentityVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.userProfileDemoObj
 import network.bisq.mobile.domain.data.replicated.user.reputation.ReputationScoreVO
-import network.bisq.mobile.domain.service.message_delivery.MessageDeliveryServiceFacade
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
@@ -313,7 +312,6 @@ class Mappings {
             message: BisqEasyOpenTradeMessage,
             citationAuthorUserProfile: UserProfile?,
             myUserProfile: UserProfile,
-            messageDeliveryServiceFacade: MessageDeliveryServiceFacade
         ): BisqEasyOpenTradeMessageModel {
             userProfileDemoObj
             val citationAuthorUserProfileVO = citationAuthorUserProfile?.let { UserProfileMapping.fromBisq2Model(it) }
@@ -329,7 +327,6 @@ class Mappings {
                 bisqEasyOpenTradeMessage,
                 myUserProfileVO,
                 chatMessageReactions,
-                messageDeliveryServiceFacade
             )
         }
     }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
@@ -147,7 +147,6 @@ class NodeTradeChatMessagesServiceFacade(
                     message,
                     citationAuthorUserProfile,
                     myUserProfile,
-                    messageDeliveryServiceFacade
                 )
                 openTradeItem.bisqEasyOpenTradeChannelModel.addChatMessages(model)
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/di/ClientModule.kt
@@ -70,8 +70,8 @@ import network.bisq.mobile.domain.service.common.LanguageServiceFacade
 import network.bisq.mobile.domain.service.explorer.ExplorerServiceFacade
 import network.bisq.mobile.domain.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.domain.service.mediation.MediationServiceFacade
-import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.message_delivery.MessageDeliveryServiceFacade
+import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.service.network.NetworkServiceFacade
 import network.bisq.mobile.domain.service.offers.OffersServiceFacade
 import network.bisq.mobile.domain.service.reputation.ReputationServiceFacade
@@ -194,7 +194,7 @@ val clientModule = module {
     single<TradesServiceFacade> { ClientTradesServiceFacade(get(), get(), get()) }
 
     single { TradeChatMessagesApiGateway(get(), get()) }
-    single<TradeChatMessagesServiceFacade> { ClientTradeChatMessagesServiceFacade(get(), get(), get(), get(), get()) }
+    single<TradeChatMessagesServiceFacade> { ClientTradeChatMessagesServiceFacade(get(), get(), get(), get()) }
 
     single { ExplorerApiGateway(get()) }
     single<ExplorerServiceFacade> { ClientExplorerServiceFacade(get()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -19,14 +19,12 @@ import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.domain.service.ServiceFacade
 import network.bisq.mobile.domain.service.chat.trade.TradeChatMessagesServiceFacade
-import network.bisq.mobile.domain.service.message_delivery.MessageDeliveryServiceFacade
 import network.bisq.mobile.domain.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 
 class ClientTradeChatMessagesServiceFacade(
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
-    private val messageDeliveryServiceFacade: MessageDeliveryServiceFacade,
     private val apiGateway: TradeChatMessagesApiGateway,
     private val json: Json
 ) : ServiceFacade(), TradeChatMessagesServiceFacade {
@@ -150,7 +148,7 @@ class ClientTradeChatMessagesServiceFacade(
             .map { message ->
                 val chatReactions =
                     allChatReactions.value.filter { it.chatMessageId == message.messageId && !it.isRemoved }
-                BisqEasyOpenTradeMessageModel(message, myUserProfile, chatReactions, messageDeliveryServiceFacade)
+                BisqEasyOpenTradeMessageModel(message, myUserProfile, chatReactions)
             }
             .toSet()
         bisqEasyOpenTradeChannelModel.setAllChatMessages(messages)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/message_delivery/ClientMessageDeliveryServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/client/service/message_delivery/ClientMessageDeliveryServiceFacade.kt
@@ -1,8 +1,5 @@
 package network.bisq.mobile.client.service.message_delivery
 
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.domain.service.message_delivery.MessageDeliveryServiceFacade
 
@@ -22,14 +19,8 @@ class ClientMessageDeliveryServiceFacade() :
         // TODO impl
     }
 
-    override fun addMessageDeliveryStatusObserver(tradeMessageId: String): StateFlow<Map<String, MessageDeliveryInfoVO>> {
+    override fun addMessageDeliveryStatusObserver(tradeMessageId: String, onNewStatus: (entry: Pair<String, MessageDeliveryInfoVO>) -> Unit) {
         // TODO impl
-        val _messageDeliveryInfoByPeersProfileId =
-            MutableStateFlow<Map<String, MessageDeliveryInfoVO>>(emptyMap())
-        val messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>> =
-            _messageDeliveryInfoByPeersProfileId.asStateFlow()
-
-        return messageDeliveryInfoByPeersProfileId
     }
 
     override fun removeMessageDeliveryStatusObserver(tradeMessageId: String) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/message_delivery/MessageDeliveryServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/message_delivery/MessageDeliveryServiceFacade.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.domain.service.message_delivery
 
-import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.LifeCycleAware
 import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.domain.service.ServiceFacade
@@ -8,6 +7,6 @@ import network.bisq.mobile.domain.utils.Logging
 
 abstract class MessageDeliveryServiceFacade : ServiceFacade(), LifeCycleAware, Logging {
     abstract fun onResendMessage(messageId: String)
-    abstract fun addMessageDeliveryStatusObserver(tradeMessageId: String): StateFlow<Map<String, MessageDeliveryInfoVO>>
+    abstract fun addMessageDeliveryStatusObserver(tradeMessageId: String, onNewStatus: (entry: Pair<String, MessageDeliveryInfoVO>) -> Unit)
     abstract fun removeMessageDeliveryStatusObserver(tradeMessageId: String)
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/MainPresenterUnreadBadgeTest.kt
@@ -91,7 +91,7 @@ class MainPresenterUnreadBadgeTest {
         every { dto1.mediator } returns null
         every { dto1.bisqEasyOffer } returns null
         every { dto1.citationAuthorUserProfile } returns null
-        val model1 = BisqEasyOpenTradeMessageModel(dto1, myUserProfile, emptyList(), messageDeliveryServiceFacade)
+        val model1 = BisqEasyOpenTradeMessageModel(dto1, myUserProfile, emptyList())
 
         val dto2 = mockk<BisqEasyOpenTradeMessageDto>()
         every { dto2.chatMessageType } returns ChatMessageTypeEnum.TEXT
@@ -104,7 +104,7 @@ class MainPresenterUnreadBadgeTest {
         every { dto2.mediator } returns null
         every { dto2.bisqEasyOffer } returns null
         every { dto2.citationAuthorUserProfile } returns null
-        val model2 = BisqEasyOpenTradeMessageModel(dto2, myUserProfile, emptyList(), messageDeliveryServiceFacade)
+        val model2 = BisqEasyOpenTradeMessageModel(dto2, myUserProfile, emptyList())
 
         val dto3 = mockk<BisqEasyOpenTradeMessageDto>()
         every { dto3.chatMessageType } returns ChatMessageTypeEnum.TEXT
@@ -117,7 +117,7 @@ class MainPresenterUnreadBadgeTest {
         every { dto3.mediator } returns null
         every { dto3.bisqEasyOffer } returns null
         every { dto3.citationAuthorUserProfile } returns null
-        val model3 = BisqEasyOpenTradeMessageModel(dto3, myUserProfile, emptyList(), messageDeliveryServiceFacade)
+        val model3 = BisqEasyOpenTradeMessageModel(dto3, myUserProfile, emptyList())
 
         val trade1MessagesFlow: StateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(setOf(model1, model2, model3))
 
@@ -133,7 +133,7 @@ class MainPresenterUnreadBadgeTest {
         every { dto4.mediator } returns null
         every { dto4.bisqEasyOffer } returns null
         every { dto4.citationAuthorUserProfile } returns null
-        val model4 = BisqEasyOpenTradeMessageModel(dto4, myUserProfile, emptyList(), messageDeliveryServiceFacade)
+        val model4 = BisqEasyOpenTradeMessageModel(dto4, myUserProfile, emptyList())
 
         val trade2MessagesFlow = MutableStateFlow(setOf(model4))
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/MessageDeliveryInfoAndroidUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/MessageDeliveryInfoAndroidUiTest.kt
@@ -3,13 +3,13 @@ package network.bisq.mobile.presentation.ui.components.molecules.chat
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import org.junit.Rule
-import org.junit.Test
-import org.junit.Ignore
-import network.bisq.mobile.i18n.I18nSupport
-import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryStatusEnum
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
 
 class MessageDeliveryInfoAndroidUiTest {
 
@@ -24,7 +24,6 @@ class MessageDeliveryInfoAndroidUiTest {
             network.bisq.mobile.presentation.ui.theme.BisqTheme {
                 MessageDeliveryInfo(
                     map = emptyMap(),
-                    multiplePeers = false,
                     userNameProvider = { _ -> "Alice" }
                 )
             }
@@ -49,7 +48,6 @@ class MessageDeliveryInfoAndroidUiTest {
             network.bisq.mobile.presentation.ui.theme.BisqTheme {
                 MessageDeliveryInfo(
                     map = map,
-                    multiplePeers = false,
                     userNameProvider = { _ -> "Alice" }
                 )
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatTextMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatTextMessageBox.kt
@@ -19,12 +19,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.ReactionEnum
-import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
@@ -46,7 +44,6 @@ fun ChatTextMessageBox(
     modifier: Modifier = Modifier,
     onResendMessage: (String) -> Unit,
     userNameProvider: suspend (String) -> String,
-    messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>>,
 ) {
     val isMyMessage = message.isMyMessage
     val chatAlign = if (isMyMessage) Alignment.End else Alignment.Start
@@ -64,13 +61,13 @@ fun ChatTextMessageBox(
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = chatAlign,
-        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingQuarter)
+        verticalArrangement = Arrangement.Center,
     ) {
         UsernameMessageDeliveryAndDate(
             message,
             onResendMessage = onResendMessage,
             userNameProvider = userNameProvider,
-            messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId
+            messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatus,
         )
         val quoteAndProfileIconAndText = @Composable {
             Column(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
@@ -1,10 +1,14 @@
 package network.bisq.mobile.presentation.ui.components.molecules.chat
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
@@ -22,26 +26,33 @@ fun UsernameMessageDeliveryAndDate(
     userNameProvider: suspend (String) -> String,
     messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>>,
 ) {
+    var showInfo by remember { mutableStateOf(false) }
+
     Row(
-        modifier = Modifier.semantics(mergeDescendants = true) {},
-        verticalAlignment = Alignment.Bottom,
+        modifier = Modifier
+            .semantics(mergeDescendants = true) {}
+            .clickable(message.isMyMessage) { showInfo = true },
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalfQuarter),
     ) {
         val username = @Composable {
-            BisqText.baseRegular(text = message.senderUserName)
+            BisqText.baseRegular(message.senderUserName, modifier = Modifier.offset(y = (-1).dp))
         }
 
         val date = @Composable {
-            BisqText.xsmallLightGrey(message.dateString, modifier = Modifier.offset(y = (-1).dp))
+            BisqText.xsmallLightGrey(message.dateString)
         }
 
         if (message.isMyMessage) {
             date()
             MessageDeliveryBox(
-                modifier = Modifier.padding(bottom = 4.dp),
                 onResendMessage = onResendMessage,
                 userNameProvider = userNameProvider,
                 messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
+                showInfo,
+                onDismissMenu = {
+                    showInfo = false
+                }
             )
             username()
         } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/trade/ProtocolLogMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/trade/ProtocolLogMessageBox.kt
@@ -1,19 +1,21 @@
 package network.bisq.mobile.presentation.ui.components.molecules.chat.trade
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
-import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.molecules.chat.MessageDeliveryBox
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
@@ -25,8 +27,9 @@ fun ProtocolLogMessageBox(
     modifier: Modifier = Modifier,
     onResendMessage: (String) -> Unit,
     userNameProvider: suspend (String) -> String,
-    messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>>,
 ) {
+    var showInfo by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier
             .background(BisqTheme.colors.dark_grey30)
@@ -42,14 +45,18 @@ fun ProtocolLogMessageBox(
             BisqText.smallLight(message.decodedText, textAlign = TextAlign.Center)
 
             Row(
-                verticalAlignment = Alignment.Bottom,
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalfQuarter),
+                modifier = Modifier.clickable {
+                    showInfo = true
+                },
             ) {
                 MessageDeliveryBox(
-                    modifier = Modifier.padding(bottom = 1.dp),
                     onResendMessage = onResendMessage,
                     userNameProvider = userNameProvider,
-                    messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
+                    messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatus,
+                    showInfo,
+                    onDismissMenu = { showInfo = false }
                 )
 
                 BisqText.xsmallLightGrey(message.dateString)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/organisms/chat/ChatMessageList.kt
@@ -14,14 +14,12 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -88,15 +86,6 @@ fun ChatMessageList(
             (messages.size - initialReadCount).coerceIn(0, messages.size)
         } else {
             0
-        }
-    }
-
-    val latestMessages by rememberUpdatedState(messages)
-    DisposableEffect(Unit) {
-        onDispose {
-            latestMessages.forEach {
-                it.removeMessageDeliveryStatusObserver()
-            }
         }
     }
 
@@ -193,7 +182,6 @@ fun ChatMessageList(
                                 ),
                                 onResendMessage = onResendMessage,
                                 userNameProvider = userNameProvider,
-                                messageDeliveryInfoByPeersProfileId = message.addMessageDeliveryStatusObserver()
                             )
                         }
 
@@ -241,7 +229,6 @@ fun ChatMessageList(
                                 ),
                                 onResendMessage = onResendMessage,
                                 userNameProvider = userNameProvider,
-                                messageDeliveryInfoByPeersProfileId = message.addMessageDeliveryStatusObserver()
                             )
                         }
                     }


### PR DESCRIPTION
Attempts to improve changes introduced in #793 
fixes #795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Tap your own chat or protocol log messages to view delivery details via a contextual info menu.
* Refactor
  * Message-delivery tracking moved to event-driven, per-message status with automatic observer management while viewing chats.
* Style
  * Adjusted alignment, spacing, and click interactions in message rows for a cleaner, more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->