### PR TITLE
Wip adjustments for new api access

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/utils/Headers.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/utils/Headers.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.client.common.domain.utils
+
+object Headers {
+    // Bisq-specific headers
+    const val SESSION_ID = "Bisq-Session-Id"
+    const val TIMESTAMP = "Bisq-Timestamp"
+    const val NONCE = "Bisq-Nonce"
+    const val SIGNATURE = "Bisq-Signature"
+    const val DEVICE_ID = "Bisq-Device-Id"
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
+import io.ktor.http.headers
 import io.ktor.http.parseUrl
 import io.ktor.http.path
 import io.ktor.util.collections.ConcurrentMap
@@ -42,6 +43,7 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.httpclient.AuthUtils
 import network.bisq.mobile.client.common.domain.httpclient.exception.PasswordIncorrectOrMissingException
+import network.bisq.mobile.client.common.domain.utils.Headers
 import network.bisq.mobile.client.common.domain.websocket.exception.IncompatibleHttpApiVersionException
 import network.bisq.mobile.client.common.domain.websocket.exception.MaximumRetryReachedException
 import network.bisq.mobile.client.common.domain.websocket.exception.WebSocketIsReconnecting
@@ -113,6 +115,13 @@ class WebSocketClientImpl(
                 log.d { "WS connecting to $apiUrl ..." }
                 _webSocketClientStatus.value = ConnectionState.Connecting
                 val startTime = DateUtils.now()
+
+                // TODO
+                val sessionId = "sessionId TODO"
+                val nonce = "nonce TODO"
+                val timestamp = "timestamp TODO"
+                val signature = "signature TODO"
+
                 val newSession =
                     withTimeout(timeout) {
                         httpClient.webSocketSession {
@@ -123,6 +132,14 @@ class WebSocketClientImpl(
                                 host = apiUrl.host
                                 port = apiUrl.port
                                 path("/websocket")
+                            }
+                            headers {
+                                append("Content-Type", "application/json")
+                                append("Accept", "application/json")
+                                append(Headers.SESSION_ID, sessionId)
+                                append(Headers.NONCE, nonce)
+                                append(Headers.TIMESTAMP, timestamp)
+                                append(Headers.SIGNATURE, signature)
                             }
                         }
                     }
@@ -401,13 +418,30 @@ class WebSocketClientImpl(
 
     private suspend fun getApiVersion(): ApiVersionSettingsVO {
         val requestId = createUuid()
+        val deviceId = "deviceId"
+
+        // TODO
+        val sessionId = "sessionId TODO"
+        val nonce = "nonce TODO"
+        val timestamp = "timestamp TODO"
+        val signature = "signature TODO"
+
         val webSocketRestApiRequest =
             WebSocketRestApiRequest(
-                requestId,
-                "GET",
-                "/api/v1/settings/version",
-                "",
-                deviceId = "TODO"
+                requestId = requestId,
+                method = "GET",
+                path = "/api/v1/settings/version",
+                body = "",
+                headers =
+                    mapOf(
+                        "Content-Type" to "application/json",
+                        "Accept" to "application/json",
+                        Headers.SESSION_ID to sessionId,
+                        Headers.NONCE to nonce,
+                        Headers.TIMESTAMP to timestamp,
+                        Headers.SIGNATURE to signature,
+                    ),
+                deviceId = deviceId,
             )
         val response = sendRequestAndAwaitResponse(webSocketRestApiRequest, false)
         require(response is WebSocketRestApiResponse) { "Response not of expected type. response=$response" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClient.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.http.headers
 import io.ktor.http.isSuccess
 import io.ktor.http.path
 import kotlinx.coroutines.CancellationException
@@ -15,13 +16,14 @@ import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
 import network.bisq.mobile.client.common.domain.httpclient.exception.PasswordIncorrectOrMissingException
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
+import network.bisq.mobile.client.common.domain.utils.Headers
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiRequest
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiResponse
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.domain.utils.createUuid
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 class WebSocketApiClient(
     val httpClientService: HttpClientService,
@@ -30,7 +32,7 @@ class WebSocketApiClient(
 ) : Logging {
     val apiPath = "/api/v1/"
 
-    // POST and PATCH request are not working yes on the backend.
+    // PUT, POST and PATCH request are not working yet on the backend.
     // So we use httpClient instead.
     val useHttpClient = true
 
@@ -57,14 +59,26 @@ class WebSocketApiClient(
         if (useHttpClient) {
             log.d { "HTTP PUT to " + (apiPath + path) }
             log.d { "Request body: $requestBody" }
+
+            // TODO
+            val sessionId = "sessionId TODO"
+            val nonce = "nonce TODO"
+            val timestamp = "timestamp TODO"
+            val signature = "signature TODO"
             try {
                 val response: HttpResponse =
                     httpClientService.put {
                         url {
                             path(apiPath + path)
                         }
-                        contentType(ContentType.Application.Json)
-                        accept(ContentType.Application.Json)
+                        headers {
+                            append("Content-Type", "application/json")
+                            append("Accept", "application/json")
+                            append(Headers.SESSION_ID, sessionId)
+                            append(Headers.NONCE, nonce)
+                            append(Headers.TIMESTAMP, timestamp)
+                            append(Headers.SIGNATURE, signature)
+                        }
                         setBody(requestBody)
                     }
                 log.d { "HTTP PUT done status=${response.status}" }
@@ -88,11 +102,17 @@ class WebSocketApiClient(
         if (useHttpClient) {
             log.d { "HTTP PATCH to ${apiPath + path}" }
             log.d { "Request body: $requestBody" }
+
+            // TODO
+            val sessionId = "sessionId TODO"
+            val nonce = "nonce TODO"
+            val timestamp = "timestamp TODO"
+            val signature = "signature TODO"
+
             try {
                 // Serialize to JSON to see what's actually being sent
                 val bodyAsJson = json.encodeToString(requestBody)
                 log.d { "Request body as JSON: $bodyAsJson" }
-
                 val response: HttpResponse =
                     httpClientService.patch {
                         url {
@@ -100,6 +120,12 @@ class WebSocketApiClient(
                         }
                         contentType(ContentType.Application.Json)
                         accept(ContentType.Application.Json)
+                        headers {
+                            append(Headers.SESSION_ID, sessionId)
+                            append(Headers.NONCE, nonce)
+                            append(Headers.TIMESTAMP, timestamp)
+                            append(Headers.SIGNATURE, signature)
+                        }
                         setBody(requestBody)
                     }
                 log.d { "HTTP PATCH done status=${response.status}" }
@@ -122,6 +148,12 @@ class WebSocketApiClient(
         if (useHttpClient) {
             log.d { "HTTP POST to ${apiPath + path}" }
             log.d { "Request body: $requestBody" }
+
+            // TODO
+            val sessionId = "sessionId TODO"
+            val nonce = "nonce TODO"
+            val timestamp = "timestamp TODO"
+            val signature = "signature TODO"
             try {
                 val response: HttpResponse =
                     httpClientService.post {
@@ -130,6 +162,12 @@ class WebSocketApiClient(
                         }
                         contentType(ContentType.Application.Json)
                         accept(ContentType.Application.Json)
+                        headers {
+                            append(Headers.SESSION_ID, sessionId)
+                            append(Headers.NONCE, nonce)
+                            append(Headers.TIMESTAMP, timestamp)
+                            append(Headers.SIGNATURE, signature)
+                        }
                         setBody(requestBody)
                     }
                 log.d { "HTTP POST done status=${response.status}" }
@@ -174,15 +212,32 @@ class WebSocketApiClient(
         bodyAsJson: String = "",
         handleNoContent: () -> Result<R>,
     ): Result<R> {
-        val requestId = Uuid.random().toString()
         val fullPath = apiPath + path
+        val requestId = createUuid()
+
+        // TODO
+        val deviceId = "deviceId"
+        val sessionId = "sessionId TODO"
+        val nonce = "nonce TODO"
+        val timestamp = "timestamp TODO"
+        val signature = "signature TODO"
+
         val webSocketRestApiRequest =
             WebSocketRestApiRequest(
-                requestId,
-                method,
-                fullPath,
-                bodyAsJson,
-                "TODO"
+                requestId = requestId,
+                method = method,
+                path = fullPath,
+                body = bodyAsJson,
+                headers =
+                    mapOf(
+                        "Content-Type" to "application/json",
+                        "Accept" to "application/json",
+                        Headers.SESSION_ID to sessionId,
+                        Headers.NONCE to nonce,
+                        Headers.TIMESTAMP to timestamp,
+                        Headers.SIGNATURE to signature,
+                    ),
+                deviceId = deviceId,
             )
         try {
             val startTime = DateUtils.now()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/messages/WebSocketRestApiRequest.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/messages/WebSocketRestApiRequest.kt
@@ -11,7 +11,7 @@ data class WebSocketRestApiRequest(
     val method: String,
     val path: String,
     val body: String,
-
+    val headers: Map<String, String>,
     // TODO
     // Device UUID is created and persisted at the client. It will be associated with a user defined device
     // name which will be sent to the server in the PairingRequestPayload.


### PR DESCRIPTION
This is a partial preparation for the new api access model as discussed in: https://github.com/bisq-network/bisq2/discussions/4206

The Bisq 2 side implementation is prepared in: https://github.com/bisq-network/bisq2/pull/4238

For testing with Bisq 2 you can set new `authRequired` flag in the new config to false to skip all authentication and authorization checks.

This PR can be treated as draft and dropped later, and instead replaced by a production ready PR.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device identification added to generate unique device IDs for improved session tracking.
  * Session-based headers (session ID, timestamp, nonce, signature) applied to WebSocket and HTTP requests for richer request context and handshake.

* **Refactor**
  * Shifted from token-centric auth fields to header-based session handling, updating request payloads and handshake flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->