### PR TITLE
bugfix/topic_subscription_failure_causes_rest_of_subscriptions_to_be_aborted

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -335,12 +335,16 @@ class WebSocketClientService(
             val subs = requestedSubscriptions.value
             log.d { "applying subscriptions on WS client, entry count: ${subs.size}" }
             subs.forEach { entry ->
-                entry.value.resetSequence()
-                client.subscribe(
-                    entry.key.topic,
-                    entry.key.parameter,
-                    entry.value,
-                )
+                try {
+                    entry.value.resetSequence()
+                    client.subscribe(
+                        entry.key.topic,
+                        entry.key.parameter,
+                        entry.value,
+                    )
+                } catch (e: Exception) {
+                    log.e(e) { "Failed to subscribe to topic ${entry.key.topic}; skipping" }
+                }
             }
             subscriptionsAreApplied = true
         }


### PR DESCRIPTION
 - handle per-topic subscription error and proper logging to avoid one failure to affect the rest of the subscriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for subscription operations. Individual subscription failures no longer prevent other subscriptions from being applied successfully, enhancing overall system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->