### PR TITLE
design/payment_accounts_tweak

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateFiatAccountWizard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateFiatAccountWizard.kt
@@ -83,6 +83,7 @@
  */
 package network.bisq.mobile.presentation.design.payment_accounts
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -91,8 +92,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -101,6 +105,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqCard
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -108,6 +113,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqTextField
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethodIcon
+import network.bisq.mobile.presentation.common.ui.components.molecules.bottom_sheet.BisqBottomSheet
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
@@ -130,6 +136,25 @@ enum class RiskFilter {
 }
 
 /**
+ * Simulated country availability for a payment method.
+ * Maps to Bisq2's FiatPaymentRail.supportedCountries:
+ *   - Single country (e.g., ACH_TRANSFER → US)
+ *   - Regional list (e.g., SEPA → 37 SEPA zone countries)
+ *   - All countries (e.g., National Bank, Cash by Mail, F2F)
+ *
+ * Production implementation derives this from FiatPaymentRail + CountryRepository.
+ */
+sealed class SimulatedCountryAvailability {
+    /** Available in all countries worldwide */
+    data object Worldwide : SimulatedCountryAvailability()
+
+    /** Available in a specific set of countries (by ISO 3166 2-letter codes) */
+    data class Countries(
+        val codes: List<String>,
+    ) : SimulatedCountryAvailability()
+}
+
+/**
  * Simulated payment method entry for the Step 1 selection list.
  * Production implementation sources this from FiatPaymentRailEnum + backend API.
  */
@@ -138,6 +163,7 @@ data class SimulatedPaymentMethod(
     val displayName: String,
     val currencies: List<String>,
     val chargebackRisk: SimulatedChargebackRisk,
+    val countryAvailability: SimulatedCountryAvailability = SimulatedCountryAvailability.Worldwide,
 )
 
 /**
@@ -151,23 +177,109 @@ data class SimulatedFormField(
     val isMultiLine: Boolean = false,
 )
 
+// Representative SEPA zone countries (37 total, matching Bisq2's FiatPaymentRailUtil)
+internal val sepaCountries =
+    listOf(
+        "AT",
+        "BE",
+        "BG",
+        "CY",
+        "CZ",
+        "DE",
+        "DK",
+        "EE",
+        "ES",
+        "FI",
+        "FR",
+        "GB",
+        "GI",
+        "GR",
+        "HR",
+        "HU",
+        "IE",
+        "IS",
+        "IT",
+        "JE",
+        "LI",
+        "LT",
+        "LU",
+        "LV",
+        "MC",
+        "MT",
+        "NL",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SE",
+        "SI",
+        "SK",
+        "SM",
+        "VA",
+        "CH",
+    )
+
+// Representative Revolut-supported countries (subset — full list is ~30 countries)
+internal val revolutCountries =
+    listOf(
+        "AT",
+        "AU",
+        "BE",
+        "BG",
+        "CA",
+        "CH",
+        "CY",
+        "CZ",
+        "DE",
+        "DK",
+        "EE",
+        "ES",
+        "FI",
+        "FR",
+        "GB",
+        "GR",
+        "HR",
+        "HU",
+        "IE",
+        "IS",
+        "IT",
+        "JP",
+        "LI",
+        "LT",
+        "LU",
+        "LV",
+        "MT",
+        "NL",
+        "NO",
+        "NZ",
+        "PL",
+        "PT",
+        "RO",
+        "SE",
+        "SG",
+        "SI",
+        "SK",
+        "US",
+    )
+
 // Sample data used across multiple preview variants
+// Country mappings replicate Bisq2's FiatPaymentRail.supportedCountries
 private val allPaymentMethods =
     listOf(
-        SimulatedPaymentMethod("SEPA", "SEPA", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW),
-        SimulatedPaymentMethod("SEPA_INSTANT", "SEPA Instant", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW),
-        SimulatedPaymentMethod("FASTER_PAYMENTS", "Faster Payments", listOf("GBP"), SimulatedChargebackRisk.VERY_LOW),
-        SimulatedPaymentMethod("PIX", "PIX", listOf("BRL"), SimulatedChargebackRisk.VERY_LOW),
-        SimulatedPaymentMethod("BIZUM", "Bizum", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW),
-        SimulatedPaymentMethod("REVOLUT", "Revolut", listOf("EUR", "USD", "GBP"), SimulatedChargebackRisk.LOW),
-        SimulatedPaymentMethod("WISE", "Wise", listOf("EUR", "USD", "GBP"), SimulatedChargebackRisk.LOW),
-        SimulatedPaymentMethod("INTERAC_E_TRANSFER", "Interac e-Transfer", listOf("CAD"), SimulatedChargebackRisk.LOW),
-        SimulatedPaymentMethod("STRIKE", "Strike", listOf("USD"), SimulatedChargebackRisk.LOW),
-        SimulatedPaymentMethod("ZELLE", "Zelle", listOf("USD"), SimulatedChargebackRisk.MODERATE),
-        SimulatedPaymentMethod("ACH_TRANSFER", "ACH Transfer", listOf("USD"), SimulatedChargebackRisk.MODERATE),
-        SimulatedPaymentMethod("CASH_APP", "Cash App", listOf("USD"), SimulatedChargebackRisk.MODERATE),
-        SimulatedPaymentMethod("NATIONAL_BANK", "National Bank Transfer", listOf("*"), SimulatedChargebackRisk.LOW),
-        SimulatedPaymentMethod("CUSTOM", "Custom", listOf("*"), SimulatedChargebackRisk.LOW),
+        SimulatedPaymentMethod("SEPA", "SEPA", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW, SimulatedCountryAvailability.Countries(sepaCountries)),
+        SimulatedPaymentMethod("SEPA_INSTANT", "SEPA Instant", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW, SimulatedCountryAvailability.Countries(sepaCountries)),
+        SimulatedPaymentMethod("FASTER_PAYMENTS", "Faster Payments", listOf("GBP"), SimulatedChargebackRisk.VERY_LOW, SimulatedCountryAvailability.Countries(listOf("GB"))),
+        SimulatedPaymentMethod("PIX", "PIX", listOf("BRL"), SimulatedChargebackRisk.VERY_LOW, SimulatedCountryAvailability.Countries(listOf("BR"))),
+        SimulatedPaymentMethod("BIZUM", "Bizum", listOf("EUR"), SimulatedChargebackRisk.VERY_LOW, SimulatedCountryAvailability.Countries(listOf("ES"))),
+        SimulatedPaymentMethod("REVOLUT", "Revolut", listOf("EUR", "USD", "GBP"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Countries(revolutCountries)),
+        SimulatedPaymentMethod("WISE", "Wise", listOf("EUR", "USD", "GBP"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Worldwide),
+        SimulatedPaymentMethod("INTERAC_E_TRANSFER", "Interac e-Transfer", listOf("CAD"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Countries(listOf("CA"))),
+        SimulatedPaymentMethod("STRIKE", "Strike", listOf("USD"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Countries(listOf("US"))),
+        SimulatedPaymentMethod("ZELLE", "Zelle", listOf("USD"), SimulatedChargebackRisk.MODERATE, SimulatedCountryAvailability.Countries(listOf("US"))),
+        SimulatedPaymentMethod("ACH_TRANSFER", "ACH Transfer", listOf("USD"), SimulatedChargebackRisk.MODERATE, SimulatedCountryAvailability.Countries(listOf("US"))),
+        SimulatedPaymentMethod("CASH_APP", "Cash App", listOf("USD"), SimulatedChargebackRisk.MODERATE, SimulatedCountryAvailability.Countries(listOf("US"))),
+        SimulatedPaymentMethod("NATIONAL_BANK", "National Bank Transfer", listOf("*"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Worldwide),
+        SimulatedPaymentMethod("CUSTOM", "Custom", listOf("*"), SimulatedChargebackRisk.LOW, SimulatedCountryAvailability.Worldwide),
     )
 
 private val sepaFormFields =
@@ -242,6 +354,9 @@ fun CreateFiatAccount_Step1_SelectMethod(
                     )
             }
 
+    // Bottom sheet state for showing full country list
+    var countrySheetMethod by remember { mutableStateOf<SimulatedPaymentMethod?>(null) }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
     ) {
@@ -308,19 +423,37 @@ fun CreateFiatAccount_Step1_SelectMethod(
                         method = method,
                         isSelected = method.methodId == selectedMethodId,
                         onSelect = { onMethodSelect(method.methodId) },
+                        onShowCountries = { countrySheetMethod = method },
                     )
                 }
             }
         }
+    }
+
+    // Country list bottom sheet — shown when tapping "N countries" on a regional method
+    countrySheetMethod?.let { method ->
+        val countries = (method.countryAvailability as? SimulatedCountryAvailability.Countries)?.codes ?: return@let
+        CountryListBottomSheet(
+            methodName = method.displayName,
+            countryCodes = countries,
+            onDismiss = { countrySheetMethod = null },
+        )
     }
 }
 
 /**
  * A single row in the payment method selection list.
  *
- * Extends PaymentTypeCard's visual pattern by adding a trailing chargeback risk
- * badge. The badge provides the critical risk signal at the point of selection —
- * it should not require the user to tap into a detail view to discover risk level.
+ * Extends PaymentTypeCard's visual pattern by adding:
+ *   - A trailing chargeback risk badge for immediate risk visibility
+ *   - A country availability subtitle showing where the method is available
+ *
+ * Country subtitle rendering:
+ *   - Single country: full country name (e.g., "United States")
+ *   - Regional list (≤5 countries): all codes listed (e.g., "DE, FR, IT, ES, NL")
+ *   - Regional list (>5 countries): first 3 codes + tappable "+N more" link
+ *     that opens a bottom sheet with the full country list
+ *   - Worldwide: "Available worldwide"
  *
  * The row uses dark_grey50 background (same as PaymentTypeCard) and primaryDim
  * when selected for consistency with the create-offer wizard.
@@ -330,6 +463,7 @@ private fun PaymentMethodSelectionRow(
     method: SimulatedPaymentMethod,
     isSelected: Boolean,
     onSelect: () -> Unit,
+    onShowCountries: () -> Unit,
 ) {
     val riskColor =
         when (method.chargebackRisk) {
@@ -363,7 +497,7 @@ private fun PaymentMethodSelectionRow(
                 contentDescription = method.displayName,
             )
 
-            // Method name + currencies
+            // Method name + currencies + country availability
             Column(modifier = Modifier.weight(1f)) {
                 BisqText.BaseRegular(method.displayName)
                 if (method.currencies.isNotEmpty() && method.currencies != listOf("*")) {
@@ -372,6 +506,11 @@ private fun PaymentMethodSelectionRow(
                         color = BisqTheme.colors.mid_grey20,
                     )
                 }
+                // Country availability subtitle
+                CountryAvailabilitySubtitle(
+                    availability = method.countryAvailability,
+                    onShowFullList = onShowCountries,
+                )
             }
 
             // Chargeback risk badge (trailing)
@@ -397,6 +536,203 @@ private fun PaymentMethodSelectionRow(
         }
     }
 }
+
+// -------------------------------------------------------------------------------------
+// Country availability components
+// -------------------------------------------------------------------------------------
+
+/**
+ * Compact country availability subtitle for payment method rows and account cards.
+ * Shared across CreateFiatAccountWizard and PaymentAccountCard.
+ *
+ * Rendering strategy:
+ *   - Worldwide → "Available worldwide" in subdued grey
+ *   - Single country → full country name via ISO code lookup
+ *   - ≤5 countries → comma-separated codes
+ *   - >5 countries → first 3 codes + tappable "+N more" link (underlined, primary color)
+ *
+ * The "+N more" link opens a bottom sheet with the full sorted country list.
+ * This keeps the row compact while still making the full list accessible.
+ *
+ * Production implementation should use CountryRepository for code → name mapping.
+ * POC uses a hardcoded subset of common country names.
+ */
+@Composable
+internal fun CountryAvailabilitySubtitle(
+    availability: SimulatedCountryAvailability,
+    onShowFullList: () -> Unit,
+) {
+    when (availability) {
+        is SimulatedCountryAvailability.Worldwide -> {
+            BisqText.SmallLight(
+                "Available worldwide",
+                color = BisqTheme.colors.mid_grey30,
+            )
+        }
+
+        is SimulatedCountryAvailability.Countries -> {
+            val codes = availability.codes
+            when {
+                codes.size == 1 -> {
+                    BisqText.SmallLight(
+                        countryName(codes.first()),
+                        color = BisqTheme.colors.mid_grey30,
+                    )
+                }
+
+                codes.size <= 5 -> {
+                    BisqText.SmallLight(
+                        codes.sorted().joinToString(", "),
+                        color = BisqTheme.colors.mid_grey30,
+                    )
+                }
+
+                else -> {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        BisqText.SmallLight(
+                            codes.sorted().take(3).joinToString(", ") + " ",
+                            color = BisqTheme.colors.mid_grey30,
+                        )
+                        Text(
+                            "+${codes.size - 3} more",
+                            style =
+                                BisqTheme.typography.smallRegular.copy(
+                                    color = BisqTheme.colors.primary,
+                                    textDecoration = TextDecoration.Underline,
+                                ),
+                            modifier = Modifier.clickable { onShowFullList() },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Bottom sheet showing the full list of supported countries for a payment method.
+ *
+ * Displays the method name as a header, followed by a scrollable list of country
+ * entries (flag placeholder + code + name). Uses LazyColumn for efficient rendering
+ * of long lists (e.g., SEPA's 37 countries, Revolut's 38 countries).
+ *
+ * Production implementation should:
+ *   - Source country names from CountryRepository.getNameByCode()
+ *   - Optionally show flag icons via DynamicImage with country flag assets
+ */
+@Composable
+internal fun CountryListBottomSheet(
+    methodName: String,
+    countryCodes: List<String>,
+    onDismiss: () -> Unit,
+) {
+    BisqBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding),
+        ) {
+            BisqText.H5Regular("$methodName — Supported Countries")
+            BisqGap.VHalf()
+            BisqText.SmallLight(
+                "${countryCodes.size} countries",
+                color = BisqTheme.colors.mid_grey20,
+            )
+            BisqGap.V1()
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                items(countryCodes.sorted()) { code ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = BisqUIConstants.ScreenPaddingQuarter),
+                        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        // Country code badge
+                        Surface(
+                            shape = RoundedCornerShape(4.dp),
+                            color = BisqTheme.colors.dark_grey40,
+                        ) {
+                            BisqText.SmallRegular(
+                                code,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                            )
+                        }
+                        // Country name
+                        BisqText.BaseLight(
+                            countryName(code),
+                            color = BisqTheme.colors.white,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Simulated country code → name lookup for POC previews.
+ * Production implementation uses CountryRepository.getNameByCode().
+ */
+internal fun countryName(code: String): String = COUNTRY_NAMES[code] ?: code
+
+internal val COUNTRY_NAMES =
+    mapOf(
+        "AD" to "Andorra",
+        "AR" to "Argentina",
+        "AT" to "Austria",
+        "AU" to "Australia",
+        "BE" to "Belgium",
+        "BG" to "Bulgaria",
+        "BR" to "Brazil",
+        "CA" to "Canada",
+        "CH" to "Switzerland",
+        "CN" to "China",
+        "CY" to "Cyprus",
+        "CZ" to "Czech Republic",
+        "DE" to "Germany",
+        "DK" to "Denmark",
+        "EE" to "Estonia",
+        "ES" to "Spain",
+        "FI" to "Finland",
+        "FR" to "France",
+        "GB" to "United Kingdom",
+        "GI" to "Gibraltar",
+        "GR" to "Greece",
+        "HR" to "Croatia",
+        "HU" to "Hungary",
+        "IE" to "Ireland",
+        "IN" to "India",
+        "IS" to "Iceland",
+        "IT" to "Italy",
+        "JE" to "Jersey",
+        "JP" to "Japan",
+        "LI" to "Liechtenstein",
+        "LT" to "Lithuania",
+        "LU" to "Luxembourg",
+        "LV" to "Latvia",
+        "MC" to "Monaco",
+        "MT" to "Malta",
+        "NL" to "Netherlands",
+        "NO" to "Norway",
+        "NZ" to "New Zealand",
+        "PL" to "Poland",
+        "PT" to "Portugal",
+        "RO" to "Romania",
+        "RU" to "Russia",
+        "SE" to "Sweden",
+        "SG" to "Singapore",
+        "SI" to "Slovenia",
+        "SK" to "Slovakia",
+        "SM" to "San Marino",
+        "TH" to "Thailand",
+        "US" to "United States",
+        "VA" to "Vatican City",
+    )
 
 /**
  * A filter chip for risk-level filtering in Step 1.
@@ -578,6 +914,22 @@ fun CreateFiatAccount_Step3_Review(
             }
 
             BisqGap.V1()
+
+            // Country availability in review
+            ReviewFieldRow(
+                label = "Available in",
+                value =
+                    when (val avail = selectedMethod.countryAvailability) {
+                        is SimulatedCountryAvailability.Worldwide -> "All countries"
+                        is SimulatedCountryAvailability.Countries ->
+                            when {
+                                avail.codes.size == 1 -> countryName(avail.codes.first())
+                                avail.codes.size <= 5 -> avail.codes.sorted().joinToString(", ") { countryName(it) }
+                                else -> "${avail.codes.size} countries"
+                            }
+                    },
+            )
+            BisqGap.VHalf()
 
             // Field summary rows
             formFields.forEach { field ->
@@ -767,6 +1119,7 @@ private fun CreateFiatAccountWizard_Step3Preview() {
                     displayName = "SEPA",
                     currencies = listOf("EUR"),
                     chargebackRisk = SimulatedChargebackRisk.VERY_LOW,
+                    countryAvailability = SimulatedCountryAvailability.Countries(sepaCountries),
                 ),
             formFields = sepaFormFields,
             fieldValues =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountCard.kt
@@ -10,15 +10,35 @@
  * ======================================================================================
  * Reusable card component for displaying a single saved payment account in the
  * PaymentAccountsRedesignScreen list. Cards are **expandable**: collapsed shows just
- * enough to identify the account (icon + name + method + risk); expanded reveals
- * currencies, address, and edit/delete actions. This lets users skim a list of 5–10
- * accounts quickly and only drill into the one they care about.
+ * enough to identify the account (icon + name + method + country summary + risk);
+ * expanded reveals full country availability, currencies, and edit/delete actions.
+ * This lets users skim a list of 5-10 accounts quickly and only drill into the one
+ * they care about.
  *
  * Two visual variants:
- *   - Fiat account: method icon, account name, method label, chargeback risk badge.
- *     Expanded: currency badges with flag icons, edit/delete actions.
+ *   - Fiat account: method icon, account name, method label + brief country summary,
+ *     chargeback risk badge. Expanded: full country availability subtitle with "+N more"
+ *     tappable link, currency badges with flag icons, edit/delete actions.
  *   - Crypto account: method icon, account name, crypto type.
  *     Expanded: truncated address, edit/delete actions.
+ *
+ * ======================================================================================
+ * COUNTRY AVAILABILITY (Hybrid approach)
+ * ======================================================================================
+ * Each fiat account carries a [SimulatedCountryAvailability] describing where the
+ * payment method can be used (single country, regional list, or worldwide).
+ *
+ * **Collapsed header** shows a brief one-liner next to the method name:
+ *   - "SEPA · 37 countries"
+ *   - "Zelle · United States"
+ *   - "Wise · Worldwide"
+ *
+ * **Expanded section** shows the full [CountryAvailabilitySubtitle] (reused from
+ * CreateFiatAccountWizard) with the "+N more" tappable link that opens a
+ * [CountryListBottomSheet] with the complete sorted country list.
+ *
+ * This hybrid approach lets users distinguish accounts at a glance (e.g., "is this
+ * my US-only or my worldwide account?") while keeping the collapsed card compact.
  *
  * ======================================================================================
  * DESKTOP ADAPTATION
@@ -43,6 +63,9 @@
  *     mobile.paymentAccounts.risk.veryLow / .low / .moderate
  * - "Edit" / "Delete" use existing action.edit / paymentAccounts.deleteAccount keys.
  * - Currency codes are ISO 4217 — no localization needed.
+ * - Country summary strings (e.g., "N countries", "Worldwide") need i18n keys:
+ *     mobile.paymentAccounts.countries.count (parameterized: "{0} countries")
+ *     mobile.paymentAccounts.countries.worldwide
  */
 package network.bisq.mobile.presentation.design.payment_accounts
 
@@ -99,6 +122,7 @@ data class SimulatedFiatAccount(
     val methodDisplayName: String,
     val currencies: List<String>,
     val chargebackRisk: SimulatedChargebackRisk,
+    val countryAvailability: SimulatedCountryAvailability = SimulatedCountryAvailability.Worldwide,
 )
 
 data class SimulatedCryptoAccount(
@@ -124,6 +148,22 @@ internal fun chargebackRiskLabel(risk: SimulatedChargebackRisk): String =
         SimulatedChargebackRisk.VERY_LOW -> "Chargeback risk: Very Low"
         SimulatedChargebackRisk.LOW -> "Chargeback risk: Low"
         SimulatedChargebackRisk.MODERATE -> "Chargeback risk: Moderate"
+    }
+
+/**
+ * Brief one-liner summary of country availability for the collapsed card header.
+ * Shows: "37 countries", "United States", or "Worldwide".
+ */
+private fun countrySummary(availability: SimulatedCountryAvailability): String =
+    when (availability) {
+        is SimulatedCountryAvailability.Worldwide -> "Worldwide"
+        is SimulatedCountryAvailability.Countries -> {
+            val codes = availability.codes
+            when {
+                codes.size == 1 -> countryName(codes.first())
+                else -> "${codes.size} countries"
+            }
+        }
     }
 
 private fun truncateAddress(address: String): String =
@@ -233,14 +273,17 @@ internal fun ChargebackRiskBadge(risk: SimulatedChargebackRisk) {
 /**
  * Expandable fiat payment account card.
  *
- * **Collapsed** (default): icon + account name + method label + chargeback risk badge
- * + expand chevron. Enough to identify the account and see its risk level at a glance.
+ * **Collapsed** (default): icon + account name + method label with brief country summary
+ * (e.g., "SEPA · 37 countries") + chargeback risk badge + expand chevron.
+ * Enough to identify the account, its geographic scope, and risk level at a glance.
  *
- * **Expanded**: adds currency badges with flag icons + edit/delete action buttons.
+ * **Expanded**: adds full country availability subtitle with tappable "+N more" link,
+ * currency badges with flag icons, and edit/delete action buttons.
+ * Tapping "+N more" opens a [CountryListBottomSheet] with the complete country list.
  *
  * Tap anywhere on the card header to toggle expansion.
  *
- * @param account Fiat account data
+ * @param account Fiat account data (includes country availability)
  * @param initiallyExpanded Whether the card starts expanded (useful for single-account view)
  * @param onEditClick Called when user taps Edit
  * @param onDeleteClick Called when user taps Delete
@@ -253,6 +296,8 @@ fun FiatPaymentAccountCard(
     initiallyExpanded: Boolean = false,
 ) {
     var expanded by remember { mutableStateOf(initiallyExpanded) }
+    // Track which method's country list bottom sheet is open (null = closed)
+    var showCountrySheet by remember { mutableStateOf(false) }
 
     BisqCard(
         modifier = Modifier.fillMaxWidth(),
@@ -276,8 +321,9 @@ fun FiatPaymentAccountCard(
             Column(modifier = Modifier.weight(1f)) {
                 BisqText.H4Regular(account.accountName)
                 BisqGap.VQuarter()
+                // Method name + brief country summary (e.g., "SEPA · 37 countries")
                 BisqText.SmallLight(
-                    account.methodDisplayName,
+                    "${account.methodDisplayName} · ${countrySummary(account.countryAvailability)}",
                     color = BisqTheme.colors.mid_grey20,
                 )
             }
@@ -292,7 +338,7 @@ fun FiatPaymentAccountCard(
         // Chargeback risk — always visible (key info for scanning)
         ChargebackRiskBadge(risk = account.chargebackRisk)
 
-        // Expanded content: currencies + actions
+        // Expanded content: country detail + currencies + actions
         AnimatedVisibility(
             visible = expanded,
             enter = expandVertically(),
@@ -301,6 +347,12 @@ fun FiatPaymentAccountCard(
             Column(
                 verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
             ) {
+                // Full country availability with "+N more" tappable link
+                CountryAvailabilitySubtitle(
+                    availability = account.countryAvailability,
+                    onShowFullList = { showCountrySheet = true },
+                )
+
                 // Currency badges with flag icons
                 if (account.currencies.isNotEmpty()) {
                     Row(
@@ -319,6 +371,18 @@ fun FiatPaymentAccountCard(
                     onDeleteClick = onDeleteClick,
                 )
             }
+        }
+    }
+
+    // Country list bottom sheet
+    if (showCountrySheet) {
+        val availability = account.countryAvailability
+        if (availability is SimulatedCountryAvailability.Countries) {
+            CountryListBottomSheet(
+                methodName = account.methodDisplayName,
+                countryCodes = availability.codes,
+                onDismiss = { showCountrySheet = false },
+            )
         }
     }
 }
@@ -405,7 +469,8 @@ fun CryptoPaymentAccountCard(
 private val previewOnClick: () -> Unit = {}
 
 /**
- * Preview: SEPA account collapsed — shows risk badge visible even when collapsed.
+ * Preview: SEPA account collapsed — shows country summary ("37 countries") and risk badge
+ * visible even when collapsed.
  */
 @ExcludeFromCoverage
 @Preview
@@ -424,6 +489,7 @@ private fun FiatCard_Sepa_CollapsedPreview() {
                         methodDisplayName = "SEPA",
                         currencies = listOf("EUR"),
                         chargebackRisk = SimulatedChargebackRisk.VERY_LOW,
+                        countryAvailability = SimulatedCountryAvailability.Countries(sepaCountries),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -433,7 +499,8 @@ private fun FiatCard_Sepa_CollapsedPreview() {
 }
 
 /**
- * Preview: SEPA account expanded — shows currency badges with flag icons and actions.
+ * Preview: SEPA account expanded — shows full country availability subtitle with "+N more",
+ * currency badges with flag icons, and actions.
  */
 @ExcludeFromCoverage
 @Preview
@@ -452,6 +519,7 @@ private fun FiatCard_Sepa_ExpandedPreview() {
                         methodDisplayName = "SEPA",
                         currencies = listOf("EUR"),
                         chargebackRisk = SimulatedChargebackRisk.VERY_LOW,
+                        countryAvailability = SimulatedCountryAvailability.Countries(sepaCountries),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -462,7 +530,7 @@ private fun FiatCard_Sepa_ExpandedPreview() {
 }
 
 /**
- * Preview: Zelle with moderate risk — red risk badge should stand out.
+ * Preview: Zelle with moderate risk — single country (US), red risk badge.
  */
 @ExcludeFromCoverage
 @Preview
@@ -481,6 +549,7 @@ private fun FiatCard_Zelle_ExpandedPreview() {
                         methodDisplayName = "Zelle",
                         currencies = listOf("USD"),
                         chargebackRisk = SimulatedChargebackRisk.MODERATE,
+                        countryAvailability = SimulatedCountryAvailability.Countries(listOf("US")),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -491,12 +560,12 @@ private fun FiatCard_Zelle_ExpandedPreview() {
 }
 
 /**
- * Preview: Custom multi-currency account expanded — multiple flag badges visible.
+ * Preview: Wise worldwide account expanded — "Worldwide" in collapsed, full detail expanded.
  */
 @ExcludeFromCoverage
 @Preview
 @Composable
-private fun FiatCard_Custom_ExpandedPreview() {
+private fun FiatCard_Wise_ExpandedPreview() {
     BisqTheme.Preview {
         Column(
             modifier = Modifier.padding(BisqUIConstants.ScreenPadding),
@@ -510,6 +579,7 @@ private fun FiatCard_Custom_ExpandedPreview() {
                         methodDisplayName = "Wise",
                         currencies = listOf("USD", "EUR", "GBP", "CHF"),
                         chargebackRisk = SimulatedChargebackRisk.LOW,
+                        countryAvailability = SimulatedCountryAvailability.Worldwide,
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -520,8 +590,9 @@ private fun FiatCard_Custom_ExpandedPreview() {
 }
 
 /**
- * Preview: multiple cards in a list — shows the scanning experience.
- * First card expanded, rest collapsed — typical user flow.
+ * Preview: multiple cards in a list — shows the scanning experience with country summaries.
+ * First card expanded (SEPA, 37 countries), rest collapsed showing brief country info.
+ * Demonstrates: regional (SEPA), single-country (Zelle/US), multi-country (Revolut).
  */
 @ExcludeFromCoverage
 @Preview
@@ -540,6 +611,7 @@ private fun FiatCards_ListPreview() {
                         methodDisplayName = "SEPA",
                         currencies = listOf("EUR"),
                         chargebackRisk = SimulatedChargebackRisk.VERY_LOW,
+                        countryAvailability = SimulatedCountryAvailability.Countries(sepaCountries),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -553,6 +625,7 @@ private fun FiatCards_ListPreview() {
                         methodDisplayName = "Zelle",
                         currencies = listOf("USD"),
                         chargebackRisk = SimulatedChargebackRisk.MODERATE,
+                        countryAvailability = SimulatedCountryAvailability.Countries(listOf("US")),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,
@@ -565,6 +638,7 @@ private fun FiatCards_ListPreview() {
                         methodDisplayName = "Revolut",
                         currencies = listOf("EUR", "USD", "GBP"),
                         chargebackRisk = SimulatedChargebackRisk.LOW,
+                        countryAvailability = SimulatedCountryAvailability.Countries(revolutCountries),
                     ),
                 onEditClick = previewOnClick,
                 onDeleteClick = previewOnClick,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountsRedesignScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountsRedesignScreen.kt
@@ -351,6 +351,7 @@ private val previewFiatAccounts =
             methodDisplayName = "SEPA",
             currencies = listOf("EUR"),
             chargebackRisk = SimulatedChargebackRisk.VERY_LOW,
+            countryAvailability = SimulatedCountryAvailability.Countries(sepaCountries),
         ),
         SimulatedFiatAccount(
             accountName = "Revolut USD",
@@ -358,6 +359,7 @@ private val previewFiatAccounts =
             methodDisplayName = "Revolut",
             currencies = listOf("USD", "EUR"),
             chargebackRisk = SimulatedChargebackRisk.LOW,
+            countryAvailability = SimulatedCountryAvailability.Countries(revolutCountries),
         ),
         SimulatedFiatAccount(
             accountName = "Zelle — Chase",
@@ -365,6 +367,7 @@ private val previewFiatAccounts =
             methodDisplayName = "Zelle",
             currencies = listOf("USD"),
             chargebackRisk = SimulatedChargebackRisk.MODERATE,
+            countryAvailability = SimulatedCountryAvailability.Countries(listOf("US")),
         ),
     )
 


### PR DESCRIPTION

<img width="612" height="642" alt="Screenshot 2026-03-26 at 10 32 00" src="https://github.com/user-attachments/assets/cfb865c2-4ec5-40c7-a99f-8df4ec13be13" />
<img width="569" height="522" alt="Screenshot 2026-03-26 at 10 39 15" src="https://github.com/user-attachments/assets/3fd82de6-a6e3-4e15-8266-db57584b22aa" />
<img width="575" height="627" alt="Screenshot 2026-03-26 at 10 39 10" src="https://github.com/user-attachments/assets/2af8ee4b-956c-4d6d-bb30-31e7ca022c85" />
<img width="792" height="450" alt="Screenshot 2026-03-26 at 10 38 50" src="https://github.com/user-attachments/assets/5523f93a-ef4e-4967-ae65-42aea98e2f16" />
<img width="579" height="634" alt="Screenshot 2026-03-26 at 10 32 14" src="https://github.com/user-attachments/assets/2fb62d5f-aff4-46e2-828c-b3777b9e565d" />
<img width="594" height="636" alt="Screenshot 2026-03-26 at 10 32 07" src="https://github.com/user-attachments/assets/20333cca-e1ec-4d02-9219-93b972d91c94" />


 - contribs designs to #991 as requested by @salottodev
 - AI designs tweaks to incorporate countries for fiat payment methods following best UX practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment methods now display their country availability information.
  * Users can view the complete list of countries where each payment method operates.
  * Payment account cards now show country information in both overview and detailed views.
  * Fiat account creation wizard includes country availability details during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->