### PR TITLE
bugfix/create_offer_disable_not_working_slow_connections

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/BasePresenter.kt
@@ -137,7 +137,7 @@ abstract class BasePresenter(private val rootPresenter: MainPresenter?) :
 
     // Presenter is interactive by default
     private val _isInteractive = MutableStateFlow(true)
-    override val isInteractive: StateFlow<Boolean> get() = _isInteractive.asStateFlow()
+    override val isInteractive: StateFlow<Boolean> = _isInteractive.asStateFlow()
     private val snackbarHostState: SnackbarHostState = SnackbarHostState()
 
     // Global UI manager for app-wide UI state (loading dialogs, etc.)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/ui/uicases/create_offer/CreateOfferReviewPresenter.kt
@@ -145,22 +145,35 @@ class CreateOfferReviewPresenter(
     }
 
     fun onCreateOffer() {
+        // TODO we need to have a general BasePresenter helper fun so every network blocking call trigggered
+        // by the user gets handled consistently and uses all the guards we have in place.
+        // these interactivity guards were here before and go erased and now restored
+        if (!isInteractive.value) return
+
+        disableInteractive()
         launchUI {
-            showLoading()
-            createOfferPresenter.createOffer()
-                .onSuccess {
-                    navigateToOfferbookTab()
-                }
-                .onFailure { exception ->
-                    if (exception is TimeoutCancellationException) {
-                        log.e(exception) { "Create offer timed out: ${exception.message}" }
-                        showSnackbar("mobile.bisqEasy.createOffer.timedOut".i18n())
-                    } else {
-                        log.e(exception) { "Failed to create offer: ${exception.message}" }
-                        showSnackbar("mobile.bisqEasy.createOffer.failed".i18n())
+            try {
+                showLoading()
+                createOfferPresenter.createOffer()
+                    .onSuccess {
+                        navigateToOfferbookTab()
                     }
-                }
-            hideLoading()
+                    .onFailure { exception ->
+                        if (exception is TimeoutCancellationException) {
+                            log.e(exception) { "Create offer timed out: ${exception.message}" }
+                            showSnackbar("mobile.bisqEasy.createOffer.timedOut".i18n())
+                        } else {
+                            log.e(exception) { "Failed to create offer: ${exception.message}" }
+                            showSnackbar("mobile.bisqEasy.createOffer.failed".i18n())
+                        }
+                    }
+            } finally {
+                hideLoading()
+                // Re-enable interactivity with the standard perceptible delay
+                // so upstream UI (wizard scaffold) can unlock controls.
+                enableInteractive()
+            }
         }
     }
 }
+


### PR DESCRIPTION
 - contribs #190 
 - fix: user is able to create several offers on slow tor connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during offer creation with distinct notifications for timeouts versus other failures
  * Enhanced UI responsiveness by preventing concurrent offer creation attempts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->