### PR TITLE
chore: migrate to the new Preview annotation

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/AdvancedOptionsDrawer.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/AdvancedOptionsDrawer.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -26,7 +27,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowDo
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun AdvancedOptionsDrawer(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.trusted_node_setup.components.SubscriptionsFailedDialog
@@ -49,7 +50,6 @@ import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @ExcludeFromCoverage

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/components/SubscriptionsFailedDialog.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/components/SubscriptionsFailedDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.domain.websocket.subscription.TopicImportance
@@ -30,7 +31,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Bi
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Non-dismissible subscription failure dialog.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ androidx-camera = "1.5.3"
 
 # -------------------- UI / Compose --------------------
 compose-material-icons = "1.10.2"
+ui-tooling-preview = "1.10.3"
 coil-compose = "3.4.0"
 
 # -------------------- Multiplatform Libraries --------------------
@@ -134,6 +135,7 @@ androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "
 
 # -------------------- UI / Compose --------------------
 compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "compose-material-icons" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "ui-tooling-preview" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil-compose" }
 
 # -------------------- Testing --------------------

--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -67,6 +67,7 @@ kotlin {
             implementation(libs.atomicfu)
             implementation(libs.bignum)
             implementation(libs.coil.compose)
+            implementation(libs.compose.ui.tooling.preview)
             implementation(libs.logging.kermit)
             implementation(libs.navigation.compose)
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBanner.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.i18n.i18n
@@ -45,7 +46,6 @@ import network.bisq.mobile.presentation.common.ui.alert.simulatedAlertNotificati
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 private const val ALERT_ANIMATION_DURATION_MS = 350
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import network.bisq.mobile.domain.model.alert.AlertType
@@ -38,7 +39,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 internal fun AlertNotificationDialog(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/BarcodeScannerView.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/BarcodeScannerView.kt
@@ -18,11 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.rememberCameraPermissionLauncher
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.ncgroup.kscan.Barcode
 import org.ncgroup.kscan.BarcodeFormat
 import org.ncgroup.kscan.BarcodeResult

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ErrorState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ErrorState.kt
@@ -10,13 +10,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ErrorState(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/BisqSelect.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/BisqSelect.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -40,7 +41,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.bottom_sh
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Dropdown.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Dropdown.kt
@@ -18,12 +18,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowDownIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/EditableFieldActions.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/EditableFieldActions.kt
@@ -9,9 +9,9 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * A reusable composable that displays Save and Cancel action buttons for editable fields.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextField.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import network.bisq.mobile.data.utils.getDecimalSeparator
@@ -50,7 +51,6 @@ import network.bisq.mobile.presentation.common.ui.components.context.LocalAnimat
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class BisqTextFieldType {
     Default,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextFieldV0.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextFieldV0.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CheckCircleIcon
@@ -39,7 +40,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CopyIco
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SearchIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun BisqTextFieldV0(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/CopyIconButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/CopyIconButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
@@ -20,7 +21,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSlider.kt
@@ -16,10 +16,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqSlider.kt
@@ -16,11 +16,11 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @ExcludeFromCoverage

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/AmountWithCurrency.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/AmountWithCurrency.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // Highly tied to how formattedPrice is formatted.
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/ToggleTab.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/ToggleTab.kt
@@ -30,13 +30,13 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator.AmountType
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun <T> ToggleTab(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.dummy_user_profile_icon
@@ -42,7 +43,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 interface ITopBarPresenter : ViewPresenter {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/amountSelector/BisqAmountSelector.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/amountSelector/BisqAmountSelector.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.utils.getDecimalSeparator
 import network.bisq.mobile.i18n.i18n
@@ -22,7 +23,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.slider.BisqSlider
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqFiatInputField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * A composable that allows users to select an amount using either a text input field or a slider,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/amountSelector/BisqRangeAmountSelector.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/amountSelector/BisqRangeAmountSelector.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.utils.getDecimalSeparator
 import network.bisq.mobile.i18n.i18n
@@ -21,7 +22,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.slider.BisqRangeSlider
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqFiatInputField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * A composable that allows users to select a range of amounts (min and max) using two text input

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/bottom_sheet/BottomSheet.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/bottom_sheet/BottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
@@ -35,7 +36,6 @@ import network.bisq.mobile.presentation.common.ui.components.organisms.market.Ma
 import network.bisq.mobile.presentation.common.ui.platform.isAffectedBottomSheetDevice
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val MAX_SHEET_HEIGHT = 500
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatMessageContextMenu.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatMessageContextMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
@@ -20,7 +21,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.EyeIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.FlagIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ReplyIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ChatMessageContextMenu(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatTextMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatTextMessageBox.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
@@ -30,7 +31,6 @@ import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.createEmptyImage
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
@@ -25,7 +26,6 @@ import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun UsernameMessageDeliveryAndDate(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/trade/TradePeerLeftMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/trade/TradePeerLeftMessageBox.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageDto
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
@@ -18,7 +19,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.LeaveChatIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun TradePeerLeftMessageBox(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -25,7 +26,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap.BisqGapHFill
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ConfirmationDialog(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/LoadingDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/LoadingDialog.kt
@@ -2,9 +2,9 @@ package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
 
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun LoadingDialog() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqCheckbox
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.InfoGreenIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/info/InfoBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/info/InfoBox.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.molecules.AmountWithCurrency
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class InfoBoxValueType {
     BoldValue,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/info/InfoBoxCurrency.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/info/InfoBoxCurrency.kt
@@ -1,9 +1,9 @@
 package network.bisq.mobile.presentation.common.ui.components.molecules.info
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.components.molecules.AmountWithCurrency
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun InfoBoxCurrency(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/BisqFiatInputField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/BisqFiatInputField.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqTextFieldV0
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun BisqFiatInputField(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/BitcoinLnAddressField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/BitcoinLnAddressField.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -26,7 +27,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BitcoinAddressValidation
 import network.bisq.mobile.presentation.common.ui.utils.LightningInvoiceValidation
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class BitcoinLnAddressFieldType {
     Bitcoin,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/BisqSnackbar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/BisqSnackbar.kt
@@ -17,10 +17,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Enum representing the type of snackbar message for styling

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/PaymentMethodCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/PaymentMethodCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -18,7 +19,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentTy
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.CustomPaymentField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.i18NPaymentMethod
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun PaymentMethodCard(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/ReportBugPanel.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/ReportBugPanel.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
@@ -29,7 +30,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
 import network.bisq.mobile.presentation.main.AppPresenter
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedBuyerLimitsPopup.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +21,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Bi
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ReputationBasedBuyerLimitsPopup(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
@@ -19,7 +20,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Bi
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ReputationBasedSellerLimitsPopup(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/BatteryOptimizationsDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/BatteryOptimizationsDialog.kt
@@ -1,10 +1,10 @@
 package network.bisq.mobile.presentation.common.ui.components.organisms.dialogs
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun BatteryOptimizationsDialog(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/BisqGeneralErrorDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/BisqGeneralErrorDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -15,7 +16,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.BisqDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun BisqGeneralErrorDialog(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/TrustedNodeAPIIncompatiblePopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/dialogs/TrustedNodeAPIIncompatiblePopup.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
@@ -14,7 +15,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.BisqDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun TrustedNodeAPIIncompatiblePopup(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/market/MarketFilters.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/market/MarketFilters.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.data.model.market.MarketFilter
 import network.bisq.mobile.data.model.market.MarketSortBy
 import network.bisq.mobile.i18n.i18n
@@ -11,7 +12,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqSegmentBu
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 fun MarketSortBy.getDisplayName(): String =
     when (this) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.check_circle
@@ -38,7 +39,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/CreatePaymentAccountTopBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/CreatePaymentAccountTopBar.kt
@@ -8,12 +8,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.BisqIconButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CloseIcon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/offerbook_filters/CollapsedFilterHeaderDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/offerbook_filters/CollapsedFilterHeaderDesign.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -29,7 +30,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.math.min
 
 /**

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/offerbook_filters/OfferbookFiltersSettingsSection.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/offerbook_filters/OfferbookFiltersSettingsSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqSwitch
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
@@ -17,7 +18,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHD
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Design POC: Offerbook section in Settings screen.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateCryptoAccountWizard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateCryptoAccountWizard.kt
@@ -87,7 +87,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateFiatAccountWizard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/CreateFiatAccountWizard.kt
@@ -91,7 +91,6 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountCard.kt
@@ -93,6 +93,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
@@ -104,7 +105,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMe
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // -------------------------------------------------------------------------------------
 // Domain models (primitives only — no presenter dependency)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountsRedesignScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/payment_accounts/PaymentAccountsRedesignScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqSegmentButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -87,7 +88,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarCon
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // -------------------------------------------------------------------------------------
 // Tab selector model

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/OpenPrivateChatButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/OpenPrivateChatButton.kt
@@ -92,6 +92,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -100,7 +101,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.StarRating
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // ---------------------------------------------------------------------------
 // Variant enum

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/PrivateChatListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/PrivateChatListScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -91,7 +92,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // ---------------------------------------------------------------------------
 // Reusable composables — these will be used by the production screen

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/PrivateChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/privatechat/PrivateChatScreen.kt
@@ -98,6 +98,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -107,7 +108,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarCon
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 // Production entry-point and PrivateChatContent composable are not included in this
 // design PoC — they will be created during implementation using the new UiState/UiAction pattern.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationPromptDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationPromptDesign.kt
@@ -6,13 +6,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Design POC: Push notification relay opt-in prompts (both platforms).

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationSettingsDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationSettingsDesign.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqSwitch
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -23,7 +24,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHD
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Design POC: Notifications section in Settings screen with relay opt-in toggle.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationTradeWarningDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/push_notifications/PushNotificationTradeWarningDesign.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIcon
@@ -20,7 +21,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHD
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Design POC: Visual indicators when relayed push notifications are OFF.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_export/TradeCompletedExportDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_export/TradeCompletedExportDesign.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.trade_completed
@@ -33,7 +34,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.info.Info
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
  * Design POC: Completed trade summary with export functionality.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverview.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverview.kt
@@ -1,8 +1,6 @@
 package network.bisq.mobile.presentation.guide.trade_guide
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.OrderedTextList
@@ -14,7 +15,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
@@ -3,7 +3,6 @@ package network.bisq.mobile.presentation.offer.create_offer.amount
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.isBuy
@@ -28,7 +29,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @ExcludeFromCoverage

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
@@ -57,7 +58,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqModifier
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @ExcludeFromCoverage
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookFilterController.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookFilterController.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -51,7 +52,6 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.bottom_sh
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.math.min
 
 /** UI model for a toggleable method icon (payment or settlement). */

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
 import network.bisq.mobile.i18n.i18n
@@ -19,7 +20,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.BisqDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccountPayload
@@ -33,7 +34,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/PaymentAccountsMusigScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/PaymentAccountsMusigScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.FiatPaymentMethodChargebackRiskVO
@@ -36,7 +37,6 @@ import network.bisq.mobile.presentation.settings.payment_accounts_musig.model.Cr
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.model.FiatAccountVO
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.CryptoPaymentAccountCard
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.FiatPaymentAccountCard
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class PaymentAccountTab(
     val titleKey: String,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/CryptoPaymentAccountCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/CryptoPaymentAccountCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.model.account.PaymentMethodVO
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -22,7 +23,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.model.CryptoAccountVO
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun CryptoPaymentAccountCard(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/FiatPaymentAccountCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/FiatPaymentAccountCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.FiatPaymentMethodChargebackRiskVO
@@ -34,7 +35,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.model.FiatAccountVO
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun FiatPaymentAccountCard(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/PaymentAccountMethodIcon.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/ui/PaymentAccountMethodIcon.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.model.account.PaymentMethodVO
@@ -21,7 +22,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.customPaymentIconIndex
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun PaymentAccountMethodIcon(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.ErrorState
@@ -34,7 +35,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/onboarding/OnboardingScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/onboarding/OnboardingScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.img_bisq_Easy
@@ -35,7 +36,6 @@ import network.bisq.mobile.presentation.common.ui.components.organisms.pager_vie
 import network.bisq.mobile.presentation.common.ui.components.organisms.pager_view.PagerViewItem
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.icon_chat_circle
@@ -54,7 +55,6 @@ import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecyc
 import network.bisq.mobile.presentation.common.ui.utils.rememberNotificationPermissionLauncher
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun DashboardScreen() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.data.model.market.MarketFilter
 import network.bisq.mobile.data.model.market.MarketSortBy
 import network.bisq.mobile.data.model.offerbook.MarketListItem
@@ -31,7 +32,6 @@ import network.bisq.mobile.presentation.common.ui.components.organisms.market.Ma
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeChatRow.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeChatRow.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessageModel
@@ -29,7 +30,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ChatIco
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @ExcludeFromCoverage
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_1/SellerState1.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/seller_state_1/SellerState1.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccountPayload
 import network.bisq.mobile.i18n.i18n
@@ -17,7 +18,6 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun SellerState1(


### PR DESCRIPTION
since the old Preview is now deprecated and it's [recommended](https://kotlinlang.org/docs/multiplatform/compose-previews.html#available-annotations) to use the new one, I made this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Compose UI preview dependencies to improve development tooling support across the codebase.
  * Removed unused imports from several files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->