### PR TITLE
fix: change jumpOffset to 12 in scroll layout

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/components/layout/ScrollLayout.kt
@@ -98,7 +98,7 @@ fun BisqScrollLayout(
                 onClicked = { scope.launch { scrollState.animateScrollTo(scrollState.maxValue) } },
                 modifier = Modifier.align(Alignment.BottomEnd)
                     .offset(x = -BisqUIConstants.ScreenPadding),
-                jumpOffset = 90,
+                jumpOffset = 12,
             )
         }
     }


### PR DESCRIPTION
after some layout changes some time ago done by salotto? I think, we forgot to fix this

the screen which uses this and can be checked for is the trade guide screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the horizontal positioning of the jump-to-bottom button for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->