### PR TITLE
Fix keyboard type in trusted node setup screen

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -112,7 +112,11 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     value = host,
                     placeholder = hostPrompt,
                     keyboardType = if (selectedNetworkType == NetworkType.LAN) {
-                        KeyboardType.Decimal
+                        if (presenter.isIOS()) {
+                            KeyboardType.Ascii
+                        } else {
+                            KeyboardType.Decimal
+                        }
                     } else {
                         KeyboardType.Text
                     },


### PR DESCRIPTION
Fixes: https://github.com/bisq-network/bisq-mobile/issues/790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted LAN host input keyboard selection: iOS now uses an ASCII keyboard, other platforms use a decimal keyboard, preserving behavior on remaining branches and maintaining cross-platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->