### PR TITLE
fix: make splash screen dialog priority clear & use mvi

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/FlowUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/FlowUtils.kt
@@ -1,0 +1,24 @@
+package network.bisq.mobile.domain.utils
+
+import kotlinx.coroutines.flow.Flow
+
+inline fun <T1, T2, T3, T4, T5, T6, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>, // how many flows specified here can be used later
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R,
+): Flow<R> =
+    kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+        )
+    }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenterNavigationTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenterNavigationTest.kt
@@ -31,6 +31,8 @@ import org.koin.dsl.module
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /**
  * Tests the navigation and fallback logic in [SplashPresenter.navigateToNextScreen].
@@ -47,6 +49,14 @@ class SplashPresenterNavigationTest {
     private lateinit var mainPresenter: MainPresenter
     private lateinit var versionProvider: VersionProvider
 
+    private val stateFlow = MutableStateFlow("")
+    private val progressFlow = MutableStateFlow(0f)
+    private val timeoutDialogVisibleFlow = MutableStateFlow(false)
+    private val bootstrapFailedFlow = MutableStateFlow(false)
+    private val torBootstrapFailedFlow = MutableStateFlow(false)
+    private val bootstrapStageFlow = MutableStateFlow("")
+    private val progressToastFlow = MutableStateFlow(false)
+
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -59,13 +69,21 @@ class SplashPresenterNavigationTest {
         versionProvider = mockk(relaxed = true)
         navigationManager = mockk(relaxed = true)
 
-        every { applicationBootstrapFacade.state } returns MutableStateFlow("")
-        every { applicationBootstrapFacade.progress } returns MutableStateFlow(0f)
-        every { applicationBootstrapFacade.isTimeoutDialogVisible } returns MutableStateFlow(false)
-        every { applicationBootstrapFacade.isBootstrapFailed } returns MutableStateFlow(false)
-        every { applicationBootstrapFacade.torBootstrapFailed } returns MutableStateFlow(false)
-        every { applicationBootstrapFacade.currentBootstrapStage } returns MutableStateFlow("")
-        every { applicationBootstrapFacade.shouldShowProgressToast } returns MutableStateFlow(false)
+        stateFlow.value = ""
+        progressFlow.value = 0f
+        timeoutDialogVisibleFlow.value = false
+        bootstrapFailedFlow.value = false
+        torBootstrapFailedFlow.value = false
+        bootstrapStageFlow.value = ""
+        progressToastFlow.value = false
+
+        every { applicationBootstrapFacade.state } returns stateFlow
+        every { applicationBootstrapFacade.progress } returns progressFlow
+        every { applicationBootstrapFacade.isTimeoutDialogVisible } returns timeoutDialogVisibleFlow
+        every { applicationBootstrapFacade.isBootstrapFailed } returns bootstrapFailedFlow
+        every { applicationBootstrapFacade.torBootstrapFailed } returns torBootstrapFailedFlow
+        every { applicationBootstrapFacade.currentBootstrapStage } returns bootstrapStageFlow
+        every { applicationBootstrapFacade.shouldShowProgressToast } returns progressToastFlow
         every { versionProvider.getAppNameAndVersion(any(), any()) } returns "Test 1.0"
 
         startKoin {
@@ -89,7 +107,7 @@ class SplashPresenterNavigationTest {
         Dispatchers.resetMain()
     }
 
-    private fun createPresenter(): TestSplashPresenter =
+    private fun createPresenter(isIos: Boolean = false): TestSplashPresenter =
         TestSplashPresenter(
             mainPresenter = mainPresenter,
             applicationBootstrapFacade = applicationBootstrapFacade,
@@ -97,6 +115,7 @@ class SplashPresenterNavigationTest {
             settingsRepository = settingsRepository,
             settingsServiceFacade = settingsServiceFacade,
             versionProvider = versionProvider,
+            isIos = isIos,
         )
 
     @Test
@@ -178,6 +197,68 @@ class SplashPresenterNavigationTest {
 
             verify { navigationManager.navigate(NavRoute.Onboarding, any(), any()) }
         }
+
+    @Test
+    fun `ui state prioritizes bootstrap failure dialog over tor and timeout dialogs`() =
+        runTest {
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+
+            stateFlow.value = "Bootstrapping"
+            bootstrapStageFlow.value = "network"
+            timeoutDialogVisibleFlow.value = true
+            torBootstrapFailedFlow.value = true
+            bootstrapFailedFlow.value = true
+
+            val activeDialog = presenter.uiState.value.activeDialog
+
+            assertNotNull(activeDialog)
+            assertEquals(SplashActiveDialog.BootstrapFailedAndroid, activeDialog)
+        }
+
+    @Test
+    fun `ui state prioritizes tor dialog over timeout dialog`() =
+        runTest {
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+
+            bootstrapStageFlow.value = "tor"
+            timeoutDialogVisibleFlow.value = true
+            torBootstrapFailedFlow.value = true
+
+            val activeDialog = presenter.uiState.value.activeDialog
+
+            assertNotNull(activeDialog)
+            assertEquals(SplashActiveDialog.TorBootstrapFailed, activeDialog)
+        }
+
+    @Test
+    fun `ui state uses iOS bootstrap failed dialog when presenter is iOS`() =
+        runTest {
+            val presenter = createPresenter(isIos = true)
+            presenter.onViewAttached()
+
+            bootstrapFailedFlow.value = true
+
+            val activeDialog = presenter.uiState.value.activeDialog
+
+            assertNotNull(activeDialog)
+            assertEquals(SplashActiveDialog.BootstrapFailedIos, activeDialog)
+        }
+
+    @Test
+    fun `ui state uses iOS timeout dialog when presenter is iOS`() =
+        runTest {
+            val presenter = createPresenter(isIos = true)
+            presenter.onViewAttached()
+
+            timeoutDialogVisibleFlow.value = true
+
+            val activeDialog = presenter.uiState.value.activeDialog
+
+            assertNotNull(activeDialog)
+            assertEquals(SplashActiveDialog.TimeoutIos, activeDialog)
+        }
 }
 
 /**
@@ -190,6 +271,7 @@ private class TestSplashPresenter(
     settingsRepository: SettingsRepository,
     settingsServiceFacade: SettingsServiceFacade,
     versionProvider: VersionProvider,
+    isIos: Boolean,
 ) : SplashPresenter(
         mainPresenter,
         applicationBootstrapFacade,
@@ -197,6 +279,7 @@ private class TestSplashPresenter(
         settingsRepository,
         settingsServiceFacade,
         versionProvider,
+        isIos,
     ) {
     override val state: StateFlow<String> = MutableStateFlow("")
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -110,7 +110,7 @@ abstract class BasePresenter(
     companion object {
         const val EXIT_WARNING_TIMEOUT = 3000L
         const val SMALLEST_PERCEPTIVE_DELAY = 250L
-        var isDemo = false
+        var isDemo = false // todo: needs to be reactive to be reliable
     }
 
     protected val navigationManager: NavigationManager by inject()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.data.utils.getPlatformInfo
 import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.domain.utils.combine
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -27,22 +28,21 @@ abstract class SplashPresenter(
     private val userProfileService: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
     private val settingsServiceFacade: SettingsServiceFacade,
-    private val versionProvider: VersionProvider,
+    versionProvider: VersionProvider,
+    private val isIos: Boolean = getPlatformInfo().type == PlatformType.IOS,
 ) : BasePresenter(mainPresenter) {
     abstract val state: StateFlow<String>
 
-    val progress: StateFlow<Float> get() = applicationBootstrapFacade.progress
-    val isTimeoutDialogVisible: StateFlow<Boolean> get() = applicationBootstrapFacade.isTimeoutDialogVisible
-    val isBootstrapFailed: StateFlow<Boolean> get() = applicationBootstrapFacade.isBootstrapFailed
+    private val progress: StateFlow<Float> get() = applicationBootstrapFacade.progress
+    private val isTimeoutDialogVisible: StateFlow<Boolean> get() = applicationBootstrapFacade.isTimeoutDialogVisible
+    private val isBootstrapFailed: StateFlow<Boolean> get() = applicationBootstrapFacade.isBootstrapFailed
+    private val torBootstrapFailed: StateFlow<Boolean> get() = applicationBootstrapFacade.torBootstrapFailed
+    private val currentBootstrapStage: StateFlow<String> get() = applicationBootstrapFacade.currentBootstrapStage
+    private val shouldShowProgressToast: StateFlow<Boolean> get() = applicationBootstrapFacade.shouldShowProgressToast
 
-    val torBootstrapFailed: StateFlow<Boolean> get() = applicationBootstrapFacade.torBootstrapFailed
-    val currentBootstrapStage: StateFlow<String> get() = applicationBootstrapFacade.currentBootstrapStage
-    val shouldShowProgressToast: StateFlow<Boolean> get() = applicationBootstrapFacade.shouldShowProgressToast
-
-    private val _appNameAndVersion: MutableStateFlow<String> = MutableStateFlow("")
-    val appNameAndVersion: StateFlow<String> get() = _appNameAndVersion.asStateFlow()
-
-    val isIos = getPlatformInfo().type == PlatformType.IOS
+    private val _uiState =
+        MutableStateFlow(SplashUiState(appNameAndVersion = versionProvider.getAppNameAndVersion(isDemo, isIos)))
+    val uiState: StateFlow<SplashUiState> = _uiState.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -50,6 +50,31 @@ abstract class SplashPresenter(
         presenterScope.launch {
             state.collect { value ->
                 log.d { "Splash State: $value" }
+            }
+        }
+
+        presenterScope.launch {
+            combine(
+                state,
+                progress,
+                isTimeoutDialogVisible,
+                isBootstrapFailed,
+                torBootstrapFailed,
+                currentBootstrapStage,
+            ) { status, progressValue, timeoutVisible, bootstrapFailed, torFailed, bootstrapStage ->
+                _uiState.value.copy(
+                    progress = progressValue,
+                    status = status,
+                    currentBootstrapStage = bootstrapStage,
+                    activeDialog =
+                        resolveActiveDialog(
+                            isTimeoutDialogVisible = timeoutVisible,
+                            isBootstrapFailed = bootstrapFailed,
+                            torBootstrapFailed = torFailed,
+                        ),
+                )
+            }.collect { uiState ->
+                _uiState.value = uiState
             }
         }
 
@@ -69,7 +94,16 @@ abstract class SplashPresenter(
                 }
             }
         }
-        _appNameAndVersion.value = versionProvider.getAppNameAndVersion(isDemo, isIOS())
+    }
+
+    fun onAction(action: SplashUiAction) {
+        when (action) {
+            SplashUiAction.OnTimeoutDialogContinue -> onTimeoutDialogContinue()
+            SplashUiAction.OnRestartApp -> onRestartApp()
+            SplashUiAction.OnRestartTor -> onRestartTor()
+            SplashUiAction.OnPurgeRestartTor -> onPurgeRestartTor()
+            SplashUiAction.OnTerminateApp -> onTerminateApp()
+        }
     }
 
     protected open suspend fun navigateToNextScreen() {
@@ -137,23 +171,37 @@ abstract class SplashPresenter(
         }
     }
 
-    fun onTimeoutDialogContinue() {
+    private fun resolveActiveDialog(
+        isTimeoutDialogVisible: Boolean,
+        isBootstrapFailed: Boolean,
+        torBootstrapFailed: Boolean,
+    ): SplashActiveDialog? =
+        when {
+            isBootstrapFailed && isIos -> SplashActiveDialog.BootstrapFailedIos
+            isBootstrapFailed -> SplashActiveDialog.BootstrapFailedAndroid
+            torBootstrapFailed -> SplashActiveDialog.TorBootstrapFailed
+            isTimeoutDialogVisible && isIos -> SplashActiveDialog.TimeoutIos
+            isTimeoutDialogVisible -> SplashActiveDialog.TimeoutAndroid
+            else -> null
+        }
+
+    private fun onTimeoutDialogContinue() {
         applicationBootstrapFacade.extendTimeout()
     }
 
-    fun onRestartApp() {
+    private fun onRestartApp() {
         restartApp()
     }
 
-    fun onRestartTor() {
+    private fun onRestartTor() {
         applicationBootstrapFacade.startTor(false)
     }
 
-    fun onPurgeRestartTor() {
+    private fun onPurgeRestartTor() {
         applicationBootstrapFacade.startTor(true)
     }
 
-    fun onTerminateApp() {
+    private fun onTerminateApp() {
         terminateApp()
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashScreen.kt
@@ -29,13 +29,7 @@ fun SplashScreen() {
     val presenter: SplashPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val progress by presenter.progress.collectAsState()
-    val state by presenter.state.collectAsState()
-    val isTimeoutDialogVisible by presenter.isTimeoutDialogVisible.collectAsState()
-    val isBootstrapFailed by presenter.isBootstrapFailed.collectAsState()
-    val torBootstrapFailed by presenter.torBootstrapFailed.collectAsState()
-    val currentBootstrapStage by presenter.currentBootstrapStage.collectAsState()
-    val appNameAndVersion by presenter.appNameAndVersion.collectAsState()
+    val uiState by presenter.uiState.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         BisqStaticScaffold(
@@ -55,87 +49,84 @@ fun SplashScreen() {
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 BisqText.BaseLight(
-                    text = appNameAndVersion,
+                    text = uiState.appNameAndVersion,
                     color = BisqTheme.colors.mid_grey20,
                     modifier = Modifier.padding(bottom = 20.dp),
                 )
 
-                BisqProgressBar(progress)
+                BisqProgressBar(uiState.progress)
 
                 BisqText.BaseRegularGrey(
-                    text = state,
+                    text = uiState.status,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
 
-        // Timeout dialog
-        if (isTimeoutDialogVisible && !torBootstrapFailed && !isBootstrapFailed) {
-            if (presenter.isIos) {
+        when (uiState.activeDialog) {
+            SplashActiveDialog.TimeoutIos -> {
                 WarningConfirmationDialog(
                     headline = "mobile.bootstrap.timeout.title".i18n(),
-                    message = "mobile.bootstrap.timeout.message.ios".i18n(currentBootstrapStage),
+                    message = "mobile.bootstrap.timeout.message.ios".i18n(uiState.currentBootstrapStage),
                     confirmButtonText = "mobile.bootstrap.timeout.continue".i18n(),
                     dismissButtonText = "",
-                    onConfirm = { presenter.onTimeoutDialogContinue() },
+                    onConfirm = { presenter.onAction(SplashUiAction.OnTimeoutDialogContinue) },
                     onDismiss = { },
                     dismissOnClickOutside = false,
                 )
-            } else {
+            }
+
+            SplashActiveDialog.TimeoutAndroid -> {
                 WarningConfirmationDialog(
                     headline = "mobile.bootstrap.timeout.title".i18n(),
-                    message = "mobile.bootstrap.timeout.message".i18n(currentBootstrapStage),
+                    message = "mobile.bootstrap.timeout.message".i18n(uiState.currentBootstrapStage),
                     confirmButtonText = "mobile.bootstrap.timeout.restart".i18n(),
                     dismissButtonText = "mobile.bootstrap.timeout.continue".i18n(),
-                    onConfirm = { presenter.onRestartApp() },
-                    onDismiss = { presenter.onTimeoutDialogContinue() },
+                    onConfirm = { presenter.onAction(SplashUiAction.OnRestartApp) },
+                    onDismiss = { presenter.onAction(SplashUiAction.OnTimeoutDialogContinue) },
                     dismissOnClickOutside = false,
                 )
             }
-        }
 
-        // Restart tor dialog
-        if (torBootstrapFailed && !isBootstrapFailed) {
-            WarningConfirmationDialog(
-                headline = "mobile.bootstrap.tor.failed.title".i18n(),
-                message = "mobile.bootstrap.tor.failed.message".i18n(),
-                confirmButtonText = "mobile.bootstrap.tor.failed.purgeRestart".i18n(),
-                dismissButtonText = "mobile.bootstrap.tor.failed.restart".i18n(),
-                onConfirm = presenter::onPurgeRestartTor,
-                onDismiss = presenter::onRestartTor,
-                verticalButtonPlacement = true,
-                dismissOnClickOutside = false,
-            )
-        }
+            SplashActiveDialog.TorBootstrapFailed -> {
+                WarningConfirmationDialog(
+                    headline = "mobile.bootstrap.tor.failed.title".i18n(),
+                    message = "mobile.bootstrap.tor.failed.message".i18n(),
+                    confirmButtonText = "mobile.bootstrap.tor.failed.purgeRestart".i18n(),
+                    dismissButtonText = "mobile.bootstrap.tor.failed.restart".i18n(),
+                    onConfirm = { presenter.onAction(SplashUiAction.OnPurgeRestartTor) },
+                    onDismiss = { presenter.onAction(SplashUiAction.OnRestartTor) },
+                    verticalButtonPlacement = true,
+                    dismissOnClickOutside = false,
+                )
+            }
 
-        // Bootstrap failure dialog
-        if (isBootstrapFailed) {
-            if (presenter.isIos) {
-                // on iOS we cannot restart the app
-                // and It's discouraged to force close the app, as it looks like the app has crashed
-                // so we just have to let user know that we cannot recover from this error
-                // and give a hint that they must restart the app
+            SplashActiveDialog.BootstrapFailedIos -> {
                 WarningConfirmationDialog(
                     headline = "mobile.bootstrap.failed.title".i18n(),
-                    message = "mobile.bootstrap.failed.message".i18n(currentBootstrapStage),
+                    message = "mobile.bootstrap.failed.message".i18n(uiState.currentBootstrapStage),
                     confirmButtonText = "",
                     dismissButtonText = "",
                     onConfirm = { },
                     onDismiss = { },
                     dismissOnClickOutside = false,
                 )
-            } else {
+            }
+
+            SplashActiveDialog.BootstrapFailedAndroid -> {
                 WarningConfirmationDialog(
                     headline = "mobile.bootstrap.failed.title".i18n(),
-                    message = "mobile.bootstrap.failed.message".i18n(currentBootstrapStage),
+                    message = "mobile.bootstrap.failed.message".i18n(uiState.currentBootstrapStage),
                     confirmButtonText = "mobile.bootstrap.failed.restart".i18n(),
                     dismissButtonText = "mobile.bootstrap.failed.shutdown".i18n(),
-                    onConfirm = { presenter.onRestartApp() },
-                    onDismiss = { presenter.onTerminateApp() },
+                    onConfirm = { presenter.onAction(SplashUiAction.OnRestartApp) },
+                    onDismiss = { presenter.onAction(SplashUiAction.OnTerminateApp) },
                     dismissOnClickOutside = false,
                 )
             }
+
+            null -> Unit
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashUiAction.kt
@@ -1,0 +1,13 @@
+package network.bisq.mobile.presentation.startup.splash
+
+sealed interface SplashUiAction {
+    data object OnTimeoutDialogContinue : SplashUiAction
+
+    data object OnRestartApp : SplashUiAction
+
+    data object OnRestartTor : SplashUiAction
+
+    data object OnPurgeRestartTor : SplashUiAction
+
+    data object OnTerminateApp : SplashUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashUiState.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.presentation.startup.splash
+
+data class SplashUiState(
+    val progress: Float = 0f,
+    val status: String = "",
+    val appNameAndVersion: String = "",
+    val currentBootstrapStage: String = "",
+    val activeDialog: SplashActiveDialog? = null,
+)
+
+sealed interface SplashActiveDialog {
+    data object TimeoutIos : SplashActiveDialog
+
+    data object TimeoutAndroid : SplashActiveDialog
+
+    data object TorBootstrapFailed : SplashActiveDialog
+
+    data object BootstrapFailedIos : SplashActiveDialog
+
+    data object BootstrapFailedAndroid : SplashActiveDialog
+}


### PR DESCRIPTION
while working on #1291 it became very clear that splash screen dialog conditions won't scale like that
so I just cleaned it up and applied MVI pattern

also added a small todo for a PR later to refactor isDemo to be a mutable state so that we can react to it's changes (as connection affects it)
or we can simply remove it at this point and make things simpler. (of course, also in another PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Enhanced dialog handling during app startup with improved prioritization and platform-specific support for iOS and Android environments.

## Refactor
- Modernized startup screen state management for more reliable and consistent application initialization experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->