### PR TITLE
Fix chat UI date time message

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/user/profile/UserProfileVO.kt
@@ -23,34 +23,36 @@ data class UserProfileVO(
     val publishDate: Long
 )
 
-val userProfileDemoObj = UserProfileVO(
-    version = 1,
-    nickName = "demo",
-    proofOfWork = ProofOfWorkVO(
-        payloadEncoded = "payload",
-        counter = 1L,
-        challengeEncoded = "challenge",
-        difficulty = 2.0,
-        solutionEncoded = "sol",
-        duration = 100L
-    ),
-    avatarVersion = 1,
-    networkId = NetworkIdVO(
-        addressByTransportTypeMap = AddressByTransportTypeMapVO(mapOf()),
-        pubKey = PubKeyVO(
-            publicKey = PublicKeyVO("pub"),
-            keyId = "key",
-            hash = "hash",
-            id = "id"
-        )
-    ),
-    terms = "my terms",
-    statement = "my statement",
-    applicationVersion = "2.1.7",
-    nym = "mynym",
-    userName = "demo",
-    publishDate = 10342435345324L
-)
+val userProfileDemoObj by lazy {
+    UserProfileVO(
+        version = 1,
+        nickName = "demo",
+        proofOfWork = ProofOfWorkVO(
+            payloadEncoded = "payload",
+            counter = 1L,
+            challengeEncoded = "challenge",
+            difficulty = 2.0,
+            solutionEncoded = "sol",
+            duration = 100L
+        ),
+        avatarVersion = 1,
+        networkId = NetworkIdVO(
+            addressByTransportTypeMap = AddressByTransportTypeMapVO(mapOf()),
+            pubKey = PubKeyVO(
+                publicKey = PublicKeyVO("pub"),
+                keyId = "key",
+                hash = "hash",
+                id = "id"
+            )
+        ),
+        terms = "my terms",
+        statement = "my statement",
+        applicationVersion = "2.1.7",
+        nym = "mynym",
+        userName = "demo",
+        publishDate = 10342435345324L
+    )
+}
 
 /**
  * a fast way to create a mock user profile
@@ -65,5 +67,6 @@ fun createMockUserProfile(name: String = createUuid()): UserProfileVO {
             )
         ),
         nym = name,
+        userName = name
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatTextMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/ChatTextMessageBox.kt
@@ -20,12 +20,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import network.bisq.mobile.domain.PlatformImage
+import network.bisq.mobile.domain.createEmptyImage
+import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReactionVO
 import network.bisq.mobile.domain.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.domain.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -49,7 +54,8 @@ fun ChatTextMessageBox(
     val chatAlign = if (isMyMessage) Alignment.End else Alignment.Start
     val contentAlign = if (isMyMessage) Alignment.CenterEnd else Alignment.CenterStart
     val menuPosition = if (isMyMessage) Alignment.Start else Alignment.CenterHorizontally
-    val bubbleBGColor = if (isMyMessage) BisqTheme.colors.primaryDisabled else BisqTheme.colors.dark_grey40
+    val bubbleBGColor =
+        if (isMyMessage) BisqTheme.colors.primaryDisabled else BisqTheme.colors.dark_grey40
     val chatPadding =
         if (isMyMessage) PaddingValues(start = BisqUIConstants.ScreenPadding) else PaddingValues(end = BisqUIConstants.ScreenPadding)
 
@@ -64,7 +70,7 @@ fun ChatTextMessageBox(
         verticalArrangement = Arrangement.Center,
     ) {
         UsernameMessageDeliveryAndDate(
-            message,
+            message = message,
             onResendMessage = onResendMessage,
             userNameProvider = userNameProvider,
             messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatus,
@@ -153,6 +159,132 @@ fun ChatTextMessageBox(
             onUndoIgnoreUser = onUndoIgnoreUser,
             onReportUser = onReportUser,
             isIgnored = isIgnored,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ChatTextMessageBoxPreview_MyMessage() {
+    BisqTheme.Preview {
+        val myUserProfile = createMockUserProfile("Bob")
+        val peerUserProfile = createMockUserProfile("Alice")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg123",
+            channelId = "channel123",
+            senderUserProfile = myUserProfile,
+            receiverUserProfileId = peerUserProfile.networkId.pubKey.id,
+            receiverNetworkId = peerUserProfile.networkId,
+            text = "Hello! I'm interested in this trade.",
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.TEXT,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList()
+        )
+
+        ChatTextMessageBox(
+            message = message,
+            userProfileIconProvider = { createEmptyImage() },
+            onAddReaction = {},
+            onRemoveReaction = {},
+            isIgnored = false,
+            onResendMessage = {},
+            userNameProvider = { it },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ChatTextMessageBoxPreview_PeerMessage() {
+    BisqTheme.Preview {
+        val myUserProfile = createMockUserProfile("Bob")
+        val peerUserProfile = createMockUserProfile("Alice")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg456",
+            channelId = "channel123",
+            senderUserProfile = peerUserProfile,
+            receiverUserProfileId = myUserProfile.networkId.pubKey.id,
+            receiverNetworkId = myUserProfile.networkId,
+            text = "Sure! Let's proceed with the payment.",
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.TEXT,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList()
+        )
+
+        ChatTextMessageBox(
+            message = message,
+            userProfileIconProvider = { createEmptyImage() },
+            onAddReaction = {},
+            onRemoveReaction = {},
+            isIgnored = false,
+            onResendMessage = {},
+            userNameProvider = { it }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ChatTextMessageBoxPreview_LongMessage() {
+    BisqTheme.Preview {
+        val myUserProfile = createMockUserProfile("Bob")
+        val peerUserProfile = createMockUserProfile("Alice")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg789",
+            channelId = "channel123",
+            senderUserProfile = peerUserProfile,
+            receiverUserProfileId = myUserProfile.networkId.pubKey.id,
+            receiverNetworkId = myUserProfile.networkId,
+            text = "This is a longer message to demonstrate how the chat message box handles multiple lines of text. It should wrap properly and maintain good readability with proper spacing and alignment.",
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.TEXT,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList(),
+        )
+
+        ChatTextMessageBox(
+            message = message,
+            userProfileIconProvider = { createEmptyImage() },
+            onAddReaction = {},
+            onRemoveReaction = {},
+            isIgnored = false,
+            onResendMessage = {},
+            userNameProvider = { it }
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
@@ -1,9 +1,12 @@
 package network.bisq.mobile.presentation.ui.components.molecules.chat
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,12 +15,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.domain.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
+import network.bisq.mobile.domain.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun UsernameMessageDeliveryAndDate(
@@ -28,36 +36,127 @@ fun UsernameMessageDeliveryAndDate(
 ) {
     var showInfo by remember { mutableStateOf(false) }
 
-    Row(
-        modifier = Modifier
-            .semantics(mergeDescendants = true) {}
-            .clickable(message.isMyMessage) { showInfo = true },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalfQuarter),
-    ) {
-        val username = @Composable {
-            BisqText.baseRegular(message.senderUserName, modifier = Modifier.offset(y = (-1).dp))
-        }
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .semantics(mergeDescendants = true) {}
+                .clickable(message.isMyMessage) { showInfo = true },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val date = @Composable {
+                BisqText.xsmallLightGrey(
+                    modifier = Modifier
+                        .widthIn(max = this@BoxWithConstraints.maxWidth * 0.4f),
+                    text = message.dateString,
+                )
+            }
+            val username = @Composable {
+                BisqText.baseRegular(
+                    modifier = Modifier
+                        .widthIn(max = this@BoxWithConstraints.maxWidth * 0.6f),
+                    text = message.senderUserName
+                )
+            }
 
-        val date = @Composable {
-            BisqText.xsmallLightGrey(message.dateString)
+            if (message.isMyMessage) {
+                Spacer(Modifier.weight(1f))
+                date()
+                Spacer(Modifier.width(BisqUIConstants.ScreenPaddingHalfQuarter))
+                MessageDeliveryBox(
+                    onResendMessage = onResendMessage,
+                    userNameProvider = userNameProvider,
+                    messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
+                    showInfo,
+                    onDismissMenu = {
+                        showInfo = false
+                    }
+                )
+                username()
+            } else {
+                username()
+                Spacer(Modifier.width(BisqUIConstants.ScreenPaddingHalfQuarter))
+                date()
+            }
         }
+    }
+}
 
-        if (message.isMyMessage) {
-            date()
-            MessageDeliveryBox(
-                onResendMessage = onResendMessage,
-                userNameProvider = userNameProvider,
-                messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
-                showInfo,
-                onDismissMenu = {
-                    showInfo = false
-                }
-            )
-            username()
-        } else {
-            username()
-            date()
-        }
+@Preview
+@Composable
+private fun UsernameMessageDeliveryAndDatePreview_MyMessage() {
+    BisqTheme.Preview {
+        val myUserProfile = createMockUserProfile("Bob [Marvelously-Extraneous-Elephant-234345435]")
+        val peerUserProfile =
+            createMockUserProfile("Alice [Marvelously-Extraneous-Elephant-234345435]")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg123",
+            channelId = "channel123",
+            senderUserProfile = myUserProfile,
+            receiverUserProfileId = peerUserProfile.networkId.pubKey.id,
+            receiverNetworkId = peerUserProfile.networkId,
+            text = "Hello!",
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.TEXT,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList()
+        )
+
+        UsernameMessageDeliveryAndDate(
+            message = message,
+            onResendMessage = {},
+            userNameProvider = { it },
+            messageDeliveryInfoByPeersProfileId = MutableStateFlow(emptyMap())
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UsernameMessageDeliveryAndDatePreview_PeerMessage() {
+    BisqTheme.Preview {
+        val myUserProfile = createMockUserProfile("Bob [Marvelously-Extraneous-Elephant-234345435]")
+        val peerUserProfile =
+            createMockUserProfile("Alice")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg456",
+            channelId = "channel123",
+            senderUserProfile = peerUserProfile,
+            receiverUserProfileId = myUserProfile.networkId.pubKey.id,
+            receiverNetworkId = myUserProfile.networkId,
+            text = "Hi there!",
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.TEXT,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList()
+        )
+
+        UsernameMessageDeliveryAndDate(
+            message = message,
+            onResendMessage = {},
+            userNameProvider = { it },
+            messageDeliveryInfoByPeersProfileId = MutableStateFlow(emptyMap())
+        )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/trade/TradePeerLeftMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/molecules/chat/trade/TradePeerLeftMessageBox.kt
@@ -9,12 +9,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import network.bisq.mobile.domain.data.replicated.chat.ChatMessageTypeEnum
+import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.domain.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
+import network.bisq.mobile.domain.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.ui.components.atoms.icons.LeaveChatIcon
 import network.bisq.mobile.presentation.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.ui.theme.BisqUIConstants
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun TradePeerLeftMessageBox(message: BisqEasyOpenTradeMessageModel, modifier: Modifier = Modifier) {
@@ -46,5 +50,39 @@ fun TradePeerLeftMessageBox(message: BisqEasyOpenTradeMessageModel, modifier: Mo
             BisqText.smallLight("bisqEasy.openTrades.chat.peerLeft.subHeadline".i18n())
             BisqText.xsmallLightGrey(message.dateString)
         }
+    }
+}
+
+@Preview
+@Composable
+private fun TradePeerLeftMessageBoxPreview() {
+    BisqTheme.Preview {
+        val peerUserProfile = createMockUserProfile("Alice")
+        val myUserProfile = createMockUserProfile("Bob")
+
+        val dto = BisqEasyOpenTradeMessageDto(
+            tradeId = "trade123",
+            messageId = "msg123",
+            channelId = "channel123",
+            senderUserProfile = peerUserProfile,
+            receiverUserProfileId = myUserProfile.networkId.pubKey.id,
+            receiverNetworkId = myUserProfile.networkId,
+            text = null,
+            citation = null,
+            date = 1234567890000L,
+            mediator = null,
+            chatMessageType = ChatMessageTypeEnum.LEAVE,
+            bisqEasyOffer = null,
+            chatMessageReactions = emptySet(),
+            citationAuthorUserProfile = null
+        )
+
+        val message = BisqEasyOpenTradeMessageModel(
+            dto,
+            myUserProfile,
+            emptyList()
+        )
+
+        TradePeerLeftMessageBox(message = message)
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/bisq-network/bisq-mobile/issues/808

Chat message screen accommodates well when username is long or font size is big.


https://github.com/user-attachments/assets/c4215183-83d7-476e-bc9a-e0970b76095c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved chat header layout (username, delivery, date) for better alignment and responsiveness across screen sizes.
  - Clarified parameter usage in message components for readability.
- Documentation
  - Added preview examples for ChatTextMessageBox (my/peer/long messages) and TradePeerLeftMessageBox to showcase UI states.
- Style
  - Minor formatting adjustments for readability.
- Chores
  - Updated mock profile generation to include provided username; switched demo profile to lazy initialization (no user-facing change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->