### PR TITLE
Release/anode 0.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.9.0
 
 node.name=Bisq Easy
-node.android.version=0.5.1
+node.android.version=0.5.2
 
 client.name=Bisq Connect
 client.android.version=0.3.3
@@ -42,7 +42,7 @@ client.ios.version=0.3.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=17
 client.android.version.code=21
-node.android.version.code=39
+node.android.version.code=40
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ client.ios.version=0.3.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=17
 client.android.version.code=21
-node.android.version.code=38
+node.android.version.code=39
 
 # Networking
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.10"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "32517a84a5acf80da129f25b7ffa9a1f48ab1fc8"
+bisq-core-commit = "e2e7c20cb4fcd68fff86fc3868362859cdf2e99c"
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing
 bisq-desktop-pairing = "2.1.10"
 # API version is usually same as bisq-core but for more control we keep it separated


### PR DESCRIPTION
 - contribs to #1347
 - update related metadata and bump versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android application version from 0.5.1 to 0.5.2 with version code increment.
  * Updated core library reference to latest commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->