### PR TITLE
bugfix/rollback_latest_kmp_tor_upgrade

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,8 +44,11 @@ coil-compose = "3.3.0"
 # -------------------- Multiplatform Libraries --------------------
 bignum-lib = "0.3.10"
 # kmp-tor for embedded Tor support
-kmp-tor = "2.5.0"
-kmp-tor-resource = "408.19.0"
+kmp-tor = "2.4.1"
+kmp-tor-resource = "408.17.0"
+## we can't upgrade to 2.5.0 - it breaks iOS
+#kmp-tor = "2.5.0"
+#kmp-tor-resource = "408.19.0"
 kermit = "2.0.8"
 
 # -------------------- Testing --------------------

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -60,7 +60,7 @@ buildConfig {
         buildConfigField("BUILD_TS", System.currentTimeMillis())
         buildConfigField("BISQ_CORE_VERSION", bisqCoreVersion)
         // Note: Update when updating kmp-tor lib
-        buildConfigField("TOR_VERSION", "0.4.8.19") // is TOR DAEMON version
+        buildConfigField("TOR_VERSION", "0.4.8.17") // is TOR DAEMON version
         buildConfigField(
             "IS_DEBUG",
             (


### PR DESCRIPTION
 - rollback latest kmp tor upgrade as it breaks iOS tor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded Gradle Multiplatform KMP Tor components to earlier versions.
  * Updated TOR daemon version number to an earlier release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->