### PR TITLE
ForegroundServiceDidNotStartInTimeException prevention

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeResourcesPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/android/node/presentation/NodeResourcesPresenter.kt
@@ -108,7 +108,7 @@ class NodeResourcesPresenter(
                             mainPresenter.showSnackbar("Saved to Downloads (debug): $outName", isError = false)
                         }
                     } catch (t: Throwable) {
-                        log.w(t) { "KMP: Failed to save backup to Downloads in debug mode" }
+                        log.w(t) { "Failed to save backup to Downloads in debug mode" }
                     }
                 }
 


### PR DESCRIPTION
 - fix #680 
 - prevent foreground not started in time crashes by using a minimal updatable foreground notification and updating in the background
 - remove KMP: prefix from logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and responsiveness of foreground service notifications with enhanced error recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->