### PR TITLE
fix: layout.buildDirectory usages

### DIFF
--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -75,20 +75,20 @@ android {
             java {
                 srcDir("src/main/resources")
                 // Debug build only includes debug proto sources
-                srcDir(layout.buildDirectory.dir("generated/source/proto/debug/java"))
+                srcDir(layout.buildDirectory.dir("/generated/source/proto/debug/java"))
             }
             proto {
-                srcDir(layout.buildDirectory.dir("extracted-include-protos/debug"))
+                srcDir(layout.buildDirectory.dir("/extracted-include-protos/debug"))
             }
         }
         getByName("release") {
             java {
                 srcDir("src/release/resources")
                 // Release build only includes release proto sources
-                srcDir(layout.buildDirectory.dir("generated/source/proto/release/java"))
+                srcDir(layout.buildDirectory.dir("/generated/source/proto/release/java"))
             }
             proto {
-                srcDir(layout.buildDirectory.dir("extracted-include-protos/release"))
+                srcDir(layout.buildDirectory.dir("/extracted-include-protos/release"))
             }
         }
     }
@@ -240,7 +240,7 @@ protobuf {
         all().forEach { task ->
             val variantName = Regex("(debug|release|profile)", RegexOption.IGNORE_CASE)
                 .find(task.name)?.value?.lowercase() ?: "debug"
-            task.inputs.dir(layout.buildDirectory.dir("extracted-include-protos/$variantName"))
+            task.inputs.dir(layout.buildDirectory.dir("/extracted-include-protos/$variantName"))
             task.builtins {
                 create("java")
             }


### PR DESCRIPTION
logging the actual string shows incorrect paths, but somehow this was working while it shouldnt
its possible that there's subtle behavior in runtime, or gradle is doing optimistic parsing of paths
either way it seems to me that we are relying on non-deterministic behavior here and that it should be fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to reliably locate and include generated sources for each build variant.
  * Made variant handling more robust and case-insensitive, with a sensible default for unmapped or unexpected variants to reduce build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->