### PR TITLE
fix: #1356: Prevent URL-launch crashes and show user feedback on failure

### DIFF
--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -2,6 +2,7 @@
 
 package network.bisq.mobile.data.utils
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -19,6 +20,7 @@ import kotlinx.datetime.toInstant
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.domain.model.PlatformInfo
 import network.bisq.mobile.domain.model.PlatformType
+import network.bisq.mobile.domain.utils.getLogger
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.scope.Scope
 import java.io.ByteArrayOutputStream
@@ -65,10 +67,35 @@ actual fun setupUncaughtExceptionHandler(onCrash: (Throwable) -> Unit) {
 class AndroidUrlLauncher(
     private val context: Context,
 ) : UrlLauncher {
-    override fun openUrl(url: String) {
+    private val log = getLogger("AndroidUrlLauncher")
+
+    override fun openUrl(url: String): Boolean {
+        val safeUrl = sanitizeUrlForLog(url)
         val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        context.startActivity(intent)
+        try {
+            context.startActivity(intent)
+            return true
+        } catch (_: ActivityNotFoundException) {
+            log.w { "No activity found to handle URL (install a browser or check link): $safeUrl" }
+            return false
+        } catch (e: Exception) {
+            log.e(e) { "Failed to open URL: $safeUrl" }
+            return false
+        }
+    }
+
+    private fun sanitizeUrlForLog(rawUrl: String): String {
+        val uri = runCatching { rawUrl.toUri() }.getOrNull()
+        return if (uri != null) {
+            buildString {
+                append(uri.scheme ?: "unknown")
+                uri.host?.let { append("://").append(it) }
+                uri.path?.let { append(it) }
+            }.take(256)
+        } else {
+            "invalid-url"
+        }
     }
 }
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidUrlLauncherTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidUrlLauncherTest.kt
@@ -1,0 +1,59 @@
+package network.bisq.mobile.data.utils
+
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidUrlLauncherTest {
+    @Test
+    fun `openUrl returns true when startActivity succeeds`() {
+        val context = TestContext()
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = launcher.openUrl("https://bisq.network")
+
+        assertTrue(result)
+        assertEquals(1, context.startActivityCalls)
+    }
+
+    @Test
+    fun `openUrl returns false when no activity can handle URL`() {
+        val context = TestContext(ActivityNotFoundException("No handler"))
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = launcher.openUrl("https://bisq.network")
+
+        assertFalse(result)
+        assertEquals(1, context.startActivityCalls)
+    }
+
+    @Test
+    fun `openUrl returns false on unexpected exception`() {
+        val context = TestContext(IllegalStateException("Broken context"))
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = launcher.openUrl("https://bisq.network")
+
+        assertFalse(result)
+        assertEquals(1, context.startActivityCalls)
+    }
+
+    private class TestContext(
+        private val exceptionToThrow: Exception? = null,
+    ) : ContextWrapper(RuntimeEnvironment.getApplication()) {
+        var startActivityCalls: Int = 0
+
+        override fun startActivity(intent: Intent) {
+            startActivityCalls++
+            exceptionToThrow?.let { throw it }
+        }
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
@@ -16,7 +16,7 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 interface UrlLauncher {
-    fun openUrl(url: String)
+    fun openUrl(url: String): Boolean
 }
 
 expect fun formatDateTime(dateTime: LocalDateTime): String

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -553,6 +553,7 @@ mobile.error.exception=Exception
 mobile.error.warning=Warning
 mobile.confirmation.areYouSure=Are you sure?
 mobile.error.generic=Something went wrong. Please try again.
+mobile.error.cannotOpenUrl=Cannot open URL.
 mobile.error.title=Error
 mobile.genericError.headline=An error occurred
 mobile.genericError.errorMessage=Error message:

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
@@ -331,12 +331,14 @@ actual fun setupUncaughtExceptionHandler(onCrash: (Throwable) -> Unit) {
 }
 
 class IOSUrlLauncher : UrlLauncher {
-    override fun openUrl(url: String) {
+    override fun openUrl(url: String): Boolean {
         val nsUrl = NSURL.URLWithString(url)
-        if (nsUrl != null) {
+        if (nsUrl != null && UIApplication.sharedApplication.canOpenURL(nsUrl)) {
             // fake secondary parameters are important so that iOS compiler knows which override to use
             UIApplication.sharedApplication.openURL(nsUrl, options = mapOf<Any?, String>(), completionHandler = null)
+            return true
         }
+        return false
     }
 }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.common.ui.base
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkStatic
@@ -8,15 +9,20 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.main.MainPresenter
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -25,6 +31,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BasePresenterTest {
@@ -153,6 +160,67 @@ class BasePresenterTest {
         // Presenter should still be registered — creating a second and detaching
         // should work without issues (parent still tracks the first)
         presenter.onViewRevealed()
+    }
+
+    @Test
+    fun `navigateToReportError shows error snackbar when URL launch fails`() {
+        val urlLauncher = mockk<UrlLauncher>()
+        every { urlLauncher.openUrl(any()) } returns false
+        mainPresenter =
+            MainPresenterTestFactory.create(
+                urlLauncher = urlLauncher,
+                applicationLifecycleService = TestApplicationLifecycleService(),
+            )
+        val presenter = TestPresenter(mainPresenter)
+
+        presenter.navigateToReportError()
+
+        verify(exactly = 1) { urlLauncher.openUrl(BisqLinks.BISQ_MOBILE_GH_ISSUES) }
+        verify(exactly = 1) {
+            globalUiManager.showSnackbar(
+                "mobile.error.cannotOpenUrl".i18n(),
+                SnackbarType.ERROR,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `navigateToReportError does not show error snackbar when URL launch succeeds`() {
+        val urlLauncher = mockk<UrlLauncher>()
+        every { urlLauncher.openUrl(any()) } returns true
+        mainPresenter =
+            MainPresenterTestFactory.create(
+                urlLauncher = urlLauncher,
+                applicationLifecycleService = TestApplicationLifecycleService(),
+            )
+        val presenter = TestPresenter(mainPresenter)
+
+        presenter.navigateToReportError()
+
+        verify(exactly = 1) { urlLauncher.openUrl(BisqLinks.BISQ_MOBILE_GH_ISSUES) }
+        verify(exactly = 0) { globalUiManager.showSnackbar(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `navigateToUrl returns false and restores interactivity when URL launcher throws`() {
+        val urlLauncher = mockk<UrlLauncher>()
+        every { urlLauncher.openUrl(any()) } throws IllegalStateException("unexpected")
+        mainPresenter =
+            MainPresenterTestFactory.create(
+                urlLauncher = urlLauncher,
+                applicationLifecycleService = TestApplicationLifecycleService(),
+            )
+        val presenter = TestPresenter(mainPresenter)
+
+        val result = presenter.navigateToUrl("https://bisq.network")
+
+        assertFalse(result)
+        assertFalse(presenter.isInteractive.value)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(presenter.isInteractive.value)
+        verify(exactly = 1) { urlLauncher.openUrl("https://bisq.network") }
     }
 
     /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -319,7 +319,7 @@ class CreateOfferPricePresenterTest {
     }
 
     private class FakeUrlLauncher : UrlLauncher {
-        override fun openUrl(url: String) {}
+        override fun openUrl(url: String): Boolean = true
     }
 
     private class FakeTradeReadStateRepository : TradeReadStateRepository {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -337,7 +337,7 @@ class CreateOfferReviewPresenterTest {
     }
 
     private class FakeUrlLauncher : UrlLauncher {
-        override fun openUrl(url: String) {}
+        override fun openUrl(url: String): Boolean = true
     }
 
     private class FakeTradeReadStateRepository : TradeReadStateRepository {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -293,7 +293,7 @@ class TakeOfferAmountPresenterTest {
     }
 
     private class FakeUrlLauncher : UrlLauncher {
-        override fun openUrl(url: String) {}
+        override fun openUrl(url: String): Boolean = true
     }
 
     private fun makeMainPresenter(): MainPresenter {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -316,11 +316,17 @@ abstract class BasePresenter(
         }
     }
 
-    open fun navigateToUrl(url: String) {
-        if (!_isInteractive.value) return
+    open fun navigateToUrl(url: String): Boolean {
+        if (!_isInteractive.value) return false
         disableInteractive()
-        rootPresenter?.navigateToUrl(url)
-        enableInteractive() // re-enables after 250ms delay — prevents rapid double-taps
+        return try {
+            rootPresenter?.navigateToUrl(url) ?: false
+        } catch (e: Exception) {
+            log.e(e) { "Failed to navigate to URL: $url" }
+            false
+        } finally {
+            enableInteractive() // re-enables after 250ms delay — prevents rapid double-taps
+        }
     }
 
     override fun onCloseGenericErrorPanel() {
@@ -328,7 +334,10 @@ abstract class BasePresenter(
     }
 
     override fun navigateToReportError() {
-        navigateToUrl(BisqLinks.BISQ_MOBILE_GH_ISSUES)
+        val isOpened = navigateToUrl(BisqLinks.BISQ_MOBILE_GH_ISSUES)
+        if (!isOpened) {
+            showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR)
+        }
     }
 
     protected fun isAtMainScreen(): Boolean = navigationManager.isAtMainScreen()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -188,9 +188,7 @@ open class MainPresenter(
         _isMainContentVisible.value = value
     }
 
-    final override fun navigateToUrl(url: String) {
-        urlLauncher.openUrl(url)
-    }
+    final override fun navigateToUrl(url: String): Boolean = urlLauncher.openUrl(url)
 
     override fun onCloseConnectionLostDialogue() {
         _showAllConnectionsLostDialogue.value = false


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1356

 - Not able to replicate in emulators with `Android 15 (SDK 35) / Version: 37 (0.5.0)`
 - But in any emulator with the browser uninstalled, able to replicate the exact same error log:
```
Exception android.content.ActivityNotFoundException:
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2437)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:2005)
  ...
```

 - This happens, when `AndroidUrlLauncher :: openUrl :: context.startActivity(intent)` fails, probably because of lack of browser in OS.
 - Now guarded it with try/catch and made openUrl to return true/false based on success/failure. Applied the same in iOS.
 - Same is reflected in BasePresenter :: navigateToReportError, BasePresenter :: navigateToUrl. They all return true/false based on success/failure.
 - Now crash is fixed and the user will get a generic snackbar error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL opening now returns explicit success/failure and shows a user-facing error snackbar when opening fails.
  * Improved robustness on mobile when launching external URLs (better error handling and logging).

* **Tests**
  * Added and updated unit tests for URL launcher behavior and error paths across platforms.

* **Documentation**
  * Added a localized error message key for "Cannot open URL."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->