### PR TITLE
bugfix/disable_flaky_ci_test

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -493,6 +493,7 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
+    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_cross_market_payment_filter_persistence() =
         runTest(testDispatcher) {
             // Scenario: User filters to only WISE and REVOLUT,


### PR DESCRIPTION
 - cherry picked from #1112 as it won't be merged anytime soon and it affects the rest of the PRs
 - Ignore CI flaky test_cross_market_payment_filter_persistence
 - Temporarily disabled until Offerbook filter timing is stabilized, consistent with other similar tests already ignored in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Skipped flaky test to improve CI stability on Linux environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->