### PR TITLE
fix: reduce height of searchbar & fix BisqTextFieldV0

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextFieldV0.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/TextFieldV0.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CheckCircleIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CloseIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.CopyIcon
@@ -82,11 +81,7 @@ fun BisqTextFieldV0(
     color: Color = BisqTheme.colors.light_grey20,
     colors: BisqTextFieldColors = BisqTextFieldColors.default(),
     textStyle: TextStyle =
-        TextStyle(
-            color = color,
-            fontSize = 18.sp,
-            textDecoration = TextDecoration.None,
-        ),
+        BisqTheme.typography.largeRegular.copy(color = color, textDecoration = TextDecoration.None),
     label: String? = null,
     placeholder: String? = null,
     leadingIcon: @Composable (() -> Unit)? = null,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
@@ -1,8 +1,8 @@
 package network.bisq.mobile.presentation.common.ui.components.molecules.inputfield
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
@@ -22,27 +23,48 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SearchI
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SortIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap.BisqGapHFill
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
 @Composable
 fun BisqSearchField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    fieldModifier: Modifier = Modifier,
     label: String = "",
     placeholder: String = "action.search".i18n(),
     rightSuffix: (@Composable () -> Unit)? = null,
     disabled: Boolean = false,
 ) {
-    BisqTextFieldV0(
-        label = label,
-        value = value,
-        onValueChange = onValueChange,
-        placeholder = placeholder,
-        leadingIcon = { SearchIcon() },
-        trailingIcon = {
+    // Custom layout: text field is measured first and dictates the height.
+    // The overlay row is then constrained to that exact height so it never
+    // inflates the wrapper
+    Layout(
+        modifier = modifier,
+        content = {
+            BisqTextFieldV0(
+                label = label,
+                value = value,
+                onValueChange = onValueChange,
+                placeholder = placeholder,
+                leadingIcon = { SearchIcon() },
+                trailingIcon = {
+                    Spacer(
+                        Modifier
+                            .width(if (rightSuffix == null) 50.dp else 90.dp)
+                            .padding(end = BisqUIConstants.ScreenPaddingHalf, bottom = 2.dp),
+                    )
+                },
+                enabled = !disabled,
+                singleLine = true,
+                modifier = fieldModifier,
+            )
+
             Row(
-                horizontalArrangement = Arrangement.End,
-                modifier = Modifier.width(if (rightSuffix == null) 50.dp else 80.dp),
+                modifier =
+                    Modifier
+                        .width(if (rightSuffix == null) 50.dp else 90.dp)
+                        .padding(end = BisqUIConstants.ScreenPaddingHalf, bottom = 2.dp),
             ) {
                 if (value.isNotEmpty()) {
                     BisqButton(
@@ -71,17 +93,26 @@ fun BisqSearchField(
                 }
             }
         },
-        enabled = !disabled,
-        singleLine = true,
-        modifier = modifier,
-    )
+    ) { measurables, constraints ->
+        val textField = measurables[0].measure(constraints)
+        // Pin the overlay to the text field's height so it never expands the wrapper
+        val overlay =
+            measurables[1].measure(
+                constraints.copy(minHeight = textField.height, maxHeight = textField.height),
+            )
+        layout(textField.width, textField.height) {
+            textField.placeRelative(0, 0)
+            // Simply Alignment.CenterEnd the overlay:
+            overlay.placeRelative(x = textField.width - overlay.width, y = 0)
+        }
+    }
 }
 
 @Preview
 @Composable
 private fun BisqSearchField_EmptyPreview() {
     BisqTheme.Preview {
-        Box(modifier = Modifier.padding(12.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
             var textState by remember { mutableStateOf("") }
             BisqSearchField(
                 value = textState,
@@ -95,7 +126,7 @@ private fun BisqSearchField_EmptyPreview() {
 @Composable
 private fun BisqSearchField_WithValuePreview() {
     BisqTheme.Preview {
-        Box(modifier = Modifier.padding(12.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
             var textState by remember { mutableStateOf("bitcoin") }
             BisqSearchField(
                 value = textState,
@@ -109,7 +140,7 @@ private fun BisqSearchField_WithValuePreview() {
 @Composable
 private fun BisqSearchField_WithFilterButtonPreview() {
     BisqTheme.Preview {
-        Box(modifier = Modifier.padding(12.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
             var textState by remember { mutableStateOf("") }
             BisqSearchField(
                 value = textState,
@@ -119,7 +150,29 @@ private fun BisqSearchField_WithFilterButtonPreview() {
                         iconOnly = { SortIcon() },
                         onClick = {},
                         type = BisqButtonType.Clear,
-                        modifier = Modifier.width(50.dp),
+                        modifier = Modifier.weight(1f),
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BisqSearchField_WithClearAndFilterButtonPreview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(12.dp)) {
+            var textState by remember { mutableStateOf("bitcoin") }
+            BisqSearchField(
+                value = textState,
+                onValueChange = { textState = it },
+                rightSuffix = {
+                    BisqButton(
+                        iconOnly = { SortIcon() },
+                        onClick = {},
+                        type = BisqButtonType.Clear,
+                        modifier = Modifier.weight(1f),
                     )
                 },
             )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.tooling.preview.Preview
@@ -65,6 +66,7 @@ fun BisqSearchField(
                     Modifier
                         .width(if (rightSuffix == null) 50.dp else 90.dp)
                         .padding(end = BisqUIConstants.ScreenPaddingHalf, bottom = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (value.isNotEmpty()) {
                     BisqButton(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
@@ -89,7 +89,6 @@ private fun OfferbookMarketScreenContent(
             value = searchText,
             onValueChange = onSearchTextChange,
             rightSuffix = {
-                // TODO: Height to be reduced with Icon only buttons
                 BisqButton(
                     iconOnly = {
                         if (filter == MarketFilter.WithOffers) {


### PR DESCRIPTION
followup to #1344 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search field gains a configurable modifier and updated preview showing clear/filter buttons.

* **Bug Fixes**
  * Fixed search field overlay layout to avoid increasing overall height when trailing content is shown.

* **Refactor**
  * Text field defaults now use the app theme typography for consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->