### PR TITLE
feature/ios_tls_certificate_pinning

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/security/SanVerifierTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/security/SanVerifierTest.kt
@@ -1,0 +1,98 @@
+package network.bisq.mobile.client.common.domain.access.security
+
+import io.mockk.every
+import io.mockk.mockk
+import java.security.cert.X509Certificate
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SanVerifierTest {
+    private fun certWithSans(vararg sans: Pair<Int, String>): X509Certificate =
+        mockk {
+            every { subjectAlternativeNames } returns
+                sans.map { (type, value) -> listOf(type, value) }
+        }
+
+    private fun certWithNoSans(): X509Certificate =
+        mockk {
+            every { subjectAlternativeNames } returns null
+        }
+
+    @Test
+    fun `matches DNS SAN entry`() {
+        val cert = certWithSans(2 to "example.com")
+        assertTrue(SanVerifier.matchesHost(cert, "example.com"))
+    }
+
+    @Test
+    fun `DNS match is case insensitive`() {
+        val cert = certWithSans(2 to "Example.COM")
+        assertTrue(SanVerifier.matchesHost(cert, "example.com"))
+    }
+
+    @Test
+    fun `matches IP SAN entry`() {
+        val cert = certWithSans(7 to "127.0.0.1")
+        assertTrue(SanVerifier.matchesHost(cert, "127.0.0.1"))
+    }
+
+    @Test
+    fun `IP match is case sensitive`() {
+        val cert = certWithSans(7 to "127.0.0.1")
+        assertFalse(SanVerifier.matchesHost(cert, "127.0.0.01"))
+    }
+
+    @Test
+    fun `returns false when no SANs present`() {
+        val cert = certWithNoSans()
+        assertFalse(SanVerifier.matchesHost(cert, "example.com"))
+    }
+
+    @Test
+    fun `returns false when host not in SANs`() {
+        val cert = certWithSans(2 to "other.com")
+        assertFalse(SanVerifier.matchesHost(cert, "example.com"))
+    }
+
+    @Test
+    fun `matches among multiple SANs`() {
+        val cert =
+            certWithSans(
+                2 to "first.com",
+                2 to "second.com",
+                7 to "192.168.1.1",
+            )
+        assertTrue(SanVerifier.matchesHost(cert, "second.com"))
+        assertTrue(SanVerifier.matchesHost(cert, "192.168.1.1"))
+        assertFalse(SanVerifier.matchesHost(cert, "third.com"))
+    }
+
+    @Test
+    fun `matches localhost as DNS entry`() {
+        val cert = certWithSans(2 to "localhost")
+        assertTrue(SanVerifier.matchesHost(cert, "localhost"))
+    }
+
+    @Test
+    fun `matches loopback as IP entry`() {
+        val cert = certWithSans(7 to "127.0.0.1")
+        assertTrue(SanVerifier.matchesHost(cert, "127.0.0.1"))
+    }
+
+    @Test
+    fun `returns false on exception`() {
+        val cert =
+            mockk<X509Certificate> {
+                every { subjectAlternativeNames } throws RuntimeException("cert error")
+            }
+        assertFalse(SanVerifier.matchesHost(cert, "example.com"))
+    }
+
+    @Test
+    fun `ignores non-DNS non-IP SAN types`() {
+        // type 1 = rfc822Name (email), should not match
+        val cert = certWithSans(1 to "example.com")
+        assertFalse(SanVerifier.matchesHost(cert, "example.com"))
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/security/TlsTrustManagerTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/security/TlsTrustManagerTest.kt
@@ -1,0 +1,144 @@
+package network.bisq.mobile.client.common.domain.access.security
+
+import android.util.Base64
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import network.bisq.mobile.client.common.domain.access.pairing.qr.ANDROID_LOCALHOST
+import network.bisq.mobile.client.common.domain.access.pairing.qr.LOOPBACK
+import java.security.MessageDigest
+import java.security.cert.X509Certificate
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TlsTrustManagerTest {
+    private val certBytes = "fake-cert-bytes".toByteArray()
+    private val certHash =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(certBytes)
+    private val validFingerprint =
+        java.util.Base64
+            .getEncoder()
+            .encodeToString(certHash)
+
+    @BeforeTest
+    fun setup() {
+        mockkStatic(Base64::class)
+        every { Base64.decode(any<String>(), any()) } answers {
+            java.util.Base64
+                .getDecoder()
+                .decode(firstArg<String>())
+        }
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkStatic(Base64::class)
+    }
+
+    private fun certWithSanAndBytes(
+        sanHost: String,
+        sanType: Int = 7,
+        encoded: ByteArray = certBytes,
+    ): X509Certificate =
+        mockk {
+            every { subjectAlternativeNames } returns listOf(listOf(sanType, sanHost))
+            every { getEncoded() } returns encoded
+        }
+
+    @Test
+    fun `accepts valid cert with matching fingerprint and SAN IP`() {
+        val cert = certWithSanAndBytes(LOOPBACK)
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        // Should not throw
+        trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+    }
+
+    @Test
+    fun `accepts valid cert with matching fingerprint and SAN DNS`() {
+        val cert = certWithSanAndBytes("example.com", sanType = 2)
+        val trustManager = TlsTrustManager("example.com", validFingerprint)
+
+        trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+    }
+
+    @Test
+    fun `rejects cert with wrong fingerprint`() {
+        val cert = certWithSanAndBytes(LOOPBACK, encoded = "different-cert".toByteArray())
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        assertFailsWith<SecurityException> {
+            trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+        }
+    }
+
+    @Test
+    fun `rejects cert with non-matching SAN`() {
+        val cert = certWithSanAndBytes("192.168.1.1")
+        val trustManager = TlsTrustManager("10.0.0.1", validFingerprint)
+
+        assertFailsWith<SecurityException> {
+            trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+        }
+    }
+
+    @Test
+    fun `throws on null certificate chain`() {
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        assertFailsWith<IllegalArgumentException> {
+            trustManager.checkServerTrusted(null, "RSA")
+        }
+    }
+
+    @Test
+    fun `throws on empty certificate chain`() {
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        assertFailsWith<IllegalArgumentException> {
+            trustManager.checkServerTrusted(emptyArray(), "RSA")
+        }
+    }
+
+    @Test
+    fun `maps ANDROID_LOCALHOST to LOOPBACK for SAN check`() {
+        // Server cert has SAN for 127.0.0.1, but client uses 10.0.2.2
+        val cert = certWithSanAndBytes(LOOPBACK)
+        val trustManager = TlsTrustManager(ANDROID_LOCALHOST, validFingerprint)
+
+        // Should succeed because ANDROID_LOCALHOST gets mapped to LOOPBACK
+        trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+    }
+
+    @Test
+    fun `falls back to localhost when LOOPBACK SAN fails`() {
+        // Cert has "localhost" as DNS SAN, not 127.0.0.1
+        val cert = certWithSanAndBytes("localhost", sanType = 2, encoded = certBytes)
+        val trustManager = TlsTrustManager(ANDROID_LOCALHOST, validFingerprint)
+
+        // Should succeed because after LOOPBACK fails, it tries "localhost"
+        trustManager.checkServerTrusted(arrayOf(cert), "RSA")
+    }
+
+    @Test
+    fun `checkClientTrusted throws UnsupportedOperationException`() {
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        assertFailsWith<UnsupportedOperationException> {
+            trustManager.checkClientTrusted(null, "RSA")
+        }
+    }
+
+    @Test
+    fun `getAcceptedIssuers returns empty array`() {
+        val trustManager = TlsTrustManager(LOOPBACK, validFingerprint)
+
+        assertTrue(trustManager.acceptedIssuers.isEmpty())
+    }
+}


### PR DESCRIPTION
 - contribs to #1087 
 - Implement iOS certificate pinning (TLS) using KTor + darwin and add/improve unit tests
 - remove now unnecessary TODO
 - full on testing is on the works to close the above issue, this is a feature to pair functionality with Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for certificate validation and Subject Alternative Name (SAN) matching.
  * Added extensive test suite for TLS trust manager functionality, including fingerprint validation, certificate chain handling, and special cases for localhost scenarios.

* **New Features**
  * Implemented TLS certificate pinning support on iOS platform with runtime validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->