### PR TITLE
Handle number separator

### DIFF
--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/market_price/NodeMarketPriceServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/market_price/NodeMarketPriceServiceFacade.kt
@@ -2,7 +2,6 @@ package network.bisq.mobile.android.node.service.market_price
 
 import bisq.bonded_roles.market_price.MarketPriceService
 import bisq.common.observable.Pin
-import bisq.presentation.formatters.PriceFormatter
 import network.bisq.mobile.android.node.AndroidApplicationService
 import network.bisq.mobile.android.node.mapping.Mappings
 import network.bisq.mobile.android.node.mapping.Mappings.MarketMapping
@@ -102,7 +101,7 @@ class NodeMarketPriceServiceFacade(
             marketPriceService.findMarketPriceQuote(market)
                 .ifPresent { priceQuote ->
                     val marketVO = MarketMapping.fromBisq2Model(market)
-                    val formattedPrice = PriceFormatter.formatWithCode(priceQuote)
+                    val formattedPrice = MarketPriceFormatter.format(priceQuote.value, marketVO)
                     _selectedFormattedMarketPrice.value = formattedPrice
                     val priceQuoteVO = Mappings.PriceQuoteMapping.fromBisq2Model(priceQuote)
                     _selectedMarketPriceItem.value = MarketPriceItem(marketVO, priceQuoteVO, formattedPrice)

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/PlatformDomainAbstractions.android.kt
@@ -122,7 +122,9 @@ actual val decimalFormatter: DecimalFormatter = object : DecimalFormatter {
         val locale = Locale.getDefault()
         val key = precision to locale
         val formatter = formatters.getOrPut(key) {
-            DecimalFormat(generatePattern(precision), DecimalFormatSymbols(locale))
+            val format = DecimalFormat(generatePattern(precision), DecimalFormatSymbols(locale))
+            format.isGroupingUsed = true
+            format
         }
         return formatter.format(value)
     }
@@ -130,11 +132,11 @@ actual val decimalFormatter: DecimalFormatter = object : DecimalFormatter {
     private fun generatePattern(precision: Int): String {
         return if (precision > 0) {
             buildString {
-                append("0.")
+                append("#,##0.")
                 repeat(precision) { append("0") }
             }
         } else {
-            "0"
+            "#,##0"
         }
     }
 }


### PR DESCRIPTION
This PR fixes: https://github.com/bisq-network/bisq-mobile/issues/303

Prices and numeric values now display thousands separators for improved readability.

https://github.com/user-attachments/assets/91903a2b-04d8-458b-afee-1d8fb9c08e91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prices and numeric values now show thousands separators for improved readability.
  * Market price display is more consistent across the app with standardized formatting.

* **Refactor**
  * Consolidated market price formatting to a single, consistent path for uniform presentation across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->