### PR TITLE
fix: remove all getters for asStateFlows

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsRepositoryMock.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsRepositoryMock.kt
@@ -10,7 +10,7 @@ class SensitiveSettingsRepositoryMock :
     SensitiveSettingsRepository,
     Logging {
     private val _data = MutableStateFlow(SensitiveSettings())
-    override val data: StateFlow<SensitiveSettings> get() = _data.asStateFlow()
+    override val data: StateFlow<SensitiveSettings> = _data.asStateFlow()
 
     override suspend fun update(transform: suspend (SensitiveSettings) -> SensitiveSettings) {
         _data.value = transform(_data.value)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/httpclient/HttpClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/httpclient/HttpClientService.kt
@@ -77,7 +77,7 @@ class HttpClientService(
         MutableStateFlow(null)
     private val _httpClientChangedFlow =
         MutableSharedFlow<HttpClientSettings>(1)
-    val httpClientChangedFlow get() = _httpClientChangedFlow.asSharedFlow()
+    val httpClientChangedFlow = _httpClientChangedFlow.asSharedFlow()
     private val stopFlow =
         MutableSharedFlow<Unit>(
             replay = 1,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/settings/ClientSettingsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/settings/ClientSettingsServiceFacade.kt
@@ -21,7 +21,7 @@ class ClientSettingsServiceFacade(
     override suspend fun confirmTacAccepted(value: Boolean): Result<Unit> = apiGateway.confirmTacAccepted(value)
 
     private val _tradeRulesConfirmed: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed.asStateFlow()
+    override val tradeRulesConfirmed: StateFlow<Boolean> = _tradeRulesConfirmed.asStateFlow()
 
     override suspend fun confirmTradeRules(value: Boolean): Result<Unit> =
         apiGateway
@@ -31,7 +31,7 @@ class ClientSettingsServiceFacade(
             }
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
-    override val languageCode: StateFlow<String> get() = _languageCode.asStateFlow()
+    override val languageCode: StateFlow<String> = _languageCode.asStateFlow()
 
     override suspend fun setLanguageCode(value: String): Result<Unit> {
         try {
@@ -57,7 +57,7 @@ class ClientSettingsServiceFacade(
     override suspend fun setMaxTradePriceDeviation(value: Double): Result<Unit> = apiGateway.setMaxTradePriceDeviation(value)
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val useAnimations: StateFlow<Boolean> get() = _useAnimations.asStateFlow()
+    override val useAnimations: StateFlow<Boolean> = _useAnimations.asStateFlow()
 
     override suspend fun setUseAnimations(value: Boolean): Result<Unit> =
         apiGateway
@@ -67,7 +67,7 @@ class ClientSettingsServiceFacade(
             }
 
     private val _difficultyAdjustmentFactor: MutableStateFlow<Double> = MutableStateFlow(DEFAULT_DIFFICULTY_ADJUSTMENT_FACTOR)
-    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor.asStateFlow()
+    override val difficultyAdjustmentFactor: StateFlow<Double> = _difficultyAdjustmentFactor.asStateFlow()
 
     override suspend fun setDifficultyAdjustmentFactor(value: Double): Result<Unit> {
         // Not applicable for xClients
@@ -79,7 +79,7 @@ class ClientSettingsServiceFacade(
     override suspend fun setNumDaysAfterRedactingTradeData(days: Int): Result<Unit> = apiGateway.setNumDaysAfterRedactingTradeData(days)
 
     private val _ignoreDiffAdjustmentFromSecManager: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
+    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
 
     override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean): Result<Unit> {
         // Not applicable for xClients
@@ -89,7 +89,7 @@ class ClientSettingsServiceFacade(
     }
 
     private val _showWebLinkConfirmation: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val showWebLinkConfirmation: StateFlow<Boolean> get() = _showWebLinkConfirmation.asStateFlow()
+    override val showWebLinkConfirmation: StateFlow<Boolean> = _showWebLinkConfirmation.asStateFlow()
 
     override suspend fun setWebLinkDontShowAgain(): Result<Unit> =
         runCatching {
@@ -106,7 +106,7 @@ class ClientSettingsServiceFacade(
         }
 
     private val _permitOpeningBrowser: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val permitOpeningBrowser: StateFlow<Boolean> get() = _permitOpeningBrowser.asStateFlow()
+    override val permitOpeningBrowser: StateFlow<Boolean> = _permitOpeningBrowser.asStateFlow()
 
     override suspend fun setPermitOpeningBrowser(value: Boolean): Result<Unit> =
         runCatching {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -52,10 +52,10 @@ class ClientTradesServiceFacade(
 
     // Properties
     private val _openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
-    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _openTradeItems.asStateFlow()
+    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = _openTradeItems.asStateFlow()
 
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
+    override val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
 
     // Misc
     private val tradeId get() = selectedTrade.value?.tradeId

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -62,14 +62,14 @@ class ClientUserProfileServiceFacade(
 
     private val _selectedUserProfile: MutableStateFlow<UserProfileVO?> =
         MutableStateFlow(null)
-    override val selectedUserProfile: StateFlow<UserProfileVO?> get() = _selectedUserProfile.asStateFlow()
+    override val selectedUserProfile: StateFlow<UserProfileVO?> = _selectedUserProfile.asStateFlow()
 
     private val _numUserProfiles = MutableStateFlow(0)
-    override val numUserProfiles: StateFlow<Int> get() = _numUserProfiles.asStateFlow()
+    override val numUserProfiles: StateFlow<Int> = _numUserProfiles.asStateFlow()
 
     private val _ignoredProfileIds: MutableStateFlow<Set<String>> =
         MutableStateFlow(emptySet())
-    override val ignoredProfileIds: StateFlow<Set<String>> get() = _ignoredProfileIds.asStateFlow()
+    override val ignoredProfileIds: StateFlow<Set<String>> = _ignoredProfileIds.asStateFlow()
     private val ignoredUserIdsMutex = Mutex()
 
     // Track initialization state to prevent race conditions

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientDemo.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientDemo.kt
@@ -47,7 +47,7 @@ class WebSocketClientDemo(
 
     private val _webSocketClientStatus =
         MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
-    override val webSocketClientStatus: StateFlow<ConnectionState> get() = _webSocketClientStatus.asStateFlow()
+    override val webSocketClientStatus: StateFlow<ConnectionState> = _webSocketClientStatus.asStateFlow()
 
     override fun isDemo(): Boolean = true
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
@@ -111,7 +111,7 @@ class WebSocketClientImpl(
 
     private val _webSocketClientStatus =
         MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
-    override val webSocketClientStatus: StateFlow<ConnectionState> get() = _webSocketClientStatus.asStateFlow()
+    override val webSocketClientStatus: StateFlow<ConnectionState> = _webSocketClientStatus.asStateFlow()
 
     private var listenerJob: Job? = null
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
@@ -22,10 +22,10 @@ class NodeNetworkServiceFacade(
     Node.Listener {
     // While tor starts up we use -1 to flag as network not available yet
     private val _numConnections = MutableStateFlow(-1)
-    override val numConnections: StateFlow<Int> get() = _numConnections.asStateFlow()
+    override val numConnections: StateFlow<Int> = _numConnections.asStateFlow()
 
     private val _allDataReceived = MutableStateFlow(false)
-    override val allDataReceived: StateFlow<Boolean> get() = _allDataReceived.asStateFlow()
+    override val allDataReceived: StateFlow<Boolean> = _allDataReceived.asStateFlow()
 
     private var defaultNode: Node? = null
     private var serviceNodeStatePin: Pin? = null

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
@@ -82,12 +82,12 @@ class NodeSettingsServiceFacade(
     override suspend fun confirmTacAccepted(value: Boolean): Result<Unit> = runCatching { settingsService.setIsTacAccepted(value) }
 
     private val _tradeRulesConfirmed = MutableStateFlow(false)
-    override val tradeRulesConfirmed: StateFlow<Boolean> get() = _tradeRulesConfirmed.asStateFlow()
+    override val tradeRulesConfirmed: StateFlow<Boolean> = _tradeRulesConfirmed.asStateFlow()
 
     override suspend fun confirmTradeRules(value: Boolean): Result<Unit> = runCatching { settingsService.setBisqEasyTradeRulesConfirmed(value) }
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
-    override val languageCode: StateFlow<String> get() = _languageCode.asStateFlow()
+    override val languageCode: StateFlow<String> = _languageCode.asStateFlow()
 
     override suspend fun setLanguageCode(value: String): Result<Unit> =
         runCatching {
@@ -104,7 +104,7 @@ class NodeSettingsServiceFacade(
     override suspend fun setMaxTradePriceDeviation(value: Double): Result<Unit> = runCatching { settingsService.setMaxTradePriceDeviation(value) }
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val useAnimations: StateFlow<Boolean> get() = _useAnimations.asStateFlow()
+    override val useAnimations: StateFlow<Boolean> = _useAnimations.asStateFlow()
 
     override suspend fun setUseAnimations(value: Boolean): Result<Unit> =
         runCatching {
@@ -113,19 +113,19 @@ class NodeSettingsServiceFacade(
         }
 
     private val _difficultyAdjustmentFactor: MutableStateFlow<Double> = MutableStateFlow(DEFAULT_DIFFICULTY_ADJUSTMENT_FACTOR)
-    override val difficultyAdjustmentFactor: StateFlow<Double> get() = _difficultyAdjustmentFactor.asStateFlow()
+    override val difficultyAdjustmentFactor: StateFlow<Double> = _difficultyAdjustmentFactor.asStateFlow()
 
     override suspend fun setDifficultyAdjustmentFactor(value: Double): Result<Unit> = runCatching { settingsService.setDifficultyAdjustmentFactor(value) }
 
     override suspend fun setNumDaysAfterRedactingTradeData(days: Int): Result<Unit> = runCatching { settingsService.setNumDaysAfterRedactingTradeData(days) }
 
     private val _ignoreDiffAdjustmentFromSecManager: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> get() = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
+    override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
 
     override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean): Result<Unit> = runCatching { settingsService.setIgnoreDiffAdjustmentFromSecManager(value) }
 
     private val _showWebLinkConfirmation: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    override val showWebLinkConfirmation: StateFlow<Boolean> get() = _showWebLinkConfirmation.asStateFlow()
+    override val showWebLinkConfirmation: StateFlow<Boolean> = _showWebLinkConfirmation.asStateFlow()
 
     override suspend fun setWebLinkDontShowAgain(): Result<Unit> =
         runCatching {
@@ -144,7 +144,7 @@ class NodeSettingsServiceFacade(
         }
 
     private val _permitOpeningBrowser: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    override val permitOpeningBrowser: StateFlow<Boolean> get() = _permitOpeningBrowser.asStateFlow()
+    override val permitOpeningBrowser: StateFlow<Boolean> = _permitOpeningBrowser.asStateFlow()
 
     override suspend fun setPermitOpeningBrowser(value: Boolean): Result<Unit> =
         runCatching {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -101,7 +101,7 @@ class NodeTradesServiceFacade(
     override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = _openTradeItems.asStateFlow()
 
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    override val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
+    override val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
 
     // Misc
     private var tradesPin: Pin? = null

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -58,17 +58,17 @@ class NodeUserProfileServiceFacade(
         MutableStateFlow(
             emptySet(),
         )
-    override val ignoredProfileIds: StateFlow<Set<String>> get() = _ignoredProfileIds.asStateFlow()
+    override val ignoredProfileIds: StateFlow<Set<String>> = _ignoredProfileIds.asStateFlow()
 
     // Properties
     private val _userProfiles: MutableStateFlow<List<UserProfileVO>> = MutableStateFlow(emptyList())
     override val userProfiles = _userProfiles.asStateFlow()
 
     private val _selectedUserProfile: MutableStateFlow<UserProfileVO?> = MutableStateFlow(null)
-    override val selectedUserProfile: StateFlow<UserProfileVO?> get() = _selectedUserProfile.asStateFlow()
+    override val selectedUserProfile: StateFlow<UserProfileVO?> = _selectedUserProfile.asStateFlow()
 
     private val _numUserProfiles = MutableStateFlow(0)
-    override val numUserProfiles: StateFlow<Int> get() = _numUserProfiles.asStateFlow()
+    override val numUserProfiles: StateFlow<Int> = _numUserProfiles.asStateFlow()
 
     // Misc
     private var pubKeyHash: ByteArray? = null

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashPresenter.kt
@@ -32,7 +32,7 @@ class NodeSplashPresenter(
         versionProvider,
     ) {
     private val _state = MutableStateFlow("")
-    override val state: StateFlow<String> get() = _state.asStateFlow()
+    override val state: StateFlow<String> = _state.asStateFlow()
     val numConnections: StateFlow<Int> = networkServiceFacade.numConnections
 
     override fun onViewAttached() {

--- a/docs/compose-guidelines/README.md
+++ b/docs/compose-guidelines/README.md
@@ -32,7 +32,7 @@ fun Counter(count: Int, onInc: () -> Unit) {
 ```kotlin
 // inside ViewModel/Presenter
 private val _uiState = MutableStateFlow(UiState())
-val uiState: StateFlow<UiState> get() = _uiState.asStateFlow()
+val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 ```
 
 ### Performance

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/service/AppForegroundController.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/service/AppForegroundController.android.kt
@@ -15,7 +15,7 @@ actual class AppForegroundController(
 ) : ForegroundDetector,
     Logging {
     private val _isForeground = MutableStateFlow(false)
-    override val isForeground: StateFlow<Boolean> get() = _isForeground.asStateFlow()
+    override val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
 
     private var startedCount: Int = 0
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/offerbook/OfferbookMarket.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/offerbook/OfferbookMarket.kt
@@ -15,7 +15,7 @@ data class OfferbookMarket(
     val market: MarketVO,
 ) {
     private val _formattedPrice = MutableStateFlow("")
-    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
+    val formattedPrice: StateFlow<String> = _formattedPrice.asStateFlow()
 
     fun setFormattedPrice(value: String) {
         _formattedPrice.value = value

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelModel.kt
@@ -26,7 +26,7 @@ class BisqEasyOpenTradeChannelModel(
 
     // Mutable properties
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
+    val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
     private val _chatMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessageModel>> = MutableStateFlow(emptySet())
     val chatMessages: StateFlow<Set<BisqEasyOpenTradeMessageModel>> = _chatMessages.asStateFlow()
     val chatChannelNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/presentation/offerbook/OfferItemPresentationModel.kt
@@ -43,22 +43,22 @@ class OfferItemPresentationModel(
     // TODO _formattedPrice is never updated from market price
     // In case of market price or float is used, the price and the base amount need to be updated at market price updates.
     private val _formattedPrice = MutableStateFlow(offerItemPresentationDto.formattedPrice)
-    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
+    val formattedPrice: StateFlow<String> = _formattedPrice.asStateFlow()
 
     // TODO _formattedBaseAmount is never updated when market/float price is used and has change
     private val _formattedBaseAmount = MutableStateFlow(offerItemPresentationDto.formattedBaseAmount)
-    val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount.asStateFlow()
+    val formattedBaseAmount: StateFlow<String> = _formattedBaseAmount.asStateFlow()
 
     // The user name is the nickname and the nym in case there are multiple nicknames in the network.
     // We get that set by the backend in the makersUserProfile but we need to update it after initial retrieval by websocket events.
     // At Bisq Easy the UserNameLookup class handles that.
     // TODO not updated when there is a duplicated nickname, though rather rare moments that it gets updated
     private val _userName = MutableStateFlow(offerItemPresentationDto.userProfile.userName)
-    val userName: StateFlow<String> get() = _userName.asStateFlow()
+    val userName: StateFlow<String> = _userName.asStateFlow()
 
     // TODO not updated, though rather rare moments that it gets updated
     private val _makersReputationScore = MutableStateFlow(offerItemPresentationDto.reputationScore)
-    val makersReputationScore: StateFlow<ReputationScoreVO> get() = _makersReputationScore.asStateFlow()
+    val makersReputationScore: StateFlow<ReputationScoreVO> = _makersReputationScore.asStateFlow()
 
     var isInvalidDueToReputation: Boolean = false
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -46,28 +46,28 @@ abstract class ApplicationBootstrapFacade(
     protected open fun currentTimeMillis(): Long = DateUtils.now()
 
     private val _state = MutableStateFlow("")
-    val state: StateFlow<String> get() = _state.asStateFlow()
+    val state: StateFlow<String> = _state.asStateFlow()
 
     fun setState(value: String) {
         _state.value = value
     }
 
     private val _progress = MutableStateFlow(0f)
-    val progress: StateFlow<Float> get() = _progress.asStateFlow()
+    val progress: StateFlow<Float> = _progress.asStateFlow()
 
     fun setProgress(value: Float) {
         _progress.value = value
     }
 
     private val _isTimeoutDialogVisible = MutableStateFlow(false)
-    val isTimeoutDialogVisible: StateFlow<Boolean> get() = _isTimeoutDialogVisible.asStateFlow()
+    val isTimeoutDialogVisible: StateFlow<Boolean> = _isTimeoutDialogVisible.asStateFlow()
 
     fun setTimeoutDialogVisible(visible: Boolean) {
         _isTimeoutDialogVisible.value = visible
     }
 
     private val _isBootstrapFailed = MutableStateFlow(false)
-    val isBootstrapFailed: StateFlow<Boolean> get() = _isBootstrapFailed.asStateFlow()
+    val isBootstrapFailed: StateFlow<Boolean> = _isBootstrapFailed.asStateFlow()
 
     fun setBootstrapFailed(failed: Boolean) {
         _isBootstrapFailed.value = failed
@@ -82,14 +82,14 @@ abstract class ApplicationBootstrapFacade(
     }
 
     private val _currentBootstrapStage = MutableStateFlow("")
-    val currentBootstrapStage: StateFlow<String> get() = _currentBootstrapStage.asStateFlow()
+    val currentBootstrapStage: StateFlow<String> = _currentBootstrapStage.asStateFlow()
 
     fun setCurrentBootstrapStage(stage: String) {
         _currentBootstrapStage.value = stage
     }
 
     private val _shouldShowProgressToast = MutableStateFlow(false)
-    val shouldShowProgressToast: StateFlow<Boolean> get() = _shouldShowProgressToast.asStateFlow()
+    val shouldShowProgressToast: StateFlow<Boolean> = _shouldShowProgressToast.asStateFlow()
 
     fun setShouldShowProgressToast(show: Boolean) {
         _shouldShowProgressToast.value = show

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/market_price/MarketPriceServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/market_price/MarketPriceServiceFacade.kt
@@ -20,11 +20,11 @@ abstract class MarketPriceServiceFacade(
     val selectedMarketPriceItem: StateFlow<MarketPriceItem?> get() = _selectedMarketPriceItem
 
     protected val _selectedFormattedMarketPrice = MutableStateFlow("N/A")
-    val selectedFormattedMarketPrice: StateFlow<String> get() = _selectedFormattedMarketPrice.asStateFlow()
+    val selectedFormattedMarketPrice: StateFlow<String> = _selectedFormattedMarketPrice.asStateFlow()
 
     // Global price update trigger - emits when any market price changes
     private val _globalPriceUpdate = MutableStateFlow(0L)
-    val globalPriceUpdate: StateFlow<Long> get() = _globalPriceUpdate.asStateFlow()
+    val globalPriceUpdate: StateFlow<Long> = _globalPriceUpdate.asStateFlow()
 
     // Abstract methods that must be implemented by concrete classes
     abstract fun findMarketPriceItem(marketVO: MarketVO): MarketPriceItem?

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/ConnectivityService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/ConnectivityService.kt
@@ -39,7 +39,7 @@ abstract class ConnectivityService :
     }
 
     protected open val _status = MutableStateFlow(ConnectivityStatus.BOOTSTRAPPING)
-    val status: StateFlow<ConnectivityStatus> get() = _status.asStateFlow()
+    val status: StateFlow<ConnectivityStatus> = _status.asStateFlow()
 
     override suspend fun activate() {
         _status.value = ConnectivityStatus.BOOTSTRAPPING

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/service/market_price/GlobalPriceUpdateTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/service/market_price/GlobalPriceUpdateTest.kt
@@ -37,7 +37,7 @@ class GlobalPriceUpdateTest {
     private inner class TestMarketPriceServiceFacade {
         // Global price update trigger - emits when any market price changes
         private val _globalPriceUpdate = MutableStateFlow(0L)
-        val globalPriceUpdate: StateFlow<Long> get() = _globalPriceUpdate.asStateFlow()
+        val globalPriceUpdate: StateFlow<Long> = _globalPriceUpdate.asStateFlow()
 
         // Expose method for testing
         fun testTriggerGlobalPriceUpdate() {

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/service/AppForegroundController.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/service/AppForegroundController.ios.kt
@@ -13,7 +13,7 @@ actual class AppForegroundController :
     ForegroundDetector,
     Logging {
     private val _isForeground = MutableStateFlow(true)
-    override val isForeground: StateFlow<Boolean> get() = _isForeground.asStateFlow()
+    override val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
 
     init {
         val notificationCenter = NSNotificationCenter.defaultCenter

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/PresenterTestFakes.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/PresenterTestFakes.kt
@@ -32,7 +32,7 @@ class TestCoroutineJobsManager(
 
 class NoopNavigationManager : NavigationManager {
     private val _currentTab = MutableStateFlow<TabNavRoute?>(null)
-    override val currentTab: StateFlow<TabNavRoute?> get() = _currentTab.asStateFlow()
+    override val currentTab: StateFlow<TabNavRoute?> = _currentTab.asStateFlow()
 
     override fun setRootNavController(navController: NavHostController?) {
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PreviewTopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PreviewTopBarPresenter.kt
@@ -23,7 +23,7 @@ class PreviewTopBarPresenter : ITopBarPresenter {
     override val showAnimation: StateFlow<Boolean> = MutableStateFlow(false)
 
     private val _userProfile: MutableStateFlow<UserProfileVO?> = MutableStateFlow(null)
-    override val userProfile: StateFlow<UserProfileVO?> get() = _userProfile.asStateFlow()
+    override val userProfile: StateFlow<UserProfileVO?> = _userProfile.asStateFlow()
     override val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = this::getUserProfileIcon
 
     override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PreviewTopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/PreviewTopBarPresenter.kt
@@ -18,7 +18,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.TabNavRoute
  */
 class PreviewTopBarPresenter : ITopBarPresenter {
     private val _isInteractive = MutableStateFlow(true)
-    override val isInteractive: StateFlow<Boolean> get() = _isInteractive
+    override val isInteractive: StateFlow<Boolean> = _isInteractive.asStateFlow()
 
     override val showAnimation: StateFlow<Boolean> = MutableStateFlow(false)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/error/GenericErrorHandler.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/error/GenericErrorHandler.kt
@@ -14,10 +14,10 @@ import kotlin.jvm.JvmStatic
 class GenericErrorHandler : Logging {
     companion object {
         private val _isUncaughtException: MutableStateFlow<Boolean> = MutableStateFlow(false)
-        val isUncaughtException: StateFlow<Boolean> get() = _isUncaughtException.asStateFlow()
+        val isUncaughtException: StateFlow<Boolean> = _isUncaughtException.asStateFlow()
 
         private val _genericErrorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
-        val genericErrorMessage: StateFlow<String?> get() = _genericErrorMessage.asStateFlow()
+        val genericErrorMessage: StateFlow<String?> = _genericErrorMessage.asStateFlow()
 
         fun clearGenericError() {
             _isUncaughtException.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -53,16 +53,16 @@ open class MainPresenter(
     AppPresenter {
     // Observable state
     private val _isMainContentVisible = MutableStateFlow(false)
-    override val isMainContentVisible: StateFlow<Boolean> get() = _isMainContentVisible.asStateFlow()
+    override val isMainContentVisible: StateFlow<Boolean> = _isMainContentVisible.asStateFlow()
 
     private val _isSmallScreen = MutableStateFlow(false)
-    override val isSmallScreen: StateFlow<Boolean> get() = _isSmallScreen.asStateFlow()
+    override val isSmallScreen: StateFlow<Boolean> = _isSmallScreen.asStateFlow()
 
     protected val _showAllConnectionsLostDialogue = MutableStateFlow(false)
-    override val showAllConnectionsLostDialogue: StateFlow<Boolean> get() = _showAllConnectionsLostDialogue.asStateFlow()
+    override val showAllConnectionsLostDialogue: StateFlow<Boolean> = _showAllConnectionsLostDialogue.asStateFlow()
 
     protected val _showReconnectOverlay = MutableStateFlow(false)
-    override val showReconnectOverlay: StateFlow<Boolean> get() = _showReconnectOverlay.asStateFlow()
+    override val showReconnectOverlay: StateFlow<Boolean> = _showReconnectOverlay.asStateFlow()
 
     final override val languageCode: StateFlow<String> get() = settingsService.languageCode
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
@@ -55,52 +55,52 @@ class CreateOfferAmountPresenter(
     lateinit var formattedMinAmount: String
 
     private val _amountType: MutableStateFlow<AmountType> = MutableStateFlow(AmountType.FIXED_AMOUNT)
-    val amountType: StateFlow<AmountType> get() = _amountType.asStateFlow()
+    val amountType: StateFlow<AmountType> = _amountType.asStateFlow()
     val amountTypes = AmountType.entries.toList()
 
     // FIXED_AMOUNT
     private val _fixedAmountSliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
-    val fixedAmountSliderPosition: StateFlow<Float> get() = _fixedAmountSliderPosition.asStateFlow()
+    val fixedAmountSliderPosition: StateFlow<Float> = _fixedAmountSliderPosition.asStateFlow()
 
     private val _reputationBasedMaxSliderValue: MutableStateFlow<Float?> = MutableStateFlow(null)
-    val reputationBasedMaxSliderValue: StateFlow<Float?> get() = _reputationBasedMaxSliderValue.asStateFlow()
+    val reputationBasedMaxSliderValue: StateFlow<Float?> = _reputationBasedMaxSliderValue.asStateFlow()
 
     private val _rightMarkerValue: MutableStateFlow<Float?> = MutableStateFlow(null)
-    val rightMarkerSliderValue: StateFlow<Float?> get() = _rightMarkerValue.asStateFlow()
+    val rightMarkerSliderValue: StateFlow<Float?> = _rightMarkerValue.asStateFlow()
 
     var formattedMinAmountWithCode: String = ""
     var formattedMaxAmountWithCode: String = ""
     private val _formattedQuoteSideFixedAmount = MutableStateFlow("")
-    val formattedQuoteSideFixedAmount: StateFlow<String> get() = _formattedQuoteSideFixedAmount.asStateFlow()
+    val formattedQuoteSideFixedAmount: StateFlow<String> = _formattedQuoteSideFixedAmount.asStateFlow()
     private val _formattedBaseSideFixedAmount = MutableStateFlow("")
-    val formattedBaseSideFixedAmount: StateFlow<String> get() = _formattedBaseSideFixedAmount.asStateFlow()
+    val formattedBaseSideFixedAmount: StateFlow<String> = _formattedBaseSideFixedAmount.asStateFlow()
 
     // RANGE_AMOUNT
     private val _minRangeSliderValue: MutableStateFlow<Float> = MutableStateFlow(0.1f)
-    val minRangeSliderValue: StateFlow<Float> get() = _minRangeSliderValue.asStateFlow()
+    val minRangeSliderValue: StateFlow<Float> = _minRangeSliderValue.asStateFlow()
     private val _maxRangeSliderValue: MutableStateFlow<Float> = MutableStateFlow(0.9f)
-    val maxRangeSliderValue: StateFlow<Float> get() = _maxRangeSliderValue.asStateFlow()
+    val maxRangeSliderValue: StateFlow<Float> = _maxRangeSliderValue.asStateFlow()
     private var rangeSliderPosition: ClosedFloatingPointRange<Float> = 0.0f..1.0f
     private val _formattedQuoteSideMinRangeAmount = MutableStateFlow("")
-    val formattedQuoteSideMinRangeAmount: StateFlow<String> get() = _formattedQuoteSideMinRangeAmount.asStateFlow()
+    val formattedQuoteSideMinRangeAmount: StateFlow<String> = _formattedQuoteSideMinRangeAmount.asStateFlow()
     private val _formattedBaseSideMinRangeAmount = MutableStateFlow("")
-    val formattedBaseSideMinRangeAmount: StateFlow<String> get() = _formattedBaseSideMinRangeAmount.asStateFlow()
+    val formattedBaseSideMinRangeAmount: StateFlow<String> = _formattedBaseSideMinRangeAmount.asStateFlow()
 
     private val _formattedQuoteSideMaxRangeAmount = MutableStateFlow("")
-    val formattedQuoteSideMaxRangeAmount: StateFlow<String> get() = _formattedQuoteSideMaxRangeAmount.asStateFlow()
+    val formattedQuoteSideMaxRangeAmount: StateFlow<String> = _formattedQuoteSideMaxRangeAmount.asStateFlow()
     private val _formattedBaseSideMaxRangeAmount = MutableStateFlow("")
-    val formattedBaseSideMaxRangeAmount: StateFlow<String> get() = _formattedBaseSideMaxRangeAmount.asStateFlow()
+    val formattedBaseSideMaxRangeAmount: StateFlow<String> = _formattedBaseSideMaxRangeAmount.asStateFlow()
     private val _requiredReputation = MutableStateFlow<Long>(0L)
-    val requiredReputation: StateFlow<Long> get() = _requiredReputation.asStateFlow()
+    val requiredReputation: StateFlow<Long> = _requiredReputation.asStateFlow()
 
     private val _amountLimitInfo = MutableStateFlow("")
-    val amountLimitInfo: StateFlow<String> get() = _amountLimitInfo.asStateFlow()
+    val amountLimitInfo: StateFlow<String> = _amountLimitInfo.asStateFlow()
 
     private val _amountLimitInfoOverlayInfo = MutableStateFlow("")
-    val amountLimitInfoOverlayInfo: StateFlow<String> get() = _amountLimitInfoOverlayInfo.asStateFlow()
+    val amountLimitInfoOverlayInfo: StateFlow<String> = _amountLimitInfoOverlayInfo.asStateFlow()
 
     private val _shouldShowWarningIcon = MutableStateFlow(false)
-    val shouldShowWarningIcon: StateFlow<Boolean> get() = _shouldShowWarningIcon.asStateFlow()
+    val shouldShowWarningIcon: StateFlow<Boolean> = _shouldShowWarningIcon.asStateFlow()
 
     private lateinit var createOfferModel: CreateOfferCoordinator.CreateOfferModel
     private var minAmount: Long = DEFAULT_MIN_USD_TRADE_AMOUNT.value
@@ -113,7 +113,7 @@ class CreateOfferAmountPresenter(
     private lateinit var quoteSideMaxRangeAmount: FiatVO
     private lateinit var baseSideMaxRangeAmount: CoinVO
     private val _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val isBuy: StateFlow<Boolean> get() = _isBuy.asStateFlow()
+    val isBuy: StateFlow<Boolean> = _isBuy.asStateFlow()
 
     // Sample heavy-ish updates during drags to reduce allocation churn on main thread.
     // 32ms ~ 30 FPS. We do a leading-edge immediate update, then coalesce subsequent updates
@@ -127,23 +127,23 @@ class CreateOfferAmountPresenter(
     private var latestRangeMaxPending: Float? = null
 
     private val _formattedReputationBasedMaxAmount: MutableStateFlow<String> = MutableStateFlow("")
-    val formattedReputationBasedMaxAmount: StateFlow<String> get() = _formattedReputationBasedMaxAmount.asStateFlow()
+    val formattedReputationBasedMaxAmount: StateFlow<String> = _formattedReputationBasedMaxAmount.asStateFlow()
 
     private val _showLimitPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showLimitPopup: StateFlow<Boolean> get() = _showLimitPopup.asStateFlow()
+    val showLimitPopup: StateFlow<Boolean> = _showLimitPopup.asStateFlow()
 
     fun setShowLimitPopup(newValue: Boolean) {
         _showLimitPopup.value = newValue
     }
 
     private val _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val amountValid: StateFlow<Boolean> get() = _amountValid.asStateFlow()
+    val amountValid: StateFlow<Boolean> = _amountValid.asStateFlow()
 
     private val _isMinRangeAmountError: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isMinRangeAmountError: StateFlow<Boolean> get() = _isMinRangeAmountError.asStateFlow()
+    val isMinRangeAmountError: StateFlow<Boolean> = _isMinRangeAmountError.asStateFlow()
 
     private val _isMaxRangeAmountError: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isMaxRangeAmountError: StateFlow<Boolean> get() = _isMaxRangeAmountError.asStateFlow()
+    val isMaxRangeAmountError: StateFlow<Boolean> = _isMaxRangeAmountError.asStateFlow()
 
     // Life cycle
     init {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/direction/CreateOfferDirectionPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/direction/CreateOfferDirectionPresenter.kt
@@ -83,7 +83,7 @@ class CreateOfferDirectionPresenter(
     private var reputationCollectorJob: Job? = null
 
     private val _showSellerReputationWarning = MutableStateFlow(false)
-    val showSellerReputationWarning: StateFlow<Boolean> get() = _showSellerReputationWarning.asStateFlow()
+    val showSellerReputationWarning: StateFlow<Boolean> = _showSellerReputationWarning.asStateFlow()
 
     fun setShowSellerReputationWarning(value: Boolean) {
         _showSellerReputationWarning.value = value

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketPresenter.kt
@@ -28,10 +28,10 @@ class CreateOfferMarketPresenter(
 ) : OfferFlowPresenter(mainPresenter) {
     var headline: String
     private val _selectedMarketItem = MutableStateFlow<MarketListItem?>(null)
-    val selectedMarketItem: StateFlow<MarketListItem?> get() = _selectedMarketItem.asStateFlow()
+    val selectedMarketItem: StateFlow<MarketListItem?> = _selectedMarketItem.asStateFlow()
 
     private var _searchText = MutableStateFlow("")
-    val searchText: StateFlow<String> get() = _searchText.asStateFlow()
+    val searchText: StateFlow<String> = _searchText.asStateFlow()
 
     fun setSearchText(newValue: String) {
         _searchText.value = newValue

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/price/CreateOfferPricePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/price/CreateOfferPricePresenter.kt
@@ -35,26 +35,26 @@ class CreateOfferPricePresenter(
     var priceQuote: PriceQuoteVO
     var percentagePriceValue: Double = 0.0
     private val _formattedPercentagePrice = MutableStateFlow("")
-    val formattedPercentagePrice: StateFlow<String> get() = _formattedPercentagePrice.asStateFlow()
+    val formattedPercentagePrice: StateFlow<String> = _formattedPercentagePrice.asStateFlow()
     private val _formattedPercentagePriceValid = MutableStateFlow(true)
-    val formattedPercentagePriceValid: StateFlow<Boolean> get() = _formattedPercentagePriceValid.asStateFlow()
+    val formattedPercentagePriceValid: StateFlow<Boolean> = _formattedPercentagePriceValid.asStateFlow()
 
     private val _formattedPrice = MutableStateFlow("")
-    val formattedPrice: StateFlow<String> get() = _formattedPrice.asStateFlow()
+    val formattedPrice: StateFlow<String> = _formattedPrice.asStateFlow()
     private val _formattedPriceValid = MutableStateFlow(true)
 
     private val _priceType = MutableStateFlow(PriceType.PERCENTAGE)
-    val priceType: StateFlow<PriceType> get() = _priceType.asStateFlow()
+    val priceType: StateFlow<PriceType> = _priceType.asStateFlow()
 
     private val _isBuy: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    val isBuy: StateFlow<Boolean> get() = _isBuy.asStateFlow()
+    val isBuy: StateFlow<Boolean> = _isBuy.asStateFlow()
     private val _hintText = MutableStateFlow("")
-    val hintText: StateFlow<String> get() = _hintText.asStateFlow()
+    val hintText: StateFlow<String> = _hintText.asStateFlow()
 
     private var createOfferModel: CreateOfferCoordinator.CreateOfferModel
 
     private val _showWhyPopup: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showWhyPopup: StateFlow<Boolean> get() = _showWhyPopup.asStateFlow()
+    val showWhyPopup: StateFlow<Boolean> = _showWhyPopup.asStateFlow()
 
     fun setShowWhyPopup(newValue: Boolean) {
         _showWhyPopup.value = newValue

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/amount/TakeOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/amount/TakeOfferAmountPresenter.kt
@@ -33,16 +33,16 @@ class TakeOfferAmountPresenter(
     private val takeOfferCoordinator: TakeOfferCoordinator,
 ) : OfferFlowPresenter(mainPresenter) {
     private val _sliderPosition: MutableStateFlow<Float> = MutableStateFlow(0.5f)
-    val sliderPosition: StateFlow<Float> get() = _sliderPosition.asStateFlow()
+    val sliderPosition: StateFlow<Float> = _sliderPosition.asStateFlow()
 
     var quoteCurrencyCode: String = ""
     var formattedMinAmount: String = ""
     var formattedMinAmountWithCode: String = ""
     var formattedMaxAmountWithCode: String = ""
     private val _formattedQuoteAmount = MutableStateFlow("")
-    val formattedQuoteAmount: StateFlow<String> get() = _formattedQuoteAmount.asStateFlow()
+    val formattedQuoteAmount: StateFlow<String> = _formattedQuoteAmount.asStateFlow()
     private val _formattedBaseAmount = MutableStateFlow("")
-    val formattedBaseAmount: StateFlow<String> get() = _formattedBaseAmount.asStateFlow()
+    val formattedBaseAmount: StateFlow<String> = _formattedBaseAmount.asStateFlow()
 
     // Guard to prevent interactions when initialization fails
     private var initializationFailed: Boolean = false
@@ -56,7 +56,7 @@ class TakeOfferAmountPresenter(
     private lateinit var baseAmount: CoinVO
 
     private val _amountValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val amountValid: StateFlow<Boolean> get() = _amountValid.asStateFlow()
+    val amountValid: StateFlow<Boolean> = _amountValid.asStateFlow()
 
     private var dragUpdateJob: Job? = null
     private var latestPending: Float? = null

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
@@ -55,14 +55,14 @@ class TakeOfferReviewPresenter(
     private val takeOfferErrorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
 
     private val _showTakeOfferProgressDialog = MutableStateFlow(false)
-    val showTakeOfferProgressDialog: StateFlow<Boolean> get() = _showTakeOfferProgressDialog.asStateFlow()
+    val showTakeOfferProgressDialog: StateFlow<Boolean> = _showTakeOfferProgressDialog.asStateFlow()
 
     private fun setShowTakeOfferProgressDialog(value: Boolean) {
         _showTakeOfferProgressDialog.value = value
     }
 
     private val _showTakeOfferSuccessDialog = MutableStateFlow(false)
-    val showTakeOfferSuccessDialog: StateFlow<Boolean> get() = _showTakeOfferSuccessDialog.asStateFlow()
+    val showTakeOfferSuccessDialog: StateFlow<Boolean> = _showTakeOfferSuccessDialog.asStateFlow()
 
     private fun setShowTakeOfferSuccessDialog(value: Boolean) {
         _showTakeOfferSuccessDialog.value = value

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -61,23 +61,23 @@ open class OfferbookPresenter(
     private val _showTradeRestrictedDialog = MutableStateFlow<AlertNotificationUiState?>(null)
     val showTradeRestrictedDialog: StateFlow<AlertNotificationUiState?> = _showTradeRestrictedDialog.asStateFlow()
     private val _selectedDirection = MutableStateFlow(DirectionEnum.BUY)
-    val selectedDirection: StateFlow<DirectionEnum> get() = _selectedDirection.asStateFlow()
+    val selectedDirection: StateFlow<DirectionEnum> = _selectedDirection.asStateFlow()
 
     private val _selectedPaymentMethodIds = MutableStateFlow<Set<String>>(emptySet())
     val selectedPaymentMethodIds: StateFlow<Set<String>> = _selectedPaymentMethodIds.asStateFlow()
     private val _selectedSettlementMethodIds = MutableStateFlow<Set<String>>(emptySet())
-    val selectedSettlementMethodIds: StateFlow<Set<String>> get() = _selectedSettlementMethodIds.asStateFlow()
+    val selectedSettlementMethodIds: StateFlow<Set<String>> = _selectedSettlementMethodIds.asStateFlow()
     private val _onlyMyOffers = MutableStateFlow(false)
-    val onlyMyOffers: StateFlow<Boolean> get() = _onlyMyOffers.asStateFlow()
+    val onlyMyOffers: StateFlow<Boolean> = _onlyMyOffers.asStateFlow()
 
     private val _sortedFilteredOffers = MutableStateFlow<List<OfferItemPresentationModel>>(emptyList())
-    val sortedFilteredOffers: StateFlow<List<OfferItemPresentationModel>> get() = _sortedFilteredOffers.asStateFlow()
+    val sortedFilteredOffers: StateFlow<List<OfferItemPresentationModel>> = _sortedFilteredOffers.asStateFlow()
 
     // Baseline available method sets (direction+ignored-user filtered, independent of method selections)
     private val _availablePaymentMethodIds = MutableStateFlow<Set<String>>(emptySet())
-    val availablePaymentMethodIds: StateFlow<Set<String>> get() = _availablePaymentMethodIds.asStateFlow()
+    val availablePaymentMethodIds: StateFlow<Set<String>> = _availablePaymentMethodIds.asStateFlow()
     private val _availableSettlementMethodIds = MutableStateFlow<Set<String>>(emptySet())
-    val availableSettlementMethodIds: StateFlow<Set<String>> get() = _availableSettlementMethodIds.asStateFlow()
+    val availableSettlementMethodIds: StateFlow<Set<String>> = _availableSettlementMethodIds.asStateFlow()
 
     // Presenter-provided UI state for the filter controller
     private val _filterUiState =
@@ -98,10 +98,10 @@ open class OfferbookPresenter(
     private var hasManualSettlementFilter: Boolean = false
 
     private val _showDeleteConfirmation = MutableStateFlow(false)
-    val showDeleteConfirmation: StateFlow<Boolean> get() = _showDeleteConfirmation.asStateFlow()
+    val showDeleteConfirmation: StateFlow<Boolean> = _showDeleteConfirmation.asStateFlow()
 
     private val _showNotEnoughReputationDialog = MutableStateFlow(false)
-    val showNotEnoughReputationDialog: StateFlow<Boolean> get() = _showNotEnoughReputationDialog.asStateFlow()
+    val showNotEnoughReputationDialog: StateFlow<Boolean> = _showNotEnoughReputationDialog.asStateFlow()
 
     val selectedMarket get() = marketPriceServiceFacade.selectedMarketPriceItem
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
@@ -16,10 +16,10 @@ class IgnoredUsersPresenter(
 ) : BasePresenter(mainPresenter),
     IIgnoredUsersPresenter {
     private val _ignoredUsers = MutableStateFlow<List<UserProfileVO>>(emptyList())
-    override val ignoredUsers: StateFlow<List<UserProfileVO>> get() = _ignoredUsers.asStateFlow()
+    override val ignoredUsers: StateFlow<List<UserProfileVO>> = _ignoredUsers.asStateFlow()
 
     private val _ignoreUserId: MutableStateFlow<String> = MutableStateFlow("")
-    override val ignoreUserId: StateFlow<String> get() = _ignoreUserId.asStateFlow()
+    override val ignoreUserId: StateFlow<String> = _ignoreUserId.asStateFlow()
 
     override val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
@@ -17,7 +17,7 @@ class SupportPresenter(
     private val deviceInfoProvider: DeviceInfoProvider,
 ) : BasePresenter(mainPresenter) {
     protected val _reportUrl: MutableStateFlow<String> = MutableStateFlow("")
-    val reportUrl: StateFlow<String> get() = _reportUrl.asStateFlow()
+    val reportUrl: StateFlow<String> = _reportUrl.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
@@ -13,7 +13,7 @@ import network.bisq.mobile.presentation.main.MainPresenter
 
 class SupportPresenter(
     mainPresenter: MainPresenter,
-    private var versionProvider: VersionProvider,
+    private val versionProvider: VersionProvider,
     private val deviceInfoProvider: DeviceInfoProvider,
 ) : BasePresenter(mainPresenter) {
     protected val _reportUrl: MutableStateFlow<String> = MutableStateFlow("")

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/create_profile/CreateProfilePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/create_profile/CreateProfilePresenter.kt
@@ -31,28 +31,28 @@ class CreateProfilePresenter(
 
     // Properties
     private val _id = MutableStateFlow("")
-    val id: StateFlow<String> get() = _id.asStateFlow()
+    val id: StateFlow<String> = _id.asStateFlow()
 
     private fun setId(value: String) {
         _id.value = value
     }
 
     private val _nym = MutableStateFlow("")
-    val nym: StateFlow<String> get() = _nym.asStateFlow()
+    val nym: StateFlow<String> = _nym.asStateFlow()
 
     private fun setNym(value: String) {
         _nym.value = value
     }
 
     private val _profileIcon = MutableStateFlow<PlatformImage?>(null)
-    val profileIcon: StateFlow<PlatformImage?> get() = _profileIcon.asStateFlow()
+    val profileIcon: StateFlow<PlatformImage?> = _profileIcon.asStateFlow()
 
     private fun setProfileIcon(value: PlatformImage?) {
         _profileIcon.value = value
     }
 
     private val _nickName = MutableStateFlow("")
-    val nickName: StateFlow<String> get() = _nickName.asStateFlow()
+    val nickName: StateFlow<String> = _nickName.asStateFlow()
 
     fun setNickname(value: String) {
         // Trim leading/trailing whitespace to avoid accidental spaces causing validation or submission errors
@@ -60,13 +60,13 @@ class CreateProfilePresenter(
     }
 
     private val _nickNameValid = MutableStateFlow(false)
-    val nickNameValid: StateFlow<Boolean> get() = _nickNameValid.asStateFlow()
+    val nickNameValid: StateFlow<Boolean> = _nickNameValid.asStateFlow()
 
     private val _generateKeyPairInProgress = MutableStateFlow(false)
-    val generateKeyPairInProgress: StateFlow<Boolean> get() = _generateKeyPairInProgress.asStateFlow()
+    val generateKeyPairInProgress: StateFlow<Boolean> = _generateKeyPairInProgress.asStateFlow()
 
     private val _createAndPublishInProgress = MutableStateFlow(false)
-    val createAndPublishInProgress: StateFlow<Boolean> get() = _createAndPublishInProgress.asStateFlow()
+    val createAndPublishInProgress: StateFlow<Boolean> = _createAndPublishInProgress.asStateFlow()
 
     // Lifecycle
     override fun onViewAttached() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenter.kt
@@ -16,7 +16,7 @@ open class UserAgreementPresenter(
 ) : BasePresenter(mainPresenter),
     IAgreementPresenter {
     private val _accepted = MutableStateFlow(false)
-    override val isAccepted: StateFlow<Boolean> get() = _accepted.asStateFlow()
+    override val isAccepted: StateFlow<Boolean> = _accepted.asStateFlow()
 
     override fun onAccepted(accepted: Boolean) {
         _accepted.value = accepted

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardPresenter.kt
@@ -41,15 +41,15 @@ open class DashboardPresenter(
     private val pushNotificationServiceFacade: PushNotificationServiceFacade,
 ) : BasePresenter(mainPresenter) {
     private val _offersOnline = MutableStateFlow(0)
-    val offersOnline: StateFlow<Int> get() = _offersOnline.asStateFlow()
+    val offersOnline: StateFlow<Int> = _offersOnline.asStateFlow()
 
     private val _publishedProfiles = MutableStateFlow(0)
-    val publishedProfiles: StateFlow<Int> get() = _publishedProfiles.asStateFlow()
+    val publishedProfiles: StateFlow<Int> = _publishedProfiles.asStateFlow()
     val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
     val marketPrice: StateFlow<String> get() = marketPriceServiceFacade.selectedFormattedMarketPrice
 
     private val _numConnections = MutableStateFlow(0)
-    val numConnections: StateFlow<Int> get() = _numConnections.asStateFlow()
+    val numConnections: StateFlow<Int> = _numConnections.asStateFlow()
 
     open val showNumConnections: Boolean = false
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -44,7 +44,7 @@ abstract class MiscItemsPresenter(
     }
 
     private val _menuItems = MutableStateFlow<MenuItem?>(null)
-    val menuItems: StateFlow<MenuItem?> get() = _menuItems.asStateFlow()
+    val menuItems: StateFlow<MenuItem?> = _menuItems.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
@@ -58,14 +58,14 @@ class OfferbookMarketPresenter(
     }
 
     private val _searchText = MutableStateFlow("")
-    val searchText: StateFlow<String> get() = _searchText.asStateFlow()
+    val searchText: StateFlow<String> = _searchText.asStateFlow()
 
     fun setSearchText(newValue: String) {
         _searchText.value = newValue
     }
 
     private val _marketListItemWithNumOffers = MutableStateFlow<List<MarketListItem>>(emptyList())
-    val marketListItemWithNumOffers: StateFlow<List<MarketListItem>> get() = _marketListItemWithNumOffers.asStateFlow()
+    val marketListItemWithNumOffers: StateFlow<List<MarketListItem>> = _marketListItemWithNumOffers.asStateFlow()
 
     fun onSelectMarket(marketListItem: MarketListItem) {
         offersServiceFacade

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListPresenter.kt
@@ -26,12 +26,12 @@ class OpenTradeListPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
 ) : BasePresenter(mainPresenter) {
     private val _sortedOpenTradeItems: MutableStateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
-    val sortedOpenTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = _sortedOpenTradeItems.asStateFlow()
+    val sortedOpenTradeItems: StateFlow<List<TradeItemPresentationModel>> = _sortedOpenTradeItems.asStateFlow()
 
     val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
 
     private val _tradeGuideVisible = MutableStateFlow(false)
-    val tradeGuideVisible: StateFlow<Boolean> get() = _tradeGuideVisible.asStateFlow()
+    val tradeGuideVisible: StateFlow<Boolean> = _tradeGuideVisible.asStateFlow()
     val tradesWithUnreadMessages: StateFlow<Map<String, Int>> get() = mainPresenter.tradesWithUnreadMessages
 
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
@@ -47,15 +47,15 @@ class TradeChatPresenter(
     private val messageDeliveryServiceFacade: MessageDeliveryServiceFacade,
 ) : BasePresenter(mainPresenter) {
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
 
     private val _sortedChatMessages: MutableStateFlow<List<BisqEasyOpenTradeMessageModel>> =
         MutableStateFlow(listOf())
-    val sortedChatMessages: StateFlow<List<BisqEasyOpenTradeMessageModel>> get() = _sortedChatMessages.asStateFlow()
+    val sortedChatMessages: StateFlow<List<BisqEasyOpenTradeMessageModel>> = _sortedChatMessages.asStateFlow()
 
     private val _quotedMessage: MutableStateFlow<BisqEasyOpenTradeMessageModel?> =
         MutableStateFlow(null)
-    val quotedMessage: StateFlow<BisqEasyOpenTradeMessageModel?> get() = _quotedMessage.asStateFlow()
+    val quotedMessage: StateFlow<BisqEasyOpenTradeMessageModel?> = _quotedMessage.asStateFlow()
     val showChatRulesWarnBox: StateFlow<Boolean> =
         settingsRepository.data.map { it.showChatRulesWarnBox }.stateIn(
             presenterScope,
@@ -65,29 +65,29 @@ class TradeChatPresenter(
 
     private val _userProfileIconByProfileId: MutableStateFlow<Map<String, PlatformImage?>> =
         MutableStateFlow(emptyMap())
-    val userProfileIconByProfileId: StateFlow<Map<String, PlatformImage?>> get() = _userProfileIconByProfileId.asStateFlow()
+    val userProfileIconByProfileId: StateFlow<Map<String, PlatformImage?>> = _userProfileIconByProfileId.asStateFlow()
 
     private val _ignoreUserId: MutableStateFlow<String> = MutableStateFlow("")
-    val ignoreUserId: StateFlow<String> get() = _ignoreUserId.asStateFlow()
+    val ignoreUserId: StateFlow<String> = _ignoreUserId.asStateFlow()
 
     private val _undoIgnoreUserId: MutableStateFlow<String> = MutableStateFlow("")
-    val undoIgnoreUserId: StateFlow<String> get() = _undoIgnoreUserId.asStateFlow()
+    val undoIgnoreUserId: StateFlow<String> = _undoIgnoreUserId.asStateFlow()
 
     val ignoredProfileIds: StateFlow<Set<String>> get() = userProfileServiceFacade.ignoredProfileIds
 
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 
     private val _showTradeNotFoundDialog = MutableStateFlow(false)
-    val showTradeNotFoundDialog: StateFlow<Boolean> get() = _showTradeNotFoundDialog.asStateFlow()
+    val showTradeNotFoundDialog: StateFlow<Boolean> = _showTradeNotFoundDialog.asStateFlow()
 
     private val _showReportUserDialog = MutableStateFlow(false)
-    val showReportUserDialog: StateFlow<Boolean> get() = _showReportUserDialog.asStateFlow()
+    val showReportUserDialog: StateFlow<Boolean> = _showReportUserDialog.asStateFlow()
 
     private val _reportUserTradeMessage = MutableStateFlow<BisqEasyOpenTradeMessageModel?>(null)
-    val reportUserTradeMessage: StateFlow<BisqEasyOpenTradeMessageModel?> get() = _reportUserTradeMessage.asStateFlow()
+    val reportUserTradeMessage: StateFlow<BisqEasyOpenTradeMessageModel?> = _reportUserTradeMessage.asStateFlow()
 
     private val _reportUserMessage = MutableStateFlow<String?>(null)
-    val reportUserMessage: StateFlow<String?> get() = _reportUserMessage.asStateFlow()
+    val reportUserMessage: StateFlow<String?> = _reportUserMessage.asStateFlow()
 
     val readCount =
         selectedTrade

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePresenter.kt
@@ -29,26 +29,26 @@ class InterruptedTradePresenter(
     val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _interruptedTradeInfo: MutableStateFlow<String> = MutableStateFlow("")
-    val interruptedTradeInfo: StateFlow<String> get() = _interruptedTradeInfo.asStateFlow()
+    val interruptedTradeInfo: StateFlow<String> = _interruptedTradeInfo.asStateFlow()
 
     private val _interruptionInfoVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val interruptionInfoVisible: StateFlow<Boolean> get() = _interruptionInfoVisible.asStateFlow()
+    val interruptionInfoVisible: StateFlow<Boolean> = _interruptionInfoVisible.asStateFlow()
 
     var errorMessage: String = ""
     private val _errorMessageVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val errorMessageVisible: StateFlow<Boolean> get() = _errorMessageVisible.asStateFlow()
+    val errorMessageVisible: StateFlow<Boolean> = _errorMessageVisible.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
+    val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
 
     private val _reportToMediatorButtonVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val reportToMediatorButtonVisible: StateFlow<Boolean> get() = _reportToMediatorButtonVisible.asStateFlow()
+    val reportToMediatorButtonVisible: StateFlow<Boolean> = _reportToMediatorButtonVisible.asStateFlow()
 
     private val _showNoMediatorAvailableWarningDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showNoMediatorAvailableWarningDialog: StateFlow<Boolean> get() = _showNoMediatorAvailableWarningDialog.asStateFlow()
+    val showNoMediatorAvailableWarningDialog: StateFlow<Boolean> = _showNoMediatorAvailableWarningDialog.asStateFlow()
 
     private val _showMediationRequestedDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showMediationRequestedDialog: StateFlow<Boolean> get() = _showMediationRequestedDialog.asStateFlow()
+    val showMediationRequestedDialog: StateFlow<Boolean> = _showMediationRequestedDialog.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -42,19 +42,19 @@ class OpenTradePresenter(
     val tradeFlowPresenter: TradeFlowPresenter,
 ) : BasePresenter(mainPresenter) {
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
-    val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = _selectedTrade.asStateFlow()
+    val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
 
     private val _tradeAbortedBoxVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val tradeAbortedBoxVisible: StateFlow<Boolean> get() = _tradeAbortedBoxVisible.asStateFlow()
+    val tradeAbortedBoxVisible: StateFlow<Boolean> = _tradeAbortedBoxVisible.asStateFlow()
 
     private val _tradeProcessBoxVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val tradeProcessBoxVisible: StateFlow<Boolean> get() = _tradeProcessBoxVisible.asStateFlow()
+    val tradeProcessBoxVisible: StateFlow<Boolean> = _tradeProcessBoxVisible.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> get() = _isInMediation.asStateFlow()
+    val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
 
     private val _showTradeNotFoundDialog = MutableStateFlow(false)
-    val showTradeNotFoundDialog: StateFlow<Boolean> get() = _showTradeNotFoundDialog.asStateFlow()
+    val showTradeNotFoundDialog: StateFlow<Boolean> = _showTradeNotFoundDialog.asStateFlow()
 
     private val readCount: Flow<Int> =
         _selectedTrade.combine(tradeReadStateRepository.data.map { it.map }) { trade, readStates ->
@@ -78,7 +78,7 @@ class OpenTradePresenter(
 
     private val _lastChatMsg: MutableStateFlow<BisqEasyOpenTradeMessageModel?> =
         MutableStateFlow(null)
-    val lastChatMsg: StateFlow<BisqEasyOpenTradeMessageModel?> get() = _lastChatMsg.asStateFlow()
+    val lastChatMsg: StateFlow<BisqEasyOpenTradeMessageModel?> = _lastChatMsg.asStateFlow()
 
     private val _tradePaneScrollState: MutableStateFlow<ScrollState?> = MutableStateFlow(null)
 
@@ -93,7 +93,7 @@ class OpenTradePresenter(
             )
 
     private val _showUndoIgnoreDialog = MutableStateFlow(false)
-    val showUndoIgnoreDialog: StateFlow<Boolean> get() = _showUndoIgnoreDialog.asStateFlow()
+    val showUndoIgnoreDialog: StateFlow<Boolean> = _showUndoIgnoreDialog.asStateFlow()
 
     private var _coroutineScope: CoroutineScope? = null
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
@@ -39,35 +39,35 @@ class TradeDetailsHeaderPresenter(
     var directionEnum: DirectionEnum = DirectionEnum.BUY
     var leftAmountDescription: String = ""
     private val _leftAmount: MutableStateFlow<String> = MutableStateFlow("")
-    val leftAmount: StateFlow<String> get() = _leftAmount.asStateFlow()
+    val leftAmount: StateFlow<String> = _leftAmount.asStateFlow()
     private val _leftCode: MutableStateFlow<String> = MutableStateFlow("")
-    val leftCode: StateFlow<String> get() = _leftCode.asStateFlow()
+    val leftCode: StateFlow<String> = _leftCode.asStateFlow()
     var rightAmountDescription: String = ""
     private val _rightAmount: MutableStateFlow<String> = MutableStateFlow("")
-    val rightAmount: StateFlow<String> get() = _rightAmount.asStateFlow()
+    val rightAmount: StateFlow<String> = _rightAmount.asStateFlow()
     private val _rightCode: MutableStateFlow<String> = MutableStateFlow("")
-    val rightCode: StateFlow<String> get() = _rightCode.asStateFlow()
+    val rightCode: StateFlow<String> = _rightCode.asStateFlow()
 
     private val _tradeCloseType: MutableStateFlow<TradeCloseType?> = MutableStateFlow(null)
-    val tradeCloseType: StateFlow<TradeCloseType?> get() = _tradeCloseType.asStateFlow()
+    val tradeCloseType: StateFlow<TradeCloseType?> = _tradeCloseType.asStateFlow()
 
     private val _interruptTradeButtonText: MutableStateFlow<String> = MutableStateFlow("")
-    val interruptTradeButtonText: StateFlow<String> get() = _interruptTradeButtonText.asStateFlow()
+    val interruptTradeButtonText: StateFlow<String> = _interruptTradeButtonText.asStateFlow()
 
     private val _openMediationButtonText: MutableStateFlow<String> = MutableStateFlow("")
-    val openMediationButtonText: StateFlow<String> get() = _openMediationButtonText.asStateFlow()
+    val openMediationButtonText: StateFlow<String> = _openMediationButtonText.asStateFlow()
 
     private val _showInterruptionConfirmationDialog = MutableStateFlow(false)
-    val showInterruptionConfirmationDialog: StateFlow<Boolean> get() = _showInterruptionConfirmationDialog.asStateFlow()
+    val showInterruptionConfirmationDialog: StateFlow<Boolean> = _showInterruptionConfirmationDialog.asStateFlow()
 
     private val _showMediationConfirmationDialog = MutableStateFlow(false)
-    val showMediationConfirmationDialog: StateFlow<Boolean> get() = _showMediationConfirmationDialog.asStateFlow()
+    val showMediationConfirmationDialog: StateFlow<Boolean> = _showMediationConfirmationDialog.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> get() = this._isInMediation.asStateFlow()
 
     private val _mediationError = MutableStateFlow("")
-    val mediationError: StateFlow<String> get() = _mediationError.asStateFlow()
+    val mediationError: StateFlow<String> = _mediationError.asStateFlow()
 
     private val _isShowDetails: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isShowDetails: StateFlow<Boolean> get() = this._isShowDetails.asStateFlow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
@@ -64,13 +64,13 @@ class TradeDetailsHeaderPresenter(
     val showMediationConfirmationDialog: StateFlow<Boolean> = _showMediationConfirmationDialog.asStateFlow()
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isInMediation: StateFlow<Boolean> get() = this._isInMediation.asStateFlow()
+    val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
 
     private val _mediationError = MutableStateFlow("")
     val mediationError: StateFlow<String> = _mediationError.asStateFlow()
 
     private val _isShowDetails: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isShowDetails: StateFlow<Boolean> get() = this._isShowDetails.asStateFlow()
+    val isShowDetails: StateFlow<Boolean> = _isShowDetails.asStateFlow()
 
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPresenter.kt
@@ -84,7 +84,7 @@ class TradeFlowPresenter(
         )
 
     private val _tradePhaseState: MutableStateFlow<TradePhaseState> = MutableStateFlow(TradePhaseState.INIT)
-    val tradePhaseState: StateFlow<TradePhaseState> get() = _tradePhaseState.asStateFlow()
+    val tradePhaseState: StateFlow<TradePhaseState> = _tradePhaseState.asStateFlow()
 
     private var isSeller: Boolean = false
     private var isMainChain: Boolean = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/buyer_state_1/state_a/BuyerState1aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/buyer_state_1/state_a/BuyerState1aPresenter.kt
@@ -17,22 +17,22 @@ class BuyerState1aPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
     private var _headline = MutableStateFlow("")
-    val headline: StateFlow<String> get() = _headline.asStateFlow()
+    val headline: StateFlow<String> = _headline.asStateFlow()
 
     private var _description = MutableStateFlow("")
-    val description: StateFlow<String> get() = _description.asStateFlow()
+    val description: StateFlow<String> = _description.asStateFlow()
 
     private var _bitcoinPaymentData = MutableStateFlow("")
-    val bitcoinPaymentData: StateFlow<String> get() = _bitcoinPaymentData.asStateFlow()
+    val bitcoinPaymentData: StateFlow<String> = _bitcoinPaymentData.asStateFlow()
 
     private var _bitcoinPaymentDataValid = MutableStateFlow(false)
-    val bitcoinPaymentDataValid: StateFlow<Boolean> get() = _bitcoinPaymentDataValid.asStateFlow()
+    val bitcoinPaymentDataValid: StateFlow<Boolean> = _bitcoinPaymentDataValid.asStateFlow()
 
     private var _bitcoinAddressFieldType = MutableStateFlow(BitcoinLnAddressFieldType.Bitcoin)
-    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType.asStateFlow()
+    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> = _bitcoinAddressFieldType.asStateFlow()
 
     private val _showInvalidAddressDialog = MutableStateFlow(false)
-    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog.asStateFlow()
+    val showInvalidAddressDialog: StateFlow<Boolean> = _showInvalidAddressDialog.asStateFlow()
 
     private val _showBarcodeView = MutableStateFlow(false)
     val showBarcodeView: StateFlow<Boolean> = _showBarcodeView.asStateFlow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/BaseTradeStateMainChain3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/BaseTradeStateMainChain3bPresenter.kt
@@ -25,27 +25,27 @@ abstract class BaseTradeStateMainChain3bPresenter(
     val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _buttonText: MutableStateFlow<String> = MutableStateFlow(EMPTY_STRING)
-    val buttonText: StateFlow<String> get() = _buttonText.asStateFlow()
+    val buttonText: StateFlow<String> = _buttonText.asStateFlow()
 
     private val _txConfirmationState: MutableStateFlow<TxConfirmationState> =
         MutableStateFlow(TxConfirmationState.IDLE)
-    val txConfirmationState: StateFlow<TxConfirmationState> get() = _txConfirmationState.asStateFlow()
+    val txConfirmationState: StateFlow<TxConfirmationState> = _txConfirmationState.asStateFlow()
 
     private val _blockExplorer: MutableStateFlow<String> = MutableStateFlow(EMPTY_STRING)
-    val blockExplorer: StateFlow<String> get() = _blockExplorer.asStateFlow()
+    val blockExplorer: StateFlow<String> = _blockExplorer.asStateFlow()
 
     private val _balanceFromTx: MutableStateFlow<String> = MutableStateFlow(EMPTY_STRING)
-    val balanceFromTx: StateFlow<String> get() = _balanceFromTx.asStateFlow()
+    val balanceFromTx: StateFlow<String> = _balanceFromTx.asStateFlow()
 
     private val _errorMessage: MutableStateFlow<String?> = MutableStateFlow(null)
-    val errorMessage: StateFlow<String?> get() = _errorMessage.asStateFlow()
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
     private val _skip: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val skip: StateFlow<Boolean> get() = _skip.asStateFlow()
+    val skip: StateFlow<Boolean> = _skip.asStateFlow()
 
     private val _amountNotMatchingDialogText: MutableStateFlow<String?> =
         MutableStateFlow(null)
-    val amountNotMatchingDialogText: StateFlow<String?> get() = _amountNotMatchingDialogText.asStateFlow()
+    val amountNotMatchingDialogText: StateFlow<String?> = _amountNotMatchingDialogText.asStateFlow()
 
     private var txAmount: Long? = null
     private var txAmountFormatted: String? = null

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4Presenter.kt
@@ -22,7 +22,7 @@ abstract class State4Presenter(
     val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _showCloseTradeDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showCloseTradeDialog: StateFlow<Boolean> get() = _showCloseTradeDialog.asStateFlow()
+    val showCloseTradeDialog: StateFlow<Boolean> = _showCloseTradeDialog.asStateFlow()
 
     override fun onViewUnattaching() {
         _showCloseTradeDialog.value = false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_1/SellerState1Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_1/SellerState1Presenter.kt
@@ -27,7 +27,7 @@ class SellerState1Presenter(
     val paymentAccountDataEntry: StateFlow<DataEntry> = _paymentAccountDataEntry.asStateFlow()
 
     private var _paymentAccountName = MutableStateFlow("")
-    val paymentAccountName: StateFlow<String> get() = _paymentAccountName.asStateFlow()
+    val paymentAccountName: StateFlow<String> = _paymentAccountName.asStateFlow()
 
     private val minPaymentAccountDataLength = 3
     private val maxPaymentAccountDataLength = 1024

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_3/state_a/SellerState3aPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_3/state_a/SellerState3aPresenter.kt
@@ -17,26 +17,26 @@ class SellerState3aPresenter(
     val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
 
     private val _paymentProof: MutableStateFlow<String?> = MutableStateFlow(null)
-    val paymentProof: StateFlow<String?> get() = _paymentProof.asStateFlow()
+    val paymentProof: StateFlow<String?> = _paymentProof.asStateFlow()
 
     private val _paymentProofValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val paymentProofValid: StateFlow<Boolean> get() = _paymentProofValid.asStateFlow()
+    val paymentProofValid: StateFlow<Boolean> = _paymentProofValid.asStateFlow()
 
     private val _showInvalidAddressDialog = MutableStateFlow(false)
-    val showInvalidAddressDialog: StateFlow<Boolean> get() = _showInvalidAddressDialog.asStateFlow()
+    val showInvalidAddressDialog: StateFlow<Boolean> = _showInvalidAddressDialog.asStateFlow()
 
     fun setShowInvalidAddressDialog(value: Boolean) {
         _showInvalidAddressDialog.value = value
     }
 
     private val _buttonEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val buttonEnabled: StateFlow<Boolean> get() = _buttonEnabled.asStateFlow()
+    val buttonEnabled: StateFlow<Boolean> = _buttonEnabled.asStateFlow()
 
     private var _bitcoinAddressFieldType = MutableStateFlow(BitcoinLnAddressFieldType.Bitcoin)
-    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> get() = _bitcoinAddressFieldType.asStateFlow()
+    val bitcoinLnAddressFieldType: StateFlow<BitcoinLnAddressFieldType> = _bitcoinAddressFieldType.asStateFlow()
 
     private val _isLightning: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isLightning: StateFlow<Boolean> get() = _isLightning.asStateFlow()
+    val isLightning: StateFlow<Boolean> = _isLightning.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_3/state_b/SellerStateLightning3bPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_3/state_b/SellerStateLightning3bPresenter.kt
@@ -16,7 +16,7 @@ class SellerStateLightning3bPresenter(
     private val tradesServiceFacade: TradesServiceFacade,
 ) : BasePresenter(mainPresenter) {
     private val _buyerHasConfirmedBitcoinReceipt: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val buyerHasConfirmedBitcoinReceipt: StateFlow<Boolean> get() = _buyerHasConfirmedBitcoinReceipt.asStateFlow()
+    val buyerHasConfirmedBitcoinReceipt: StateFlow<Boolean> = _buyerHasConfirmedBitcoinReceipt.asStateFlow()
 
     fun setBuyerHasConfirmedBitcoinReceipt(value: Boolean) {
         _buyerHasConfirmedBitcoinReceipt.value = value

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/mocks/SettingsRepositoryMock.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/mocks/SettingsRepositoryMock.kt
@@ -16,7 +16,7 @@ class SettingsRepositoryMock :
     SettingsRepository,
     Logging {
     private val _data = MutableStateFlow(Settings())
-    override val data: StateFlow<Settings> get() = _data.asStateFlow()
+    override val data: StateFlow<Settings> = _data.asStateFlow()
 
     override suspend fun setFirstLaunch(value: Boolean) {
         _data.update {


### PR DESCRIPTION
Unifies usages of `.asStateFlow` based on our conversations and decisions in the past

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized many internal property declarations across presenters, services, and models to improve code consistency. No user-visible behavior, UI, or functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->