### PR TITLE
Improve Gradle caching on CI to prevent Maven Central 403 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
-          cache: gradle
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -58,18 +67,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
-          cache: gradle
 
-      - name: Cache Gradle dependencies (Mac only)
-        if: startsWith(matrix.os, 'macos')
+      - name: Cache Gradle dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: macos-gradle-v1
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            macos-gradle-
+            ${{ runner.os }}-gradle-
 
       - name: Cache Kotlin/Native (konan) (Mac only)
         if: startsWith(matrix.os, 'macos')
@@ -77,9 +84,9 @@ jobs:
         with:
           path: |
             ~/.konan
-          key: macos-konan-v1
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            macos-konan-
+            ${{ runner.os }}-konan-
 
 
       - name: Grant execute permission for gradlew
@@ -217,7 +224,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
-          cache: gradle
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated build cache configuration across platforms to improve CI/CD pipeline efficiency and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->