### PR TITLE
fix: wait for openTradeItems before chat sub

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -90,6 +90,8 @@ class ClientTradeChatMessagesServiceFacade(
     }
 
     private suspend fun subscribeChatReactions() {
+        // wait for first open trade to start subscribing so that updateChatMessages works properly
+        tradesServiceFacade.openTradeItems.first { it.isNotEmpty() }
         val observer = apiGateway.subscribeChatReactions()
         observer.webSocketEvent.collect { webSocketEvent ->
             if (webSocketEvent?.deferredPayload == null) {


### PR DESCRIPTION
resolves #1141 

I also cleaned up the unnecessary tracking of jobs as it's already tracked by job manager and cancelled on deactivation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified background processing for trade chat updates to reduce complexity.
  * Added synchronization to ensure chat subscriptions wait for necessary trade data before starting.
  * Result: more reliable and timely chat message and reaction updates with improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->