### PR TITLE
chore: make all platform checks consistent

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoder.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoder.kt
@@ -3,8 +3,9 @@ package network.bisq.mobile.client.common.domain.access.pairing.qr
 import network.bisq.mobile.client.common.domain.access.LOCALHOST
 import network.bisq.mobile.client.common.domain.access.pairing.PairingCodeDecoder
 import network.bisq.mobile.client.common.domain.utils.BinaryDecodingUtils
+import network.bisq.mobile.domain.PlatformType
 import network.bisq.mobile.domain.data.EnvironmentController
-import network.bisq.mobile.domain.utils.isIOS
+import network.bisq.mobile.domain.getPlatformInfo
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -75,7 +76,7 @@ class PairingQrCodeDecoder(
         if (url.contains(".onion")) return url
         // On emulators/simulators, replace the host with the appropriate loopback
         // because emulators can't reach LAN IPs — they route to the host via special addresses
-        val emulatorHost = if (isIOS()) LOCALHOST else ANDROID_LOCALHOST
+        val emulatorHost = if (getPlatformInfo().type == PlatformType.IOS) LOCALHOST else ANDROID_LOCALHOST
         return replaceHost(url, emulatorHost)
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/PlatformUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/PlatformUtils.kt
@@ -1,9 +1,0 @@
-package network.bisq.mobile.domain.utils
-
-import network.bisq.mobile.domain.getPlatformInfo
-
-fun isIOS(): Boolean {
-    val platformInfo = getPlatformInfo()
-    val isIOS = platformInfo.name.lowercase().contains("ios")
-    return isIOS
-}

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.android.kt
@@ -3,5 +3,3 @@ package network.bisq.mobile.presentation.common.ui.platform
 import androidx.compose.ui.text.PlatformTextStyle
 
 actual fun platformTextStyleNoFontPadding(): PlatformTextStyle? = PlatformTextStyle(includeFontPadding = false)
-
-actual fun isIOSPlatform(): Boolean = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import network.bisq.mobile.domain.PlatformType
 import network.bisq.mobile.domain.data.model.BaseModel
 import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
@@ -185,8 +186,7 @@ abstract class BasePresenter(
     }
 
     override fun isIOS(): Boolean {
-        val platformInfo = getPlatformInfo()
-        val isIOS = platformInfo.name.lowercase().contains("ios")
+        val isIOS = getPlatformInfo().type == PlatformType.IOS
         log.d { "isIOS = $isIOS" }
         return isIOS
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PaymentMethodIcon.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PaymentMethodIcon.kt
@@ -14,11 +14,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.domain.PlatformType
+import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.common.ui.platform.CUSTOM_PAYMENT_BACKGROUND_COLORS
 import network.bisq.mobile.presentation.common.ui.platform.customPaymentOverlayLetterColor
-import network.bisq.mobile.presentation.common.ui.platform.isIOSPlatform
 import network.bisq.mobile.presentation.common.ui.platform.platformTextStyleNoFontPadding
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.customPaymentIconIndex
@@ -81,7 +82,7 @@ fun PaymentMethodIcon(
         modifier = Modifier.size(size),
         contentAlignment = Alignment.Center,
     ) {
-        if (isMissingIcon && isIOSPlatform()) {
+        if (isMissingIcon && getPlatformInfo().type == PlatformType.IOS) {
             // For custom icons on iOS, use a programmatic colored background
             val bgColor =
                 CUSTOM_PAYMENT_BACKGROUND_COLORS.getOrElse(customIndex) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.kt
@@ -2,20 +2,19 @@ package network.bisq.mobile.presentation.common.ui.platform
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.PlatformTextStyle
+import network.bisq.mobile.domain.PlatformType
+import network.bisq.mobile.domain.getPlatformInfo
 
 // Expect/actual helper to provide a PlatformTextStyle that disables font padding on platforms that support it.
 // On platforms that don't support this flag (e.g., iOS), return null to keep defaults.
 expect fun platformTextStyleNoFontPadding(): PlatformTextStyle?
-
-// Returns true if running on iOS platform
-expect fun isIOSPlatform(): Boolean
 
 // Returns the appropriate color for custom payment icon overlay letters.
 // iOS needs a lighter color due to different text rendering that makes dark text barely visible.
 fun customPaymentOverlayLetterColor(
     darkColor: Color,
     lightColor: Color,
-): Color = if (isIOSPlatform()) lightColor else darkColor
+): Color = if (getPlatformInfo().type == PlatformType.IOS) lightColor else darkColor
 
 // Colors for custom payment icon backgrounds (matching Bisq2 desktop custom-payment-*.png)
 // These are used on iOS where the PNG images don't render correctly

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/ui/platform/TextPlatform.ios.kt
@@ -3,5 +3,3 @@ package network.bisq.mobile.presentation.common.ui.platform
 import androidx.compose.ui.text.PlatformTextStyle
 
 actual fun platformTextStyleNoFontPadding(): PlatformTextStyle? = null
-
-actual fun isIOSPlatform(): Boolean = true


### PR DESCRIPTION
resolves #1138

my reasoning:
we already had an enum defined and it was also available using getPlatformInfo
it made more sense to me to use that directly instead of creating a new function named isIosPlatform, which then imply that we would need a function named isAndroidPlatform, and then basically they do the same check under the hood, or an expect actual that returns a boolean. while that would make it shorter, it didn't seem right to have two sources of truths for this, or a wrapper function to make the check shorter.
let me know if you think otherwise

I did not touch the presenter as it seemed to be used in mocks and previews (?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated platform detection to a single, type-safe method for iOS vs Android.
  * Unified logic affects UI decisions: icon rendering and payment-method background/overlay colors now consistently reflect the device platform.
  * Introduced a predefined set of custom background colors used in payment UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->