### PR TITLE
fix: prevent compose from handling the deeplink directly on android

### DIFF
--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
@@ -39,9 +39,24 @@ abstract class MainActivity :
         }
     }
 
+    private fun sanitizeDeepLinkIntent(intent: Intent): Intent {
+        if (intent.action != Intent.ACTION_VIEW || intent.data == null) {
+            return intent
+        }
+
+        // strip the deeplink off the activity intent after caching it, to stop premature navigation
+        return Intent(intent).apply {
+            action = null
+            data = null
+            clipData = null
+        }
+    }
+
     override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
         handleDeepLinkIntent(intent)
+        val sanitizedIntent = sanitizeDeepLinkIntent(intent)
+        setIntent(sanitizedIntent)
+        super.onNewIntent(sanitizedIntent)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -55,6 +70,9 @@ abstract class MainActivity :
         // Set up coroutine exception handler after DI is initialized
         GenericErrorHandler.setupCoroutineExceptionHandler(exceptionHandlerSetup)
 
+        handleDeepLinkIntent(intent)
+        intent?.let { intent = sanitizeDeepLinkIntent(it) }
+
         presenter.attachView(this)
 
         val bgColor = Color(BACKGROUND_COLOR_CODE).adjustGamma().toArgb()
@@ -67,7 +85,6 @@ abstract class MainActivity :
     override fun onStart() {
         super.onStart()
         presenter.onStart()
-        handleDeepLinkIntent(intent)
     }
 
     override fun onResume() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainActivityDeepLinkTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainActivityDeepLinkTest.kt
@@ -1,0 +1,123 @@
+package network.bisq.mobile.presentation.main
+
+import android.content.ClipData
+import android.content.Intent
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
+import network.bisq.mobile.presentation.common.ui.navigation.ExternalUriHandler
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.Robolectric
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityDeepLinkTest {
+    private val presenter = mockk<MainPresenter>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        MainApplication.wasProcessDead.set(false)
+        clearCachedUri()
+
+        startKoin {
+            modules(
+                module {
+                    single { presenter }
+                    single { CoroutineExceptionHandlerSetup() }
+                },
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        clearCachedUri()
+        stopKoin()
+    }
+
+    @Test
+    fun `onCreate caches deep link and strips it from activity intent`() {
+        val deepLinkIntent = createDeepLinkIntent("bisq://trade/123")
+
+        val activity =
+            Robolectric
+                .buildActivity(TestMainActivity::class.java, deepLinkIntent)
+                .setup()
+                .get()
+
+        assertNull(activity.intent.action)
+        assertNull(activity.intent.data)
+        assertNull(activity.intent.clipData)
+        assertEquals("bisq://trade/123", consumeCachedUri())
+        assertNull(consumeCachedUri())
+    }
+
+    @Test
+    fun `onNewIntent caches deep link and updates activity intent with sanitized copy`() {
+        val activity =
+            Robolectric
+                .buildActivity(TestMainActivity::class.java, Intent(Intent.ACTION_MAIN))
+                .setup()
+                .get()
+
+        val deepLinkIntent = createDeepLinkIntent("bisq://openTrade?id=7")
+
+        activity.dispatchNewIntent(deepLinkIntent)
+
+        assertNull(activity.intent.action)
+        assertNull(activity.intent.data)
+        assertNull(activity.intent.clipData)
+        assertEquals("bisq://openTrade?id=7", consumeCachedUri())
+        assertNull(consumeCachedUri())
+    }
+
+    @Test
+    fun `non deeplink intents remain intact and do not populate external uri cache`() {
+        val launchIntent =
+            Intent(Intent.ACTION_MAIN).apply {
+                `package` = "network.bisq.mobile.test"
+            }
+
+        val activity =
+            Robolectric
+                .buildActivity(TestMainActivity::class.java, launchIntent)
+                .setup()
+                .get()
+
+        assertEquals(Intent.ACTION_MAIN, activity.intent.action)
+        assertNotNull(activity.intent.`package`)
+        assertNull(consumeCachedUri())
+    }
+
+    private fun createDeepLinkIntent(uri: String): Intent =
+        Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+            clipData = ClipData.newPlainText("deeplink", uri)
+        }
+
+    private fun clearCachedUri() {
+        consumeCachedUri()
+        ExternalUriHandler.listener = null
+    }
+
+    private fun consumeCachedUri(): String? {
+        var cachedUri: String? = null
+        ExternalUriHandler.listener = { uri -> cachedUri = uri }
+        ExternalUriHandler.listener = null
+        return cachedUri
+    }
+}
+
+class TestMainActivity : MainActivity() {
+    fun dispatchNewIntent(intent: Intent) {
+        onNewIntent(intent)
+    }
+}


### PR DESCRIPTION
resolves #1283
currently I cannot test and develop on iOS, I appreciate if you can test it later on that

this simply does 2 things:
1. prevent jetpack compose from handling the deeplink itself
2. ensure that container tab loads first, so we have somewhere to go back to on the backstack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep link handling with enhanced intent sanitization to ensure stable behavior when launching the application through external links.

* **Tests**
  * Added comprehensive test suite covering deep link ingestion and intent sanitization validation across multiple activation scenarios, including initial launch and subsequent deep link dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->