### PR TITLE
bugfix/coroutines_freq_cancelled_before_tor_timeout

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClient.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClient.kt
@@ -13,7 +13,7 @@ interface WebSocketClient {
         const val TOR_CONNECT_TIMEOUT = 60_000L
 
         fun determineTimeout(host: String): Long =
-            if (host.endsWith(".onion")) {
+            if (host.contains(".onion")) {
                 TOR_CONNECT_TIMEOUT
             } else {
                 CLEARNET_CONNECT_TIMEOUT


### PR DESCRIPTION
 - most of the tor requests where using clearnet timeout instead of tor much longer one causing them to be cancelled degrading tor experience for connect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced onion domain detection for improved identification of TOR network connections and timeout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->