### PR TITLE
chore/fix_ci_flaky_tests

### DIFF
--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/UncaughtExceptionHandlerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/UncaughtExceptionHandlerTest.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.domain
 
 import network.bisq.mobile.data.utils.setupUncaughtExceptionHandler
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -9,31 +11,51 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+/**
+ * The production [setupUncaughtExceptionHandler] writes diagnostic output via raw
+ * `println(...)` and `Throwable.printStackTrace()` (see `PlatformDomainAbstractions.android.kt`).
+ * Two consequences for tests that exercise the handler:
+ *
+ * 1. The string `"Uncaught exception on thread: Test worker"` reaching the JVM's stderr
+ *    can be flagged by Gradle's test runner as a worker-thread failure heuristic, even when
+ *    the test itself passes. We invoke the handler on a separate thread so that string
+ *    references that thread instead of the test worker.
+ * 2. The exception's stack trace lands on stderr regardless. We capture stdout/stderr for
+ *    the lifetime of the test so the staged crash never escapes into Gradle's report.
+ */
 class UncaughtExceptionHandlerTest {
     private var previousHandler: Thread.UncaughtExceptionHandler? = null
+    private var previousOut: PrintStream? = null
+    private var previousErr: PrintStream? = null
 
     @BeforeTest
     fun setUp() {
         previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+        previousOut = System.out
+        previousErr = System.err
+        System.setOut(PrintStream(ByteArrayOutputStream()))
+        System.setErr(PrintStream(ByteArrayOutputStream()))
     }
 
     @AfterTest
     fun tearDown() {
-        // Restore whatever handler was there before the test
         Thread.setDefaultUncaughtExceptionHandler(previousHandler)
+        previousOut?.let { System.setOut(it) }
+        previousErr?.let { System.setErr(it) }
     }
 
     @Test
     fun setupUncaughtExceptionHandler_invokesOnCrash_andDelegatesToOriginal() {
         val onCrashCalled = AtomicBoolean(false)
         val originalCalled = AtomicBoolean(false)
-        val latch = CountDownLatch(1)
+        val originalLatch = CountDownLatch(1)
+        val invocationLatch = CountDownLatch(1)
 
         // Install a fake original handler that only records invocation
         val fakeOriginal =
             Thread.UncaughtExceptionHandler { _, _ ->
                 originalCalled.set(true)
-                latch.countDown()
+                originalLatch.countDown()
             }
         Thread.setDefaultUncaughtExceptionHandler(fakeOriginal)
 
@@ -42,12 +64,23 @@ class UncaughtExceptionHandlerTest {
             onCrashCalled.set(true)
         }
 
-        // Simulate an uncaught exception by directly invoking the installed handler
+        // Invoke the handler on a dedicated thread so any thread-name-based diagnostic
+        // output references that thread, not "Test worker". The exception is thrown
+        // and immediately handed to the handler — it never propagates through the
+        // thread's normal exception path.
         val handlerUnderTest = Thread.getDefaultUncaughtExceptionHandler()
-        handlerUnderTest?.uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+        val invocationThread =
+            Thread({
+                try {
+                    handlerUnderTest?.uncaughtException(Thread.currentThread(), RuntimeException("staged-crash"))
+                } finally {
+                    invocationLatch.countDown()
+                }
+            }, "uncaught-exception-handler-test")
+        invocationThread.start()
 
-        // Wait briefly to ensure delegation executed
-        assertTrue(latch.await(1, TimeUnit.SECONDS), "Expected original handler to be invoked")
+        assertTrue(invocationLatch.await(2, TimeUnit.SECONDS), "Handler invocation thread did not complete")
+        assertTrue(originalLatch.await(2, TimeUnit.SECONDS), "Expected original handler to be invoked")
         assertTrue(onCrashCalled.get(), "Expected onCrash callback to be invoked")
         assertTrue(originalCalled.get(), "Expected original handler to be delegated to")
     }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
@@ -16,6 +16,8 @@ import network.bisq.mobile.data.service.network.KmpTorService
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.test.KoinTest
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -26,17 +28,29 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class ApplicationBootstrapFacadeTest : KoinTest {
     private val testDispatcher = StandardTestDispatcher()
+    private var previousOut: PrintStream? = null
+    private var previousErr: PrintStream? = null
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         startKoin { modules(testModule) }
+        // Failure-path tests intentionally drive the facade through Tor failures; the
+        // production code logs the staged failure to stdout/stderr. Capture both for the
+        // lifetime of the test so that diagnostic output (in particular anything that
+        // could pattern-match Gradle's test-worker-failure heuristic) is contained.
+        previousOut = System.out
+        previousErr = System.err
+        System.setOut(PrintStream(ByteArrayOutputStream()))
+        System.setErr(PrintStream(ByteArrayOutputStream()))
     }
 
     @AfterTest
     fun tearDown() {
         stopKoin()
         Dispatchers.resetMain()
+        previousOut?.let { System.setOut(it) }
+        previousErr?.let { System.setErr(it) }
     }
 
     @Test


### PR DESCRIPTION
 - Run handler invocation on a separate thread + defensive stdout/stderr capture in setUp/tearDown