### PR TITLE
fix: #1331: Reputation link bypasses WebLinkConfirmationDialog; Followups on PR#1299

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
@@ -1,0 +1,250 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms.button
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.di.presentationTestModule
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class LinkButtonUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val dialogTitle get() = "hyperlinks.openInBrowser.attention.headline".i18n()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+        val settingsFacade = WebLinkDialogSettingsServiceFake(initialShowWebLinkConfirmation = true)
+
+        startKoin {
+            modules(
+                module {
+                    single<MainPresenter> { mockk(relaxed = true) }
+                    single<SettingsServiceFacade> { settingsFacade }
+                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { stopKoin() }
+    }
+
+    private fun setLinkButton(
+        uriHandler: UriHandler,
+        text: String = "Open docs",
+        link: String = "https://example.com",
+        onClick: (() -> Unit)? = null,
+        onError: ((Throwable) -> Unit)? = null,
+        openConfirmation: Boolean = true,
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides uriHandler) {
+                BisqTheme {
+                    LinkButton(
+                        text = text,
+                        link = link,
+                        onClick = onClick,
+                        onError = onError,
+                        openConfirmation = openConfirmation,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when clicked with openConfirmation true then shows confirmation dialog`() {
+        setLinkButton(uriHandler = NoopUriHandler())
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when clicked with openConfirmation false then invokes onClick without dialog`() {
+        val capturingUriHandler = CapturingUriHandler()
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = capturingUriHandler,
+            onClick = onClick,
+            openConfirmation = false,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+        assertEquals(listOf("https://example.com"), capturingUriHandler.openedUris)
+    }
+
+    @Test
+    fun `when openConfirmation false and uri open fails then invokes onError with throwable and does not invoke onClick`() {
+        val receivedErrors = mutableListOf<Throwable>()
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = ThrowingUriHandler(),
+            link = "https://example.com/bypass-fail",
+            onClick = onClick,
+            onError = { receivedErrors += it },
+            openConfirmation = false,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, receivedErrors.size)
+        assertEquals("forced openUri failure", receivedErrors.first().message)
+        verify(exactly = 0) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when openConfirmation false and uri open fails without onError then does not invoke onClick`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = ThrowingUriHandler(),
+            link = "https://example.com/bypass-fail",
+            onClick = onClick,
+            openConfirmation = false,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 0) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when dialog confirm clicked then opens uri and invokes onClick`() {
+        val capturingUriHandler = CapturingUriHandler()
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = capturingUriHandler,
+            link = "https://example.com/confirm",
+            onClick = onClick,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) { onClick() }
+        assertEquals(listOf("https://example.com/confirm"), capturingUriHandler.openedUris)
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when dialog dismiss clicked then closes dialog without invoking onClick`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = NoopUriHandler(),
+            onClick = onClick,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_no").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 0) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when dialog close button clicked then closes dialog without invoking onClick`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = NoopUriHandler(),
+            onClick = onClick,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("close").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 0) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when uri open fails then invokes onError and closes dialog without invoking onClick`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<(Throwable) -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = ThrowingUriHandler(),
+            link = "https://example.com/fail",
+            onClick = onClick,
+            onError = onError,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) { onError(any()) }
+        verify(exactly = 0) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    private fun assertNoNodeWithText(text: String) {
+        val nodes =
+            composeTestRule
+                .onAllNodesWithText(text)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        assertTrue(nodes.isEmpty(), "Expected no composable with text \"$text\"")
+    }
+
+    private class NoopUriHandler : UriHandler {
+        override fun openUri(uri: String) {}
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class ThrowingUriHandler : UriHandler {
+        override fun openUri(uri: String): Unit = throw RuntimeException("forced openUri failure")
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import network.bisq.mobile.i18n.I18nSupport
@@ -286,6 +287,56 @@ class WebLinkDialogUiKoinTest {
         }
         verify(exactly = 1) { onDismiss() }
         assertEquals(link, clipboardPrimaryText())
+    }
+
+    @Test
+    fun `when copy snackbar throws on dismiss then invokes onError and shows generic error snackbar`() {
+        // Given
+        val link = "https://example.com/copy-throws"
+        val onDismiss = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<() -> Unit>(relaxed = true)
+        val (_, presenter) = startKoinWithWebLinkDeps()
+        every {
+            presenter.showSnackbar(
+                "mobile.components.copyIconButton.copied".i18n(),
+                SnackbarType.SUCCESS,
+                SnackbarPosition.BOTTOM,
+                SnackbarDuration.Short,
+            )
+        } throws RuntimeException("forced copy snackbar failure")
+
+        // When
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
+            WebLinkConfirmationDialog(
+                link = link,
+                onConfirm = {},
+                onDismiss = onDismiss,
+                onError = onError,
+                headline = "Headline",
+                headlineLeftIcon = null,
+                message = "Message",
+                confirmButtonText = "Yes",
+                dismissButtonText = "No",
+            )
+        }
+
+        // Action
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_no").performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        verify(exactly = 1) { onError() }
+        verify(exactly = 0) { onDismiss() }
+        assertEquals(link, clipboardPrimaryText())
+        verify(exactly = 1) {
+            presenter.showSnackbar(
+                "mobile.error.generic".i18n(),
+                SnackbarType.ERROR,
+                SnackbarPosition.BOTTOM,
+                SnackbarDuration.Short,
+            )
+        }
     }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
@@ -1,0 +1,90 @@
+package network.bisq.mobile.presentation.settings.reputation
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.di.presentationTestModule
+import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.PreviewTopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+@RunWith(AndroidJUnit4::class)
+class ReputationScreenUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+
+        val reputationPresenter = mockk<ReputationPresenter>(relaxed = true)
+        every { reputationPresenter.isInteractive } returns MutableStateFlow(true)
+        every { reputationPresenter.profileId } returns MutableStateFlow("abc123-profile-id")
+
+        startKoin {
+            modules(
+                module {
+                    single<MainPresenter> { mockk(relaxed = true) }
+                    single<SettingsServiceFacade> { WebLinkDialogSettingsServiceFake() }
+                    single<ReputationPresenter> { reputationPresenter }
+                    single<ITopBarPresenter> { PreviewTopBarPresenter() }
+                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { stopKoin() }
+    }
+
+    private fun renderScreen() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalUriHandler provides
+                    object : UriHandler {
+                        override fun openUri(uri: String) = Unit
+                    },
+            ) {
+                BisqTheme {
+                    ReputationScreen()
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `shows learn more text with wiki link`() {
+        renderScreen()
+        composeTestRule
+            .onNodeWithText("mobile.reputation.learnMore.part1".i18n(), substring = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.reputation.learnMore.part2".i18n(), substring = true)
+            .assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
@@ -1,0 +1,175 @@
+package network.bisq.mobile.presentation.settings.reputation
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.di.presentationTestModule
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialog
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the selectedWebLink-driven dialog lifecycle pattern used by [ReputationScreen]:
+ * a nullable link state gates [WebLinkConfirmationDialog], and each callback (onConfirm,
+ * onDismiss, onError) resets it to null to dismiss the dialog.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReputationWebLinkDialogUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var uriHandler: TestUriHandler
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+        uriHandler = TestUriHandler()
+
+        startKoin {
+            modules(
+                module {
+                    single<MainPresenter> { mockk(relaxed = true) }
+                    single<SettingsServiceFacade> { WebLinkDialogSettingsServiceFake() }
+                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { stopKoin() }
+    }
+
+    @Test
+    fun `dismiss callback clears selected link and closes dialog`() {
+        var selectedWebLink by mutableStateOf<String?>(null)
+        setDialogContent(selectedWebLink = { selectedWebLink }, onClear = { selectedWebLink = null })
+
+        composeTestRule.runOnIdle { selectedWebLink = "https://example.com/dismiss" }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_no").performClick()
+        composeTestRule.waitForIdle()
+        assertNoDialog()
+    }
+
+    @Test
+    fun `confirm callback opens uri clears selected link and closes dialog`() {
+        var selectedWebLink by mutableStateOf<String?>(null)
+        setDialogContent(selectedWebLink = { selectedWebLink }, onClear = { selectedWebLink = null })
+
+        composeTestRule.runOnIdle { selectedWebLink = "https://example.com/confirm" }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+        assertNoDialog()
+        assertEquals(listOf("https://example.com/confirm"), uriHandler.openedUris)
+    }
+
+    @Test
+    fun `error callback clears selected link and closes dialog when uri open fails`() {
+        uriHandler.shouldThrow = true
+        var selectedWebLink by mutableStateOf<String?>(null)
+        var errorFlag = false
+        var clearedFlag = false
+        setDialogContent(
+            selectedWebLink = { selectedWebLink },
+            onClear = {
+                selectedWebLink = null
+                clearedFlag = true
+            },
+            onError = {
+                selectedWebLink = null
+                errorFlag = true
+            },
+        )
+
+        composeTestRule.runOnIdle { selectedWebLink = "https://example.com/error" }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(dialogTitle).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+        assertNoDialog()
+        assertTrue(errorFlag)
+        assertFalse(clearedFlag)
+        assertTrue(uriHandler.failureTriggered)
+    }
+
+    private val dialogTitle get() = "hyperlinks.openInBrowser.attention.headline".i18n()
+
+    private fun setDialogContent(
+        selectedWebLink: () -> String?,
+        onClear: () -> Unit,
+        onError: () -> Unit = onClear,
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides uriHandler) {
+                BisqTheme {
+                    selectedWebLink()?.let { webLink ->
+                        WebLinkConfirmationDialog(
+                            link = webLink,
+                            onConfirm = { onClear() },
+                            onDismiss = { onClear() },
+                            onError = { onError() },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun assertNoDialog() {
+        val nodes =
+            composeTestRule
+                .onAllNodesWithText(dialogTitle)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        assertTrue(nodes.isEmpty(), "Expected dialog to be dismissed")
+    }
+
+    private class TestUriHandler : UriHandler {
+        var shouldThrow = false
+        var failureTriggered = false
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            if (shouldThrow) {
+                failureTriggered = true
+                throw RuntimeException("forced failure")
+            }
+            openedUris += uri
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -463,14 +463,6 @@ abstract class BasePresenter(
         this.dependants!!.remove(child)
     }
 
-    /**
-     * Allows custom onViewUnattaching implementations to keep parent unregistration
-     * while opting out of other base teardown behavior.
-     */
-    protected fun unregisterFromParent() {
-        rootPresenter?.unregisterChild(this)
-    }
-
     protected open fun isDevMode(): Boolean = rootPresenter?.isDevMode() ?: false
 
     /**

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
@@ -8,13 +8,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import kotlinx.coroutines.CancellationException
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
-// TODO: Don't show again checkbox
 @Composable
 fun LinkButton(
     text: String,
@@ -24,12 +25,14 @@ fun LinkButton(
     color: Color = BisqTheme.colors.primary,
     padding: PaddingValues = PaddingValues(all = BisqUIConstants.ScreenPaddingHalf),
     onClick: (() -> Unit)? = null,
+    onError: ((Throwable) -> Unit)? = null,
     fullWidth: Boolean = false,
     openConfirmation: Boolean = true,
     leftIcon: (@Composable () -> Unit)? = null,
     rightIcon: (@Composable () -> Unit)? = null,
 ) {
     var showConfirmDialog by remember { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
 
     BisqButton(
         text = text,
@@ -41,7 +44,17 @@ fun LinkButton(
             if (openConfirmation) {
                 showConfirmDialog = true
             } else {
-                onClick?.invoke()
+                if (link.isBlank()) {
+                    onClick?.invoke()
+                    return@BisqButton
+                }
+                try {
+                    uriHandler.openUri(link)
+                    onClick?.invoke()
+                } catch (t: Throwable) {
+                    if (t is CancellationException) throw t
+                    onError?.invoke(t)
+                }
             }
         },
         modifier = modifier,
@@ -58,6 +71,10 @@ fun LinkButton(
             },
             onDismiss = {
                 showConfirmDialog = false
+            },
+            onError = {
+                showConfirmDialog = false
+                onError?.invoke(RuntimeException("Web link confirmation failed"))
             },
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
@@ -73,11 +73,11 @@ fun ConfirmationDialog(
         }
         if (message.isNotEmpty()) {
             BisqText.BaseLight(message)
-            BisqGap.V2()
+            BisqGap.V1()
         }
         extraContent?.invoke()
         if (extraContent != null) {
-            BisqGap.V2()
+            BisqGap.V1()
         }
         if (verticalButtonPlacement) {
             Column {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
@@ -20,6 +20,7 @@ fun WebLinkConfirmationDialog(
     link: String,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    onError: () -> Unit = {},
     headline: String? = null,
     headlineColor: Color? = null,
     headlineLeftIcon: (@Composable () -> Unit)? = null,
@@ -38,6 +39,7 @@ fun WebLinkConfirmationDialog(
             clipboard = clipboard,
             onConfirm = onConfirm,
             onDismiss = onDismiss,
+            onError = onError,
         )
     })
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.AnnotatedString
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,6 +25,7 @@ class WebLinkConfirmationDialogPresenter(
 
     private var userOnConfirm: () -> Unit = {}
     private var userOnDismiss: () -> Unit = {}
+    private var userOnError: () -> Unit = {}
     private var currentUriHandler: UriHandler? = null
     private var currentClipboard: Clipboard? = null
     private var activeLink: String = ""
@@ -34,10 +36,12 @@ class WebLinkConfirmationDialogPresenter(
         clipboard: Clipboard,
         onConfirm: () -> Unit,
         onDismiss: () -> Unit,
+        onError: () -> Unit,
     ) {
         activeLink = link
         userOnConfirm = onConfirm
         userOnDismiss = onDismiss
+        userOnError = onError
         currentUriHandler = uriHandler
         currentClipboard = clipboard
 
@@ -78,16 +82,25 @@ class WebLinkConfirmationDialogPresenter(
         persist: Boolean,
     ) {
         presenterScope.launch {
-            showLoading()
-            if (persist) {
-                persistWebLinkDialogChoice(
-                    permitOpeningBrowser = true,
-                    dontShowAgain = _uiState.value.dontShowAgain,
-                )
+            if (persist) showLoading()
+            try {
+                if (persist) {
+                    persistWebLinkDialogChoice(
+                        permitOpeningBrowser = true,
+                        dontShowAgain = _uiState.value.dontShowAgain,
+                    )
+                }
+                currentUriHandler?.openUri(uri)
+                userOnConfirm.invoke()
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (throwable: Throwable) {
+                log.e(throwable) { "Failed to open URI from web link confirmation dialog" }
+                userOnError.invoke()
+                showSnackbar("mobile.error.generic".i18n(), type = SnackbarType.ERROR)
+            } finally {
+                if (persist) hideLoading()
             }
-            currentUriHandler?.openUri(uri)
-            userOnConfirm.invoke()
-            hideLoading()
         }
     }
 
@@ -96,17 +109,26 @@ class WebLinkConfirmationDialogPresenter(
         persist: Boolean,
     ) {
         presenterScope.launch {
-            showLoading()
-            currentClipboard?.setClipEntry(AnnotatedString(uri).toClipEntry())
-            mainPresenter.showSnackbar("mobile.components.copyIconButton.copied".i18n())
-            if (persist) {
-                persistWebLinkDialogChoice(
-                    permitOpeningBrowser = false,
-                    dontShowAgain = _uiState.value.dontShowAgain,
-                )
+            if (persist) showLoading()
+            try {
+                currentClipboard?.setClipEntry(AnnotatedString(uri).toClipEntry())
+                mainPresenter.showSnackbar("mobile.components.copyIconButton.copied".i18n())
+                if (persist) {
+                    persistWebLinkDialogChoice(
+                        permitOpeningBrowser = false,
+                        dontShowAgain = _uiState.value.dontShowAgain,
+                    )
+                }
+                userOnDismiss.invoke()
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (throwable: Throwable) {
+                log.e(throwable) { "Failed to copy URI from web link confirmation dialog" }
+                userOnError.invoke()
+                mainPresenter.showSnackbar("mobile.error.generic".i18n(), type = SnackbarType.ERROR)
+            } finally {
+                if (persist) hideLoading()
             }
-            userOnDismiss.invoke()
-            hideLoading()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationPresenter.kt
@@ -22,8 +22,4 @@ open class ReputationPresenter(
                 SharingStarted.Lazily,
                 "data.na".i18n(),
             )
-
-    fun onOpenWebUrl(url: String) {
-        navigateToUrl(url)
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,6 +40,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
@@ -50,6 +54,7 @@ fun ReputationScreen() {
 
     val isInteractive by presenter.isInteractive.collectAsState()
     val profileId by presenter.profileId.collectAsState()
+    var selectedWebLink by remember { mutableStateOf<String?>(null) }
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.more.reputation".i18n(), showUserAvatar = false) },
@@ -76,7 +81,6 @@ fun ReputationScreen() {
 
         val part1 = "mobile.reputation.learnMore.part1".i18n()
         val part2 = "mobile.reputation.learnMore.part2".i18n()
-        val fullText = "$part1 $part2"
         val annotatedString =
             buildAnnotatedString {
                 withStyle(
@@ -118,10 +122,26 @@ fun ReputationScreen() {
                         end = offset,
                     ).firstOrNull()
                     ?.let { annotation ->
-                        presenter.onOpenWebUrl(annotation.item)
+                        selectedWebLink = annotation.item
                     }
             },
         )
+
+        selectedWebLink?.let { webLink ->
+            WebLinkConfirmationDialog(
+                link = webLink,
+                onConfirm = {
+                    // The dialog presenter already opens the link.
+                    selectedWebLink = null
+                },
+                onDismiss = {
+                    selectedWebLink = null
+                },
+                onError = {
+                    selectedWebLink = null
+                },
+            )
+        }
 
         BisqHDivider(modifier = Modifier.padding(top = BisqUIConstants.ScreenPadding, bottom = BisqUIConstants.ScreenPadding3X))
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
@@ -205,7 +205,7 @@ fun SettingsContent(
                     BisqButton(
                         text = "settings.display.resetDontShowAgain".i18n(),
                         onClick = { onAction(SettingsUiAction.OnResetAllDontShowAgainClick) },
-                        type = BisqButtonType.GreyOutline,
+                        type = BisqButtonType.Outline,
                         fullWidth = true,
                     )
 


### PR DESCRIPTION
 - fixes #1331
 - Followups on [PR#1299](https://github.com/bisq-network/bisq-mobile/pull/1299)
   - Dead code: unregisterFromParent() added to BasePresenter but never called - should be removed or justified
   - Missing exception handling: openUri()/copyToClipboard() coroutines don't guard hideLoading() against unexpected exceptions — could leave loading overlay stuck, risk is minor but possible
   - Brief loading flash: auto-handle path (no dialog) calls showLoading() unnecessarily ?
   - I think the dialog now has a little bit too much padding around the new "don't show again" option? please review
   - Salotto's feedback on 'Reset flags' button style

Since it's all related to `WebLinkConfirmationDialog`, grouped together in a single PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-user error callbacks for web-link confirmation flows and unified link-opening confirmation behavior.

* **Bug Fixes**
  * Improved error handling for link opening, clipboard copy and snackbar failures; failures now dismiss dialogs and invoke error handlers with generic feedback.

* **Style**
  * Tweaked dialog spacing and adjusted a settings button style for visual consistency.

* **Refactor**
  * Simplified presenter lifecycle/teardown by removing an explicit unregister helper.

* **Tests**
  * Added comprehensive UI tests for link/button/dialog/reputation flows and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->