### PR TITLE
chore: improve build

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -27,7 +27,7 @@ val sharedKScanModule = ":shared:kscan"
 val sharedTestUtilsModule = ":shared:test-utils"
 
 dependencies {
-    debugImplementation(compose.uiTooling)
+    debugImplementation(libs.compose.ui.tooling)
     // IMPORTANT: This is needed for Robolectric tests to work in both variants
     // The fact that its needed to be included in the build might be a compose issue
     // We accept that for now as the lib size is minimal and won't impact the prod code.
@@ -111,11 +111,11 @@ kotlin {
             api(project(sharedPresentationModule))
 
             // Compose
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
+            implementation(libs.compose.components.resources)
+            implementation(libs.compose.ui.tooling.preview)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material3)
+            implementation(libs.compose.ui)
 
             // AndroidX
             implementation(libs.androidx.datastore.okio)
@@ -155,9 +155,6 @@ kotlin {
         }
 
         androidMain.dependencies {
-            // Compose
-            implementation(compose.preview)
-
             // AndroidX
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.core.splashscreen)
@@ -329,11 +326,6 @@ android {
 
     // Needed for aab files renaming
     setProperty("archivesBaseName", getArtifactName(defaultConfig))
-}
-
-// -------------------- Dependencies --------------------
-dependencies {
-    debugImplementation(compose.uiTooling)
 }
 
 // -------------------- Build Tasks Configuration --------------------

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacadeTest.kt
@@ -129,9 +129,6 @@ class ClientApplicationBootstrapFacadeTest {
                     selectedProxyOption = BisqProxyOption.NONE,
                 )
 
-            // Then: Facade should be created successfully
-            assertTrue(facade != null, "Facade should be created")
-
             // Verify settings are correctly stored
             val settings = sensitiveSettingsRepository.fetch()
             assertTrue(settings.bisqApiUrl == DEMO_API_URL, "Settings should have demo API URL")

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImplReconnectTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImplReconnectTest.kt
@@ -147,7 +147,7 @@ class WebSocketClientImplReconnectTest {
             // Then - final state should be Disconnected with MaximumRetryReachedException
             val state = client.webSocketClientStatus.value
             assertTrue(state is ConnectionState.Disconnected)
-            val error = (state as ConnectionState.Disconnected).error
+            val error = state.error
             // Enforce strict MaximumRetryReachedException - not just any RuntimeException
             assertTrue(
                 error is MaximumRetryReachedException,

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
@@ -249,7 +249,7 @@ class WebSocketClientServiceTest {
 
             // Then
             assertTrue(initialState is ConnectionState.Disconnected)
-            assertEquals(null, (initialState as ConnectionState.Disconnected).error)
+            assertEquals(null, initialState.error)
         }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/data/mapping/alert/AlertTypeDtoMapping.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/data/mapping/alert/AlertTypeDtoMapping.kt
@@ -10,5 +10,4 @@ fun AlertTypeDto.toAlertTypeOrNull(): AlertType? =
         AlertTypeDto.EMERGENCY -> AlertType.EMERGENCY
         AlertTypeDto.BAN -> AlertType.BAN
         AlertTypeDto.BANNED_ACCOUNT_DATA -> AlertType.BANNED_ACCOUNT_DATA
-        else -> null
     }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -162,7 +162,7 @@ class ClientUserProfileServiceFacade(
         createSimulatedDelay(Clock.System.now().toEpochMilliseconds() - ts)
         val pubKeyHash: ByteArray = preparedData.id.hexToByteArray()
         val solutionEncoded = preparedData.proofOfWork.solutionEncoded
-        val image: PlatformImage? =
+        val image: PlatformImage =
             clientCatHashService.getImage(
                 pubKeyHash,
                 Base64.decode(solutionEncoded),

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.client.common.domain.service.user_profile
 
-import io.ktor.util.decodeBase64Bytes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -166,7 +165,7 @@ class ClientUserProfileServiceFacade(
         val image: PlatformImage? =
             clientCatHashService.getImage(
                 pubKeyHash,
-                solutionEncoded.decodeBase64Bytes(),
+                Base64.decode(solutionEncoded),
                 0,
                 imageSize,
             )

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -41,8 +41,8 @@ kotlin {
             api(project(sharedPresentationModule))
 
             // Compose
-            implementation(compose.foundation)
-            implementation(compose.material3)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material3)
 
             // Other libraries
             implementation(libs.navigation.compose)
@@ -50,7 +50,7 @@ kotlin {
 
         androidMain.dependencies {
             // Compose
-            implementation(compose.preview)
+            implementation(libs.compose.ui.tooling.preview)
 
             // AndroidX
             implementation(libs.androidx.activity.compose)
@@ -310,7 +310,7 @@ dependencies {
     implementation(project(sharedDomainModule))
 
     // Debug tools
-    debugImplementation(compose.uiTooling)
+    debugImplementation(libs.compose.ui.tooling)
 
     // Android libraries
     implementation(libs.androidx.multidex)

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -43,15 +43,13 @@ kotlin {
             // Compose
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
+            implementation(libs.compose.ui.tooling.preview)
 
             // Other libraries
             implementation(libs.navigation.compose)
         }
 
         androidMain.dependencies {
-            // Compose
-            implementation(libs.compose.ui.tooling.preview)
-
             // AndroidX
             implementation(libs.androidx.activity.compose)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 atomicfu = "0.31.0"
-compose-plugin = "1.10.2"
+compose-plugin = "1.10.3"
 ksp = "2.3.6"
 kover = "0.9.7"
 
@@ -34,8 +34,8 @@ android-mlkit-barcode-scanning = "17.3.0"
 
 # -------------------- AndroidX --------------------
 androidx-core = "1.16.0"
-androidx-activity-compose = "1.10.1"
-androidx-lifecycle = "2.9.2"
+androidx-activity-compose = "1.13.0"
+androidx-lifecycle = "2.10.0"
 androidx-multidex = "2.0.1"
 androidx-core-splashscreen = "1.0.1"
 androidx-navigation-compose = "2.9.2"
@@ -43,8 +43,8 @@ androidx-datastore = "1.1.7"
 androidx-camera = "1.5.3"
 
 # -------------------- UI / Compose --------------------
-compose-material-icons = "1.10.2"
-ui-tooling-preview = "1.10.3"
+material-icons-extended =  "1.7.3"
+compose-material3 = "1.9.0"
 coil-compose = "3.4.0"
 
 # -------------------- Multiplatform Libraries --------------------
@@ -134,8 +134,15 @@ androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", versi
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "androidx-camera" }
 
 # -------------------- UI / Compose --------------------
-compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "compose-material-icons" }
-compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "ui-tooling-preview" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-plugin" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-plugin" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "material-icons-extended" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-plugin" }
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-plugin" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-plugin" }
+compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-plugin" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-plugin" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil-compose" }
 
 # -------------------- Testing --------------------

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ androidx-camera = "1.5.3"
 
 # -------------------- UI / Compose --------------------
 material-icons-extended =  "1.7.3"
-compose-material3 = "1.9.0"
+compose-material3 = "1.10.0-alpha05"
 coil-compose = "3.4.0"
 
 # -------------------- Multiplatform Libraries --------------------

--- a/shared/kscan/build.gradle.kts
+++ b/shared/kscan/build.gradle.kts
@@ -26,10 +26,10 @@ kotlin {
             implementation(libs.bundles.camera)
         }
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.materialIconsExtended)
+            implementation(libs.compose.runtime)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material3)
+            implementation(libs.compose.material.icons.extended)
         }
     }
 }

--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 dependencies {
-    debugImplementation(compose.uiTooling)
+    debugImplementation(libs.compose.ui.tooling)
 }
 
 version = project.findProperty("shared.version") as String
@@ -40,15 +40,12 @@ kotlin {
             implementation(project(":shared:domain"))
             implementation(project(":shared:kscan"))
 
-            api(compose.material3)
-            api(compose.components.resources)
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.ui)
-            implementation(compose.components.uiToolingPreview)
-            implementation(compose.material3)
-            implementation(compose.materialIconsExtended)
-            implementation(compose.ui)
+            api(libs.compose.material3)
+            api(libs.compose.components.resources)
+            implementation(libs.compose.runtime)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.ui)
+            implementation(libs.compose.material.icons.extended)
 
             // AndroidX
             implementation(libs.androidx.lifecycle.runtime.compose)
@@ -109,8 +106,7 @@ kotlin {
                 implementation(libs.kotlin.test)
 
                 // Compose
-                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
-                implementation(compose.uiTest)
+                implementation(libs.compose.ui.test)
 
                 // Test utilities
                 implementation(project(sharedTestUtilsModule))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/SelectPaymentMethodScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/SelectPaymentMethodScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.FiatPaymentMethodChargebackRiskVO
@@ -35,7 +36,6 @@ import network.bisq.mobile.presentation.create_payment_account.select_payment_me
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.ui.CryptoPaymentMethodCard
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.ui.FiatChargebackRiskFilterSection
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.ui.FiatPaymentMethodCard
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @ExcludeFromCoverage
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/CryptoPaymentMethodCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/CryptoPaymentMethodCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.model.account.PaymentMethodVO
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -19,7 +20,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.PaymentAccountMethodIcon
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun CryptoPaymentMethodCard(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/FiatChargebackRiskFilterSection.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/FiatChargebackRiskFilterSection.kt
@@ -9,13 +9,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.FiatPaymentMethodChargebackRiskVO
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun FiatChargebackRiskFilterSection(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/FiatPaymentMethodCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/select_payment_method/ui/FiatPaymentMethodCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.FiatPaymentMethodChargebackRiskVO
@@ -31,7 +32,6 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.FiatPaymentMethodVO
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.AccountFlowDialog
 import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.PaymentAccountMethodIcon
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun FiatPaymentMethodCard(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.SettingsRepository
+import network.bisq.mobile.domain.utils.combine
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -104,17 +105,16 @@ class OfferbookMarketPresenter(
 
     private fun observeMarketListItems() {
         presenterScope.launch {
-            network.bisq.mobile.domain.utils
-                .combine(
-                    filter,
-                    _searchText,
-                    sortBy,
-                    _marketPriceUpdated,
-                    mainPresenter.languageCode,
-                    offersServiceFacade.offerbookMarketItems,
-                ) { filter, searchText, sortBy, _, languageCode, items ->
-                    computeOfferbookMarketListUseCase(filter, searchText, sortBy, languageCode, items)
-                }.flowOn(Dispatchers.Default)
+            combine(
+                filter,
+                _searchText,
+                sortBy,
+                _marketPriceUpdated,
+                mainPresenter.languageCode,
+                offersServiceFacade.offerbookMarketItems,
+            ) { filter, searchText, sortBy, _, languageCode, items ->
+                computeOfferbookMarketListUseCase(filter, searchText, sortBy, languageCode, items)
+            }.flowOn(Dispatchers.Default)
                 .collect { result ->
                     _marketListItemWithNumOffers.value = result
                 }


### PR DESCRIPTION
followup to #1361
progress toward #1363

fixes some small issues and warnings

directly references the jetbrains dependencies as recommended by [docs](https://kotlinlang.org/docs/multiplatform/whats-new-compose-110.html#deprecated-dependency-aliases), till BOMs are implemented for kotlin multiplatform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Compose plugin to 1.10.3; updated androidx-activity-compose to 1.13.0 and lifecycle to 2.10.0.
  * Migrated Compose dependencies to the centralized version catalog (libs.*); updated Material Icons Extended to 1.7.3 and Material3 to 1.10.0-alpha05.
  * Cleaned up and unified preview/tooling dependency declarations and imports.

* **Tests**
  * Simplified and clarified several unit test assertions for more direct state/error checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->