### PR TITLE
Rename generic isLoading to more specific state names in presenters

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenterCancelInternalTorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenterCancelInternalTorTest.kt
@@ -151,14 +151,14 @@ class TrustedNodeSetupPresenterCancelInternalTorTest {
             delay(10)
             tries++
         }
-        assertTrue(presenter.isLoading.value)
+        assertTrue(presenter.isNodeSetupInProgress.value)
 
         // Cancel while Tor is Starting
         presenter.onCancelPressed()
         delay(50)
 
         // Presenter state reset
-        assertFalse(presenter.isLoading.value)
+        assertFalse(presenter.isNodeSetupInProgress.value)
         assertEquals("", presenter.status.value)
         assertTrue(presenter.wsClientConnectionState.value is ConnectionState.Disconnected &&
                 (presenter.wsClientConnectionState.value as ConnectionState.Disconnected).error == null)
@@ -197,7 +197,7 @@ class TrustedNodeSetupPresenterCancelInternalTorTest {
         validators.cancel()
 
         // Presenter state reset
-        assertFalse(presenter.isLoading.value)
+        assertFalse(presenter.isNodeSetupInProgress.value)
         assertEquals("", presenter.status.value)
 
         // Tor should not be stopped if it was already Started

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenterCancelTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenterCancelTest.kt
@@ -141,7 +141,7 @@ class TrustedNodeSetupPresenterCancelTest {
         presenter.onTestAndSavePressed(isWorkflow = true)
         // Let things start
         delay(100)
-        assertTrue(presenter.isLoading.value)
+        assertTrue(presenter.isNodeSetupInProgress.value)
         assertTrue(presenter.wsClientConnectionState.value is ConnectionState.Connecting)
 
         // Cancel
@@ -151,7 +151,7 @@ class TrustedNodeSetupPresenterCancelTest {
         collectorJob.cancel()
 
         // Assert state reset
-        assertFalse(presenter.isLoading.value)
+        assertFalse(presenter.isNodeSetupInProgress.value)
         assertEquals("", presenter.status.value)
         val state = presenter.wsClientConnectionState.value
         assertTrue(state is ConnectionState.Disconnected && state.error == null)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListPresenter.kt
@@ -33,21 +33,24 @@ class OpenTradeListPresenter(
 
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 
-    private val _isLoading = MutableStateFlow(true)
-    val isLoading = _isLoading.asStateFlow()
+    private val _isLoadingTrades = MutableStateFlow(true)
+    val isLoadingTrades = _isLoadingTrades.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
         tradesServiceFacade.resetSelectedTradeToNull()
-        _isLoading.value = true
+        _isLoadingTrades.value = true
         launchUI {
             combine(
-                mainPresenter.tradesWithUnreadMessages, tradesServiceFacade.openTradeItems, mainPresenter.languageCode
+                mainPresenter.tradesWithUnreadMessages,
+                tradesServiceFacade.openTradeItems,
+                mainPresenter.languageCode
             ) { unreadMessages, openTrades, _ ->
                 Pair(unreadMessages, openTrades)
             }.collect { (unreadMessages, openTrades) ->
-                _sortedOpenTradeItems.value = openTrades.sortedByDescending { it.bisqEasyTradeModel.takeOfferDate }
-                _isLoading.value = false
+                _sortedOpenTradeItems.value =
+                    openTrades.sortedByDescending { it.bisqEasyTradeModel.takeOfferDate }
+                _isLoadingTrades.value = false
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/open_trades/OpenTradeListScreen.kt
@@ -55,7 +55,7 @@ fun OpenTradeListScreen() {
     val tradeRulesConfirmed by presenter.tradeRulesConfirmed.collectAsState()
     val tradesWithUnreadMessages by presenter.tradesWithUnreadMessages.collectAsState()
     val sortedOpenTradeItems by presenter.sortedOpenTradeItems.collectAsState()
-    val isLoading by presenter.isLoading.collectAsState()
+    val isLoadingTrades by presenter.isLoadingTrades.collectAsState()
 
     if (tradeGuideVisible) {
         InformationConfirmationDialog(
@@ -75,7 +75,7 @@ fun OpenTradeListScreen() {
         isInteractive = isInteractive,
     ) {
         when {
-            isLoading -> {
+            isLoadingTrades -> {
                 Box(
                     modifier = Modifier
                         .fillMaxSize(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountsPresenter.kt
@@ -22,18 +22,18 @@ open class PaymentAccountsPresenter(
 
     override val selectedAccount: StateFlow<UserDefinedFiatAccountVO?> get() = accountsServiceFacade.selectedAccount
 
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading = _isLoading.asStateFlow()
+    private val _isLoadingAccounts = MutableStateFlow(false)
+    val isLoadingAccounts = _isLoadingAccounts.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
         launchIO {
             try {
-                _isLoading.value = true
+                _isLoadingAccounts.value = true
                 accountsServiceFacade.getAccounts()
                 accountsServiceFacade.getSelectedAccount()
             } finally {
-                _isLoading.value = false
+                _isLoadingAccounts.value = false
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/settings/PaymentAccountsScreen.kt
@@ -57,7 +57,7 @@ fun PaymentAccountsScreen() {
 
     val accounts by presenter.accounts.collectAsState()
     val selectedAccount by presenter.selectedAccount.collectAsState()
-    val isLoading by presenter.isLoading.collectAsState()
+    val isLoadingAccounts by presenter.isLoadingAccounts.collectAsState()
 
     var accountName by remember { mutableStateOf(selectedAccount?.accountName ?: "") }
     var accountNameValid by remember { mutableStateOf(true) }
@@ -100,7 +100,7 @@ fun PaymentAccountsScreen() {
         }
 
         when {
-            isLoading -> {
+            isLoadingAccounts -> {
                 CircularProgressIndicator(
                     color = BisqTheme.colors.primary,
                     strokeWidth = 2.dp,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupPresenter.kt
@@ -90,8 +90,8 @@ class TrustedNodeSetupPresenter(
     private val _status = MutableStateFlow("")
     val status: StateFlow<String> = _status.asStateFlow()
 
-    private val _isLoading = MutableStateFlow(true)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    private val _isNodeSetupInProgress = MutableStateFlow(true)
+    val isNodeSetupInProgress: StateFlow<Boolean> = _isNodeSetupInProgress.asStateFlow()
 
     private val _selectedProxyOption = MutableStateFlow(BisqProxyOption.NONE)
     val selectedProxyOption = _selectedProxyOption.asStateFlow()
@@ -184,7 +184,7 @@ class TrustedNodeSetupPresenter(
             } catch (e: Exception) {
                 log.e("Failed to load from repository", e)
             } finally {
-                _isLoading.value = false
+                _isNodeSetupInProgress.value = false
             }
         }
     }
@@ -224,7 +224,7 @@ class TrustedNodeSetupPresenter(
 
         if (!isApiUrlValid.value || !isProxyUrlValid.value) return
 
-        _isLoading.value = true
+        _isNodeSetupInProgress.value = true
         _status.value = "mobile.trustedNodeSetup.status.settingUpConnection".i18n()
 
         val newApiUrlString = apiUrl.value
@@ -237,7 +237,7 @@ class TrustedNodeSetupPresenter(
                     IllegalArgumentException("mobile.trustedNodeSetup.apiUrl.invalid.format".i18n()),
                     newApiUrlString
                 )
-                _isLoading.value = false
+                _isNodeSetupInProgress.value = false
                 connectJob = null
                 return@launchUI
             }
@@ -372,7 +372,7 @@ class TrustedNodeSetupPresenter(
             } finally {
                 countdownJob?.cancel()
                 countdownJob = null
-                _isLoading.value = false
+                _isNodeSetupInProgress.value = false
                 connectJob = null
             }
         }
@@ -396,7 +396,7 @@ class TrustedNodeSetupPresenter(
 
         _wsClientConnectionState.value = ConnectionState.Disconnected()
         _status.value = ""
-        _isLoading.value = false
+        _isNodeSetupInProgress.value = false
         _timeoutCounter.value = 0
         connectJob = null
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/startup/TrustedNodeSetupScreen.kt
@@ -70,7 +70,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
     RememberPresenterLifecycle(presenter)
 
     val connectionState by presenter.wsClientConnectionState.collectAsState()
-    val isLoading by presenter.isLoading.collectAsState()
+    val isNodeSetupInProgress by presenter.isNodeSetupInProgress.collectAsState()
     val selectedProxyOption by presenter.selectedProxyOption.collectAsState()
     val apiUrl by presenter.apiUrl.collectAsState()
     val apiUrlPrompt by presenter.apiUrlPrompt.collectAsState()
@@ -109,7 +109,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                 ) {
                     BisqText.largeRegular(
                         status,
-                        color = if (isLoading) BisqTheme.colors.warning
+                        color = if (isNodeSetupInProgress) BisqTheme.colors.warning
                         else if (connectionState is ConnectionState.Connected) BisqTheme.colors.primary
                         else BisqTheme.colors.danger,
                     )
@@ -128,11 +128,11 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     BisqButton(
-                        text = if (isLoading) "mobile.trustedNodeSetup.cancel".i18n() else "mobile.trustedNodeSetup.testAndSave".i18n(),
-                        color = if (!isLoading && (!isApiUrlValid || !isProxyUrlValid)) BisqTheme.colors.mid_grey10 else BisqTheme.colors.light_grey10,
-                        disabled = if (isLoading) false else (!isWorkflow || !isApiUrlValid || !isProxyUrlValid),
+                        text = if (isNodeSetupInProgress) "mobile.trustedNodeSetup.cancel".i18n() else "mobile.trustedNodeSetup.testAndSave".i18n(),
+                        color = if (!isNodeSetupInProgress && (!isApiUrlValid || !isProxyUrlValid)) BisqTheme.colors.mid_grey10 else BisqTheme.colors.light_grey10,
+                        disabled = if (isNodeSetupInProgress) false else (!isWorkflow || !isApiUrlValid || !isProxyUrlValid),
                         onClick = {
-                            if (isLoading) {
+                            if (isNodeSetupInProgress) {
                                 presenter.onCancelPressed()
                             } else if (isNewApiUrl) {
                                 showConfirmDialog = true
@@ -171,7 +171,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                     onValueChange = { apiUrl, _ -> if (isWorkflow) presenter.onApiUrlChanged(apiUrl) },
                     value = apiUrl,
                     placeholder = apiUrlPrompt,
-                    disabled = isLoading,
+                    disabled = isNodeSetupInProgress,
                     showPaste = true,
                     validation = {
                         presenter.validateApiUrl(
@@ -196,7 +196,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                             presenter.onProxyOptionChanged(it)
                             blurTriggerSetup.triggerBlur()
                         },
-                        disabled = isLoading || !isWorkflow,
+                        disabled = isNodeSetupInProgress || !isWorkflow,
                     )
 
                     BisqTextField(
@@ -205,7 +205,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                         onValueChange = {value, _ -> presenter.onPasswordChanged(value)},
                         keyboardType = KeyboardType.Password,
                         isPasswordField = true,
-                        disabled = isLoading || !isWorkflow,
+                        disabled = isNodeSetupInProgress || !isWorkflow,
                     )
                 }
             }
@@ -235,7 +235,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                         value = proxyHost,
                         placeholder = "127.0.0.1",
                         keyboardType = KeyboardType.Decimal,
-                        disabled = isLoading || !isWorkflow,
+                        disabled = isNodeSetupInProgress || !isWorkflow,
                         validation = presenter::validateProxyHost,
                     )
                     BisqTextField(
@@ -245,7 +245,7 @@ fun TrustedNodeSetupScreen(isWorkflow: Boolean = true) {
                         value = proxyPort,
                         placeholder = "9050",
                         keyboardType = KeyboardType.Decimal,
-                        disabled = isLoading || !isWorkflow,
+                        disabled = isNodeSetupInProgress || !isWorkflow,
                         validation = presenter::validatePort,
                     )
                 }


### PR DESCRIPTION
Fixes: https://github.com/bisq-network/bisq-mobile/issues/948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity by renaming loading state indicators to be more contextually specific across multiple presenters and screens for open trades, payment accounts, and trusted node setup operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->