### PR TITLE
bugfix/remote_foreground_slow_devices_crash

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
@@ -60,6 +60,7 @@ val androidClientPresentationModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -43,6 +43,7 @@ val iosClientDomainModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
         single<UrlLauncher> { IOSUrlLauncher() }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -105,6 +105,11 @@ class NodeApplicationLifecycleService(
     }
 
     override suspend fun activateServiceFacades() {
+        // Start foreground service FIRST, before any heavy work, to avoid
+        // ForegroundServiceDidNotStartInTimeException
+        log.i { "Starting foreground notification service" }
+        openTradesNotificationService.startService()
+
         androidMemoryReportService.initialize()
         applicationBootstrapFacade.activate() // sets bootstraps states and listeners
         networkServiceFacade.activate()


### PR DESCRIPTION
 - fix #853 
 - separate foreground service init from register/unrester observers and use it appropriatly to launch the service on app start only once
 - this will avoid the system crash issues on slower devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents a startup timeout when the notification service is started in the background.
  * Stabilizes behavior across foreground/background transitions to avoid missed notifications.

* **Improvements**
  * Keeps the notification service running across transitions to maintain process priority.
  * Better cleanup of orphaned trade state and safer observer registration/unregistration.
  * Added lifecycle logging for easier troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->