### PR TITLE
Release/connect 0.4.0

### DIFF
--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.3.5'
+    spec.version                  = '0.4.0'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.4.0'
+    spec.version                  = '0.4.1'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/apps/clientApp/proguard-rules.pro
+++ b/apps/clientApp/proguard-rules.pro
@@ -19,23 +19,11 @@
     public <methods>;
 }
 
-### The following were suggested by R8 engine, should be reviewed carefully on release build testing
+## Ktor's IntellijIdeaDebugDetector probes for IDE debugger attachment via
+## java.lang.management.* — JVM-only APIs unavailable on Android. Safe to suppress;
+## the detector returns false at runtime and the references are never executed.
 -dontwarn java.lang.management.ManagementFactory
 -dontwarn java.lang.management.RuntimeMXBean
--dontwarn org.gradle.api.Action
--dontwarn org.gradle.api.Named
--dontwarn org.gradle.api.Plugin
--dontwarn org.gradle.api.Task
--dontwarn org.gradle.api.artifacts.Dependency
--dontwarn org.gradle.api.artifacts.ExternalModuleDependency
--dontwarn org.gradle.api.attributes.Attribute
--dontwarn org.gradle.api.attributes.AttributeCompatibilityRule
--dontwarn org.gradle.api.attributes.AttributeContainer
--dontwarn org.gradle.api.attributes.AttributeDisambiguationRule
--dontwarn org.gradle.api.attributes.HasAttributes
--dontwarn org.gradle.api.component.SoftwareComponent
--dontwarn org.gradle.api.plugins.ExtensionAware
--dontwarn org.gradle.api.tasks.util.PatternFilterable
 
 ## General
 

--- a/apps/clientApp/proguard-rules.pro
+++ b/apps/clientApp/proguard-rules.pro
@@ -97,3 +97,18 @@
 
 # Preserve Tor service classes moved to shared/domain
 -keep class network.bisq.mobile.domain.service.network.** { *; }
+
+## Tink (com.google.crypto.tink) — used transitively for EncryptedSharedPreferences /
+## push-notification-key encryption. Tink ships an unused KeysDownloader utility that
+## references google-http-client + joda-time; those are not on our classpath because
+## we never call KeysDownloader. R8 fails the build on the unresolved references unless
+## we explicitly tell it to ignore them.
+-dontwarn com.google.api.client.http.GenericUrl
+-dontwarn com.google.api.client.http.HttpHeaders
+-dontwarn com.google.api.client.http.HttpRequest
+-dontwarn com.google.api.client.http.HttpRequestFactory
+-dontwarn com.google.api.client.http.HttpResponse
+-dontwarn com.google.api.client.http.HttpTransport
+-dontwarn com.google.api.client.http.javanet.NetHttpTransport
+-dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
+-dontwarn org.joda.time.Instant

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/utils/ClientVersionProvider.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/utils/ClientVersionProvider.kt
@@ -9,7 +9,7 @@ class ClientVersionProvider : VersionProvider {
         isDemo: Boolean,
         isIOS: Boolean,
     ): String {
-        val demo = if (isDemo) "-demo-" else ""
+        val demo = if (isDemo) "demo-" else ""
         return demo + if (isIOS) BuildConfig.IOS_APP_VERSION else BuildConfig.ANDROID_APP_VERSION
     }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/NodeVersionProvider.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/NodeVersionProvider.kt
@@ -6,7 +6,7 @@ import network.bisq.mobile.i18n.i18n
 
 class NodeVersionProvider : VersionProvider {
     private fun getAppName(isDemo: Boolean): String {
-        val demo = if (isDemo) "-demo-" else ""
+        val demo = if (isDemo) "demo-" else ""
         return demo + BuildNodeConfig.APP_NAME
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,13 +35,13 @@ node.name=Bisq Easy
 node.android.version=0.5.3
 
 client.name=Bisq Connect
-client.android.version=0.4.0
-client.ios.version=0.4.0
+client.android.version=0.4.1
+client.ios.version=0.4.1
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=29
-client.android.version.code=22
+client.ios.version.code=30
+client.android.version.code=23
 node.android.version.code=41
 
 # Networking

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,14 +29,14 @@ android.enableR8.fullMode=true
 android.enableJetifier=false
 
 # Versioning
-shared.version=0.9.0
+shared.version=0.10.0
 
 node.name=Bisq Easy
 node.android.version=0.5.3
 
 client.name=Bisq Connect
-client.android.version=0.3.4
-client.ios.version=0.3.5
+client.android.version=0.4.0
+client.ios.version=0.4.0
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.3.5
+APP_VERSION=0.4.0
 APP_VERSION_CODE=29

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.4.0
-APP_VERSION_CODE=29
+APP_VERSION=0.4.1
+APP_VERSION_CODE=30

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.3.5)
+  - clientApp (0.4.0)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 513e44dcd9f415f2d408520e58cf27e56a6d2b60
+  clientApp: d0e38bb1708833cf6a82a8496cb90cdbdef4df3f
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.4.0)
+  - clientApp (0.4.1)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: d0e38bb1708833cf6a82a8496cb90cdbdef4df3f
+  clientApp: 08f1670e9b49a86c1f51da4b16f9fd673cc5bedc
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.3.5)
+  - clientApp (0.4.0)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 513e44dcd9f415f2d408520e58cf27e56a6d2b60
+  clientApp: d0e38bb1708833cf6a82a8496cb90cdbdef4df3f
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.4.0)
+  - clientApp (0.4.1)
 
 DEPENDENCIES:
   - clientApp (from `../apps/clientApp`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: d0e38bb1708833cf6a82a8496cb90cdbdef4df3f
+  clientApp: 08f1670e9b49a86c1f51da4b16f9fd673cc5bedc
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8
 

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/utils/ClientVersionProvider.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/utils/ClientVersionProvider.kt
@@ -3,12 +3,15 @@ package network.bisq.mobile.domain.utils
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.i18n.i18n
 
+// TODO: Delete this file — it duplicates apps/clientApp/.../ClientVersionProvider.kt
+//   byte-for-byte. ClientVersionProvider is Connect-app specific (counterpart to
+//   NodeVersionProvider in apps/nodeApp), so it shouldn't live in shared/domain at all.
 class ClientVersionProvider : VersionProvider {
     private fun getAppVersion(
         isDemo: Boolean,
         isIOS: Boolean,
     ): String {
-        val demo = if (isDemo) "-demo-" else ""
+        val demo = if (isDemo) "demo-" else ""
         return demo + if (isIOS) BuildConfig.IOS_APP_VERSION else BuildConfig.ANDROID_APP_VERSION
     }
 


### PR DESCRIPTION
 - contribs to #1406 
 - updated metadata + versioning
 - fix issue on android proguard rules preventing release after latest changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated client application version to 0.4.1
  * Updated shared library version to 0.10.0
  * Bumped iOS and Android version codes to support app store releases
  * Refined demo application naming convention for improved identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->