### PR TITLE
bugfix/profile_switch_avoid_unnecessary_update

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -331,29 +331,33 @@ class NodeUserProfileServiceFacade(
         )
 
     override suspend fun selectUserProfile(id: String): Result<UserProfileVO> =
-        runCatching {
-            val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
-            if (identity != null) {
-                userService.userIdentityService.selectChatUserIdentity(identity)
-                val userProfile = getSelectedUserProfile()
-                _selectedUserProfile.value = userProfile
-                userProfile ?: throw IllegalStateException("expected selected user identity to have a profile, but did not")
-            } else {
-                throw IllegalArgumentException("profile id not found")
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
+                if (identity != null) {
+                    userService.userIdentityService.selectChatUserIdentity(identity)
+                    val userProfile = getSelectedUserProfile()
+                    _selectedUserProfile.value = userProfile
+                    userProfile ?: throw IllegalStateException("expected selected user identity to have a profile, but did not")
+                } else {
+                    throw IllegalArgumentException("profile id not found")
+                }
             }
         }
 
     override suspend fun deleteUserProfile(id: String): Result<UserProfileVO> =
-        runCatching {
-            val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
-            if (identity != null) {
-                userService.userIdentityService.deleteUserIdentity(identity).await()
-                _userProfiles.update { list -> list.filterNot { it.id == id } }
-                val userProfile = getSelectedUserProfile()
-                _selectedUserProfile.value = userProfile
-                userProfile ?: throw IllegalStateException("expected selected user identity to have a profile after delete, but did not")
-            } else {
-                throw IllegalArgumentException("profile id not found")
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
+                if (identity != null) {
+                    userService.userIdentityService.deleteUserIdentity(identity).await()
+                    _userProfiles.update { list -> list.filterNot { it.id == id } }
+                    val userProfile = getSelectedUserProfile()
+                    _selectedUserProfile.value = userProfile
+                    userProfile ?: throw IllegalStateException("expected selected user identity to have a profile after delete, but did not")
+                } else {
+                    throw IllegalArgumentException("profile id not found")
+                }
             }
         }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/user_profile/UserProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/user_profile/UserProfilePresenter.kt
@@ -149,6 +149,8 @@ class UserProfilePresenter(
     }
 
     private fun onUserProfileSelect(profileId: String) {
+        if (_uiState.value.selectedUserProfile?.id == profileId) return
+
         disableInteractive()
         _uiState.update { it.copy(isBusyWithAction = true) }
         presenterScope.launch {


### PR DESCRIPTION
 - fixes #1308 
 - guard against switching to the same profile in profile settings screen
 - move profile delete/switch network calls to IO dispatcher off the main thread for node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized user profile service operations (selection and deletion) for improved responsiveness
  * Enhanced profile selection to skip redundant processing when the same profile is already selected
  * Streamlined profile management workflow for a smoother user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->