### PR TITLE
Change background colour of success snackbar

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/BisqSnackbar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/BisqSnackbar.kt
@@ -45,7 +45,7 @@ fun BisqSnackbar(snackbarHostState: SnackbarHostState) {
                 when (type) {
                     SnackbarType.ERROR -> BisqTheme.colors.danger
                     SnackbarType.WARNING -> BisqTheme.colors.warning
-                    SnackbarType.SUCCESS -> BisqTheme.colors.secondary
+                    SnackbarType.SUCCESS -> BisqTheme.colors.primaryDim
                 }.copy(alpha = 0.95f)
 
             val contentColor =


### PR DESCRIPTION
<img width="384" height="646" alt="Screenshot 2026-03-12 at 11 40 49" src="https://github.com/user-attachments/assets/9734f6d1-d91f-4ac2-9d58-c3d7964b812f" />
