### PR TITLE
bugfix/ios_reconnection_system_flaky

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.di.commonTestModule
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.domain.PlatformInfo
+import network.bisq.mobile.domain.PlatformType
 import network.bisq.mobile.domain.service.network.ConnectivityService
 import org.junit.After
 import org.junit.Before
@@ -37,11 +39,25 @@ class ClientConnectivityServiceTest {
         webSocketClientService = mockk(relaxed = true)
         // Default: health check passes when connected
         coEvery { webSocketClientService.sendHealthCheck() } returns true
-        clientConnectivityService = ClientConnectivityService(webSocketClientService)
+        clientConnectivityService = ClientConnectivityService(webSocketClientService, androidPlatformInfo)
         // Reset static averageTripTime via public API: the averaging formula
         // (current + new) / 2 converges quickly to 0, ensuring isSlow() returns false.
         repeat(20) { ClientConnectivityService.newRequestRoundTripTime(0) }
     }
+
+    private val androidPlatformInfo =
+        object : PlatformInfo {
+            override val name = "Android Test"
+            override val type = PlatformType.ANDROID
+        }
+
+    private val iosPlatformInfo =
+        object : PlatformInfo {
+            override val name = "iOS Test"
+            override val type = PlatformType.IOS
+        }
+
+    private fun createIosService(): ClientConnectivityService = ClientConnectivityService(webSocketClientService, iosPlatformInfo)
 
     @After
     fun tearDown() {
@@ -345,5 +361,91 @@ class ClientConnectivityServiceTest {
                 ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED,
                 clientConnectivityService.status.value,
             )
+        }
+
+    // ///////////////////////////////////////////////////////////////////////////
+    // iOS-specific reconnection recovery tests
+    // ///////////////////////////////////////////////////////////////////////////
+
+    @Test
+    fun `iOS calls forceClientRecreation after threshold disconnected cycles`() =
+        runBlocking {
+            val iosService = createIosService()
+            every { webSocketClientService.isConnected() } returns false
+            coEvery { webSocketClientService.triggerReconnect() } just Runs
+            coEvery { webSocketClientService.forceClientRecreation() } just Runs
+
+            iosService.activate()
+            // Use period shorter than threshold to hit it quickly
+            // Threshold is IOS_FORCE_RECREATE_CYCLES (12), so we need 12+ cycles
+            iosService.startMonitoring(period = 50, startDelay = 0)
+            delay(50 * 15) // enough for >12 cycles
+
+            coVerify(atLeast = 1) { webSocketClientService.forceClientRecreation() }
+            iosService.stopMonitoring()
+        }
+
+    @Test
+    fun `Android never calls forceClientRecreation even after many disconnected cycles`() =
+        runBlocking {
+            every { webSocketClientService.isConnected() } returns false
+            coEvery { webSocketClientService.triggerReconnect() } just Runs
+            coEvery { webSocketClientService.forceClientRecreation() } just Runs
+
+            clientConnectivityService.activate()
+            clientConnectivityService.startMonitoring(period = 50, startDelay = 0)
+            delay(50 * 20) // well past the iOS threshold
+
+            coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
+        }
+
+    @Test
+    fun `iOS resets reconnecting counter when connection recovers`() =
+        runBlocking {
+            val iosService = createIosService()
+            var connected = false
+            every { webSocketClientService.isConnected() } answers { connected }
+            coEvery { webSocketClientService.triggerReconnect() } just Runs
+            coEvery { webSocketClientService.forceClientRecreation() } just Runs
+
+            iosService.activate()
+            iosService.startMonitoring(period = 50, startDelay = 0)
+            // Accumulate some disconnected cycles (but below threshold)
+            delay(50 * 5)
+
+            // Connection recovers
+            connected = true
+            delay(50 * 3)
+
+            assertEquals(
+                ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED,
+                iosService.status.value,
+            )
+
+            // Disconnect again — counter should have reset, so forceClientRecreation
+            // should not be called yet (we haven't hit the threshold again)
+            connected = false
+            delay(50 * 5) // only 5 cycles, below threshold of 12
+
+            coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
+            iosService.stopMonitoring()
+        }
+
+    @Test
+    fun `iOS uses triggerReconnect before reaching threshold`() =
+        runBlocking {
+            val iosService = createIosService()
+            every { webSocketClientService.isConnected() } returns false
+            coEvery { webSocketClientService.triggerReconnect() } just Runs
+            coEvery { webSocketClientService.forceClientRecreation() } just Runs
+
+            iosService.activate()
+            iosService.startMonitoring(period = 50, startDelay = 0)
+            // Only run a few cycles, below threshold
+            delay(50 * 5)
+
+            coVerify(atLeast = 1) { webSocketClientService.triggerReconnect() }
+            coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
+            iosService.stopMonitoring()
         }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/httpclient/HttpClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/httpclient/HttpClientService.kt
@@ -150,6 +150,26 @@ class HttpClientService(
     }
 
     /**
+     * Disposes the current HTTP client and recreates it from the last known settings.
+     * Used on iOS to get a fresh NSURLSession when the old one can no longer create
+     * functional WebSocket connections after repeated disconnections.
+     *
+     * Unlike [disposeClient], this immediately creates a new client and emits the
+     * settings change so [WebSocketClientService] picks it up reactively.
+     */
+    suspend fun recreateClient() {
+        val config = lastConfig ?: return
+        val oldClient = _httpClient.value
+        _httpClient.value = null
+        oldClient?.close()
+        lastConfig = null
+        // Treat as new config by resetting lastConfig first
+        lastConfig = config
+        _httpClient.value = createNewInstance(config)
+        _httpClientChangedFlow.emit(config)
+    }
+
+    /**
      * Suspends until the HTTP client has been created/updated and is ready for use.
      * This should be called before making requests that depend on updated settings.
      * @param timeoutMs Maximum time to wait for the client to be ready (default 5000ms)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
@@ -12,18 +12,23 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.domain.PlatformInfo
+import network.bisq.mobile.domain.PlatformType
+import network.bisq.mobile.domain.getPlatformInfo
 import network.bisq.mobile.domain.service.network.ConnectivityService
 import network.bisq.mobile.domain.utils.Logging
 import kotlin.concurrent.Volatile
 
 class ClientConnectivityService(
     private val webSocketClientService: WebSocketClientService,
+    private val platformInfo: PlatformInfo = getPlatformInfo(),
 ) : ConnectivityService(),
     Logging {
     companion object {
         const val TIMEOUT = 5000L
         const val PERIOD = 5000L // default check every 5 sec
         const val ROUND_TRIP_SLOW_THRESHOLD = 500L
+        internal const val IOS_FORCE_RECREATE_CYCLES = 12 // ~60s at default 5s period
 
         private const val DEFAULT_AVERAGE_TRIP_TIME = -1L // invalid
         const val MIN_REQUESTS_TO_ASSESS_SPEED = 3 // invalid
@@ -61,6 +66,7 @@ class ClientConnectivityService(
     private val pendingJobs = mutableListOf<Job>()
     private val pendingConnectivityBlocks = mutableListOf<suspend () -> Unit>()
     private val mutex = Mutex()
+    private var consecutiveReconnectingCycles = 0
 
     override suspend fun activate() {
         super.activate()
@@ -112,12 +118,23 @@ class ClientConnectivityService(
             val newStatus =
                 when {
                     !isConnected() -> {
-                        // Trigger reconnection attempt to recover from max-retry
-                        // exhaustion or transient network outages
-                        webSocketClientService.triggerReconnect()
+                        consecutiveReconnectingCycles++
+                        if (shouldForceClientRecreation()) {
+                            // iOS: Darwin engine's NSURLSession may not create functional
+                            // WebSocket connections after repeated failures on the same
+                            // session. Force full client recreation with a fresh NSURLSession.
+                            log.i { "iOS: forcing client recreation after $consecutiveReconnectingCycles failed cycles" }
+                            webSocketClientService.forceClientRecreation()
+                            consecutiveReconnectingCycles = 0
+                        } else {
+                            // Trigger reconnection attempt to recover from max-retry
+                            // exhaustion or transient network outages
+                            webSocketClientService.triggerReconnect()
+                        }
                         ConnectivityStatus.RECONNECTING
                     }
                     else -> {
+                        consecutiveReconnectingCycles = 0
                         // Actively verify the connection with a lightweight request.
                         // On iOS the Darwin engine does not reliably detect dead TCP
                         // connections, so isConnected() can return true even when the
@@ -148,6 +165,10 @@ class ClientConnectivityService(
             _status.value = ConnectivityStatus.DISCONNECTED
         }
     }
+
+    private fun shouldForceClientRecreation(): Boolean =
+        platformInfo.type == PlatformType.IOS &&
+            consecutiveReconnectingCycles >= IOS_FORCE_RECREATE_CYCLES
 
     /**
      * Sends a lightweight health check request to verify the server is responsive.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -377,6 +377,38 @@ class WebSocketClientService(
     }
 
     /**
+     * Forces full client recreation: disposes the current WebSocket client and
+     * re-triggers [updateWebSocketClient] with the same settings, producing a
+     * brand-new [HttpClient] and [WebSocketClientImpl].
+     *
+     * Used on iOS where the Darwin engine's NSURLSession may not create
+     * functional WebSocket connections after repeated disconnections on the
+     * same session instance.
+     */
+    internal suspend fun forceClientRecreation() {
+        clientUpdateMutex.withLock {
+            val settings = currentClientSettings ?: return@withLock
+            log.i { "Forcing full client recreation to recover stale iOS NSURLSession" }
+            // Dispose current client and clear settings so updateWebSocketClient
+            // treats the next call as a fresh configuration
+            currentClient.value?.dispose()
+            currentClient.value = null
+            stateCollectionJob?.cancel()
+            stateCollectionJob = null
+            subscriptionMutex.withLock {
+                subscriptionsAreApplied = false
+                requestedSubscriptions.value.forEach { it.value.resetSequence() }
+            }
+            _connectionState.value = ConnectionState.Disconnected()
+            currentClientSettings = null
+            // Re-trigger with same settings — this creates fresh httpClient + wsClient
+            // Must release clientUpdateMutex first since updateWebSocketClient acquires it
+        }
+        // Call outside the lock since updateWebSocketClient acquires clientUpdateMutex
+        httpClientService.recreateClient()
+    }
+
+    /**
      * Sends a lightweight request (settings/version) to verify the connection
      * is actually alive and the server is responsive.
      *


### PR DESCRIPTION
 - resolves #1195 
 - force a full websocket client recreation (iOS only) to tackle Darwin race conditions when reconnecting usign the same client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network reconnection stability with platform-aware recovery mechanisms and automatic client recreation when reconnection attempts exceed thresholds.

* **Tests**
  * Expanded test coverage for platform-specific reconnection scenarios and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->