### PR TITLE
fix: make StarRating lighter

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
@@ -26,7 +26,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import org.jetbrains.compose.resources.painterResource
 
-@Immutable
+@Stable
 data class StarPainters(
     val fill: Painter,
     val half: Painter,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
@@ -1,31 +1,107 @@
 package network.bisq.mobile.presentation.common.ui.components.atoms
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.StarEmptyIcon
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.StarFillIcon
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.StarHalfFilledIcon
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.icon_star_green
+import bisqapps.shared.presentation.generated.resources.icon_star_grey_hollow
+import bisqapps.shared.presentation.generated.resources.icon_star_half_green
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import org.jetbrains.compose.resources.painterResource
+
+@Immutable
+data class StarPainters(
+    val fill: Painter,
+    val half: Painter,
+    val empty: Painter,
+)
 
 @Composable
-fun StarRating(rating: Double) {
-    val fullStars = rating.toInt()
-    val hasHalfStar = rating - fullStars >= 0.5
-    val emptyStars = 5 - fullStars - if (hasHalfStar) 1 else 0
+fun rememberStarPainters(): StarPainters {
+    val fill = painterResource(Res.drawable.icon_star_green)
+    val half = painterResource(Res.drawable.icon_star_half_green)
+    val empty = painterResource(Res.drawable.icon_star_grey_hollow)
 
-    Row(horizontalArrangement = Arrangement.spacedBy(1.dp)) {
-        repeat(fullStars) {
-            StarFillIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding))
-        }
-        if (hasHalfStar) {
-            StarHalfFilledIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding))
-        }
-        repeat(emptyStars) {
-            StarEmptyIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding))
+    return remember(fill, half, empty) {
+        StarPainters(
+            fill = fill,
+            half = half,
+            empty = empty,
+        )
+    }
+}
+
+/**
+ * Renders a 5-star rating inside a single LayoutNode via drawWithCache, instead of
+ * composing 5 separate Image composables (≈ 5× LayoutNode + SemanticsConfiguration per row).
+ * Important in high-cardinality lists where composition cost dominates.
+ */
+@Composable
+fun StarRating(
+    rating: Double,
+    painters: StarPainters = rememberStarPainters(),
+) {
+    val fullStars = rating.toInt().coerceIn(0, 5)
+    val hasHalfStar = (rating - fullStars) >= 0.5 && fullStars < 5
+    val starSizeDp = BisqUIConstants.ScreenPadding
+    val spacingDp = 1.dp
+    val density = LocalDensity.current
+    val starSizePx = with(density) { starSizeDp.toPx() }
+    val spacingPx = with(density) { spacingDp.toPx() }
+
+    Box(
+        modifier =
+            Modifier
+                .width(starSizeDp * 5 + spacingDp * 4)
+                .height(starSizeDp)
+                .drawWithCache {
+                    val slot = Size(starSizePx, starSizePx)
+                    onDrawBehind {
+                        var x = 0f
+                        for (i in 0 until 5) {
+                            val painter =
+                                when {
+                                    i < fullStars -> painters.fill
+                                    i == fullStars && hasHalfStar -> painters.half
+                                    else -> painters.empty
+                                }
+                            translate(x, 0f) {
+                                with(painter) { draw(slot) }
+                            }
+                            x += starSizePx + spacingPx
+                        }
+                    }
+                },
+    ) {}
+}
+
+@Preview
+@Composable
+private fun StarRating_NewCanvasPreview() {
+    BisqTheme.Preview {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            listOf(0.0, 1.0, 2.5, 3.0, 4.5, 5.0).forEach { r ->
+                StarRating(rating = r)
+            }
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
@@ -23,6 +23,7 @@ import bisqapps.shared.presentation.generated.resources.icon_star_grey_hollow
 import bisqapps.shared.presentation.generated.resources.icon_star_half_green
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import org.jetbrains.compose.resources.painterResource
 
 @Immutable
@@ -88,9 +89,13 @@ fun StarRating(
                         }
                     }
                 },
-    ) {}
+    ) {
+        // all rendering is done by drawWithCache modifier.
+        // Box exists only as sized LayoutNode to host draw modifier.
+    }
 }
 
+@ExcludeFromCoverage
 @Preview
 @Composable
 private fun StarRating_NewCanvasPreview() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRating.kt
@@ -56,6 +56,7 @@ fun rememberStarPainters(): StarPainters {
 @Composable
 fun StarRating(
     rating: Double,
+    modifier: Modifier = Modifier,
     painters: StarPainters = rememberStarPainters(),
 ) {
     val fullStars = rating.toInt().coerceIn(0, 5)
@@ -68,7 +69,7 @@ fun StarRating(
 
     Box(
         modifier =
-            Modifier
+            modifier
                 .width(starSizeDp * 5 + spacingDp * 4)
                 .height(starSizeDp)
                 .drawWithCache {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/icons/Icons.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/icons/Icons.kt
@@ -54,9 +54,6 @@ import bisqapps.shared.presentation.generated.resources.icon_search_dimmed
 import bisqapps.shared.presentation.generated.resources.icon_send
 import bisqapps.shared.presentation.generated.resources.icon_sort
 import bisqapps.shared.presentation.generated.resources.icon_sort_green
-import bisqapps.shared.presentation.generated.resources.icon_star_green
-import bisqapps.shared.presentation.generated.resources.icon_star_grey_hollow
-import bisqapps.shared.presentation.generated.resources.icon_star_half_green
 import bisqapps.shared.presentation.generated.resources.icon_warning
 import bisqapps.shared.presentation.generated.resources.icon_warning_filled
 import bisqapps.shared.presentation.generated.resources.icon_warning_grey
@@ -342,25 +339,6 @@ fun SortIcon(modifier: Modifier = Modifier) {
 @Composable
 fun GreenSortIcon(modifier: Modifier = Modifier) {
     BisqResourceIcon(Res.drawable.icon_sort_green, "Sort icon", modifier)
-}
-
-@ExcludeFromCoverage
-@Composable
-fun StarEmptyIcon(modifier: Modifier = Modifier.size(16.dp)) {
-    // TODO: Import right resource for this
-    BisqResourceIcon(Res.drawable.icon_star_grey_hollow, "Empty star icon", modifier)
-}
-
-@ExcludeFromCoverage
-@Composable
-fun StarHalfFilledIcon(modifier: Modifier = Modifier.size(16.dp)) {
-    BisqResourceIcon(Res.drawable.icon_star_half_green, "Half filled star icon", modifier)
-}
-
-@ExcludeFromCoverage
-@Composable
-fun StarFillIcon(modifier: Modifier = Modifier.size(16.dp)) {
-    BisqResourceIcon(Res.drawable.icon_star_green, "Filled star icon", modifier)
 }
 
 @ExcludeFromCoverage


### PR DESCRIPTION
During implementation of [trade history](https://github.com/bisq-network/bisq-mobile/issues/1266) feature, I came across a weird bug where the app got out of memory and crashed, and it crashed consistently, until I applied this change.

resolves https://github.com/bisq-network/bisq-mobile/issues/1352

with this small change it stopped crashing for me

codes using the component probably can be refactored further but lets keep this one small

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable star appearance for the rating component with sensible defaults.

* **Refactor**
  * Reworked star-rating rendering for smoother visuals and reduced layout overhead.

* **Bug Fixes**
  * More accurate rating handling: values are clamped and half-star display is corrected for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->