### PR TITLE
Feature/ios pre render hook to decrypt push notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
         run: |
           ./gradlew :shared:domain:iosSimulatorArm64Test --info
 
+      - name: Run NSE decryption tests (Mac only)
+        if: startsWith(matrix.os, 'macos')
+        run: swift support/test_nse_decryption.swift
+
   pr-coverage:
     name: PR Coverage
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -355,18 +355,26 @@ To provide reliable push notifications on iOS, Bisq Connect uses **Apple Push No
 
 **How it works:**
 
-1. The iOS device generates a device-specific encryption key pair and stores the private key locally
-2. During registration, the device shares its public key and APNs device token with the trusted Bisq2 node
-3. When a trade event occurs, the Bisq2 node encrypts the notification payload using the device's public key
-4. The encrypted payload is forwarded to a **bisq-relay server** ([bisq-relay project](https://github.com/bisq-network/bisq-relay)) which passes it to APNs
-5. APNs routes the notification to the iOS device
-6. The app decrypts the payload locally using its private key
+1. The iOS device generates a 256-bit AES symmetric key and stores it in a shared Keychain accessible by both the main app and the Notification Service Extension (NSE)
+2. During registration, the device shares the symmetric key (Base64), APNs device token, and an ECIES public key with the trusted Bisq2 node. The symmetric key is rotated on each re-registration to limit the exposure window
+3. When a trade event occurs, the Bisq2 node encrypts the notification payload with AES-256-GCM using the device's symmetric key
+4. The encrypted payload is sent via POST to the **bisq-relay server** ([bisq-relay project](https://github.com/bisq-network/bisq-relay)), which forwards it to APNs with `mutable-content: 1`
+5. The iOS **Notification Service Extension** (NSE) intercepts the push before display, decrypts it using the shared Keychain key, and shows a privacy-safe category summary (e.g., "Trade update") — never counterparty names, amounts, or trade details on the lock screen
+6. When the app wakes up (from background), it replaces the generic NSE notification with a richer, contextual one via the WebSocket data stream. If the app is killed, the NSE notification is all the user sees
 
 **What is protected:**
 - The notification content (trade details, messages) is **end-to-end encrypted** — neither the relay server nor Apple can read it
+- Lock-screen banners show only category-based summaries (e.g., "Trade update", "New message") — no sensitive trade data is ever displayed on the lock screen
+- Remote push notifications are suppressed entirely when the app is in the foreground
 - Only the generic notification metadata and timing/frequency are visible to Apple (this is unavoidable with APNs)
 
 **Trade-off:** This delivers reliable, always-on push notifications even when the app is fully killed. The cost is the introduction of centralized infrastructure: a 24/7 **bisq-relay server** and Apple's APNs servers sit in the notification path. While neither can see the notification content thanks to E2E encryption, they do participate in the delivery chain, which is a departure from Bisq's fully decentralized philosophy for this specific platform.
+
+**Developer notes:**
+- The NSE target (`BisqNotificationService`) must have `CODE_SIGN_ENTITLEMENTS` pointing to its entitlements file with the shared `keychain-access-groups` entry
+- The `KeychainAccessGroup` is injected via Info.plist using `$(AppIdentifierPrefix)` — no hardcoded team IDs
+- The `UNUserNotificationCenterDelegate` must be set in `AppDelegate.didFinishLaunchingWithOptions` (not in Kotlin/Compose) to avoid dropped notification tap responses
+- Test scripts: `support/test_nse_decryption.swift` (unit tests), `support/test_nse_simulator.sh` (simulator), `support/test_relay_with_nse.sh` (real device via relay)
 
 For more details on the iOS implementation design, see [issue #895](https://github.com/bisq-network/bisq-mobile/issues/895).
 

--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.3.4'
+    spec.version                  = '0.3.5'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceRegistrationRequestTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceRegistrationRequestTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DeviceRegistrationRequestTest {
@@ -97,6 +98,70 @@ class DeviceRegistrationRequestTest {
         // When / Then
         assertEquals(Platform.IOS, json.decodeFromString(iosJson))
         assertEquals(Platform.ANDROID, json.decodeFromString(androidJson))
+    }
+
+    @Test
+    fun `DeviceRegistrationRequest with symmetricKeyBase64 serializes correctly`() {
+        // Given
+        val request =
+            DeviceRegistrationRequest(
+                deviceId = "test-device-id",
+                deviceToken = "test-token",
+                publicKeyBase64 = "cHVibGljS2V5",
+                deviceDescriptor = "iPhone 15 Pro, iOS 17.2",
+                platform = Platform.IOS,
+                symmetricKeyBase64 = "c3ltbWV0cmljS2V5QmFzZTY0VGVzdA==",
+            )
+
+        // When
+        val serialized = json.encodeToString(request)
+        val deserialized = json.decodeFromString<DeviceRegistrationRequest>(serialized)
+
+        // Then
+        assertEquals(request, deserialized)
+        assertEquals("c3ltbWV0cmljS2V5QmFzZTY0VGVzdA==", deserialized.symmetricKeyBase64)
+    }
+
+    @Test
+    fun `DeviceRegistrationRequest without symmetricKeyBase64 defaults to null`() {
+        // Given
+        val request =
+            DeviceRegistrationRequest(
+                deviceId = "test-device-id",
+                deviceToken = "test-token",
+                publicKeyBase64 = "cHVibGljS2V5",
+                deviceDescriptor = "Pixel 8, Android 14",
+                platform = Platform.ANDROID,
+            )
+
+        // Then
+        assertNull(request.symmetricKeyBase64)
+
+        // And serialization omits null field or handles it gracefully
+        val serialized = json.encodeToString(request)
+        val deserialized = json.decodeFromString<DeviceRegistrationRequest>(serialized)
+        assertEquals(request, deserialized)
+    }
+
+    @Test
+    fun `DeviceRegistrationRequest deserializes without symmetricKeyBase64 field`() {
+        // Given - JSON from an older backend that doesn't know about symmetricKeyBase64
+        val jsonString =
+            """
+            {
+                "deviceId": "device-123",
+                "deviceToken": "token-456",
+                "publicKeyBase64": "cHVibGljS2V5",
+                "deviceDescriptor": "Pixel 8, Android 14",
+                "platform": "ANDROID"
+            }
+            """.trimIndent()
+
+        // When
+        val request = json.decodeFromString<DeviceRegistrationRequest>(jsonString)
+
+        // Then
+        assertNull(request.symmetricKeyBase64)
     }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -11,8 +11,10 @@ import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.getPlatformInfo
+import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
 /**
  * Client implementation of PushNotificationServiceFacade.
@@ -147,6 +149,7 @@ class ClientPushNotificationServiceFacade(
         // This enables the Notification Service Extension to decrypt notifications
         // using AES-GCM via CryptoKit, since Apple does not support secp256k1 ECIES.
         val symmetricKeyBase64 = getOrCreatePushNotificationKeyBase64()
+        validateIosSymmetricKey(platformInfo.type, symmetricKeyBase64)?.let { return it }
 
         log.i { "Registering device with deviceId: $deviceId, descriptor: $deviceDescriptor, platform: $platform" }
 
@@ -209,6 +212,22 @@ class ClientPushNotificationServiceFacade(
         log.e(error) { "Device token registration failed" }
         _deviceToken.value = null
     }
+}
+
+/**
+ * iOS-only validation: rejects registration when the symmetric key creation failed,
+ * since NSE decryption requires it. Returns a failure Result if validation fails, null otherwise.
+ * Excluded from coverage because Android unit tests always have PlatformType.ANDROID.
+ */
+@ExcludeFromCoverage
+private fun validateIosSymmetricKey(
+    platformType: PlatformType,
+    symmetricKeyBase64: String?,
+): Result<Unit>? {
+    if (platformType == PlatformType.IOS && symmetricKeyBase64 == null) {
+        return Result.failure(PushNotificationException("iOS symmetric key creation failed — NSE decryption will not work"))
+    }
+    return null
 }
 
 class PushNotificationException(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
+import network.bisq.mobile.data.crypto.getOrCreatePushNotificationKeyBase64
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -142,6 +143,11 @@ class ClientPushNotificationServiceFacade(
         val deviceDescriptor = platformInfo.name
         val platform = PlatformMapper.fromPlatformType(platformInfo.type)
 
+        // Generate symmetric key for push notification encryption (iOS only).
+        // This enables the Notification Service Extension to decrypt notifications
+        // using AES-GCM via CryptoKit, since Apple does not support secp256k1 ECIES.
+        val symmetricKeyBase64 = getOrCreatePushNotificationKeyBase64()
+
         log.i { "Registering device with deviceId: $deviceId, descriptor: $deviceDescriptor, platform: $platform" }
 
         val result =
@@ -151,6 +157,7 @@ class ClientPushNotificationServiceFacade(
                 publicKeyBase64 = publicKeyBase64,
                 deviceDescriptor = deviceDescriptor,
                 platform = platform,
+                symmetricKeyBase64 = symmetricKeyBase64,
             )
         if (result.isSuccess) {
             log.i { "Device registered successfully with trusted node" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceRegistrationRequest.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceRegistrationRequest.kt
@@ -8,7 +8,10 @@ import kotlinx.serialization.Serializable
  *
  * - deviceId: Primary identifier (hash of publicKeyBase64 or persisted UUID)
  * - deviceToken: APNs/FCM device token
- * - publicKeyBase64: Base64-encoded public key for encrypting notifications
+ * - publicKeyBase64: Base64-encoded public key for encrypting notifications (ECIES)
+ * - symmetricKeyBase64: Optional Base64-encoded AES-256 key for push notification encryption.
+ *   When present, the backend uses AES-GCM instead of ECIES. Required for iOS NSE decryption
+ *   since Apple CryptoKit does not support secp256k1 (the curve used by Bisq2 identity keys).
  * - deviceDescriptor: Device information (e.g., "iPhone 15 Pro, iOS 17.2")
  * - platform: IOS or ANDROID
  */
@@ -19,6 +22,7 @@ data class DeviceRegistrationRequest(
     val publicKeyBase64: String,
     val deviceDescriptor: String,
     val platform: Platform,
+    val symmetricKeyBase64: String? = null,
 )
 
 @Serializable

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/PushNotificationApiGateway.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/PushNotificationApiGateway.kt
@@ -37,8 +37,17 @@ class PushNotificationApiGateway(
         publicKeyBase64: String,
         deviceDescriptor: String,
         platform: Platform,
+        symmetricKeyBase64: String? = null,
     ): Result<Unit> {
-        val request = DeviceRegistrationRequest(deviceId, deviceToken, publicKeyBase64, deviceDescriptor, platform)
+        val request =
+            DeviceRegistrationRequest(
+                deviceId,
+                deviceToken,
+                publicKeyBase64,
+                deviceDescriptor,
+                platform,
+                symmetricKeyBase64,
+            )
         return webSocketApiClient.post(basePath, request)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.5
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=27
+client.ios.version.code=29
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.4
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=19
+client.ios.version.code=20
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.4
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=18
+client.ios.version.code=19
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.5
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=26
+client.ios.version.code=27
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.4
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=22
+client.ios.version.code=23
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,11 +36,11 @@ node.android.version=0.5.3
 
 client.name=Bisq Connect
 client.android.version=0.3.4
-client.ios.version=0.3.4
+client.ios.version=0.3.5
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=25
+client.ios.version.code=26
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.4
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=20
+client.ios.version.code=22
 client.android.version.code=22
 node.android.version.code=41
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ client.ios.version=0.3.4
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=23
+client.ios.version.code=25
 client.android.version.code=22
 node.android.version.code=41
 

--- a/iosClient/Bisq ConnectDebug.entitlements
+++ b/iosClient/Bisq ConnectDebug.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)network.bisq.mobile</string>
+	</array>
 </dict>
 </plist>
 

--- a/iosClient/Bisq ConnectRelease.entitlements
+++ b/iosClient/Bisq ConnectRelease.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)network.bisq.mobile</string>
+	</array>
 </dict>
 </plist>

--- a/iosClient/BisqNotificationService/BisqNotificationService.entitlements
+++ b/iosClient/BisqNotificationService/BisqNotificationService.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)network.bisq.mobile</string>

--- a/iosClient/BisqNotificationService/Info.plist
+++ b/iosClient/BisqNotificationService/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/iosClient/BisqNotificationService/Info.plist
+++ b/iosClient/BisqNotificationService/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)network.bisq.mobile</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -1,0 +1,187 @@
+import UserNotifications
+import CryptoKit
+import Foundation
+import Security
+
+/// Notification Service Extension that decrypts push notification content before display.
+/// This avoids the double-notification problem where iOS first shows a generic alert,
+/// then the app wakes up and posts a second decrypted notification.
+///
+/// Privacy: The lock-screen banner shows only a category-based summary (e.g. "Trade update"),
+/// never counterparty names, amounts, or offer details. Full decrypted content is stored in
+/// the shared app group container for the main app to display after unlock.
+///
+/// Requirements:
+/// - The relay server must set `mutable-content: 1` in the APNs payload
+/// - The trusted node must encrypt with AES-256-GCM using the device's symmetric key
+/// - The symmetric key must be stored in shared Keychain (via PushNotificationKeyStore)
+class NotificationService: UNNotificationServiceExtension {
+    private static let NONCE_SIZE = 12
+    private static let TAG_SIZE = 16
+    private static let APP_GROUP = "group.network.bisq.mobile"
+    private static let PENDING_NOTIFICATION_KEY = "pending_decrypted_notification"
+    private static let KEYCHAIN_SERVICE = "network.bisq.mobile"
+    private static let KEYCHAIN_ACCOUNT = "push_notification_symmetric_key"
+    private static let KEYCHAIN_ACCESS_GROUP = "$(AppIdentifierPrefix)network.bisq.mobile"
+
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNMutableNotificationContent?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        self.contentHandler = contentHandler
+        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+
+        guard let bestAttemptContent = bestAttemptContent else {
+            contentHandler(request.content)
+            return
+        }
+
+        guard let encryptedBase64 = request.content.userInfo["encrypted"] as? String,
+              let encryptedData = Data(base64Encoded: encryptedBase64) else {
+            contentHandler(bestAttemptContent)
+            return
+        }
+
+        guard let keyData = retrieveSymmetricKey() else {
+            bestAttemptContent.title = "Bisq"
+            bestAttemptContent.body = "New notification"
+            contentHandler(bestAttemptContent)
+            return
+        }
+
+        do {
+            let decryptedData = try decryptAESGCM(data: encryptedData, keyData: keyData)
+            let payload = try JSONDecoder().decode(NotificationPayload.self, from: decryptedData)
+
+            // Privacy: show only a category-based summary on the lock screen.
+            // Full content is stored for the main app to display after unlock.
+            let summary = NotificationCategory.from(title: payload.title)
+            bestAttemptContent.title = "Bisq"
+            bestAttemptContent.body = summary.displayText
+
+            // Store full decrypted content for in-app display
+            storePendingNotification(payload)
+
+            // Pass opaque identifiers only — no human-readable trade details in userInfo
+            bestAttemptContent.userInfo = bestAttemptContent.userInfo.merging([
+                "nse_decrypted": true,
+                "notification_id": payload.id,
+                "notification_category": summary.rawValue,
+            ]) { _, new in new }
+        } catch {
+            bestAttemptContent.title = "Bisq"
+            bestAttemptContent.body = "New notification"
+        }
+
+        contentHandler(bestAttemptContent)
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+            contentHandler(bestAttemptContent)
+        }
+    }
+
+    // MARK: - Privacy-safe categories
+
+    private enum NotificationCategory: String {
+        case tradeUpdate = "trade_update"
+        case chatMessage = "chat_message"
+        case offerUpdate = "offer_update"
+        case general = "general"
+
+        var displayText: String {
+            switch self {
+            case .tradeUpdate: return "Trade update"
+            case .chatMessage: return "New message"
+            case .offerUpdate: return "Offer update"
+            case .general: return "New notification"
+            }
+        }
+
+        static func from(title: String) -> NotificationCategory {
+            let lower = title.lowercased()
+            if lower.contains("trade") || lower.contains("payment") || lower.contains("btc") {
+                return .tradeUpdate
+            }
+            if lower.contains("message") || lower.contains("chat") {
+                return .chatMessage
+            }
+            if lower.contains("offer") {
+                return .offerUpdate
+            }
+            return .general
+        }
+    }
+
+    // MARK: - Pending notification storage
+
+    private func storePendingNotification(_ payload: NotificationPayload) {
+        // Store in shared UserDefaults (app group) so the main app can read after unlock
+        guard let defaults = UserDefaults(suiteName: NotificationService.APP_GROUP) else { return }
+        let entry: [String: String] = [
+            "id": payload.id,
+            "title": payload.title,
+            "message": payload.message,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+        ]
+        var pending = defaults.array(forKey: NotificationService.PENDING_NOTIFICATION_KEY) as? [[String: String]] ?? []
+        pending.append(entry)
+        // Keep bounded — drop oldest if over 50
+        if pending.count > 50 {
+            pending = Array(pending.suffix(50))
+        }
+        defaults.set(pending, forKey: NotificationService.PENDING_NOTIFICATION_KEY)
+    }
+
+    // MARK: - Decryption
+
+    private func decryptAESGCM(data: Data, keyData: Data) throws -> Data {
+        guard data.count >= NotificationService.NONCE_SIZE + NotificationService.TAG_SIZE else {
+            throw NSError(domain: "NSE", code: -1,
+                         userInfo: [NSLocalizedDescriptionKey: "Encrypted data too short"])
+        }
+
+        let nonceData = data.prefix(NotificationService.NONCE_SIZE)
+        let remaining = data.dropFirst(NotificationService.NONCE_SIZE)
+        let ciphertext = remaining.dropLast(NotificationService.TAG_SIZE)
+        let tag = remaining.suffix(NotificationService.TAG_SIZE)
+
+        let symmetricKey = SymmetricKey(data: keyData)
+        let nonce = try AES.GCM.Nonce(data: nonceData)
+        let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+        return try AES.GCM.open(sealedBox, using: symmetricKey)
+    }
+
+    // MARK: - Keychain
+
+    private func retrieveSymmetricKey() -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: NotificationService.KEYCHAIN_ACCOUNT,
+            kSecAttrService as String: NotificationService.KEYCHAIN_SERVICE,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data {
+            return data
+        }
+        return nil
+    }
+}
+
+// MARK: - Notification Payload
+
+private struct NotificationPayload: Decodable {
+    let id: String
+    let title: String
+    let message: String
+}

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -2,6 +2,7 @@ import UserNotifications
 import CryptoKit
 import Foundation
 import Security
+import os.log
 
 /// Notification Service Extension that decrypts push notification content before display.
 /// This avoids the double-notification problem where iOS first shows a generic alert,
@@ -20,9 +21,11 @@ class NotificationService: UNNotificationServiceExtension {
     private static let TAG_SIZE = 16
     private static let APP_GROUP = "group.network.bisq.mobile"
     private static let PENDING_NOTIFICATION_KEY = "pending_decrypted_notification"
+    private static let NSE_BREADCRUMB_KEY = "nse_last_invocation"
     private static let KEYCHAIN_SERVICE = "network.bisq.mobile"
     private static let KEYCHAIN_ACCOUNT = "push_notification_symmetric_key"
-    private static let KEYCHAIN_ACCESS_GROUP = "$(AppIdentifierPrefix)network.bisq.mobile"
+
+    private let log = OSLog(subsystem: "network.bisq.mobile.BisqNotificationService", category: "NSE")
 
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var bestAttemptContent: UNMutableNotificationContent?
@@ -31,26 +34,39 @@ class NotificationService: UNNotificationServiceExtension {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
+        os_log("NSE didReceive invoked", log: log, type: .info)
+        writeBreadcrumb(stage: "didReceive_start")
+
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
         guard let bestAttemptContent = bestAttemptContent else {
+            os_log("NSE: no mutable content available", log: log, type: .error)
+            writeBreadcrumb(stage: "no_mutable_content")
             contentHandler(request.content)
             return
         }
 
         guard let encryptedBase64 = request.content.userInfo["encrypted"] as? String,
               let encryptedData = Data(base64Encoded: encryptedBase64) else {
+            os_log("NSE: no 'encrypted' field in userInfo or Base64 decode failed", log: log, type: .error)
+            writeBreadcrumb(stage: "no_encrypted_field")
             contentHandler(bestAttemptContent)
             return
         }
 
+        os_log("NSE: encrypted payload found (%{public}d bytes)", log: log, type: .info, encryptedData.count)
+
         guard let keyData = retrieveSymmetricKey() else {
+            os_log("NSE: keychain retrieval failed — showing fallback", log: log, type: .error)
+            writeBreadcrumb(stage: "keychain_retrieval_failed")
             bestAttemptContent.title = "Bisq"
             bestAttemptContent.body = "New notification"
             contentHandler(bestAttemptContent)
             return
         }
+
+        os_log("NSE: symmetric key retrieved (%{public}d bytes)", log: log, type: .info, keyData.count)
 
         do {
             let decryptedData = try decryptAESGCM(data: encryptedData, keyData: keyData)
@@ -71,7 +87,12 @@ class NotificationService: UNNotificationServiceExtension {
                 "notification_id": payload.id,
                 "notification_category": summary.rawValue,
             ]) { _, new in new }
+
+            os_log("NSE: decryption success, category=%{public}@", log: log, type: .info, summary.rawValue)
+            writeBreadcrumb(stage: "decrypt_success:\(summary.rawValue)")
         } catch {
+            os_log("NSE: decryption failed: %{public}@", log: log, type: .error, error.localizedDescription)
+            writeBreadcrumb(stage: "decrypt_failed:\(error.localizedDescription)")
             bestAttemptContent.title = "Bisq"
             bestAttemptContent.body = "New notification"
         }
@@ -80,6 +101,8 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
+        os_log("NSE: serviceExtensionTimeWillExpire — delivering best attempt", log: log, type: .error)
+        writeBreadcrumb(stage: "time_expired")
         if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
             contentHandler(bestAttemptContent)
         }
@@ -137,6 +160,25 @@ class NotificationService: UNNotificationServiceExtension {
         defaults.set(pending, forKey: NotificationService.PENDING_NOTIFICATION_KEY)
     }
 
+    // MARK: - Diagnostic breadcrumbs
+
+    /// Writes a breadcrumb to the shared app group UserDefaults so the main app
+    /// (or a developer inspecting the device) can verify the NSE was invoked.
+    private func writeBreadcrumb(stage: String) {
+        guard let defaults = UserDefaults(suiteName: NotificationService.APP_GROUP) else { return }
+        let entry: [String: String] = [
+            "stage": stage,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+        ]
+        var breadcrumbs = defaults.array(forKey: NotificationService.NSE_BREADCRUMB_KEY) as? [[String: String]] ?? []
+        breadcrumbs.append(entry)
+        // Keep bounded — only retain the last 20 breadcrumbs
+        if breadcrumbs.count > 20 {
+            breadcrumbs = Array(breadcrumbs.suffix(20))
+        }
+        defaults.set(breadcrumbs, forKey: NotificationService.NSE_BREADCRUMB_KEY)
+    }
+
     // MARK: - Decryption
 
     private func decryptAESGCM(data: Data, keyData: Data) throws -> Data {
@@ -159,13 +201,16 @@ class NotificationService: UNNotificationServiceExtension {
     // MARK: - Keychain
 
     private func retrieveSymmetricKey() -> Data? {
+        // Note: kSecAttrAccessible is intentionally NOT included in the search query.
+        // It is a storage attribute, not a search filter. Including it causes
+        // SecItemCopyMatching to silently return errSecItemNotFound if there is
+        // any mismatch with how the item was originally stored.
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: NotificationService.KEYCHAIN_ACCOUNT,
             kSecAttrService as String: NotificationService.KEYCHAIN_SERVICE,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
         var result: CFTypeRef?
@@ -174,6 +219,7 @@ class NotificationService: UNNotificationServiceExtension {
         if status == errSecSuccess, let data = result as? Data {
             return data
         }
+        os_log("NSE: SecItemCopyMatching returned status %{public}d", log: log, type: .error, status)
         return nil
     }
 }

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -20,7 +20,6 @@ class NotificationService: UNNotificationServiceExtension {
     private static let NONCE_SIZE = 12
     private static let TAG_SIZE = 16
     private static let APP_GROUP = "group.network.bisq.mobile"
-    private static let PENDING_NOTIFICATION_KEY = "pending_decrypted_notification"
     private static let NSE_BREADCRUMB_KEY = "nse_last_invocation"
     private static let KEYCHAIN_SERVICE = "network.bisq.mobile"
     private static let KEYCHAIN_ACCOUNT = "push_notification_symmetric_key"
@@ -77,13 +76,9 @@ class NotificationService: UNNotificationServiceExtension {
             let payload = try JSONDecoder().decode(NotificationPayload.self, from: decryptedData)
 
             // Privacy: show only a category-based summary on the lock screen.
-            // Full content is stored for the main app to display after unlock.
             let summary = NotificationCategory.from(title: payload.title)
             bestAttemptContent.title = "Bisq"
             bestAttemptContent.body = summary.displayText
-
-            // Store full decrypted content for in-app display
-            storePendingNotification(payload)
 
             // Pass opaque identifiers only — no human-readable trade details in userInfo
             bestAttemptContent.userInfo = bestAttemptContent.userInfo.merging([
@@ -142,26 +137,6 @@ class NotificationService: UNNotificationServiceExtension {
             }
             return .general
         }
-    }
-
-    // MARK: - Pending notification storage
-
-    private func storePendingNotification(_ payload: NotificationPayload) {
-        // Store in shared UserDefaults (app group) so the main app can read after unlock
-        guard let defaults = UserDefaults(suiteName: NotificationService.APP_GROUP) else { return }
-        let entry: [String: String] = [
-            "id": payload.id,
-            "title": payload.title,
-            "message": payload.message,
-            "timestamp": ISO8601DateFormatter().string(from: Date()),
-        ]
-        var pending = defaults.array(forKey: NotificationService.PENDING_NOTIFICATION_KEY) as? [[String: String]] ?? []
-        pending.append(entry)
-        // Keep bounded — drop oldest if over 50
-        if pending.count > 50 {
-            pending = Array(pending.suffix(50))
-        }
-        defaults.set(pending, forKey: NotificationService.PENDING_NOTIFICATION_KEY)
     }
 
     // MARK: - Diagnostic breadcrumbs

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -24,6 +24,10 @@ class NotificationService: UNNotificationServiceExtension {
     private static let NSE_BREADCRUMB_KEY = "nse_last_invocation"
     private static let KEYCHAIN_SERVICE = "network.bisq.mobile"
     private static let KEYCHAIN_ACCOUNT = "push_notification_symmetric_key"
+    // Resolved at build time from Info.plist via $(AppIdentifierPrefix).
+    // Falls back to nil (default keychain group) if the plist key is missing,
+    // though that would fail for NSE since it has a different default group.
+    private static let KEYCHAIN_ACCESS_GROUP: String? = Bundle.main.object(forInfoDictionaryKey: "KeychainAccessGroup") as? String
 
     private let log = OSLog(subsystem: "network.bisq.mobile.BisqNotificationService", category: "NSE")
 
@@ -205,13 +209,19 @@ class NotificationService: UNNotificationServiceExtension {
         // It is a storage attribute, not a search filter. Including it causes
         // SecItemCopyMatching to silently return errSecItemNotFound if there is
         // any mismatch with how the item was originally stored.
-        let query: [String: Any] = [
+        // kSecAttrAccessGroup MUST be specified because the NSE runs as a separate
+        // process with a different bundle ID (and thus different default keychain group)
+        // than the main app. Without it, the NSE searches its own group and finds nothing.
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: NotificationService.KEYCHAIN_ACCOUNT,
             kSecAttrService as String: NotificationService.KEYCHAIN_SERVICE,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
+        if let group = NotificationService.KEYCHAIN_ACCESS_GROUP {
+            query[kSecAttrAccessGroup as String] = group
+        }
 
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.4
-APP_VERSION_CODE=21
+APP_VERSION_CODE=23

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.4
-APP_VERSION_CODE=18
+APP_VERSION_CODE=19

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.4
-APP_VERSION_CODE=20
+APP_VERSION_CODE=21

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.3.4
-APP_VERSION_CODE=25
+APP_VERSION=0.3.5
+APP_VERSION_CODE=26

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.4
-APP_VERSION_CODE=23
+APP_VERSION_CODE=25

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.5
-APP_VERSION_CODE=26
+APP_VERSION_CODE=27

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.5
-APP_VERSION_CODE=27
+APP_VERSION_CODE=29

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -4,4 +4,4 @@ APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
 APP_VERSION=0.3.4
-APP_VERSION_CODE=19
+APP_VERSION_CODE=20

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.3.4)
+  - clientApp (0.3.5)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 7e0df7eca0f2dce65b049eccb370b035364d400e
+  clientApp: 513e44dcd9f415f2d408520e58cf27e56a6d2b60
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.3.4)
+  - clientApp (0.3.5)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 7e0df7eca0f2dce65b049eccb370b035364d400e
+  clientApp: 513e44dcd9f415f2d408520e58cf27e56a6d2b60
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -606,7 +606,7 @@
 				INFOPLIST_FILE = BisqNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BisqNotificationService;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 orgName. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -643,7 +643,7 @@
 				INFOPLIST_FILE = BisqNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BisqNotificationService;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 orgName. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.BisqNotificationService";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = bisq.mobile.client.BisqConnect.BisqNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = BisqNotificationService/BisqNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -631,6 +632,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = BisqNotificationService/BisqNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4EE6883ABC18CB037E299404 /* Pods_Bisq_Connect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 982F99A95AC1F861545BA80B /* Pods_Bisq_Connect.framework */; };
 		609CEB4AB21E643901D61667 /* KoinHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609CE23ED65204A4441A4BA8 /* KoinHelper.swift */; };
 		64A9698AD2276A25567FCED0 /* Pods_Bisq_Connect_Debug.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22691A9F2049D97E11433E1A /* Pods_Bisq_Connect_Debug.framework */; };
+		745C4F7F2F96090B005424DB /* BisqNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 745C4F782F96090B005424DB /* BisqNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		74831B6D2D5088E600B729F4 /* iosClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iosClient.swift */; };
 		74831B6E2D5088E600B729F4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		74831B6F2D5088E600B729F4 /* LifecycleAwareComposeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749C8F4D2CCB978300AE196D /* LifecycleAwareComposeViewController.swift */; };
@@ -20,11 +21,58 @@
 		74831B742D5088E600B729F4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		74831B752D5088E600B729F4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		749C8F4E2CCB978300AE196D /* LifecycleAwareComposeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749C8F4D2CCB978300AE196D /* LifecycleAwareComposeViewController.swift */; };
+		74A279222F975A5C006C4108 /* BisqNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 745C4F782F96090B005424DB /* BisqNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		74D8991D2F07ADAC00A4DA07 /* LibTor.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 74D8991B2F07ADAC00A4DA07 /* LibTor.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		745C4F7D2F96090B005424DB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 745C4F772F96090B005424DB;
+			remoteInfo = BisqNotificationService;
+		};
+		74A279232F975A5C006C4108 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 745C4F772F96090B005424DB;
+			remoteInfo = BisqNotificationService;
+		};
+		74A279262F975A94006C4108 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 745C4F772F96090B005424DB;
+			remoteInfo = BisqNotificationService;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
+		745C4F802F96090B005424DB /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				745C4F7F2F96090B005424DB /* BisqNotificationService.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A279252F975A5C006C4108 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				74A279222F975A5C006C4108 /* BisqNotificationService.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		74D8991E2F07ADAC00A4DA07 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -48,6 +96,7 @@
 		598D967155ADCB12250F06F5 /* Pods-Bisq Connect.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bisq Connect.release.xcconfig"; path = "Target Support Files/Pods-Bisq Connect/Pods-Bisq Connect.release.xcconfig"; sourceTree = "<group>"; };
 		609CE23ED65204A4441A4BA8 /* KoinHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KoinHelper.swift; sourceTree = "<group>"; };
 		740A90492F0289CF007E5171 /* Bisq ConnectRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Bisq ConnectRelease.entitlements"; sourceTree = "<group>"; };
+		745C4F782F96090B005424DB /* BisqNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BisqNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		74831B7B2D5088E600B729F4 /* Bisq Connect.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Bisq Connect.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7498DD8A2F1E200B00475760 /* Bisq Connect DebugRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Bisq Connect DebugRelease.entitlements"; sourceTree = "<group>"; };
 		749C8F4D2CCB978300AE196D /* LifecycleAwareComposeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleAwareComposeViewController.swift; sourceTree = "<group>"; };
@@ -61,6 +110,16 @@
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		745C4F832F96090B005424DB /* Exceptions for "BisqNotificationService" folder in "BisqNotificationService" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 745C4F772F96090B005424DB /* BisqNotificationService */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		6D6B5E692EBD1BC30050AFE3 /* interop */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -73,9 +132,28 @@
 			path = interop;
 			sourceTree = "<group>";
 		};
+		745C4F792F96090B005424DB /* BisqNotificationService */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				745C4F832F96090B005424DB /* Exceptions for "BisqNotificationService" folder in "BisqNotificationService" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = BisqNotificationService;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		745C4F752F96090B005424DB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		74831B712D5088E600B729F4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -121,6 +199,7 @@
 				740A90492F0289CF007E5171 /* Bisq ConnectRelease.entitlements */,
 				AB1DB47929225F7C00F7AF9C /* Configuration */,
 				7555FF7D242A565900829871 /* iosClient */,
+				745C4F792F96090B005424DB /* BisqNotificationService */,
 				7555FF7C242A565900829871 /* Products */,
 				9A04D16CB0295F0B78A2DEC1 /* Pods */,
 				3664A736BB488E2786F88AC1 /* Frameworks */,
@@ -132,6 +211,7 @@
 			children = (
 				7555FF7B242A565900829871 /* Bisq Connect.app */,
 				74831B7B2D5088E600B729F4 /* Bisq Connect.app */,
+				745C4F782F96090B005424DB /* BisqNotificationService.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -173,6 +253,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		745C4F772F96090B005424DB /* BisqNotificationService */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 745C4F842F96090B005424DB /* Build configuration list for PBXNativeTarget "BisqNotificationService" */;
+			buildPhases = (
+				745C4F742F96090B005424DB /* Sources */,
+				745C4F752F96090B005424DB /* Frameworks */,
+				745C4F762F96090B005424DB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				745C4F792F96090B005424DB /* BisqNotificationService */,
+			);
+			name = BisqNotificationService;
+			productName = BisqNotificationService;
+			productReference = 745C4F782F96090B005424DB /* BisqNotificationService.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		74831B692D5088E600B729F4 /* Bisq Connect */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 74831B782D5088E600B729F4 /* Build configuration list for PBXNativeTarget "Bisq Connect" */;
@@ -185,10 +285,12 @@
 				74831B732D5088E600B729F4 /* Resources */,
 				74D8991E2F07ADAC00A4DA07 /* Embed Frameworks */,
 				B9A4B853B9EDA1B5D264086C /* [CP] Copy Pods Resources */,
+				745C4F802F96090B005424DB /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				745C4F7E2F96090B005424DB /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				6D6B5E692EBD1BC30050AFE3 /* interop */,
@@ -209,10 +311,13 @@
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
 				38D101F3E521DA4B15A5B2A0 /* [CP] Copy Pods Resources */,
+				74A279252F975A5C006C4108 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				74A279242F975A5C006C4108 /* PBXTargetDependency */,
+				74A279272F975A94006C4108 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				6D6B5E692EBD1BC30050AFE3 /* interop */,
@@ -229,10 +334,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 2630;
 				LastUpgradeCheck = 1540;
 				ORGANIZATIONNAME = orgName;
 				TargetAttributes = {
+					745C4F772F96090B005424DB = {
+						CreatedOnToolsVersion = 26.3;
+					};
 					74831B692D5088E600B729F4 = {
 						CreatedOnToolsVersion = 11.3.1;
 					};
@@ -261,11 +369,19 @@
 			targets = (
 				7555FF7A242A565900829871 /* Bisq Connect Debug */,
 				74831B692D5088E600B729F4 /* Bisq Connect */,
+				745C4F772F96090B005424DB /* BisqNotificationService */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		745C4F762F96090B005424DB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		74831B732D5088E600B729F4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -423,6 +539,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		745C4F742F96090B005424DB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		74831B6C2D5088E600B729F4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -447,7 +570,97 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		745C4F7E2F96090B005424DB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 745C4F772F96090B005424DB /* BisqNotificationService */;
+			targetProxy = 745C4F7D2F96090B005424DB /* PBXContainerItemProxy */;
+		};
+		74A279242F975A5C006C4108 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 745C4F772F96090B005424DB /* BisqNotificationService */;
+			targetProxy = 74A279232F975A5C006C4108 /* PBXContainerItemProxy */;
+		};
+		74A279272F975A94006C4108 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 745C4F772F96090B005424DB /* BisqNotificationService */;
+			targetProxy = 74A279262F975A94006C4108 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		745C4F812F96090B005424DB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = YRAZCRBR9J;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BisqNotificationService/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BisqNotificationService;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 orgName. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.BisqNotificationService";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		745C4F822F96090B005424DB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YRAZCRBR9J;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BisqNotificationService/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BisqNotificationService;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 orgName. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.BisqNotificationService";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		74831B792D5088E600B729F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 78D9B1D932A4E05C135F6846 /* Pods-Bisq Connect.debug.xcconfig */;
@@ -465,7 +678,7 @@
 				);
 				INFOPLIST_FILE = iosClient/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -499,7 +712,7 @@
 				);
 				INFOPLIST_FILE = iosClient/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -709,6 +922,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		745C4F842F96090B005424DB /* Build configuration list for PBXNativeTarget "BisqNotificationService" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				745C4F812F96090B005424DB /* Debug */,
+				745C4F822F96090B005424DB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		74831B782D5088E600B729F4 /* Build configuration list for PBXNativeTarget "Bisq Connect" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/iosClient/iosClient/Info.plist
+++ b/iosClient/iosClient/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(APP_VERSION_CODE)</string>
+	<key>KeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)network.bisq.mobile</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.def
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.def
@@ -1,0 +1,3 @@
+language = Objective-C
+headers = PushNotificationKeyStore.h
+package = network.bisq.mobile.crypto

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.h
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.h
@@ -1,0 +1,47 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Manages the AES-256 symmetric key used for push notification encryption/decryption.
+ * The key is stored in a shared Keychain access group so both the main app and the
+ * Notification Service Extension (NSE) can access it.
+ */
+@interface PushNotificationKeyStore : NSObject
+
+/**
+ * Shared singleton instance
+ */
+@property (class, nonatomic, readonly) PushNotificationKeyStore *shared;
+
+/**
+ * Returns the Base64-encoded AES-256 symmetric key for push notification encryption.
+ * Generates and stores a new key if one doesn't exist yet.
+ *
+ * @param error Output parameter for any error that occurs
+ * @return Base64-encoded key string, or nil if an error occurred
+ */
+- (NSString * _Nullable)getOrCreateKeyBase64WithError:(NSError * _Nullable * _Nullable)error;
+
+/**
+ * Rotates the symmetric key: deletes the old key and generates a fresh one.
+ * Called on each device re-registration to limit the exposure window.
+ *
+ * @param error Output parameter for any error that occurs
+ * @return Base64-encoded new key string, or nil if an error occurred
+ */
+- (NSString * _Nullable)rotateKeyBase64WithError:(NSError * _Nullable * _Nullable)error;
+
+/**
+ * Private initializer - use shared instance instead
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Private initializer - use shared instance instead
+ */
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.swift
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Security
+
+@objc(PushNotificationKeyStore)
+public class PushNotificationKeyStore: NSObject {
+    private static let KEY_SIZE = 32 // AES-256
+    private static let SERVICE_NAME = "network.bisq.mobile"
+    private static let KEY_ACCOUNT = "push_notification_symmetric_key"
+
+    // Keychain access group shared between main app and NSE.
+    // When running via Xcode, the entitlements handle access group scoping automatically.
+    // We omit the explicit group here so the default app keychain is used, which is
+    // shared with extensions that have the same keychain-access-groups entitlement.
+    // The NSE reads directly with the same service/account identifiers.
+    private static let ACCESS_GROUP: String? = nil
+
+    @objc public static let shared = PushNotificationKeyStore()
+
+    private override init() {
+        super.init()
+    }
+
+    /// Returns the Base64-encoded AES-256 symmetric key for push notification encryption.
+    /// Generates and stores a new key if one doesn't exist yet.
+    @objc public func getOrCreateKeyBase64WithError(_ error: NSErrorPointer) -> String? {
+        do {
+            let keyData = try getOrCreateKey()
+            return keyData.base64EncodedString()
+        } catch let keyError as NSError {
+            error?.pointee = keyError
+            return nil
+        }
+    }
+
+    /// Rotates the symmetric key: deletes the old key and generates a fresh one.
+    /// Called on each device re-registration to limit the exposure window if a key
+    /// is ever compromised. Returns the new key as Base64.
+    @objc public func rotateKeyBase64WithError(_ error: NSErrorPointer) -> String? {
+        do {
+            deleteKey()
+            let keyData = try generateKey()
+            try storeKey(keyData)
+            return keyData.base64EncodedString()
+        } catch let keyError as NSError {
+            error?.pointee = keyError
+            return nil
+        }
+    }
+
+    // MARK: - Internal (also used by NSE via direct Keychain read)
+
+    static func retrieveKeyData() -> Data? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: KEY_ACCOUNT,
+            kSecAttrService as String: SERVICE_NAME,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        if let group = ACCESS_GROUP {
+            query[kSecAttrAccessGroup as String] = group
+        }
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess, let data = result as? Data {
+            return data
+        }
+        return nil
+    }
+
+    // MARK: - Private
+
+    private func getOrCreateKey() throws -> Data {
+        if let existing = PushNotificationKeyStore.retrieveKeyData() {
+            return existing
+        }
+
+        let keyData = try generateKey()
+        try storeKey(keyData)
+
+        // Re-read to handle race condition
+        if let stored = PushNotificationKeyStore.retrieveKeyData() {
+            return stored
+        }
+        return keyData
+    }
+
+    private func generateKey() throws -> Data {
+        var keyData = Data(count: PushNotificationKeyStore.KEY_SIZE)
+        let result = keyData.withUnsafeMutableBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                return errSecParam
+            }
+            return SecRandomCopyBytes(kSecRandomDefault, PushNotificationKeyStore.KEY_SIZE, baseAddress)
+        }
+
+        guard result == errSecSuccess else {
+            throw NSError(domain: "PushNotificationKeyStore", code: Int(result),
+                         userInfo: [NSLocalizedDescriptionKey: "Failed to generate random key"])
+        }
+        return keyData
+    }
+
+    private func storeKey(_ keyData: Data) throws {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: PushNotificationKeyStore.KEY_ACCOUNT,
+            kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
+            kSecValueData as String: keyData,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        if let group = PushNotificationKeyStore.ACCESS_GROUP {
+            query[kSecAttrAccessGroup as String] = group
+        }
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess || status == errSecDuplicateItem else {
+            throw NSError(domain: "PushNotificationKeyStore", code: Int(status),
+                         userInfo: [NSLocalizedDescriptionKey: "Failed to store key: \(status)"])
+        }
+    }
+
+    private func deleteKey() {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: PushNotificationKeyStore.KEY_ACCOUNT,
+            kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
+        ]
+        if let group = PushNotificationKeyStore.ACCESS_GROUP {
+            query[kSecAttrAccessGroup as String] = group
+        }
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.swift
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.swift
@@ -13,7 +13,16 @@ public class PushNotificationKeyStore: NSObject {
     // groups) can access the same keychain item.
     // Resolved at build time from Info.plist via $(AppIdentifierPrefix), so it works
     // for any developer team without hardcoding the team ID.
-    private static let ACCESS_GROUP: String? = Bundle.main.object(forInfoDictionaryKey: "KeychainAccessGroup") as? String
+    private static let ACCESS_GROUP: String? = {
+        let group = Bundle.main.object(forInfoDictionaryKey: "KeychainAccessGroup") as? String
+        if group == nil {
+            #if DEBUG
+            assertionFailure("KeychainAccessGroup missing from Info.plist — keychain sharing between app and NSE will fail")
+            #endif
+            NSLog("[PushNotificationKeyStore] WARNING: KeychainAccessGroup missing from Info.plist")
+        }
+        return group
+    }()
 
     @objc public static let shared = PushNotificationKeyStore()
 

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.swift
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.swift
@@ -8,11 +8,12 @@ public class PushNotificationKeyStore: NSObject {
     private static let KEY_ACCOUNT = "push_notification_symmetric_key"
 
     // Keychain access group shared between main app and NSE.
-    // When running via Xcode, the entitlements handle access group scoping automatically.
-    // We omit the explicit group here so the default app keychain is used, which is
-    // shared with extensions that have the same keychain-access-groups entitlement.
-    // The NSE reads directly with the same service/account identifiers.
-    private static let ACCESS_GROUP: String? = nil
+    // Must be explicitly specified in queries so that both the main app process and
+    // the NSE process (which have different bundle IDs and different default keychain
+    // groups) can access the same keychain item.
+    // Resolved at build time from Info.plist via $(AppIdentifierPrefix), so it works
+    // for any developer team without hardcoding the team ID.
+    private static let ACCESS_GROUP: String? = Bundle.main.object(forInfoDictionaryKey: "KeychainAccessGroup") as? String
 
     @objc public static let shared = PushNotificationKeyStore()
 

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -3,7 +3,7 @@ import UIKit
 import UserNotifications
 import ClientApp
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     // handles deep links
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
@@ -11,7 +11,47 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
 
+    // MARK: - UNUserNotificationCenterDelegate
+
+    // Handle notification tap — must be on the delegate set in didFinishLaunchingWithOptions,
+    // otherwise iOS drops the response when the app launches from a terminated state.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        let actionId = response.actionIdentifier == UNNotificationDefaultActionIdentifier ? "default" : response.actionIdentifier
+
+        if actionId == "default" || actionId == "route" {
+            if let uri = userInfo[actionId] as? String {
+                ExternalUriHandler.shared.onNewUri(uri: uri)
+            }
+        }
+        completionHandler()
+    }
+
+    // Handle notification presentation while app is in foreground
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        let userInfo = notification.request.content.userInfo
+        if userInfo["skipForeground"] == nil {
+            completionHandler([.alert, .sound, .badge])
+        } else {
+            completionHandler([])
+        }
+    }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Set the notification center delegate early — before the system delivers any
+        // pending notification responses. If the delegate is set too late (e.g., after
+        // Compose initializes), tapping a notification while the app is terminated
+        // causes the response to be silently dropped by iOS.
+        UNUserNotificationCenter.current().delegate = self
+
         // Provide Kotlin with a callback to trigger remote notification registration.
         // This replaces the old polling timer approach — Kotlin invokes this directly
         // when it needs a device token, and APNs delivers the result back via the

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -38,13 +38,17 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         let userInfo = notification.request.content.userInfo
-        // Suppress NSE notifications when the app is in foreground — the app can
-        // handle the event directly via WebSocket, so showing the generic "Trade update"
-        // placeholder would just flicker before being replaced or dismissed.
-        if userInfo["skipForeground"] == nil && userInfo["nse_decrypted"] == nil {
-            completionHandler([.alert, .sound, .badge])
-        } else {
+        // Suppress all remote push notifications when the app is in foreground.
+        // iOS skips the NSE for foreground apps, delivering the raw APNs payload
+        // ("Bisq Connect Notification") which is unhelpful. The app's WebSocket
+        // handles all trade/chat events directly when active.
+        // Local notifications (from OpenTradesNotificationService) don't have "aps"
+        // in userInfo, so they pass through unless skipForeground is set.
+        let isRemotePush = userInfo["aps"] != nil
+        if userInfo["skipForeground"] != nil || isRemotePush {
             completionHandler([])
+        } else {
+            completionHandler([.alert, .sound, .badge])
         }
     }
 

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -38,7 +38,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         let userInfo = notification.request.content.userInfo
-        if userInfo["skipForeground"] == nil {
+        // Suppress NSE notifications when the app is in foreground — the app can
+        // handle the event directly via WebSocket, so showing the generic "Trade update"
+        // placeholder would just flicker before being replaced or dismissed.
+        if userInfo["skipForeground"] == nil && userInfo["nse_decrypted"] == nil {
             completionHandler([.alert, .sound, .badge])
         } else {
             completionHandler([])

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
@@ -1,0 +1,3 @@
+package network.bisq.mobile.data.crypto
+
+actual fun getOrCreatePushNotificationKeyBase64(): String? = null

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.kt
@@ -1,0 +1,8 @@
+package network.bisq.mobile.data.crypto
+
+/**
+ * Returns the Base64-encoded AES-256 symmetric key for push notification encryption.
+ * On iOS, the key is stored in a shared Keychain accessible by the Notification Service Extension.
+ * On Android, returns null (Android does not need symmetric key for push notification decryption).
+ */
+expect fun getOrCreatePushNotificationKeyBase64(): String?

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.ios.kt
@@ -1,0 +1,13 @@
+package network.bisq.mobile.data.crypto
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import network.bisq.mobile.crypto.PushNotificationKeyStore
+
+/**
+ * Rotates and returns the AES-256 symmetric key for push notification encryption.
+ * A fresh key is generated on each call (every app launch / re-registration) to limit
+ * the exposure window if a key is ever compromised. The key is stored in a shared
+ * Keychain access group accessible by both the main app and the NSE.
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual fun getOrCreatePushNotificationKeyBase64(): String? = PushNotificationKeyStore.Companion.shared().rotateKeyBase64WithError(null)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationController.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationController.kt
@@ -16,4 +16,12 @@ interface NotificationController {
     fun cancel(id: String)
 
     fun isAppInForeground(): Boolean
+
+    /**
+     * Removes any delivered notifications that were posted by a platform-specific
+     * pre-rendering hook (e.g. iOS Notification Service Extension). Called when the
+     * app enters foreground so stale placeholder notifications don't linger.
+     * Default no-op; overridden on platforms that use pre-rendering hooks.
+     */
+    fun clearPreRenderedNotifications() {}
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
@@ -101,6 +101,7 @@ class OpenTradesNotificationService(
                 .onEach { isForeground ->
                     if (isForeground) {
                         log.d { "App entered foreground (debounced). Unregistering observers." }
+                        notificationController.clearPreRenderedNotifications()
                         unregisterObservers()
                     } else {
                         log.d { "App entered background (debounced). Registering observers." }

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
@@ -103,15 +103,50 @@ class NotificationControllerImpl(
                 content,
                 null,
             )
-        UNUserNotificationCenter
-            .currentNotificationCenter()
-            .addNotificationRequest(request) { error ->
-                if (error != null) {
-                    logDebug("Error adding notification request: ${error.localizedDescription}")
-                } else {
-                    logDebug("Notification $requestId added successfully")
+
+        // Remove any NSE-delivered push notifications before posting the richer local
+        // notification. The NSE shows a privacy-safe generic message (e.g. "Trade update");
+        // once the app wakes up and has full context, we replace it with detailed content.
+        removeNseDeliveredNotifications {
+            UNUserNotificationCenter
+                .currentNotificationCenter()
+                .addNotificationRequest(request) { error ->
+                    if (error != null) {
+                        logDebug("Error adding notification request: ${error.localizedDescription}")
+                    } else {
+                        logDebug("Notification $requestId added successfully")
+                    }
                 }
+        }
+    }
+
+    /**
+     * Finds and removes delivered notifications that were posted by the Notification
+     * Service Extension (identified by `nse_decrypted: true` in userInfo), then
+     * invokes [onComplete]. This prevents duplicate notifications when the app posts
+     * a richer local notification to replace the NSE's privacy-safe placeholder.
+     */
+    private fun removeNseDeliveredNotifications(onComplete: () -> Unit) {
+        val center = UNUserNotificationCenter.currentNotificationCenter()
+        center.getDeliveredNotificationsWithCompletionHandler { delivered ->
+            val nseIds = delivered
+                ?.mapNotNull { it as? UNNotification }
+                ?.filter { it.request.content.userInfo["nse_decrypted"] != null }
+                ?.map { it.request.identifier }
+                ?: emptyList()
+
+            if (nseIds.isNotEmpty()) {
+                logDebug("Removing ${nseIds.size} NSE-delivered notification(s)")
+                center.removeDeliveredNotificationsWithIdentifiers(nseIds)
             }
+            onComplete()
+        }
+    }
+
+    override fun clearPreRenderedNotifications() {
+        removeNseDeliveredNotifications {
+            logDebug("Pre-rendered (NSE) notifications cleared on foreground entry")
+        }
     }
 
     override fun cancel(id: String) {

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
@@ -11,7 +11,6 @@ import network.bisq.mobile.presentation.common.notification.model.NotificationCo
 import network.bisq.mobile.presentation.common.notification.model.NotificationPressAction
 import network.bisq.mobile.presentation.common.notification.model.ios.IosNotificationCategory
 import network.bisq.mobile.presentation.common.notification.model.toPlatformEnum
-import network.bisq.mobile.presentation.common.ui.navigation.ExternalUriHandler
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import platform.Foundation.NSNumber
 import platform.UserNotifications.UNAuthorizationStatusAuthorized
@@ -21,16 +20,9 @@ import platform.UserNotifications.UNNotificationAction
 import platform.UserNotifications.UNNotificationActionOptionForeground
 import platform.UserNotifications.UNNotificationCategory
 import platform.UserNotifications.UNNotificationCategoryOptionNone
-import platform.UserNotifications.UNNotificationDefaultActionIdentifier
-import platform.UserNotifications.UNNotificationPresentationOptionAlert
-import platform.UserNotifications.UNNotificationPresentationOptionBadge
-import platform.UserNotifications.UNNotificationPresentationOptionSound
-import platform.UserNotifications.UNNotificationPresentationOptions
 import platform.UserNotifications.UNNotificationRequest
-import platform.UserNotifications.UNNotificationResponse
 import platform.UserNotifications.UNNotificationSound
 import platform.UserNotifications.UNUserNotificationCenter
-import platform.UserNotifications.UNUserNotificationCenterDelegateProtocol
 import platform.darwin.NSObject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -40,9 +32,6 @@ class NotificationControllerImpl(
 ) : NotificationController,
     Logging {
     private val logScope = CoroutineScope(Dispatchers.Main)
-
-    // strong reference to delegate to keep it in memory and working
-    private var notificationDelegate: NSObject? = null
 
     @OptIn(ExperimentalForeignApi::class)
     override suspend fun hasPermission(): Boolean =
@@ -303,64 +292,12 @@ class NotificationControllerImpl(
         }
     }
 
-    private fun setupDelegate() {
-        val delegate =
-            object : NSObject(), UNUserNotificationCenterDelegateProtocol {
-                // Handle user actions on the notification
-                override fun userNotificationCenter(
-                    center: UNUserNotificationCenter,
-                    didReceiveNotificationResponse: UNNotificationResponse,
-                    withCompletionHandler: () -> Unit,
-                ) {
-                    // Handle the response when the user taps the notification
-                    val userInfo = didReceiveNotificationResponse.notification.request.content.userInfo
-                    val actionId =
-                        didReceiveNotificationResponse.actionIdentifier.let {
-                            if (it == UNNotificationDefaultActionIdentifier) "default" else it
-                        }
-                    log.i {
-                        "didReceiveNotificationResponse: actionId=$actionId, " +
-                            "userInfo keys=${(userInfo as? Map<*, *>)?.keys}, " +
-                            "requestId=${didReceiveNotificationResponse.notification.request.identifier}"
-                    }
-                    when (actionId) {
-                        "default",
-                        "route",
-                        -> {
-                            val userInfoMap = userInfo as? Map<*, *>
-                            val uri = userInfoMap?.get(actionId) as? String
-                            log.i { "Deep link URI from notification: $uri" }
-                            if (uri != null) {
-                                ExternalUriHandler.onNewUri(uri)
-                            } else {
-                                log.w { "No URI found for actionId=$actionId in userInfo" }
-                            }
-                        }
-                    }
-                    withCompletionHandler()
-                }
-
-                // Asks the delegate how to handle a notification that arrived while
-                // the app was running in the foreground.
-                override fun userNotificationCenter(
-                    center: UNUserNotificationCenter,
-                    willPresentNotification: UNNotification,
-                    withCompletionHandler: (UNNotificationPresentationOptions) -> Unit,
-                ) {
-                    val userInfo = willPresentNotification.request.content.userInfo
-
-                    if (!userInfo.contains("skipForeground")) {
-                        // Display alert, sound, or badge when the app is in the foreground
-                        withCompletionHandler(
-                            UNNotificationPresentationOptionAlert or UNNotificationPresentationOptionSound or UNNotificationPresentationOptionBadge,
-                        )
-                    }
-                }
-            }
-        notificationDelegate = delegate
-        UNUserNotificationCenter.currentNotificationCenter().delegate = delegate
-        logDebug("Notification center delegate applied")
-    }
+    // NOTE: The UNUserNotificationCenter delegate is now set in Swift's AppDelegate
+    // (didFinishLaunchingWithOptions) to ensure it's available before iOS delivers any
+    // pending notification responses. Previously it was set here in Kotlin, but that was
+    // too late — tapping a notification while the app was terminated caused the response
+    // to be silently dropped. The Swift delegate handles both didReceiveNotificationResponse
+    // (deep linking via ExternalUriHandler) and willPresent (foreground presentation).
 
     private fun setupNotificationCategories() {
         setNotificationCategories(
@@ -383,7 +320,6 @@ class NotificationControllerImpl(
 
     @Suppress("unused") // Called from iosClient.swift
     fun setup() {
-        setupDelegate()
         setupNotificationCategories()
     }
 }

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
@@ -318,14 +318,22 @@ class NotificationControllerImpl(
                         didReceiveNotificationResponse.actionIdentifier.let {
                             if (it == UNNotificationDefaultActionIdentifier) "default" else it
                         }
+                    log.i {
+                        "didReceiveNotificationResponse: actionId=$actionId, " +
+                            "userInfo keys=${(userInfo as? Map<*, *>)?.keys}, " +
+                            "requestId=${didReceiveNotificationResponse.notification.request.identifier}"
+                    }
                     when (actionId) {
                         "default",
                         "route",
                         -> {
                             val userInfoMap = userInfo as? Map<*, *>
                             val uri = userInfoMap?.get(actionId) as? String
+                            log.i { "Deep link URI from notification: $uri" }
                             if (uri != null) {
                                 ExternalUriHandler.onNewUri(uri)
+                            } else {
+                                log.w { "No URI found for actionId=$actionId in userInfo" }
                             }
                         }
                     }

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/NotificationControllerImpl.ios.kt
@@ -107,6 +107,7 @@ class NotificationControllerImpl(
         // Remove any NSE-delivered push notifications before posting the richer local
         // notification. The NSE shows a privacy-safe generic message (e.g. "Trade update");
         // once the app wakes up and has full context, we replace it with detailed content.
+        log.d { "notify(): removing NSE notifications before posting local '$requestId'" }
         removeNseDeliveredNotifications {
             UNUserNotificationCenter
                 .currentNotificationCenter()
@@ -129,23 +130,37 @@ class NotificationControllerImpl(
     private fun removeNseDeliveredNotifications(onComplete: () -> Unit) {
         val center = UNUserNotificationCenter.currentNotificationCenter()
         center.getDeliveredNotificationsWithCompletionHandler { delivered ->
-            val nseIds = delivered
-                ?.mapNotNull { it as? UNNotification }
-                ?.filter { it.request.content.userInfo["nse_decrypted"] != null }
-                ?.map { it.request.identifier }
-                ?: emptyList()
+            val allNotifications = delivered?.mapNotNull { it as? UNNotification } ?: emptyList()
+            log.d { "Delivered notifications count: ${allNotifications.size}" }
+            allNotifications.forEach { notification ->
+                val userInfo = notification.request.content.userInfo
+                log.d {
+                    "  Notification id=${notification.request.identifier}, " +
+                        "title='${notification.request.content.title}', " +
+                        "nse_decrypted=${userInfo["nse_decrypted"]}, " +
+                        "keys=${userInfo.keys.joinToString()}"
+                }
+            }
+
+            val nseIds =
+                allNotifications
+                    .filter { it.request.content.userInfo["nse_decrypted"] != null }
+                    .map { it.request.identifier }
 
             if (nseIds.isNotEmpty()) {
-                logDebug("Removing ${nseIds.size} NSE-delivered notification(s)")
+                log.d { "Removing ${nseIds.size} NSE-delivered notification(s): $nseIds" }
                 center.removeDeliveredNotificationsWithIdentifiers(nseIds)
+            } else {
+                log.d { "No NSE notifications found to remove" }
             }
             onComplete()
         }
     }
 
     override fun clearPreRenderedNotifications() {
+        log.i { "clearPreRenderedNotifications called (app entered foreground)" }
         removeNseDeliveredNotifications {
-            logDebug("Pre-rendered (NSE) notifications cleared on foreground entry")
+            log.i { "Pre-rendered (NSE) notifications cleared on foreground entry" }
         }
     }
 

--- a/support/test_bisq_relay.sh
+++ b/support/test_bisq_relay.sh
@@ -17,7 +17,7 @@ echo "Test 1: Checking if server is running..."
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
     -X POST "$RELAY_URL/v1/apns/device/test" \
     -H "Content-Type: application/json" \
-    -d '{"encrypted":"test","isUrgent":false}')
+    -d '{"encrypted":"test","isUrgent":false,"isMutableContent":false}')
 if [ "$HTTP_CODE" -eq 400 ] || [ "$HTTP_CODE" -eq 200 ]; then
     echo "✅ Server is running (HTTP $HTTP_CODE)"
 else
@@ -29,14 +29,14 @@ echo ""
 # Test 2: Send a test APNs notification
 echo "Test 2: Sending test APNs notification..."
 echo "Endpoint: POST $RELAY_URL/v1/apns/device/$DEVICE_TOKEN"
-echo "Payload: {\"encrypted\":\"$ENCRYPTED_MESSAGE\",\"isUrgent\":true}"
+echo "Payload: {\"encrypted\":\"$ENCRYPTED_MESSAGE\",\"isUrgent\":true,\"isMutableContent\":true}"
 echo ""
 
 RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
     -X POST "$RELAY_URL/v1/apns/device/$DEVICE_TOKEN" \
     -H "Content-Type: application/json" \
     -H "User-Agent: bisq-mobile-test/1.0" \
-    -d "{\"encrypted\":\"$ENCRYPTED_MESSAGE\",\"isUrgent\":true}")
+    -d "{\"encrypted\":\"$ENCRYPTED_MESSAGE\",\"isUrgent\":true,\"isMutableContent\":true}")
 
 HTTP_CODE=$(echo "$RESPONSE" | grep "HTTP_CODE:" | cut -d: -f2)
 BODY=$(echo "$RESPONSE" | sed '/HTTP_CODE:/d')

--- a/support/test_nse_decryption.swift
+++ b/support/test_nse_decryption.swift
@@ -267,6 +267,54 @@ do {
 }
 print("")
 
+// Test 9: Empty encrypted field is rejected gracefully
+print("Test 9: Empty/missing encrypted payload handled gracefully")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+
+    // Empty string should fail Base64 decode (returns empty Data)
+    let emptyData = Data(base64Encoded: "")!
+    do {
+        _ = try decryptAESGCM(data: emptyData, keyData: keyData)
+        failed += 1
+        print("  FAIL: Should have thrown with empty data")
+    } catch {
+        passed += 1
+        print("  PASS: Empty encrypted data correctly rejected")
+    }
+
+    // Valid Base64 but too short for nonce+tag (< 28 bytes)
+    let shortPayload = Data([0, 1, 2, 3, 4, 5])
+    do {
+        _ = try decryptAESGCM(data: shortPayload, keyData: keyData)
+        failed += 1
+        print("  FAIL: Should have thrown with short payload")
+    } catch {
+        passed += 1
+        print("  PASS: Short payload correctly rejected")
+    }
+}
+print("")
+
+// Test 10: Payload with extra JSON fields decodes (forward compatibility)
+print("Test 10: Payload with extra fields decodes successfully")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let jsonStr = "{\"id\":\"compat-1\",\"title\":\"Trade update\",\"message\":\"test\",\"extraField\":42}"
+    let json = jsonStr.data(using: .utf8)!
+
+    let encrypted = try encryptAESGCM(plaintext: json, keyData: keyData)
+    let decrypted = try decryptAESGCM(data: encrypted, keyData: keyData)
+    let decoded = try JSONDecoder().decode(NotificationPayload.self, from: decrypted)
+
+    assert(decoded.id == "compat-1", "ID decoded despite extra fields")
+    assert(decoded.title == "Trade update", "Title decoded despite extra fields")
+} catch {
+    failed += 1
+    print("  FAIL: Forward compatibility test threw error: \(error)")
+}
+print("")
+
 // Summary
 print("==========================================")
 print("Results: \(passed) passed, \(failed) failed")

--- a/support/test_nse_decryption.swift
+++ b/support/test_nse_decryption.swift
@@ -1,0 +1,277 @@
+#!/usr/bin/env swift
+//
+// Unit test for the NSE decryption logic.
+// Verifies that AES-256-GCM encryption (matching bisq2 MobileNotificationEncryption.encryptWithSymmetricKey)
+// can be correctly decrypted using the same logic as NotificationService.swift.
+//
+// Run: swift support/test_nse_decryption.swift
+//
+
+import Foundation
+import CryptoKit
+
+// MARK: - Decryption logic (mirrors NotificationService.swift)
+
+let NONCE_SIZE = 12
+let TAG_SIZE = 16
+
+func decryptAESGCM(data: Data, keyData: Data) throws -> Data {
+    guard data.count >= NONCE_SIZE + TAG_SIZE else {
+        throw NSError(domain: "NSE", code: -1,
+                     userInfo: [NSLocalizedDescriptionKey: "Encrypted data too short"])
+    }
+
+    let nonceData = data.prefix(NONCE_SIZE)
+    let remaining = data.dropFirst(NONCE_SIZE)
+    let ciphertext = remaining.dropLast(TAG_SIZE)
+    let tag = remaining.suffix(TAG_SIZE)
+
+    let symmetricKey = SymmetricKey(data: keyData)
+    let nonce = try AES.GCM.Nonce(data: nonceData)
+    let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+    return try AES.GCM.open(sealedBox, using: symmetricKey)
+}
+
+// MARK: - Encryption logic (mirrors bisq2 MobileNotificationEncryption.encryptWithSymmetricKey)
+
+func encryptAESGCM(plaintext: Data, keyData: Data) throws -> Data {
+    let symmetricKey = SymmetricKey(data: keyData)
+    let sealedBox = try AES.GCM.seal(plaintext, using: symmetricKey)
+
+    // Output format: nonce (12) || ciphertext || tag (16)
+    // This matches Java's AES/GCM/NoPadding output format used by bisq2
+    var result = Data()
+    result.append(contentsOf: sealedBox.nonce)
+    result.append(sealedBox.ciphertext)
+    result.append(sealedBox.tag)
+    return result
+}
+
+// MARK: - Notification category logic (mirrors NotificationService.swift)
+
+enum NotificationCategory: String {
+    case tradeUpdate = "trade_update"
+    case chatMessage = "chat_message"
+    case offerUpdate = "offer_update"
+    case general = "general"
+
+    var displayText: String {
+        switch self {
+        case .tradeUpdate: return "Trade update"
+        case .chatMessage: return "New message"
+        case .offerUpdate: return "Offer update"
+        case .general: return "New notification"
+        }
+    }
+
+    static func from(title: String) -> NotificationCategory {
+        let lower = title.lowercased()
+        if lower.contains("trade") || lower.contains("payment") || lower.contains("btc") {
+            return .tradeUpdate
+        }
+        if lower.contains("message") || lower.contains("chat") {
+            return .chatMessage
+        }
+        if lower.contains("offer") {
+            return .offerUpdate
+        }
+        return .general
+    }
+}
+
+struct NotificationPayload: Codable {
+    let id: String
+    let title: String
+    let message: String
+}
+
+// MARK: - Tests
+
+var passed = 0
+var failed = 0
+
+func assert(_ condition: Bool, _ message: String, file: String = #file, line: Int = #line) {
+    if condition {
+        passed += 1
+        print("  PASS: \(message)")
+    } else {
+        failed += 1
+        print("  FAIL: \(message) (line \(line))")
+    }
+}
+
+print("==========================================")
+print("NSE Decryption Unit Tests")
+print("==========================================")
+print("")
+
+// Test 1: Round-trip encrypt/decrypt
+print("Test 1: AES-256-GCM round-trip encrypt/decrypt")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let payload = NotificationPayload(id: "test-1", title: "Trade update", message: "Payment confirmed")
+    let json = try JSONEncoder().encode(payload)
+
+    let encrypted = try encryptAESGCM(plaintext: json, keyData: keyData)
+    let decrypted = try decryptAESGCM(data: encrypted, keyData: keyData)
+    let decoded = try JSONDecoder().decode(NotificationPayload.self, from: decrypted)
+
+    assert(decoded.id == "test-1", "ID matches")
+    assert(decoded.title == "Trade update", "Title matches")
+    assert(decoded.message == "Payment confirmed", "Message matches")
+} catch {
+    failed += 1
+    print("  FAIL: Round-trip threw error: \(error)")
+}
+print("")
+
+// Test 2: Correct output format (nonce + ciphertext + tag)
+print("Test 2: Output format is nonce(12) + ciphertext + tag(16)")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let plaintext = "Hello, world!".data(using: .utf8)!
+
+    let encrypted = try encryptAESGCM(plaintext: plaintext, keyData: keyData)
+    assert(encrypted.count == NONCE_SIZE + plaintext.count + TAG_SIZE,
+           "Encrypted size = \(NONCE_SIZE) + \(plaintext.count) + \(TAG_SIZE) = \(encrypted.count)")
+} catch {
+    failed += 1
+    print("  FAIL: Threw error: \(error)")
+}
+print("")
+
+// Test 3: Wrong key fails decryption
+print("Test 3: Wrong key fails decryption")
+do {
+    let correctKey = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let wrongKey = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let plaintext = "Secret data".data(using: .utf8)!
+
+    let encrypted = try encryptAESGCM(plaintext: plaintext, keyData: correctKey)
+    do {
+        _ = try decryptAESGCM(data: encrypted, keyData: wrongKey)
+        failed += 1
+        print("  FAIL: Should have thrown with wrong key")
+    } catch {
+        passed += 1
+        print("  PASS: Decryption correctly fails with wrong key")
+    }
+} catch {
+    failed += 1
+    print("  FAIL: Encryption threw error: \(error)")
+}
+print("")
+
+// Test 4: Truncated data fails
+print("Test 4: Truncated data fails")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let shortData = Data([1, 2, 3]) // Too short
+
+    do {
+        _ = try decryptAESGCM(data: shortData, keyData: keyData)
+        failed += 1
+        print("  FAIL: Should have thrown with short data")
+    } catch {
+        passed += 1
+        print("  PASS: Decryption correctly rejects truncated data")
+    }
+}
+print("")
+
+// Test 5: Tampered ciphertext fails
+print("Test 5: Tampered ciphertext fails")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let plaintext = "Authentic data".data(using: .utf8)!
+
+    var encrypted = try encryptAESGCM(plaintext: plaintext, keyData: keyData)
+    // Flip a byte in the ciphertext (after nonce, before tag)
+    encrypted[NONCE_SIZE + 1] ^= 0xFF
+
+    do {
+        _ = try decryptAESGCM(data: encrypted, keyData: keyData)
+        failed += 1
+        print("  FAIL: Should have thrown with tampered data")
+    } catch {
+        passed += 1
+        print("  PASS: Decryption correctly rejects tampered ciphertext")
+    }
+} catch {
+    failed += 1
+    print("  FAIL: Encryption threw error: \(error)")
+}
+print("")
+
+// Test 6: Base64 round-trip (simulates relay payload)
+print("Test 6: Base64 round-trip (simulates relay/APNs payload)")
+do {
+    let keyData = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+    let payload = NotificationPayload(id: "relay-test", title: "New message from peer", message: "Are you ready to trade?")
+    let json = try JSONEncoder().encode(payload)
+
+    let encrypted = try encryptAESGCM(plaintext: json, keyData: keyData)
+    let base64 = encrypted.base64EncodedString()
+
+    // Simulate NSE receiving Base64 from APNs userInfo
+    guard let fromBase64 = Data(base64Encoded: base64) else {
+        failed += 1
+        print("  FAIL: Base64 decode failed")
+        fatalError()
+    }
+
+    let decrypted = try decryptAESGCM(data: fromBase64, keyData: keyData)
+    let decoded = try JSONDecoder().decode(NotificationPayload.self, from: decrypted)
+
+    assert(decoded.id == "relay-test", "ID matches after Base64 round-trip")
+    assert(decoded.title == "New message from peer", "Title matches after Base64 round-trip")
+    assert(decoded.message == "Are you ready to trade?", "Message matches after Base64 round-trip")
+} catch {
+    failed += 1
+    print("  FAIL: Base64 round-trip threw error: \(error)")
+}
+print("")
+
+// Test 7: Notification category classification
+print("Test 7: Notification category classification")
+assert(NotificationCategory.from(title: "Trade update") == .tradeUpdate, "Trade classified as tradeUpdate")
+assert(NotificationCategory.from(title: "Payment confirmed") == .tradeUpdate, "Payment classified as tradeUpdate")
+assert(NotificationCategory.from(title: "BTC sent") == .tradeUpdate, "BTC classified as tradeUpdate")
+assert(NotificationCategory.from(title: "New message from Alice") == .chatMessage, "Message classified as chatMessage")
+assert(NotificationCategory.from(title: "Chat notification") == .chatMessage, "Chat classified as chatMessage")
+assert(NotificationCategory.from(title: "Offer accepted") == .offerUpdate, "Offer classified as offerUpdate")
+assert(NotificationCategory.from(title: "System alert") == .general, "Unknown classified as general")
+print("")
+
+// Test 8: Key from known Base64 (simulates real registration key)
+print("Test 8: Known Base64 key encrypt/decrypt")
+do {
+    let keyBase64 = "MqybkhyRZoc3k8ZcXYxyfN6N49vUNaD5lw5zzIIgxbI="
+    guard let keyData = Data(base64Encoded: keyBase64) else {
+        failed += 1
+        print("  FAIL: Could not decode Base64 key")
+        fatalError()
+    }
+    assert(keyData.count == 32, "Key is 256 bits (32 bytes)")
+
+    let payload = NotificationPayload(id: "key-test", title: "Offer taken", message: "Your offer was taken by Bob")
+    let json = try JSONEncoder().encode(payload)
+    let encrypted = try encryptAESGCM(plaintext: json, keyData: keyData)
+    let decrypted = try decryptAESGCM(data: encrypted, keyData: keyData)
+    let decoded = try JSONDecoder().decode(NotificationPayload.self, from: decrypted)
+
+    assert(decoded.title == "Offer taken", "Decryption with known key works")
+} catch {
+    failed += 1
+    print("  FAIL: Known key test threw error: \(error)")
+}
+print("")
+
+// Summary
+print("==========================================")
+print("Results: \(passed) passed, \(failed) failed")
+print("==========================================")
+
+if failed > 0 {
+    exit(1)
+}

--- a/support/test_nse_simulator.sh
+++ b/support/test_nse_simulator.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Test script for the Notification Service Extension (NSE) on iOS Simulator.
+# Generates an AES-256-GCM encrypted notification payload and pushes it
+# directly to the simulator using xcrun simctl.
+#
+# Prerequisites:
+#   - iOS Simulator running with the app installed
+#   - Python 3 with pycryptodome: pip3 install pycryptodome
+#
+# Usage:
+#   ./support/test_nse_simulator.sh
+#   ./support/test_nse_simulator.sh "Custom title" "Custom message"
+#   SYMMETRIC_KEY="your_base64_key" ./support/test_nse_simulator.sh
+
+BUNDLE_ID="${BUNDLE_ID:-network.bisq.mobile.ios}"
+TITLE="${1:-Test notification}"
+MESSAGE="${2:-Push notification pipeline is working}"
+NOTIFICATION_ID="test-$(date +%s)"
+
+# Use env var or default test key.
+# Replace with the actual key from device registration logs:
+#   "symmetricKeyBase64": "MqybkhyRZoc3k8ZcXYxyfN6N49vUNaD5lw5zzIIgxbI="
+SYMMETRIC_KEY="${SYMMETRIC_KEY:-MqybkhyRZoc3k8ZcXYxyfN6N49vUNaD5lw5zzIIgxbI=}"
+
+echo "=========================================="
+echo "Testing NSE on iOS Simulator"
+echo "=========================================="
+echo ""
+echo "Bundle ID:  $BUNDLE_ID"
+echo "Title:      $TITLE"
+echo "Message:    $MESSAGE"
+echo "Key:        ${SYMMETRIC_KEY:0:10}..."
+echo ""
+
+# Generate encrypted payload using Swift (no external dependencies needed on macOS)
+ENCRYPTED_BASE64=$(swift -e "
+import Foundation
+import CryptoKit
+
+let keyData = Data(base64Encoded: \"$SYMMETRIC_KEY\")!
+precondition(keyData.count == 32, \"Key must be 32 bytes\")
+
+let payload = \"{\\\"id\\\":\\\"$NOTIFICATION_ID\\\",\\\"title\\\":\\\"$TITLE\\\",\\\"message\\\":\\\"$MESSAGE\\\"}\"
+let plaintextData = payload.data(using: .utf8)!
+
+let symmetricKey = SymmetricKey(data: keyData)
+let sealedBox = try! AES.GCM.seal(plaintextData, using: symmetricKey)
+
+// Output format: nonce (12) + ciphertext + tag (16)
+var result = Data()
+result.append(contentsOf: sealedBox.nonce)
+result.append(sealedBox.ciphertext)
+result.append(sealedBox.tag)
+print(result.base64EncodedString())
+" 2>&1)
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to generate encrypted payload."
+    echo "$ENCRYPTED_BASE64"
+    exit 1
+fi
+
+echo "Encrypted payload: ${ENCRYPTED_BASE64:0:40}..."
+echo ""
+
+# Create APNs payload JSON
+PAYLOAD_FILE=$(mktemp /tmp/bisq_apns_XXXXXX.json)
+cat > "$PAYLOAD_FILE" << EOF
+{
+    "aps": {
+        "alert": {
+            "loc-key": "notification"
+        },
+        "content-available": 1,
+        "mutable-content": 1
+    },
+    "encrypted": "$ENCRYPTED_BASE64"
+}
+EOF
+
+echo "APNs payload written to: $PAYLOAD_FILE"
+echo ""
+cat "$PAYLOAD_FILE"
+echo ""
+echo ""
+
+# Push to simulator
+echo "Pushing to simulator..."
+xcrun simctl push booted "$BUNDLE_ID" "$PAYLOAD_FILE"
+RESULT=$?
+
+rm -f "$PAYLOAD_FILE"
+
+if [ $RESULT -eq 0 ]; then
+    echo ""
+    echo "=========================================="
+    echo "SUCCESS - Notification pushed to simulator"
+    echo "=========================================="
+    echo ""
+    echo "Expected behavior:"
+    echo "  - NSE intercepts (mutable-content: 1)"
+    echo "  - Decrypts AES-GCM payload"
+    echo "  - Shows privacy-safe banner: 'Bisq - New notification'"
+    echo "  - Full content stored for in-app display"
+else
+    echo ""
+    echo "FAILED - simctl push returned error code $RESULT"
+    echo "Make sure the simulator is running with the app installed."
+fi

--- a/support/test_relay_with_nse.sh
+++ b/support/test_relay_with_nse.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Test script for the relay server with mutableContent support.
+# Sends an AES-GCM encrypted notification to the local relay, which then
+# forwards to APNs with mutable-content:1 for NSE processing.
+#
+# Prerequisites:
+#   - Local bisq-relay running on localhost:8080
+#   - Valid APNs certificate configured in the relay
+#   - A real device token (simulators can't receive APNs)
+#   - Python 3 with pycryptodome: pip3 install pycryptodome
+#
+# Usage:
+#   DEVICE_TOKEN="<64-char-hex>" SYMMETRIC_KEY="<base64>" ./support/test_relay_with_nse.sh
+#
+# For testing relay without actually hitting APNs (just validates the relay accepts the request):
+#   ./support/test_relay_with_nse.sh --dry-run
+
+
+## working example
+# DEVICE_TOKEN="b162a243b6ce4bf944d5c795475d900d508269216ad1e6e4b6214cc64da941c2" \
+#  SYMMETRIC_KEY="MqybkhyRZoc3k8ZcXYxyfN6N49vUNaD5lw5zzIIgxbI=" \                                                               #    ./support/test_relay_with_nse.sh
+
+RELAY_URL="${RELAY_URL:-http://localhost:8080}"
+DEVICE_TOKEN="${DEVICE_TOKEN:-b162a243b6ce4bf944d5c795475d900d508269216ad1e6e4b6214cc64da941c2}"
+SYMMETRIC_KEY="${SYMMETRIC_KEY:-MqybkhyRZoc3k8ZcXYxyfN6N49vUNaD5lw5zzIIgxbI=}"
+TITLE="${TITLE:-Trade update}"
+MESSAGE="${MESSAGE:-Payment confirmed for your trade}"
+DRY_RUN="${1:-}"
+
+echo "=========================================="
+echo "Testing Relay with mutableContent Support"
+echo "=========================================="
+echo ""
+echo "Relay URL:     $RELAY_URL"
+echo "Device Token:  ${DEVICE_TOKEN:0:16}..."
+echo "Key:           ${SYMMETRIC_KEY:0:10}..."
+echo "Dry run:       ${DRY_RUN:-no}"
+echo ""
+
+# Generate encrypted payload using Swift (no external dependencies needed on macOS)
+NOTIFICATION_ID="test-$(date +%s)"
+ENCRYPTED_HEX=$(swift -e "
+import Foundation
+import CryptoKit
+
+let keyData = Data(base64Encoded: \"$SYMMETRIC_KEY\")!
+precondition(keyData.count == 32, \"Key must be 32 bytes\")
+
+let payload = \"{\\\"id\\\":\\\"$NOTIFICATION_ID\\\",\\\"title\\\":\\\"$TITLE\\\",\\\"message\\\":\\\"$MESSAGE\\\"}\"
+let plaintextData = payload.data(using: .utf8)!
+
+let symmetricKey = SymmetricKey(data: keyData)
+let sealedBox = try! AES.GCM.seal(plaintextData, using: symmetricKey)
+
+// Output format: nonce (12) + ciphertext + tag (16)
+var result = Data()
+result.append(contentsOf: sealedBox.nonce)
+result.append(sealedBox.ciphertext)
+result.append(sealedBox.tag)
+
+// Relay expects hex of raw bytes (matching bisq2 format)
+print(result.map { String(format: \"%02x\", \$0) }.joined())
+" 2>&1)
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to generate encrypted payload."
+    echo "$ENCRYPTED_HEX"
+    exit 1
+fi
+
+echo "Encrypted hex: ${ENCRYPTED_HEX:0:40}..."
+echo ""
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "DRY RUN - would send to relay:"
+    echo "  GET $RELAY_URL/relay?isAndroid=false&token=$DEVICE_TOKEN&msg=$ENCRYPTED_HEX&mutableContent=true"
+    echo ""
+    echo "Equivalent POST (v1 endpoint):"
+    echo "  POST $RELAY_URL/v1/apns/device/$DEVICE_TOKEN"
+    echo "  Body: {\"encrypted\":\"$(echo -n "$ENCRYPTED_HEX" | xxd -r -p | base64)\",\"isUrgent\":true,\"isMutableContent\":true}"
+    exit 0
+fi
+
+# Test 1: Legacy endpoint with mutableContent param
+echo "Test 1: Legacy /relay endpoint with mutableContent=true"
+echo "---"
+RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+    "$RELAY_URL/relay?isAndroid=false&token=$DEVICE_TOKEN&msg=$ENCRYPTED_HEX&mutableContent=true")
+
+HTTP_CODE=$(echo "$RESPONSE" | grep "HTTP_CODE:" | cut -d: -f2)
+BODY=$(echo "$RESPONSE" | sed '/HTTP_CODE:/d')
+
+echo "Response: $HTTP_CODE"
+echo "Body: $BODY"
+echo ""
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "SUCCESS - Relay accepted and forwarded to APNs with mutable-content:1"
+elif [ "$HTTP_CODE" = "400" ]; then
+    echo "APNs rejected (expected if cert/bundle mismatch or invalid token)"
+    echo "But the relay DID process the mutableContent flag correctly."
+else
+    echo "Unexpected response: $HTTP_CODE"
+fi
+
+echo ""
+
+# Test 2: New POST endpoint
+echo "Test 2: POST /v1/apns/device endpoint with isMutableContent=true"
+echo "---"
+# For POST endpoint, encrypted field is Base64 (not hex)
+ENCRYPTED_FOR_POST=$(swift -e "
+import Foundation
+let hex = \"$ENCRYPTED_HEX\"
+var data = Data()
+var i = hex.startIndex
+while i < hex.endIndex {
+    let end = hex.index(i, offsetBy: 2)
+    data.append(UInt8(hex[i..<end], radix: 16)!)
+    i = end
+}
+print(data.base64EncodedString())
+")
+
+RESPONSE2=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+    -X POST "$RELAY_URL/v1/apns/device/$DEVICE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: bisq-mobile-test/1.0" \
+    -d "{\"encrypted\":\"$ENCRYPTED_FOR_POST\",\"isUrgent\":true,\"isMutableContent\":true}")
+
+HTTP_CODE2=$(echo "$RESPONSE2" | grep "HTTP_CODE:" | cut -d: -f2)
+BODY2=$(echo "$RESPONSE2" | sed '/HTTP_CODE:/d')
+
+echo "Response: $HTTP_CODE2"
+echo "Body: $BODY2"
+echo ""
+
+if [ "$HTTP_CODE2" = "200" ]; then
+    echo "SUCCESS - POST endpoint accepted with mutable-content:1"
+elif [ "$HTTP_CODE2" = "400" ]; then
+    echo "APNs rejected (cert/bundle mismatch) - but relay processed correctly"
+else
+    echo "Unexpected response: $HTTP_CODE2"
+fi
+
+echo ""
+echo "=========================================="
+echo "Done"
+echo "=========================================="


### PR DESCRIPTION
 - resolves #1230 
 - resolves #1378 
 - depends on https://github.com/bisq-network/bisq2/pull/4675

### Future lines of dev

 - found this issue whilst working on this #1378 , added logs to troubleshot and fix soon
 - this has not been implemented in this PR, need to work on it a bit more #1379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS Notification Service Extension to decrypt and display secure push notifications
  * Optional AES‑GCM symmetric key support for push notifications and device registration
  * App clears pre-rendered/placeholder notifications before scheduling richer local notifications

* **Chores**
  * iOS client version bumped to 0.3.5 (build 29)
  * Keychain access groups and entitlements configured for shared key access between app and extension
  * New test and simulator/relay scripts for push notification encryption/decryption validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->