### PR TITLE
bugfix/market_premium_offers_show_market_snapshot_price_instead_off_final

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/data/replicated/presentation/open_trades/TradeItemPresentationModel.kt
@@ -33,7 +33,8 @@ data class TradeItemPresentationModel(
     val formattedTime: String get() = tradeItemPresentationDto.formattedTime
     val market: String get() = tradeItemPresentationDto.market
     val price: Long get() = tradeItemPresentationDto.price
-    val formattedPrice: String get() = PriceSpecFormatter.getFormattedPriceSpec(bisqEasyOffer.priceSpec, true)
+    val formattedPrice: String get() = tradeItemPresentationDto.formattedPrice
+    val formattedPriceSpec: String get() = PriceSpecFormatter.getFormattedPriceSpec(bisqEasyOffer.priceSpec, true)
     val baseAmount: Long get() = tradeItemPresentationDto.baseAmount
     val formattedBaseAmount: String get() = NumberFormatter.btcFormat(baseAmount)
     val quoteAmount: Long get() = tradeItemPresentationDto.quoteAmount

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/formatters/PriceSpecFormatter.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/formatters/PriceSpecFormatter.kt
@@ -40,6 +40,15 @@ object PriceSpecFormatter {
             else -> "bisqEasy.tradeWizard.review.chatMessage.marketPrice".i18n()
         }
 
+    fun formatPriceWithSpec(
+        formattedPrice: String,
+        priceSpec: PriceSpecVO,
+    ): String {
+        if (priceSpec is FixPriceSpecVO) return formattedPrice
+        val abbreviated = getFormattedPriceSpec(priceSpec, abbreviated = true)
+        return "$formattedPrice ($abbreviated)"
+    }
+
     fun getFormattedPriceSpecWithOfferPrice(
         priceSpec: PriceSpecVO,
         offerPrice: String,

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/formatters/PriceSpecFormatterTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/formatters/PriceSpecFormatterTest.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.domain.data.replicated.offer.price.spec.MarketPriceSp
 import network.bisq.mobile.i18n.I18nSupport
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class PriceSpecFormatterTest {
@@ -103,5 +104,42 @@ class PriceSpecFormatterTest {
         val priceSpec = MarketPriceSpecVO()
         val result = PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(priceSpec, "50,000 USD")
         assertTrue(result.isNotEmpty())
+    }
+
+    // --- formatPriceWithSpec tests ---
+
+    @Test
+    fun `formatPriceWithSpec with FixPriceSpec returns just the price`() {
+        val priceQuote = createTestPriceQuote(500000000)
+        val priceSpec = FixPriceSpecVO(priceQuote)
+        val result = PriceSpecFormatter.formatPriceWithSpec("50,000 USD", priceSpec)
+        assertEquals("50,000 USD", result)
+    }
+
+    @Test
+    fun `formatPriceWithSpec with FloatPriceSpec positive appends abbreviated spec`() {
+        val priceSpec = FloatPriceSpecVO(0.05) // 5% above
+        val result = PriceSpecFormatter.formatPriceWithSpec("105,000 USD", priceSpec)
+        // Should be "105,000 USD (+5%)" or similar with abbreviated spec in parentheses
+        assertTrue(result.startsWith("105,000 USD ("), "Result should start with price and open paren, was: $result")
+        assertTrue(result.endsWith(")"), "Result should end with close paren, was: $result")
+        assertTrue(result.contains("5"), "Result should contain the percentage value, was: $result")
+    }
+
+    @Test
+    fun `formatPriceWithSpec with FloatPriceSpec negative appends abbreviated spec`() {
+        val priceSpec = FloatPriceSpecVO(-0.03) // 3% below
+        val result = PriceSpecFormatter.formatPriceWithSpec("97,000 USD", priceSpec)
+        assertTrue(result.startsWith("97,000 USD ("), "Result should start with price and open paren, was: $result")
+        assertTrue(result.endsWith(")"), "Result should end with close paren, was: $result")
+        assertTrue(result.contains("3"), "Result should contain the percentage value, was: $result")
+    }
+
+    @Test
+    fun `formatPriceWithSpec with MarketPriceSpec appends market price label`() {
+        val priceSpec = MarketPriceSpecVO()
+        val result = PriceSpecFormatter.formatPriceWithSpec("100,000 USD", priceSpec)
+        assertTrue(result.startsWith("100,000 USD ("), "Result should start with price and open paren, was: $result")
+        assertTrue(result.endsWith(")"), "Result should end with close paren, was: $result")
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferCard.kt
@@ -26,6 +26,7 @@ import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.mirror
 import network.bisq.mobile.domain.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.domain.formatters.PriceSpecFormatter
 import network.bisq.mobile.domain.utils.StringUtils.truncate
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.AutoResizeText
@@ -162,8 +163,14 @@ fun OfferCard(
 
             BisqGap.VHalf()
 
+            val formattedPrice by item.formattedPrice.collectAsState()
+            val priceDisplay =
+                PriceSpecFormatter.formatPriceWithSpec(
+                    formattedPrice,
+                    item.bisqEasyOffer.priceSpec,
+                )
             AutoResizeText(
-                text = "@ " + item.formattedPriceSpec,
+                text = "@ $priceDisplay",
                 textStyle = BisqTheme.typography.smallLight,
                 maxLines = 1,
             )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.PlatformImage
 import network.bisq.mobile.domain.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.domain.formatters.PriceSpecFormatter
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
@@ -83,13 +84,18 @@ fun OpenTradeListItem(
                     color = BisqTheme.colors.primary,
                 )
                 BisqGap.VHalf()
+                val priceDisplay =
+                    PriceSpecFormatter.formatPriceWithSpec(
+                        item.formattedPrice,
+                        item.bisqEasyOffer.priceSpec,
+                    )
                 Row(modifier = Modifier.padding(top = 1.dp)) {
-                    if (item.formattedPrice.length > 18) {
+                    if (priceDisplay.length > 18) {
                         BisqText.XSmallRegularGrey("@ ")
-                        BisqText.XSmallRegular(item.formattedPrice)
+                        BisqText.XSmallRegular(priceDisplay)
                     } else {
                         BisqText.SmallRegularGrey("@ ")
-                        BisqText.SmallRegular(item.formattedPrice)
+                        BisqText.SmallRegular(priceDisplay)
                     }
                 }
                 BisqGap.VQuarter()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.data.replicated.offer.DirectionEnumExtensions.isSell
+import network.bisq.mobile.domain.formatters.PriceSpecFormatter
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
@@ -193,10 +194,15 @@ fun TradeDetailsHeader(presenter: TradeDetailsHeaderPresenter = koinInject()) {
                         verticalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier.weight(2f),
                     ) {
+                        val priceDisplay =
+                            PriceSpecFormatter.formatPriceWithSpec(
+                                item.formattedPrice,
+                                item.bisqEasyOffer.priceSpec,
+                            )
                         if (presenter.isSmallScreen()) {
                             InfoBox(
                                 label = "bisqEasy.openTrades.table.price".i18n(),
-                                value = item.formattedPrice,
+                                value = priceDisplay,
                             )
                             BisqGap.V1()
                             InfoBox(
@@ -206,7 +212,7 @@ fun TradeDetailsHeader(presenter: TradeDetailsHeaderPresenter = koinInject()) {
                         } else {
                             InfoRow(
                                 label1 = "bisqEasy.openTrades.table.price".i18n(),
-                                value1 = item.formattedPrice,
+                                value1 = priceDisplay,
                                 label2 = "bisqEasy.openTrades.tradeDetails.tradeDate".i18n(),
                                 value2 = "${item.formattedDate} ${item.formattedTime}",
                             )


### PR DESCRIPTION
 - fixes #1203 
 - fixed  Offerbook (OfferCard) — formattedPrice StateFlow (actual trade price) existed but was never displayed; only formattedPriceSpec (e.g., "5% above market price") was shown
 - Trade screens — TradeItemPresentationModel.formattedPrice was overriding the backend's actual formatted trade price(e.g., "105,000 USD") with PriceSpecFormatter.getFormattedPriceSpec(...) which returns abbreviated spec text ("+5%")
 - add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price display consistency across trade interfaces by showing prices with their specifications (fixed, floating, or market-based).

* **Tests**
  * Added comprehensive test coverage for price specification formatting across different pricing models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->