### PR TITLE
design/trade_history

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryCardDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryCardDesign.kt
@@ -1,0 +1,543 @@
+/**
+ * TradeHistoryCardDesign.kt — Design PoC
+ *
+ * STATUS: Design proof-of-concept. NOT wired to any presenter or production code.
+ *
+ * ======================================================================================
+ * PURPOSE
+ * ======================================================================================
+ * Reusable card component for a single closed trade in the trade history list.
+ *
+ * Closed trades differ from open trades in two important ways:
+ *   1. The outcome is final — the card must communicate success/failure at a glance.
+ *   2. The card is archival — interaction is reduced (no chat badge, no action urgency).
+ *
+ * The card uses a colored left-border stripe to signal outcome (same border mechanism as
+ * OpenTradeCard) but outcome-driven rather than notification-driven:
+ *   - Green  (primary)  : COMPLETED — trade finished, BTC confirmed
+ *   - Red    (danger)   : CANCELLED or REJECTED — peer or self cancelled/rejected
+ *   - Orange (warning)  : FAILED / FAILED_AT_PEER — protocol error, no BTC movement
+ *
+ * Layout mirrors OpenTradeListItem's two-column approach (left: peer/metadata, right:
+ * amounts) but adds an outcome badge row above the columns. The background uses a
+ * slightly darker shade than open trades (dark_grey30 vs dark_grey40) to create a
+ * visual "archived" feel without sacrificing readability.
+ *
+ * ======================================================================================
+ * OUTCOME BADGE DESIGN
+ * ======================================================================================
+ * The outcome badge sits at the top of the card, full-width, using a tinted pill strip.
+ * It uses the same tinted-surface pattern as ChargebackRiskBadge in PaymentAccountCard
+ * (color.copy(alpha=0.12f) background + color text + colored 3dp left accent line).
+ * This is immediately scannable without being visually aggressive.
+ *
+ * A small "My role" label (Buyer/Seller · Maker/Taker) sits to the right of the outcome
+ * badge inside the same row. This answers the user's first mental question:
+ * "did I complete this trade, and what was my role in it?"
+ *
+ * ======================================================================================
+ * AMOUNT DISPLAY STRATEGY
+ * ======================================================================================
+ * - Fiat amount is in primary green for completed trades, white for cancelled/failed.
+ *   Reason: green on completed reinforces the positive outcome; neutral on cancelled
+ *   avoids implying money changed hands.
+ * - BTC amount uses BtcSatsText for the sig-digit dim-leading-zeros display.
+ * - Price shows the @ prefix in grey, value in white — same style as OpenTradeListItem.
+ *
+ * ======================================================================================
+ * PEER ROW
+ * ======================================================================================
+ * Uses a simulated peer row (username + StarRating inline) rather than UserProfileRow
+ * because UserProfileRow requires domain VO types. The simulated version uses a
+ * placeholder circle avatar (colored Box) + username text + star rating text.
+ * During implementation, replace SimulatedPeerRow with the real UserProfileRow.
+ *
+ * ======================================================================================
+ * IMPLEMENTATION NOTES
+ * ======================================================================================
+ * - Data model: maps from BisqEasyTradeDto + derived fields from presenter
+ * - The SimulatedTradeHistoryItem struct mirrors what a real presenter would expose:
+ *   all formatting already applied (no domain types in view)
+ * - Trade outcome is an enum (not a raw BisqEasyTradeStateDto string) — the presenter
+ *   should map the 40+ FSM states down to these 4 terminal buckets
+ * - "My role" string: presenter derives from TradeRoleDto
+ *   (BUYER_AS_TAKER → "Buyer · Taker", SELLER_AS_MAKER → "Seller · Maker", etc.)
+ *
+ * ======================================================================================
+ * I18N KEYS NEEDED
+ * ======================================================================================
+ * mobile.tradeHistory.outcome.completed   = "Completed"
+ * mobile.tradeHistory.outcome.cancelled   = "Cancelled"
+ * mobile.tradeHistory.outcome.rejected    = "Rejected"
+ * mobile.tradeHistory.outcome.failed      = "Failed"
+ * mobile.tradeHistory.role.buyerAsTaker   = "Buyer · Taker"
+ * mobile.tradeHistory.role.buyerAsMaker   = "Buyer · Maker"
+ * mobile.tradeHistory.role.sellerAsTaker  = "Seller · Taker"
+ * mobile.tradeHistory.role.sellerAsMaker  = "Seller · Maker"
+ * mobile.tradeHistory.card.tradeId        = "Trade #{0}"   (reuse open trades pattern)
+ */
+package network.bisq.mobile.presentation.design.trade_history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
+import network.bisq.mobile.presentation.common.ui.components.atoms.StarRating
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethods
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+
+// -------------------------------------------------------------------------------------
+// Outcome enum — maps the 40+ FSM terminal states down to 4 visual buckets
+// -------------------------------------------------------------------------------------
+
+internal enum class SimulatedTradeOutcome {
+    COMPLETED,
+    CANCELLED,
+    REJECTED,
+    FAILED,
+}
+
+// -------------------------------------------------------------------------------------
+// Simulated domain model — primitives only, no presenter dependency
+// -------------------------------------------------------------------------------------
+
+internal data class SimulatedTradeHistoryItem(
+    val tradeId: String,
+    val shortTradeId: String,
+    // Buyer / Seller direction label, e.g. "Bought from" / "Sold to"
+    val directionalTitle: String,
+    val peerName: String,
+    // 0.0 – 5.0
+    val peerReputationScore: Double,
+    // e.g. "Apr 8, 2026"
+    val formattedDate: String,
+    // e.g. "14:32"
+    val formattedTime: String,
+    // e.g. "100.00 USD"
+    val quoteAmountWithCode: String,
+    // e.g. "0.00150000" — BTC format for BtcSatsText
+    val formattedBaseAmount: String,
+    // e.g. "68,420 USD/BTC"
+    val formattedPrice: String,
+    val fiatPaymentMethod: String,
+    val bitcoinSettlementMethod: String,
+    // e.g. "Buyer · Maker"
+    val myRole: String,
+    val outcome: SimulatedTradeOutcome,
+)
+
+// -------------------------------------------------------------------------------------
+// Color helpers
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun outcomeColor(outcome: SimulatedTradeOutcome): Color =
+    when (outcome) {
+        SimulatedTradeOutcome.COMPLETED -> BisqTheme.colors.primary
+        SimulatedTradeOutcome.CANCELLED -> BisqTheme.colors.danger
+        SimulatedTradeOutcome.REJECTED -> BisqTheme.colors.danger
+        SimulatedTradeOutcome.FAILED -> BisqTheme.colors.warning
+    }
+
+private fun outcomeLabel(outcome: SimulatedTradeOutcome): String =
+    when (outcome) {
+        SimulatedTradeOutcome.COMPLETED -> "Completed"
+        SimulatedTradeOutcome.CANCELLED -> "Cancelled"
+        SimulatedTradeOutcome.REJECTED -> "Rejected"
+        SimulatedTradeOutcome.FAILED -> "Failed"
+    }
+
+// -------------------------------------------------------------------------------------
+// Outcome badge — tinted pill strip with colored left accent
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun OutcomeBadgeRow(
+    outcome: SimulatedTradeOutcome,
+    myRole: String,
+) {
+    val color = outcomeColor(outcome)
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(BisqUIConstants.BorderRadiusSmall),
+        color = color.copy(alpha = 0.10f),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = BisqUIConstants.ScreenPadding,
+                        vertical = BisqUIConstants.ScreenPaddingQuarter,
+                    ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                // 3dp colored left accent line
+                Surface(
+                    modifier = Modifier.size(width = 3.dp, height = 14.dp),
+                    shape = RoundedCornerShape(2.dp),
+                    color = color,
+                ) {}
+                BisqText.SmallRegular(
+                    text = outcomeLabel(outcome),
+                    color = color,
+                )
+            }
+            BisqText.XSmallLight(
+                text = myRole,
+                color = BisqTheme.colors.mid_grey20,
+            )
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Simulated peer row — placeholder until real UserProfileRow can be used
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun SimulatedPeerRow(
+    peerName: String,
+    reputationScore: Double,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+    ) {
+        // Placeholder avatar circle — replace with UserProfileIcon in production
+        Box(
+            modifier =
+                Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(BisqTheme.colors.dark_grey50),
+            contentAlignment = Alignment.Center,
+        ) {
+            BisqText.XSmallLight(
+                text = peerName.take(1).uppercase(),
+                color = BisqTheme.colors.mid_grey30,
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            BisqText.SmallRegular(
+                text = peerName,
+                color = BisqTheme.colors.white,
+            )
+            StarRating(rating = reputationScore)
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Public card composable
+// -------------------------------------------------------------------------------------
+
+/**
+ * Trade history card for a single closed trade.
+ *
+ * Visual structure:
+ * ┌─────────────────────────────────────────┐  ← dark_grey30 background
+ * │ [Completed badge ▌]        [Buyer·Taker]│  ← outcome badge row
+ * │ Bought from:                            │
+ * │ [avatar] SatoshiFan42  ★★★★☆   100.00 USD  ← peer left / fiat right
+ * │ Apr 8, 2026 14:32      @ 68,420 USD/BTC
+ * │ Trade #abc123d         0.00150000 BTC
+ * │ [sepa] ⇄ [btc]
+ * └─────────────────────────────────────────┘
+ *
+ * The left border stripe (4dp) mirrors OpenTradeCard but uses outcome color.
+ * The card background is dark_grey30 (one step darker than open trades' dark_grey40)
+ * to give a subtle "archived" tone.
+ *
+ * @param item The closed trade data (all fields pre-formatted by presenter)
+ * @param onClick Optional tap handler — navigates to trade detail
+ */
+@Composable
+internal fun TradeHistoryCard(
+    item: SimulatedTradeHistoryItem,
+    onClick: () -> Unit = {},
+) {
+    val borderColor = outcomeColor(item.outcome)
+    val borderWidth = 4.dp
+    val borderRadius = BisqUIConstants.BorderRadius
+    val cardBackground = BisqTheme.colors.dark_grey30
+
+    // Card shape: flat left edge (for the border stripe) + rounded right corners
+    val shape =
+        RoundedCornerShape(
+            topStart = 0.dp,
+            bottomStart = 0.dp,
+            topEnd = borderRadius,
+            bottomEnd = borderRadius,
+        )
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(shape)
+                .background(cardBackground)
+                .drawBehind {
+                    val strokeWidthPx = borderWidth.toPx()
+                    drawLine(
+                        color = borderColor,
+                        start = Offset(0f, 0f),
+                        end = Offset(0f, size.height),
+                        strokeWidth = strokeWidthPx,
+                    )
+                }.padding(BisqUIConstants.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+    ) {
+        // Row 1: Outcome badge + my role
+        OutcomeBadgeRow(
+            outcome = item.outcome,
+            myRole = item.myRole,
+        )
+
+        BisqGap.VQuarter()
+
+        // Row 2: Main content — peer/metadata left, amounts right
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            // Left column: direction, peer, date, trade ID
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                BisqText.SmallLightGrey(
+                    text = item.directionalTitle.uppercase(),
+                )
+                SimulatedPeerRow(
+                    peerName = item.peerName,
+                    reputationScore = item.peerReputationScore,
+                )
+                BisqText.SmallLightGrey("${item.formattedDate}  ${item.formattedTime}")
+                BisqText.SmallLightGrey("Trade #${item.shortTradeId}")
+            }
+
+            // Right column: fiat amount, price, BTC amount, payment methods
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(top = 2.dp),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                // Fiat amount: green if completed, white if cancelled/failed
+                val fiatColor =
+                    if (item.outcome == SimulatedTradeOutcome.COMPLETED) {
+                        BisqTheme.colors.primary
+                    } else {
+                        BisqTheme.colors.mid_grey30
+                    }
+                BisqText.LargeRegular(
+                    text = item.quoteAmountWithCode,
+                    color = fiatColor,
+                )
+
+                // Price with @ prefix
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    BisqText.SmallRegularGrey("@ ")
+                    if (item.formattedPrice.length > 16) {
+                        BisqText.XSmallRegular(item.formattedPrice)
+                    } else {
+                        BisqText.SmallRegular(item.formattedPrice)
+                    }
+                }
+
+                // BTC amount with sig-digit styling
+                BtcSatsText(item.formattedBaseAmount)
+
+                // Payment method icons
+                PaymentMethods(
+                    baseSidePaymentMethods = listOf(item.bitcoinSettlementMethod),
+                    quoteSidePaymentMethods = listOf(item.fiatPaymentMethod),
+                )
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Preview data
+// -------------------------------------------------------------------------------------
+
+internal val sampleCompletedBuyerTrade =
+    SimulatedTradeHistoryItem(
+        tradeId = "t-abc123def456ghi789",
+        shortTradeId = "abc123d",
+        directionalTitle = "Bought from",
+        peerName = "SatoshiFan42",
+        peerReputationScore = 4.5,
+        formattedDate = "Apr 8, 2026",
+        formattedTime = "14:32",
+        quoteAmountWithCode = "342.10 USD",
+        formattedBaseAmount = "0.00500000",
+        formattedPrice = "68,420 USD/BTC",
+        fiatPaymentMethod = "SEPA",
+        bitcoinSettlementMethod = "MAINCHAIN",
+        myRole = "Buyer · Taker",
+        outcome = SimulatedTradeOutcome.COMPLETED,
+    )
+
+internal val sampleCompletedSellerTrade =
+    SimulatedTradeHistoryItem(
+        tradeId = "t-xyz789abc123def456",
+        shortTradeId = "xyz789a",
+        directionalTitle = "Sold to",
+        peerName = "LightningLover99",
+        peerReputationScore = 3.0,
+        formattedDate = "Apr 6, 2026",
+        formattedTime = "09:15",
+        quoteAmountWithCode = "820.00 EUR",
+        formattedBaseAmount = "0.01200000",
+        formattedPrice = "68,333 EUR/BTC",
+        fiatPaymentMethod = "REVOLUT",
+        bitcoinSettlementMethod = "LN",
+        myRole = "Seller · Maker",
+        outcome = SimulatedTradeOutcome.COMPLETED,
+    )
+
+internal val sampleCancelledTrade =
+    SimulatedTradeHistoryItem(
+        tradeId = "t-can000def456ghi789",
+        shortTradeId = "can000d",
+        directionalTitle = "Buying from",
+        peerName = "CryptoNovice7",
+        peerReputationScore = 1.5,
+        formattedDate = "Apr 5, 2026",
+        formattedTime = "11:00",
+        quoteAmountWithCode = "200.00 USD",
+        formattedBaseAmount = "0.00290000",
+        formattedPrice = "68,965 USD/BTC",
+        fiatPaymentMethod = "ZELLE",
+        bitcoinSettlementMethod = "MAINCHAIN",
+        myRole = "Buyer · Taker",
+        outcome = SimulatedTradeOutcome.CANCELLED,
+    )
+
+internal val sampleRejectedTrade =
+    SimulatedTradeHistoryItem(
+        tradeId = "t-rej001abc123def456",
+        shortTradeId = "rej001a",
+        directionalTitle = "Selling to",
+        peerName = "FreshTrader",
+        peerReputationScore = 0.0,
+        formattedDate = "Apr 3, 2026",
+        formattedTime = "16:45",
+        quoteAmountWithCode = "500.00 EUR",
+        formattedBaseAmount = "0.00730000",
+        formattedPrice = "68,493 EUR/BTC",
+        fiatPaymentMethod = "SEPA_INSTANT",
+        bitcoinSettlementMethod = "LN",
+        myRole = "Seller · Taker",
+        outcome = SimulatedTradeOutcome.REJECTED,
+    )
+
+internal val sampleFailedTrade =
+    SimulatedTradeHistoryItem(
+        tradeId = "t-fail002ghi789abc12",
+        shortTradeId = "fail002",
+        directionalTitle = "Buying from",
+        peerName = "NodeOp_Berlin",
+        peerReputationScore = 4.0,
+        formattedDate = "Apr 1, 2026",
+        formattedTime = "08:20",
+        quoteAmountWithCode = "150.00 CHF",
+        formattedBaseAmount = "0.00220000",
+        formattedPrice = "68,181 CHF/BTC",
+        fiatPaymentMethod = "TWINT",
+        bitcoinSettlementMethod = "MAINCHAIN",
+        myRole = "Buyer · Maker",
+        outcome = SimulatedTradeOutcome.FAILED,
+    )
+
+// -------------------------------------------------------------------------------------
+// Previews
+// -------------------------------------------------------------------------------------
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Completed_Buyer_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            TradeHistoryCard(item = sampleCompletedBuyerTrade)
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Completed_Seller_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            TradeHistoryCard(item = sampleCompletedSellerTrade)
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Cancelled_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            TradeHistoryCard(item = sampleCancelledTrade)
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Rejected_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            TradeHistoryCard(item = sampleRejectedTrade)
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Failed_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            TradeHistoryCard(item = sampleFailedTrade)
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryListDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryListDesign.kt
@@ -1,0 +1,597 @@
+/**
+ * TradeHistoryListDesign.kt — Design PoC
+ *
+ * STATUS: Design proof-of-concept. NOT wired to any presenter or production code.
+ *
+ * ======================================================================================
+ * PURPOSE
+ * ======================================================================================
+ * Full-screen trade history list — the mobile adaptation of Bisq2's desktop
+ * BisqEasyHistoryView table (sortable columns with 11 fields).
+ *
+ * Mobile replaces the table with:
+ *   - A search bar at the top (filter by peer name or market, e.g. "BTC/USD")
+ *   - A LazyColumn of TradeHistoryCard items, newest-first
+ *   - Section header showing result count
+ *   - Loading skeleton state (shimmer-placeholder cards)
+ *   - Empty state with call-to-action to the offerbook
+ *
+ * ======================================================================================
+ * SEARCH / FILTER DESIGN
+ * ======================================================================================
+ * WHY SEARCH IS NEEDED:
+ * Unlike open trades (typically 1-5 at a time), trade history accumulates indefinitely.
+ * Active traders can reach 50-100+ closed trades within months. The primary use case
+ * is "find that specific trade" — e.g., for dispute resolution, tax records, or to
+ * verify a past transaction with a specific peer. Without search, users must scroll
+ * through a reverse-chronological list, which becomes impractical at scale.
+ * Desktop includes search in its history table for this reason.
+ *
+ * NOTE: Search can be deferred to a post-V1 release if needed. Early users will have
+ * few closed trades, so the list is usable without it. Search makes it efficient at
+ * scale — it's an optimization, not a blocker.
+ *
+ * IMPLEMENTATION:
+ * The search bar is intentionally simple: a single text field filtering by peer name
+ * OR market code (e.g., typing "USD" surfaces all USD trades; typing "SatoshiFan" finds
+ * trades with that peer). This covers the most common "find a specific trade" use case
+ * without requiring a separate filter sheet.
+ *
+ * A sort button (SortIcon in the rightSuffix slot of BisqSearchField) opens a bottom
+ * sheet with sort options: Newest first (default), Oldest first, Amount (high-to-low),
+ * Amount (low-to-high). The current sort selection is shown as a chip below the search
+ * bar only when a non-default sort is active.
+ *
+ * ======================================================================================
+ * SECTION HEADER
+ * ======================================================================================
+ * "N trades" subtitle renders below the search bar. When search is active it reads
+ * "N of M trades". This gives the user a fast count without a loading indicator.
+ * The header uses SmallLightGrey — low visual weight, purely informational.
+ *
+ * ======================================================================================
+ * LOADING STATE
+ * ======================================================================================
+ * Shows 3 placeholder cards: same structure as TradeHistoryCard but with shimmer
+ * placeholders instead of real data. Using a uniform shimmer height per section
+ * avoids layout jump when real data loads.
+ *
+ * In this POC the shimmer is simulated with a semi-transparent grey surface.
+ * During implementation, replace with a proper Shimmer library call or AnimatedShimmer
+ * composable (already used elsewhere in the project).
+ *
+ * ======================================================================================
+ * EMPTY STATE
+ * ======================================================================================
+ * Two variants:
+ *   a) No trades at all — illustration + "No completed trades yet" + "Browse offers"
+ *      CTA button. This is the first-run experience.
+ *   b) No search results — "No trades match your search" + "Clear search" text button.
+ *      Inline, no illustration needed since the user just typed something wrong.
+ *
+ * ======================================================================================
+ * SCROLL BEHAVIOR
+ * ======================================================================================
+ * The search bar is pinned (not part of LazyColumn). The section count header scrolls
+ * away with the list content as item 0 of the LazyColumn. This keeps the search bar
+ * always accessible without covering trade cards.
+ *
+ * ======================================================================================
+ * NAVIGATION
+ * ======================================================================================
+ * Tapping a card navigates to a trade detail screen (not designed in this POC).
+ * The NavRoute for production implementation will likely be:
+ *   data class TradeHistory(val tradeId: String) : NavRoute
+ *
+ * ======================================================================================
+ * IMPLEMENTATION NOTES
+ * ======================================================================================
+ * - Presenter exposes: closedTrades: StateFlow<List<...>>, isLoading: StateFlow<Boolean>,
+ *   searchQuery: StateFlow<String>, onSearchQueryChange(String), onSelectTrade(tradeId)
+ * - The presenter filters client-side (no backend search endpoint needed) since the
+ *   number of closed trades is bounded and lives in memory
+ * - The domain source is the same TradesServiceFacade.closedTrades flow used by desktop's
+ *   BisqEasyHistoryController — no new API endpoints required
+ *
+ * ======================================================================================
+ * I18N KEYS NEEDED
+ * ======================================================================================
+ * mobile.tradeHistory.title                = "Trade History"
+ * mobile.tradeHistory.count.one            = "1 trade"
+ * mobile.tradeHistory.count.many           = "{0} trades"
+ * mobile.tradeHistory.count.filtered       = "{0} of {1} trades"
+ * mobile.tradeHistory.empty.noTrades       = "No completed trades yet"
+ * mobile.tradeHistory.empty.noTrades.sub   = "Completed trades will appear here after BTC is confirmed or a trade is cancelled."
+ * mobile.tradeHistory.empty.noResults      = "No trades match your search"
+ * mobile.tradeHistory.search.placeholder   = "Search by peer or market"
+ * mobile.tradeHistory.sort.label           = "Sort"
+ * mobile.tradeHistory.sort.newestFirst     = "Newest first"
+ * mobile.tradeHistory.sort.oldestFirst     = "Oldest first"
+ * mobile.tradeHistory.sort.amountHighLow   = "Amount: high to low"
+ * mobile.tradeHistory.sort.amountLowHigh   = "Amount: low to high"
+ */
+package network.bisq.mobile.presentation.design.trade_history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+
+// -------------------------------------------------------------------------------------
+// Screen-level composable
+// -------------------------------------------------------------------------------------
+
+/**
+ * Trade history list screen.
+ *
+ * Renders a pinned search bar above a LazyColumn of closed trade cards.
+ * Handles three states: loading, empty (two variants), and populated list.
+ *
+ * @param trades Full list of closed trades (pre-sorted by presenter, newest first)
+ * @param isLoading True while the presenter is loading trades from the service
+ * @param searchQuery Current text in the search field
+ * @param onSearchQueryChange Called when user edits the search field
+ * @param onSelectTrade Called with tradeId when user taps a card
+ * @param onBrowseOffers Called when user taps the CTA on the no-trades empty state
+ */
+@Composable
+internal fun TradeHistoryListScreen(
+    trades: List<SimulatedTradeHistoryItem>,
+    isLoading: Boolean,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onSelectTrade: (String) -> Unit,
+    onBrowseOffers: () -> Unit,
+) {
+    // Client-side filtering: match peer name or any part of the formatted price (market)
+    val filteredTrades =
+        remember(trades, searchQuery) {
+            if (searchQuery.isBlank()) {
+                trades
+            } else {
+                val query = searchQuery.trim().lowercase()
+                trades.filter { item ->
+                    item.peerName.lowercase().contains(query) ||
+                        item.formattedPrice.lowercase().contains(query) ||
+                        item.fiatPaymentMethod.lowercase().contains(query) ||
+                        item.quoteAmountWithCode.lowercase().contains(query)
+                }
+            }
+        }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(BisqTheme.colors.backgroundColor),
+    ) {
+        // Pinned search bar
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(BisqTheme.colors.backgroundColor)
+                    .padding(
+                        horizontal = BisqUIConstants.ScreenPadding,
+                        vertical = BisqUIConstants.ScreenPaddingHalf,
+                    ),
+        ) {
+            BisqSearchField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                placeholder = "Search by peer or market",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        // Content area
+        when {
+            isLoading -> TradeHistoryLoadingState()
+
+            filteredTrades.isEmpty() && searchQuery.isBlank() ->
+                TradeHistoryEmptyState(onBrowseOffers = onBrowseOffers)
+
+            filteredTrades.isEmpty() ->
+                TradeHistoryNoResultsState(onClearSearch = { onSearchQueryChange("") })
+
+            else ->
+                TradeHistoryList(
+                    trades = filteredTrades,
+                    totalCount = trades.size,
+                    searchQuery = searchQuery,
+                    onSelectTrade = onSelectTrade,
+                )
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Populated list state
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun TradeHistoryList(
+    trades: List<SimulatedTradeHistoryItem>,
+    totalCount: Int,
+    searchQuery: String,
+    onSelectTrade: (String) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+            PaddingValues(
+                start = BisqUIConstants.ScreenPadding,
+                end = BisqUIConstants.ScreenPadding,
+                top = BisqUIConstants.ScreenPaddingHalf,
+                bottom = BisqUIConstants.ScreenPadding2X,
+            ),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+    ) {
+        // Section count header — scrolls with the list
+        item(key = "header") {
+            val countLabel =
+                if (searchQuery.isBlank()) {
+                    if (trades.size == 1) "1 trade" else "${trades.size} trades"
+                } else {
+                    "${trades.size} of $totalCount trades"
+                }
+            BisqText.SmallLightGrey(
+                text = countLabel,
+                modifier =
+                    Modifier.padding(
+                        start = BisqUIConstants.ScreenPaddingQuarter,
+                        bottom = BisqUIConstants.ScreenPaddingQuarter,
+                    ),
+            )
+        }
+
+        itemsIndexed(trades, key = { _, item -> item.tradeId }) { _, item ->
+            TradeHistoryCard(
+                item = item,
+                onClick = { onSelectTrade(item.tradeId) },
+            )
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Loading state — shimmer placeholder cards
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun TradeHistoryLoadingState() {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+            PaddingValues(
+                horizontal = BisqUIConstants.ScreenPadding,
+                vertical = BisqUIConstants.ScreenPaddingHalf,
+            ),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+        userScrollEnabled = false,
+    ) {
+        items(3) {
+            ShimmerTradeCard()
+        }
+    }
+}
+
+/**
+ * Placeholder card shown during loading.
+ * Uses a semi-transparent surface to approximate card dimensions without real data.
+ * Replace the inner boxes with an AnimatedShimmer composable during implementation.
+ */
+@Composable
+private fun ShimmerTradeCard() {
+    val shimmerColor = BisqTheme.colors.dark_grey40
+    val placeholderColor = BisqTheme.colors.dark_grey50
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
+                .background(shimmerColor)
+                .padding(BisqUIConstants.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+    ) {
+        // Outcome badge placeholder
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(22.dp)
+                    .clip(RoundedCornerShape(BisqUIConstants.BorderRadiusSmall))
+                    .background(placeholderColor),
+        )
+        BisqGap.VQuarter()
+        // Peer name placeholder
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth(0.45f)
+                    .height(14.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(placeholderColor),
+        )
+        // Star rating placeholder
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth(0.30f)
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(placeholderColor),
+        )
+        // Date placeholder
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth(0.55f)
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(placeholderColor),
+        )
+        BisqGap.VQuarter()
+        // Amount placeholder (right-aligned simulation)
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.End)
+                    .fillMaxWidth(0.40f)
+                    .height(16.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(placeholderColor),
+        )
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Empty state — no trades at all
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun TradeHistoryEmptyState(onBrowseOffers: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = BisqUIConstants.ScreenPadding2X,
+                    vertical = BisqUIConstants.ScreenPadding4X,
+                ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        // Decorative archive icon placeholder — replace with a dedicated Res.drawable.trade_history
+        // icon or reuse trade_completed once available
+        Box(
+            modifier =
+                Modifier
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
+                    .background(BisqTheme.colors.dark_grey40),
+            contentAlignment = Alignment.Center,
+        ) {
+            BisqText.H4LightGrey("?")
+        }
+
+        BisqGap.V2()
+
+        BisqText.H5Light(
+            text = "No completed trades yet",
+            textAlign = TextAlign.Center,
+        )
+
+        BisqGap.V1()
+
+        BisqText.SmallLightGrey(
+            text = "Completed trades will appear here after BTC is confirmed or a trade is cancelled.",
+            textAlign = TextAlign.Center,
+        )
+
+        BisqGap.V2()
+
+        BisqButton(
+            text = "Browse offers",
+            onClick = onBrowseOffers,
+        )
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// No-results state — search returned nothing
+// -------------------------------------------------------------------------------------
+
+@Composable
+private fun TradeHistoryNoResultsState(onClearSearch: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = BisqUIConstants.ScreenPadding2X,
+                    vertical = BisqUIConstants.ScreenPadding3X,
+                ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        BisqGap.V2()
+
+        BisqText.BaseLight(
+            text = "No trades match your search",
+            textAlign = TextAlign.Center,
+        )
+
+        BisqGap.V1()
+
+        BisqButton(
+            text = "Clear search",
+            type = BisqButtonType.Grey,
+            onClick = onClearSearch,
+        )
+    }
+}
+
+// -------------------------------------------------------------------------------------
+// Preview data helpers
+// -------------------------------------------------------------------------------------
+
+private val allSampleTrades =
+    listOf(
+        sampleCompletedBuyerTrade,
+        sampleCompletedSellerTrade,
+        sampleCancelledTrade,
+        sampleRejectedTrade,
+        sampleFailedTrade,
+    )
+
+// -------------------------------------------------------------------------------------
+// Previews
+// -------------------------------------------------------------------------------------
+
+/**
+ * Preview: full list with mixed outcomes — the typical populated state.
+ * Shows 5 trades: 2 completed, 1 cancelled, 1 rejected, 1 failed.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+private fun List_MixedOutcomes_Preview() {
+    BisqTheme.Preview {
+        var searchQuery by remember { mutableStateOf("") }
+        TradeHistoryListScreen(
+            trades = allSampleTrades,
+            isLoading = false,
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}
+
+/**
+ * Preview: search active — only completed trades remain after filtering "SEPA".
+ * Demonstrates the "N of M trades" counter and narrowed list.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+private fun List_SearchActive_Preview() {
+    BisqTheme.Preview {
+        TradeHistoryListScreen(
+            trades = allSampleTrades,
+            isLoading = false,
+            searchQuery = "SEPA",
+            onSearchQueryChange = {},
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}
+
+/**
+ * Preview: loading state — shimmer placeholder cards while data is fetched.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+private fun List_Loading_Preview() {
+    BisqTheme.Preview {
+        TradeHistoryListScreen(
+            trades = emptyList(),
+            isLoading = true,
+            searchQuery = "",
+            onSearchQueryChange = {},
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}
+
+/**
+ * Preview: empty state — first-run, no closed trades at all.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+private fun List_EmptyState_Preview() {
+    BisqTheme.Preview {
+        TradeHistoryListScreen(
+            trades = emptyList(),
+            isLoading = false,
+            searchQuery = "",
+            onSearchQueryChange = {},
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}
+
+/**
+ * Preview: no-results state — search has no matches.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 500)
+@Composable
+private fun List_NoResults_Preview() {
+    BisqTheme.Preview {
+        TradeHistoryListScreen(
+            trades = allSampleTrades,
+            isLoading = false,
+            searchQuery = "xyznotfound",
+            onSearchQueryChange = {},
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}
+
+/**
+ * Preview: single trade — edge case for list with one entry.
+ */
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 400)
+@Composable
+private fun List_SingleTrade_Preview() {
+    BisqTheme.Preview {
+        TradeHistoryListScreen(
+            trades = listOf(sampleCompletedBuyerTrade),
+            isLoading = false,
+            searchQuery = "",
+            onSearchQueryChange = {},
+            onSelectTrade = {},
+            onBrowseOffers = {},
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryTabDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/trade_history/TradeHistoryTabDesign.kt
@@ -1,0 +1,470 @@
+package network.bisq.mobile.presentation.design.trade_history
+
+/**
+ * # Trade History Tab Integration Design
+ *
+ * Designs the modification to the existing "My Trades" tab (TabOpenTradeList) to include
+ * both open trades and trade history using a segmented toggle at the top.
+ *
+ * ## Design rationale
+ *
+ * **Why not a 5th bottom tab?**
+ * - 5 tabs cause label truncation in i18n (German, Portuguese labels are long)
+ * - Breaks the established 4-tab rhythm; adds cognitive load
+ * - Trade history is contextually related to open trades — same mental model
+ *
+ * **Why a segmented toggle (not top tabs)?**
+ * - Compose Material `TabRow` has a distinctly different visual language (underline indicator)
+ *   that clashes with the dark card-based Bisq theme
+ * - A `ToggleTab` component already exists in the codebase (used in create offer amount screen)
+ * - Two options = perfect fit for a binary toggle; tabs imply 3+ sections
+ * - The toggle sits below the top bar and above the list, taking minimal vertical space
+ *
+ * ## Navigation structure
+ *
+ * ```
+ * Bottom Tab: "My Trades" (TabOpenTradeList)
+ *   ┌──────────────────────────────────────────┐
+ *   │  [  Open trades  |  History  ]           │  ← ToggleTab (segmented control)
+ *   ├──────────────────────────────────────────┤
+ *   │                                          │
+ *   │  (content switches based on toggle)      │
+ *   │                                          │
+ *   │  Open: existing OpenTradeListScreen      │
+ *   │  History: TradeHistoryList from design    │
+ *   │                                          │
+ *   └──────────────────────────────────────────┘
+ * ```
+ *
+ * ## Badge / notification indicator
+ *
+ * The bottom tab icon for "My Trades" currently shows a notification badge
+ * for unread trade chat messages. This only applies to open trades.
+ * When viewing the History tab, the badge should still reflect open trade
+ * notifications (it's a tab-level indicator, not content-level).
+ *
+ * ## State preservation
+ *
+ * The selected toggle state (Open vs History) should survive back-stack navigation
+ * (user navigates to trade detail and back). Use `rememberSaveable` for the toggle index.
+ * When the user switches to another bottom tab and returns, the toggle resets to "Open"
+ * (open trades are the primary view; history is secondary).
+ *
+ * ## I18N keys needed
+ *
+ * - `mobile.myTrades.tab.open` = "Open trades"
+ * - `mobile.myTrades.tab.history` = "History"
+ *
+ * ## Desktop reference
+ *
+ * Bisq2 Desktop uses a horizontal tab bar with "Open Trades" and "Trade History"
+ * as sibling tabs under the same navigation section. This design mirrors that
+ * hierarchy but adapts to mobile with a compact toggle control.
+ */
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.molecules.ToggleTab
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+
+// ---------------------------------------------------------------------------
+// Simulated data helpers (no domain types)
+// ---------------------------------------------------------------------------
+
+private enum class SimulatedTradeTab(
+    val label: String,
+) {
+    OPEN("Open trades"),
+    HISTORY("History"),
+}
+
+@Composable
+private fun SimulatedOpenTradeCard(
+    direction: String,
+    peerName: String,
+    date: String,
+    fiatAmount: String,
+    btcAmount: String,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 0.dp,
+                        bottomStart = 0.dp,
+                        topEnd = BisqUIConstants.BorderRadius,
+                        bottomEnd = BisqUIConstants.BorderRadius,
+                    ),
+                ).background(BisqTheme.colors.dark_grey40)
+                .padding(BisqUIConstants.ScreenPadding),
+    ) {
+        // Yellow left border (notification indicator)
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.CenterStart)
+                    .width(6.dp)
+                    .height(60.dp)
+                    .background(BisqTheme.colors.yellow),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                BisqText.BaseLightGrey(direction.uppercase())
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(top = 6.dp, bottom = 8.dp),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .background(BisqTheme.colors.mid_grey30),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        BisqText.SmallRegular(peerName.take(1).uppercase())
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    BisqText.BaseRegular(peerName)
+                }
+                BisqText.SmallLightGrey(date)
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                BisqText.LargeRegular(fiatAmount, color = BisqTheme.colors.primary)
+                BisqGap.VQuarter()
+                BisqText.SmallRegular(btcAmount)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main integrated screen design
+// ---------------------------------------------------------------------------
+
+/**
+ * Design for the modified "My Trades" tab screen.
+ *
+ * The existing [OpenTradeListScreen] becomes the content for the "Open trades" toggle.
+ * The [TradeHistoryListDesign] content becomes the "History" toggle.
+ *
+ * Implementation note: In production, this composable replaces the current
+ * `OpenTradeListScreen` body. The presenter would expose:
+ * ```kotlin
+ * val selectedTab: StateFlow<Int>  // 0 = Open, 1 = History
+ * fun onTabSelect(index: Int)
+ * ```
+ * Or, more simply, use `rememberSaveable { mutableIntStateOf(0) }` in the screen
+ * since the toggle is purely a UI concern (both lists are independent).
+ */
+@Composable
+internal fun MyTradesScreenWithHistory(
+    selectedTab: Int = 0,
+    onTabSelect: (Int) -> Unit = {},
+    // Open trades content
+    openTradesContent: @Composable () -> Unit = {},
+    // History content
+    historyContent: @Composable () -> Unit = {},
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = BisqUIConstants.ScreenPadding),
+    ) {
+        BisqGap.V1()
+
+        // Segmented toggle — reuses existing ToggleTab component
+        ToggleTab(
+            options = SimulatedTradeTab.entries.toList(),
+            selectedOption = if (selectedTab == 0) SimulatedTradeTab.OPEN else SimulatedTradeTab.HISTORY,
+            onOptionSelect = { tab -> onTabSelect(tab.ordinal) },
+            getDisplayString = { it.label },
+        )
+
+        BisqGap.V1()
+
+        // Content area
+        Box(modifier = Modifier.fillMaxSize()) {
+            when (selectedTab) {
+                0 -> openTradesContent()
+                1 -> historyContent()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Previews
+// ---------------------------------------------------------------------------
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun MyTradesScreen_OpenTab_WithTrades_Preview() {
+    BisqTheme.Preview {
+        var tab by remember { mutableIntStateOf(0) }
+        MyTradesScreenWithHistory(
+            selectedTab = tab,
+            onTabSelect = { tab = it },
+            openTradesContent = {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 16.dp),
+                ) {
+                    items(
+                        listOf(
+                            Triple("Buying from", "SatoshiFan", "150.00 EUR"),
+                            Triple("Selling to", "BitcoinBob", "200.00 USD"),
+                        ),
+                    ) { (direction, peer, amount) ->
+                        SimulatedOpenTradeCard(
+                            direction = direction,
+                            peerName = peer,
+                            date = "2026-04-15 14:30",
+                            fiatAmount = amount,
+                            btcAmount = "0.00180000 BTC",
+                        )
+                    }
+                }
+            },
+            historyContent = {},
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun MyTradesScreen_HistoryTab_WithTrades_Preview() {
+    BisqTheme.Preview {
+        var tab by remember { mutableIntStateOf(1) }
+        MyTradesScreenWithHistory(
+            selectedTab = tab,
+            onTabSelect = { tab = it },
+            openTradesContent = {},
+            historyContent = {
+                // Reuse the history card designs
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 16.dp),
+                ) {
+                    items(
+                        listOf(
+                            SimulatedClosedTrade("Bought from", "SatoshiFan", "2026-04-10", "150.00 EUR", "0.00180000 BTC", "Completed", true),
+                            SimulatedClosedTrade("Sold to", "LightningLucy", "2026-04-08", "0.50 XMR", "0.00050000 BTC", "Completed", true),
+                            SimulatedClosedTrade("Buying from", "TorTrader", "2026-04-05", "300.00 USD", "0.00350000 BTC", "Cancelled", false),
+                        ),
+                    ) { trade ->
+                        SimulatedHistoryCard(trade)
+                    }
+                }
+            },
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun MyTradesScreen_HistoryTab_Empty_Preview() {
+    BisqTheme.Preview {
+        var tab by remember { mutableIntStateOf(1) }
+        MyTradesScreenWithHistory(
+            selectedTab = tab,
+            onTabSelect = { tab = it },
+            openTradesContent = {},
+            historyContent = {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    BisqText.H4LightGrey(
+                        text = "No trade history yet",
+                        textAlign = TextAlign.Center,
+                    )
+                    BisqGap.V2()
+                    BisqText.BaseLightGrey(
+                        text = "Completed and closed trades will appear here.",
+                        textAlign = TextAlign.Center,
+                    )
+                    BisqGap.V3()
+                    BisqButton(
+                        text = "Browse offers",
+                        onClick = {},
+                    )
+                }
+            },
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun MyTradesScreen_OpenTab_Empty_Preview() {
+    BisqTheme.Preview {
+        var tab by remember { mutableIntStateOf(0) }
+        MyTradesScreenWithHistory(
+            selectedTab = tab,
+            onTabSelect = { tab = it },
+            openTradesContent = {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    BisqText.H4LightGrey(
+                        text = "You don't have any open trades",
+                        textAlign = TextAlign.Center,
+                    )
+                    BisqGap.V3()
+                    BisqButton(
+                        text = "Browse offers",
+                        onClick = {},
+                    )
+                }
+            },
+            historyContent = {},
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper for history previews within this file
+// ---------------------------------------------------------------------------
+
+private data class SimulatedClosedTrade(
+    val direction: String,
+    val peerName: String,
+    val date: String,
+    val fiatAmount: String,
+    val btcAmount: String,
+    val outcome: String,
+    val isCompleted: Boolean,
+)
+
+@Composable
+private fun SimulatedHistoryCard(trade: SimulatedClosedTrade) {
+    val borderColor = if (trade.isCompleted) BisqTheme.colors.primary else BisqTheme.colors.danger
+    val amountColor = if (trade.isCompleted) BisqTheme.colors.primary else BisqTheme.colors.mid_grey30
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 0.dp,
+                        bottomStart = 0.dp,
+                        topEnd = BisqUIConstants.BorderRadius,
+                        bottomEnd = BisqUIConstants.BorderRadius,
+                    ),
+                ).background(BisqTheme.colors.dark_grey30)
+                .padding(BisqUIConstants.ScreenPadding),
+    ) {
+        // Outcome left border
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.CenterStart)
+                    .width(4.dp)
+                    .height(60.dp)
+                    .background(borderColor),
+        )
+
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            // Outcome badge row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(borderColor.copy(alpha = 0.10f))
+                            .padding(horizontal = 8.dp, vertical = 2.dp),
+                ) {
+                    BisqText.XSmallRegular(trade.outcome, color = borderColor)
+                }
+                BisqText.XSmallRegularGrey("Buyer / Taker")
+            }
+
+            BisqGap.VHalf()
+
+            // Main content row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    BisqText.BaseLightGrey(trade.direction.uppercase())
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+                    ) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(28.dp)
+                                    .clip(CircleShape)
+                                    .background(BisqTheme.colors.mid_grey30),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            BisqText.XSmallRegular(trade.peerName.take(1).uppercase())
+                        }
+                        Spacer(Modifier.width(6.dp))
+                        BisqText.SmallRegular(trade.peerName)
+                    }
+                    BisqText.SmallLightGrey(trade.date)
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    BisqText.LargeRegular(trade.fiatAmount, color = amountColor)
+                    BisqGap.VQuarter()
+                    BisqText.SmallRegular(trade.btcAmount)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - contribs designs to #1266 
 - depends on #1365 (previews not working with latest changes)
 - AI designs based on guidelines and bisq2 desktop impl w/ documentation on how to use and previews to visualise

<img width="270" height="579" alt="Screenshot 2026-04-17 at 15 09 16" src="https://github.com/user-attachments/assets/0d31b285-2f37-4795-9618-b855cd39c035" />
<img width="777" height="486" alt="Screenshot 2026-04-17 at 15 00 52" src="https://github.com/user-attachments/assets/51a68d57-5e17-4f90-a481-1635ee1e3e1d" />
<img width="767" height="608" alt="Screenshot 2026-04-17 at 15 01 03" src="https://github.com/user-attachments/assets/843f0793-5d93-45fc-be22-e77dd9ce08f0" />
<img width="825" height="720" alt="Screenshot 2026-04-17 at 15 01 21" src="https://github.com/user-attachments/assets/0c1b7bd8-55d0-4dca-9c10-d0ea6add3bea" />
<img width="773" height="570" alt="Screenshot 2026-04-17 at 15 09 04" src="https://github.com/user-attachments/assets/a8fee3cd-23d2-4d2e-9242-f75b262de11c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trade history cards now display completed and cancelled trades with color-coded outcome indicators and peer information
  * Trade history list with integrated search to filter trades by peer name and details
  * Tabbed interface to navigate between open trades and trade history sections
  * Enhanced UI states for loading, empty, and no-results scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->