### PR TITLE
Dismiss current snackbar to first to display the new one

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -153,6 +153,8 @@ fun App(
         globalUiManager.snackbarActions.collect { action ->
             when (action) {
                 is SnackbarAction.Show -> {
+                    // Dismiss any existing snackbar first, then show the new one
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     // Launch in child coroutine so collector isn't blocked while snackbar shows
                     launch {
                         snackbarHostState.showSnackbar(


### PR DESCRIPTION


https://github.com/user-attachments/assets/04f35308-1316-435d-bf93-f9de25d08d50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved snackbar display issue where previous notification messages could remain visible when new messages arrived. The app now properly clears prior notifications before displaying new ones, ensuring clean notification display without overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->