### PR TITLE
bugfix/fix_ci_not_grabbing_latest_deps_for_node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -76,7 +76,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -86,7 +86,7 @@ jobs:
         with:
           path: |
             ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-konan-
 
@@ -276,7 +276,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,8 @@
 
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.8"
-bisq-core-commit = "2428db01510b3fa6f5290a6cd3b805d91580e0ec"
+# Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
+bisq-core-commit = "96a07890a2c65c5e98f9525ad92282bc4fac04ad"
 # API version is usually same as bisq-core but for more control we keep it separated
 #bisq-api = "2.1.8"
 


### PR DESCRIPTION
 - fixes #1125 
  - add toml file to gradle deps cache key generation
 - update bisq-core commit reference to latest to force deps redownload when running node CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline caching efficiency by including dependency manifest files in cache invalidation calculations across multiple build workflows.
  * Updated internal build dependency versions to latest available commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->