### PR TITLE
fix: make sure appType is explicitly sent for dismissing alert

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/alert/AlertNotificationsApiGatewayTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/alert/AlertNotificationsApiGatewayTest.kt
@@ -51,7 +51,28 @@ class AlertNotificationsApiGatewayTest {
 
             assertTrue(result.isSuccess)
             assertEquals("DELETE", requestSlot.captured.method)
-            assertEquals("/api/v1/alert-notifications/alert-1", requestSlot.captured.path)
+            assertEquals("/api/v1/alert-notifications/alert-1?appType=MOBILE_CLIENT", requestSlot.captured.path)
             coVerify(exactly = 1) { webSocketClientService.sendRequestAndAwaitResponse(any()) }
+        }
+
+    @Test
+    fun `dismissAlert always sends appType query parameter`() =
+        runTest {
+            val requestSlot = slot<WebSocketRestApiRequest>()
+            coEvery {
+                webSocketClientService.sendRequestAndAwaitResponse(capture(requestSlot))
+            } returns
+                WebSocketRestApiResponse(
+                    requestId = "request-1",
+                    statusCode = HttpStatusCode.NoContent.value,
+                    body = "",
+                )
+
+            gateway.dismissAlert("any-alert-id")
+
+            assertTrue(
+                requestSlot.captured.path.contains("appType="),
+                "Expected path to contain `appType=` in query parameters but was: ${requestSlot.captured.path}",
+            )
         }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/AlertNotificationsApiGateway.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/AlertNotificationsApiGateway.kt
@@ -10,12 +10,16 @@ class AlertNotificationsApiGateway(
     private val webSocketApiClient: WebSocketApiClient,
     private val webSocketClientService: WebSocketClientService,
 ) : Logging {
+    companion object {
+        const val APP_TYPE = "MOBILE_CLIENT"
+    }
+
     private val basePath = "alert-notifications"
 
     suspend fun subscribeAlerts(): Result<WebSocketEventObserver> =
         runCatching {
-            webSocketClientService.subscribe(Topic.ALERT_NOTIFICATIONS, "MOBILE_CLIENT")
+            webSocketClientService.subscribe(Topic.ALERT_NOTIFICATIONS, APP_TYPE)
         }
 
-    suspend fun dismissAlert(alertId: String): Result<Unit> = webSocketApiClient.delete("$basePath/$alertId")
+    suspend fun dismissAlert(alertId: String): Result<Unit> = webSocketApiClient.delete("$basePath/$alertId?appType=$APP_TYPE")
 }


### PR DESCRIPTION
this is to fix the previous behavior that relied on default value on the API, which is changed now on bisq2 side to always require the parameter to be present