### PR TITLE
disable_jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,8 @@ android.enableR8.fullMode=true
 #android.enableR8.debug=true
 
 # Performance optimizations
-# Temporary AndroidX compatibility (Jetifier), remove after library bumps
-android.enableJetifier=true
+# Not needed anymore after lib bumps
+android.enableJetifier=false
 
 # Versioning
 shared.version=0.2.0


### PR DESCRIPTION
This should have been done when we upgraded the android stack

 - disable unneeded android jetifier for legacy libs causing build times increase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.
- Chores
  - Optimized Android build configuration by removing an outdated compatibility step no longer needed after library updates, leading to faster and cleaner builds.
  - Improves developer workflow stability and may reduce build times in local and CI environments.
  - No changes to app functionality or UI are expected for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->