### PR TITLE
Potential fix service crash

### DIFF
--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundService.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundService.android.kt
@@ -12,7 +12,7 @@ import network.bisq.mobile.domain.helper.ResourceUtils
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.ui.navigation.NavRoute
-import org.koin.android.ext.android.inject
+import org.koin.android.ext.android.get
 
 /**
  * Implements foreground service (api >= 26) or background service accordingly
@@ -26,32 +26,48 @@ open class ForegroundService : Service(), Logging {
         const val SERVICE_NOTIF_ID = 1
     }
 
-    private val notificationController: NotificationControllerImpl by inject()
-
     private fun getServiceNotification(): Notification {
-        val contentPendingIntent =
-            notificationController.createNavDeepLinkPendingIntent(NavRoute.TabOpenTradeList)
+        return try {
+            val notificationController: NotificationControllerImpl = get()
 
-        return NotificationCompat.Builder(this, NotificationChannels.BISQ_SERVICE)
-            .setContentTitle("mobile.bisqService.title".i18n())
-            .setContentText("mobile.bisqService.subTitle".i18n())
-            .setSmallIcon(ResourceUtils.getNotifResId(applicationContext))
-            .setOngoing(true)
-            .setContentIntent(contentPendingIntent)
-            .build()
+            val contentPendingIntent =
+                notificationController.createNavDeepLinkPendingIntent(NavRoute.TabOpenTradeList)
+
+            NotificationCompat.Builder(this, NotificationChannels.BISQ_SERVICE)
+                .setContentTitle("mobile.bisqService.title".i18n())
+                .setContentText("mobile.bisqService.subTitle".i18n())
+                .setSmallIcon(ResourceUtils.getNotifResId(applicationContext))
+                .setOngoing(true)
+                .setContentIntent(contentPendingIntent)
+                .build()
+        } catch (e: Exception) {
+            log.e(e) { "Failed to create full service notification, falling back to minimal" }
+            // Return a minimal notification as fallback
+            NotificationCompat.Builder(this, NotificationChannels.BISQ_SERVICE)
+                .setContentTitle("Bisq")
+                .setContentText("Service running")
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setOngoing(true)
+                .build()
+        }
     }
 
     @SuppressLint("InlinedApi")
     override fun onCreate() {
         super.onCreate()
-        // ServiceCompat impl. checks for android versions internally
-        ServiceCompat.startForeground(
-            this,
-            SERVICE_NOTIF_ID,
-            getServiceNotification(),
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
-        )
-        log.i { "Started as foreground service" }
+        try {
+            ServiceCompat.startForeground(
+                this,
+                SERVICE_NOTIF_ID,
+                getServiceNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
+            )
+            log.i { "Service successfully foregrounded." }
+        } catch (e: Exception) {
+            log.e(e) { "startForeground failed with minimal notification; stopping service." }
+            stopSelf()
+            return
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceControllerImpl.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/notification/ForegroundServiceControllerImpl.android.kt
@@ -74,7 +74,7 @@ class ForegroundServiceControllerImpl(
             try {
                 flow.collect { onStateChange(it) }
             } catch (e: Exception) {
-                log.e(e) { "Error in flow observer, flow collection terminated" }
+                log.w(e) { "Error in flow observer, flow collection terminated" }
             }
         }
         observerJobs[flow] = job


### PR DESCRIPTION
This PR tries to fix this crash that is very hard to reproduce: https://github.com/bisq-network/bisq-mobile/issues/853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented a two-step notification startup: attempt full notification setup and foregrounding, with a minimal fallback if creation fails.
  * Wrapped notification creation and service foregrounding in try/catch with logging to ensure graceful exit on failure.
  * Lowered severity of certain observer logs from error to warning to reduce noisy error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->