### PR TITLE
fix: dont resume state when app gets killed

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/ClientMainActivity.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/ClientMainActivity.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client
 import android.os.Bundle
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import network.bisq.mobile.presentation.MainActivity
+import network.bisq.mobile.presentation.MainApplication
 
 /**
  * Android Bisq Connect Main Activity
@@ -11,6 +12,12 @@ class ClientMainActivity : MainActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-        super.onCreate(savedInstanceState)
+
+        if (MainApplication.wasProcessDead.getAndSet(false)) {
+            // this is to enforce proper initialization if process was killed by OS
+            super.onCreate(null)
+        } else {
+            super.onCreate(savedInstanceState)
+        }
     }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainActivity.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/android/node/NodeMainActivity.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.android.node
 import android.os.Bundle
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import network.bisq.mobile.presentation.MainActivity
+import network.bisq.mobile.presentation.MainApplication
 
 /**
  * Bisq Android Node Main Activity
@@ -12,7 +13,13 @@ class NodeMainActivity : MainActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         // Install splash screen before super.onCreate to prevent UI blocking
         installSplashScreen()
-        super.onCreate(savedInstanceState)
+
+        if (MainApplication.wasProcessDead.getAndSet(false)) {
+            // this is to enforce proper initialization if process was killed by OS
+            super.onCreate(null)
+        } else {
+            super.onCreate(savedInstanceState)
+        }
 
         // Enforce enable hardware acceleration for better graphics performance
         // tested with better results than manifest flag

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/MainApplication.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/MainApplication.kt
@@ -19,11 +19,18 @@ import network.bisq.mobile.presentation.notification.NotificationChannels
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Base class for Bisq Android Applications
  */
 abstract class MainApplication : Application(), Logging {
+
+    companion object {
+        @Volatile
+        var wasProcessDead = AtomicBoolean(true)
+    }
+
     override fun onCreate() {
         super.onCreate()
 


### PR DESCRIPTION
 - fixes #824 

This will make the app always start from the bootstrap screen no matter how it is killed. if it starts from a dead state, it needs to go through bootstrap instead of jumping straight to the app

you can test the before/after this PR by killing the app and starting it again using this:
```
# Restart ADB daemon as root
adb root

# Now you can use kill commands
adb shell kill -9 $(adb shell pidof network.bisq.mobile.node.debug)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app initialization and recovery when the system terminates the application process, ensuring proper reinitiation on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->