### PR TITLE
bugfix/regression_foreground_not_started_in_time_exception

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.common.di
 import network.bisq.mobile.client.main.ClientMainActivity
 import network.bisq.mobile.domain.service.AppForegroundController
 import network.bisq.mobile.domain.service.ForegroundDetector
+import network.bisq.mobile.domain.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.presentation.common.notification.ForegroundServiceController
 import network.bisq.mobile.presentation.common.notification.ForegroundServiceControllerImpl
 import network.bisq.mobile.presentation.common.notification.NotificationController
@@ -23,6 +24,14 @@ val androidClientDomainModule =
         } bind NotificationController::class
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
         single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
+            val applicationLifecycleService: ApplicationLifecycleService = get()
+            OpenTradesNotificationService(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                applicationLifecycleService.isInitializationComplete,
+            )
         }
     }

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -21,9 +21,6 @@ val iosClientDomainModule =
         single { AppForegroundController() } bind ForegroundDetector::class
         single { NotificationControllerImpl(get()) } bind NotificationController::class
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
-        single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
-        }
 
         single<ApplicationLifecycleService> {
             ClientApplicationLifecycleService(
@@ -45,6 +42,19 @@ val iosClientDomainModule =
                 get(),
             )
         }
+
+        single {
+            val applicationLifecycleService: ApplicationLifecycleService = get()
+            OpenTradesNotificationService(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                applicationLifecycleService.isInitializationComplete,
+            )
+        }
+
         single<UrlLauncher> { IOSUrlLauncher() }
         single<VersionProvider> { ClientVersionProvider() }
     }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -154,7 +154,6 @@ val androidNodeDomainModule =
                 get(),
                 get(),
                 get(),
-                get(),
             )
         } bind ApplicationLifecycleService::class
 
@@ -174,6 +173,14 @@ val androidNodeDomainModule =
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
 
         single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
+            val applicationLifecycleService: ApplicationLifecycleService = get()
+            OpenTradesNotificationService(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                applicationLifecycleService.isInitializationComplete,
+            )
         }
     }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -24,14 +24,12 @@ import network.bisq.mobile.domain.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.restartProcess
 import network.bisq.mobile.node.common.domain.service.network.NodeConnectivityService
 import network.bisq.mobile.node.common.domain.utils.AndroidMemoryReportService
-import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
 import java.io.File
 
 /**
  * Node main presenter has a very different setup than the rest of the apps (bisq2 core dependencies)
  */
 class NodeApplicationLifecycleService(
-    private val openTradesNotificationService: OpenTradesNotificationService,
     private val fiatAccountsServiceFacade: FiatAccountsServiceFacade,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val tradeChatMessagesServiceFacade: TradeChatMessagesServiceFacade,
@@ -134,14 +132,6 @@ class NodeApplicationLifecycleService(
     }
 
     override suspend fun deactivateServiceFacades() {
-        // tear down notification service, since we may be terminating the app
-        // and cleaning it up later makes it unnecessarily complex
-        try {
-            openTradesNotificationService.stopNotificationService()
-        } catch (e: Exception) {
-            log.w(e) { "Error at openTradesNotificationService.stopNotificationService" }
-        }
-
         // deactivate in opposite direction of activation
         messageDeliveryServiceFacade.deactivate()
         userProfileServiceFacade.deactivate()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationLifecycleService.kt
@@ -1,6 +1,9 @@
 package network.bisq.mobile.domain.service.bootstrap
 
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import network.bisq.mobile.domain.PlatformType
 import network.bisq.mobile.domain.getPlatformInfo
@@ -14,6 +17,9 @@ abstract class ApplicationLifecycleService(
     private val kmpTorService: KmpTorService,
 ) : BaseService() {
     private val isTerminating = atomic<Boolean>(false)
+
+    private val _isInitializationComplete = MutableStateFlow(false)
+    val isInitializationComplete: StateFlow<Boolean> = _isInitializationComplete.asStateFlow()
 
     /**
      * Marks the app as terminating if not already started, returns true if this is the first call.
@@ -33,6 +39,8 @@ abstract class ApplicationLifecycleService(
         serviceScope.launch {
             try {
                 activateServiceFacades()
+                _isInitializationComplete.value = true
+                log.i { "Service facades activation completed" }
             } catch (e: Exception) {
                 onUnrecoverableError(e)
             }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
@@ -331,6 +331,7 @@ class CreateOfferAmountPresenterTest {
         val notificationController = FakeNotificationController()
         val foregroundServiceController = FakeForegroundServiceController()
         val foregroundDetector = FakeForegroundDetector()
+        val testApplicationLifecycleService = TestApplicationLifecycleService()
         val openTradesNotificationService =
             OpenTradesNotificationService(
                 notificationController,
@@ -338,6 +339,7 @@ class CreateOfferAmountPresenterTest {
                 tradesServiceFacade,
                 userProfileServiceFacade,
                 foregroundDetector,
+                testApplicationLifecycleService.isInitializationComplete,
             )
         val settingsService = FakeSettingsServiceFacade()
         val tradeReadStateRepository = FakeTradeReadStateRepository()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -341,6 +341,7 @@ class TakeOfferAmountPresenterTest {
         val notificationController = FakeNotificationController()
         val foregroundServiceController = FakeForegroundServiceController()
         val foregroundDetector = FakeForegroundDetector()
+        val testApplicationLifecycleService = TestApplicationLifecycleService()
         val openTradesNotificationService =
             OpenTradesNotificationService(
                 notificationController,
@@ -348,6 +349,7 @@ class TakeOfferAmountPresenterTest {
                 tradesServiceFacade,
                 userProfileServiceFacade,
                 foregroundDetector,
+                testApplicationLifecycleService.isInitializationComplete,
             )
         val settingsService = FakeSettingsServiceFacade()
         val tradeReadStateRepository = FakeTradeReadStateRepository()


### PR DESCRIPTION
 - resolves #853 
 - please see explanations in associated issue last comment☝️ 
 - This PR do not allow foreground service init if app is still doing the init sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of the notification service by ensuring it only activates after the application is fully initialized, preventing startup errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->