### PR TITLE
Release/anode 0.5.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.9.0
 
 node.name=Bisq Easy
-node.android.version=0.5.2
+node.android.version=0.5.3
 
 client.name=Bisq Connect
 client.android.version=0.3.4
@@ -42,7 +42,7 @@ client.ios.version=0.3.4
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=18
 client.android.version.code=22
-node.android.version.code=40
+node.android.version.code=41
 
 # Networking
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.10"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "e2e7c20cb4fcd68fff86fc3868362859cdf2e99c"
+bisq-core-commit = "1f38347f1e69e9bf7efdade4b01c4cc71a4e3298"
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing
 bisq-desktop-pairing = "2.1.10"
 # API version is usually same as bisq-core but for more control we keep it separated


### PR DESCRIPTION
 - contribs to #1376
 - updated metadata and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Android build version to 0.5.3
  * Updated core dependency references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->