### PR TITLE
chore/upgrade_libs_stack_non_kotlin_upgrade_dependant

### DIFF
--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/utils/PlatformAbstractions.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/utils/PlatformAbstractions.ios.kt
@@ -46,6 +46,9 @@ actual fun createHttpClient(
             tlsFingerprint?.let { fingerprint ->
                 handleChallenge { _, _, challenge, completionHandler ->
                     handleTlsChallenge(fingerprint, challenge) { disposition, credential ->
+                        // Ktor Darwin engine types completionHandler as (Int, ...) in metadata
+                        // but (Long, ...) on arm64. Cast to Function2<Any?, Any?, Unit> so both
+                        // targets compile — safe at runtime since disposition is always numeric.
                         @Suppress("UNCHECKED_CAST")
                         (completionHandler as Function2<Any?, Any?, Unit>)(disposition, credential)
                     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -144,8 +144,6 @@ androidx-test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifes
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-mockk-common = { module = "io.mockk:mockk-common", version.ref = "mockk" }
-mockk-darwin = { module = "io.mockk:mockk-darwin", version.ref = "mockk" }
 
 
 # -------------------- Multiplatform Libraries --------------------


### PR DESCRIPTION
 - contribs to #1163 
 - bump up non kotlin bump dependent libs first with minimal adjustments for iOS case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tools and development dependencies (code coverage, testing, and linting utilities).

* **Internal Updates**
  * Adjusted iOS networking TLS handling to preserve runtime behavior across platform boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->