### PR TITLE
Fix notification service crash and improve lifecycle management

### DIFF
--- a/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/ServiceModule.android.kt
+++ b/androidClient/src/androidMain/kotlin/network/bisq/mobile/client/di/ServiceModule.android.kt
@@ -14,9 +14,14 @@ import org.koin.dsl.module
 
 val serviceModule = module {
     single { AppForegroundController(androidContext()) } bind ForegroundDetector::class
-    single { NotificationControllerImpl(get(), ClientMainActivity::class.java) } bind NotificationController::class
+    single {
+        NotificationControllerImpl(
+            get(),
+            ClientMainActivity::class.java
+        )
+    } bind NotificationController::class
     single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
     single {
-        OpenTradesNotificationService(get(), get(), get(), get())
+        OpenTradesNotificationService(get(), get(), get(), get(), get())
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/ServiceModule.android.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/di/ServiceModule.android.kt
@@ -14,9 +14,14 @@ import org.koin.dsl.module
 
 val serviceModule = module {
     single { AppForegroundController(androidContext()) } bind ForegroundDetector::class
-    single { NotificationControllerImpl(get(), NodeMainActivity::class.java) } bind NotificationController::class
+    single {
+        NotificationControllerImpl(
+            get(),
+            NodeMainActivity::class.java
+        )
+    } bind NotificationController::class
     single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
     single {
-        OpenTradesNotificationService(get(), get(), get(), get())
+        OpenTradesNotificationService(get(), get(), get(), get(), get())
     }
 }

--- a/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
+++ b/androidNode/src/androidMain/kotlin/network/bisq/mobile/android/node/service/trades/NodeTradesServiceFacade.kt
@@ -91,7 +91,7 @@ class NodeTradesServiceFacade(
 
     // Properties
     private val _openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
-    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems.asStateFlow()
+    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = _openTradeItems.asStateFlow()
 
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
     override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/client/ClientMainPresenter.kt
@@ -45,13 +45,13 @@ open class ClientMainPresenter(
         connectivityService.startMonitoring()
     }
 
-    override fun onResumeServices() {
-        super.onResumeServices()
+    override fun onResume() {
+        super.onResume()
         connectivityService.startMonitoring()
     }
 
-    override fun onPauseServices() {
-        super.onPauseServices()
+    override fun onPause() {
+        super.onPause()
         connectivityService.stopMonitoring()
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/MainPresenter.kt
@@ -124,33 +124,11 @@ open class MainPresenter(
         }.take(1).launchIn(presenterScope)
     }
 
-    override fun onResume() {
-        super.onResume()
-        onResumeServices()
-    }
-
-    override fun onPause() {
-        onPauseServices()
-        super.onPause()
-    }
-
     @CallSuper
     override fun onDestroying() {
         // to stop notification service and fully kill app (no zombie mode)
         stopOpenTradeNotificationsService()
         super.onDestroying()
-    }
-
-    open fun reactivateServices() {
-        log.d { "Reactivating services default: skip" }
-    }
-
-    protected open fun onResumeServices() {
-        stopOpenTradeNotificationsService()
-    }
-
-    protected open fun onPauseServices() {
-        openTradesNotificationService.launchNotificationService()
     }
 
     private fun stopOpenTradeNotificationsService() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceController.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceController.kt
@@ -1,6 +1,6 @@
 package network.bisq.mobile.presentation.notification
 
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 /**
  * An interface for a controller of a notification service
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.StateFlow
 interface ForegroundServiceController {
     fun startService()
     fun stopService()
-    fun <T> registerObserver(stateFlow: StateFlow<T>, onStateChange: (T) -> Unit)
-    fun unregisterObserver(stateFlow: StateFlow<*>)
+    fun <T> registerObserver(flow: Flow<T>, onStateChange: (T) -> Unit)
+    fun unregisterObserver(flow: Flow<*>)
+    fun unregisterObservers()
     fun isServiceRunning(): Boolean
+    fun dispose()
 }

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/ServiceModule.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/di/ServiceModule.ios.kt
@@ -16,7 +16,7 @@ val serviceModule = module {
     single { NotificationControllerImpl(get()) } bind NotificationController::class
     single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
     single {
-        OpenTradesNotificationService(get(), get(), get(), get())
+        OpenTradesNotificationService(get(), get(), get(), get(), get())
     }
 
     single<ClientApplicationLifecycleService> {

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceControllerImpl.ios.kt
@@ -5,8 +5,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -17,7 +18,8 @@ import platform.BackgroundTasks.BGTaskScheduler
 import platform.Foundation.NSDate
 
 
-class ForegroundServiceControllerImpl(private val notificationController: NotificationController) : ForegroundServiceController, Logging {
+class ForegroundServiceControllerImpl(private val notificationController: NotificationController) :
+    ForegroundServiceController, Logging {
 
     companion object {
         const val BACKGROUND_TASK_ID = "network.bisq.mobile.iosUC4273Y485"
@@ -25,7 +27,7 @@ class ForegroundServiceControllerImpl(private val notificationController: Notifi
     }
 
     private val serviceScope = CoroutineScope(SupervisorJob())
-    private val observerJobs = mutableMapOf<StateFlow<*>, Job>()
+    private val observerJobs = mutableMapOf<Flow<*>, Job>()
 
     private var isRunning = false
     private val isRunningMutex = Mutex()
@@ -68,29 +70,39 @@ class ForegroundServiceControllerImpl(private val notificationController: Notifi
     }
 
 
-    override fun <T> registerObserver(stateFlow: StateFlow<T>, onStateChange: (T) -> Unit) {
-        if (observerJobs.contains(stateFlow)) {
+    override fun <T> registerObserver(flow: Flow<T>, onStateChange: (T) -> Unit) {
+        if (observerJobs.contains(flow)) {
             log.w { "State flow observer already registered, skipping registration" }
             return
         }
         val job = serviceScope.launch(Dispatchers.Default) {
-            stateFlow.collect { onStateChange(it) }
+            try {
+                flow.collect { onStateChange(it) }
+            } catch (e: Exception) {
+                log.e(e) { "Error in flow observer, flow collection terminated" }
+            }
         }
-        observerJobs[stateFlow] = job
+        observerJobs[flow] = job
     }
 
-    override fun unregisterObserver(stateFlow: StateFlow<*>) {
-        observerJobs[stateFlow]?.cancel()
-        observerJobs.remove(stateFlow)
+    override fun unregisterObserver(flow: Flow<*>) {
+        observerJobs[flow]?.cancel()
+        observerJobs.remove(flow)
     }
 
-    private fun unregisterAllObservers() {
-        observerJobs?.keys?.forEach { unregisterObserver(it) }
+    override fun unregisterObservers() {
+        observerJobs.forEach { it.value.cancel() }
+        observerJobs.clear()
     }
 
     override fun isServiceRunning(): Boolean {
         // iOS doesn't allow querying background task state directly
         return isRunning
+    }
+
+    override fun dispose() {
+        unregisterObservers()
+        serviceScope.cancel()
     }
 
     private fun handleBackgroundTask(task: BGProcessingTask) {


### PR DESCRIPTION
 - fix #821 

# Fix notification service crash and improve lifecycle management

The application was crashing when users tapped notifications while the app was in the foreground, with the following error:

android.app.RemoteServiceExceptionForegroundServiceDidNotStartInTimeException: Context.startForegroundService did not then call Service.startForeground

The root cause was a race condition in the notification service lifecycle management where:
1. Manual pause/resume service control created timing conflicts
2. Notification taps triggered rapid service start/stop cycles
3. The foreground service wasn't calling `startForeground()` within the required time window

## Solution

### Automatic Lifecycle Management
- **Replaced manual service control** with reactive foreground/background detection
- **Added debounced lifecycle observer** (1s delay) to prevent rapid service toggling
- **Eliminated race conditions** by removing manual `onResume`/`onPause` service calls

### Improved Notification Flow
- **Simplified notification logic** by removing complex deduplication tracking
- **Used `Flow.drop(1)`** to skip initial values, preventing startup notification spam
- **Enhanced flow management** with generic `Flow` support instead of `StateFlow`

### Better Resource Management
- **Added comprehensive cleanup** with dedicated coroutine scope and proper cancellation
- **Bulk observer unregistration** with new `unregisterObservers()` method
- **Automatic orphan cleanup** for completed trades

### Architecture Improvements
- **Dependency injection updates** to support new `ForegroundDetector` parameter
- **Enhanced error handling** with proper exception logging
- **Cleaner separation of concerns** between service management and notification logic

## Key Changes

- `OpenTradesNotificationService`: Complete rewrite with lifecycle observer pattern
- `ForegroundServiceController`: Enhanced to support generic `Flow` types and bulk cleanup
- `MainPresenter`: Removed manual service lifecycle management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now respond to app foreground/background transitions and register per-trade observers lazily for timely, role-aware messages.

* **Bug Fixes**
  * Reduced missed or duplicate notifications; terminal trades cleaned up promptly. Improved observer error handling to avoid crashes.

* **Refactor**
  * Lifecycle and observer APIs simplified (Flow-based observers, bulk-unregister, dispose) and service wiring updated to support the new lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->