### PR TITLE
feature/node_app_rename

### DIFF
--- a/androidClient/build.gradle.kts
+++ b/androidClient/build.gradle.kts
@@ -142,7 +142,7 @@ dependencies {
 
 fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String {
 //    val date = SimpleDateFormat("yyyyMMdd").format(Date())
-    return "BisqConnect-${defaultConfig.versionName}_${defaultConfig.versionCode}"
+    return "${appName.replace(" ", "")}-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 }
 
 // Configure ProGuard mapping file management using shared script

--- a/androidClient/build.gradle.kts
+++ b/androidClient/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 version = project.findProperty("client.android.version") as String
 val versionCodeValue = (project.findProperty("client.android.version.code") as String).toInt()
 val sharedVersion = project.findProperty("shared.version") as String
+val appName = project.findProperty("client.name") as String
 
 kotlin {
     androidTarget {
@@ -119,9 +120,8 @@ android {
         val variant = this
         outputs.all {
             val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
-            val appName = "Bisq Connect"
             val version = variant.versionName
-            val fileName = "$appName-$version.apk"
+            val fileName = "${appName.replace(" ", "_")}-$version.apk"
             output.outputFileName = fileName
         }
     }

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -333,7 +333,7 @@ tasks.withType<Test> {
 }
 
 fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String {
-    return "BisqEasy-${defaultConfig.versionName}_${defaultConfig.versionCode}"
+    return "${appName.replace(" ", "")}-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 }
 
 // Configure ProGuard mapping file management using shared script

--- a/androidNode/build.gradle.kts
+++ b/androidNode/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 version = project.findProperty("node.android.version") as String
 val versionCodeValue = (project.findProperty("node.android.version.code") as String).toInt()
 val sharedVersion = project.findProperty("shared.version") as String
+val appName = project.findProperty("node.name") as String
 
 kotlin {
     // using JDK21 for full bisq2 compatibility
@@ -209,9 +210,8 @@ android {
         val variant = this
         outputs.all {
             val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
-            val appName = project.name
             val version = variant.versionName
-            val fileName = "$appName-$version.apk"
+            val fileName = "${appName.replace(" ", "_")}-$version.apk"
             output.outputFileName = fileName
         }
     }
@@ -333,7 +333,7 @@ tasks.withType<Test> {
 }
 
 fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String {
-    return "Bisq-${defaultConfig.versionName}_${defaultConfig.versionCode}"
+    return "BisqEasy-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 }
 
 // Configure ProGuard mapping file management using shared script

--- a/androidNode/src/androidDebug/res/values/strings.xml
+++ b/androidNode/src/androidDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Bisq (debug)</string>
+    <string name="app_name">Bisq Easy (debug)</string>
 </resources>

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainApplication.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainApplication.kt
@@ -59,7 +59,7 @@ class NodeMainApplication : MainApplication(), ComponentCallbacks2 {
         // Note: NodeMainApplication already implements ComponentCallbacks2, so onTrimMemory is automatically called
         // No need to registerComponentCallbacks(this) - that would cause infinite recursion
         // Note: Tor initialization is now handled in NodeApplicationBootstrapFacade
-        log.i { "Bisq Node Application Created" }
+        log.i { "Bisq Easy Node Application Created" }
     }
 
     override fun onTrimMemory(level: Int) {

--- a/androidNode/src/androidMain/res/values/strings.xml
+++ b/androidNode/src/androidMain/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Bisq</string>
+    <string name="app_name">Bisq Easy</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ android.enableJetifier=true
 # Versioning
 shared.version=0.2.0
 
-node.name=Bisq
+node.name=Bisq Easy
 node.android.version=0.1.1
 
 client.name=Bisq Connect


### PR DESCRIPTION
 - contribs to #803 
  - rename node app "Bisq" -> "Bisq Easy"
 - standarise apk naming using the gradle properties name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized app naming to “Bisq Easy” across configuration and logs.
  - Updated public property to use the new node name.
- Style
  - Updated visible app name in the UI to “Bisq Easy,” including the debug variant.
- Build
  - APK and artifact filenames now derive from a dynamic app name with spaces replaced by underscores.
  - Updated artifact prefix to “BisqEasy” and aligned version formatting across releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->