### PR TITLE
Implement one button dialog for the no mediator dialog

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
@@ -102,7 +102,9 @@ fun InterruptedTradePane() {
         if (showNoMediatorAvailableWarningDialog) {
             WarningConfirmationDialog(
                 onConfirm = presenter::onDismissNoMediatorAvailableWarningDialog,
-                onDismiss = presenter::onDismissNoMediatorAvailableWarningDialog,
+                onDismiss = { },
+                dismissButtonText = EMPTY_STRING,
+                confirmButtonText = "action.close".i18n(),
                 message = "bisqEasy.takeOffer.noMediatorAvailable.warning".i18n(),
             )
         }


### PR DESCRIPTION
<img width="320" height="714" alt="one-button-dialog" src="https://github.com/user-attachments/assets/6e185016-e417-46b1-891f-f9dbe00aa084" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the interrupted trade dialog to display correct button labels and improve dismissal behavior. The confirm button now displays "Close" and the dismiss button is hidden, streamlining the user interaction with trade interruption notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->