### PR TITLE
release/iconnect_0.2.2_update

### DIFF
--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.2.2'
+    spec.version                  = '0.2.3'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,11 +37,11 @@ node.android.version=0.5.0
 
 client.name=Bisq Connect
 client.android.version=0.2.3
-client.ios.version=0.2.2
+client.ios.version=0.2.3
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=11
+client.ios.version.code=12
 client.android.version.code=17
 node.android.version.code=37
 

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.2.2
-APP_VERSION_CODE=11
+APP_VERSION=0.2.3
+APP_VERSION_CODE=12

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.2.2)
+  - clientApp (0.2.3)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: a159bcc88a4661d07e653903e84aeb81193f5dd8
+  clientApp: e4bae9b32bbdb3fe64aecaa746234499f2f0cb36
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.2.2)
+  - clientApp (0.2.3)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: a159bcc88a4661d07e653903e84aeb81193f5dd8
+  clientApp: e4bae9b32bbdb3fe64aecaa746234499f2f0cb36
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 


### PR DESCRIPTION
 - Ready for next dev iteration Bisq Connect iOS 0.2.3
 - update metadata and versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS client version to 0.2.3 with version code incremented to 12 across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->