### PR TITLE
fix: For SecurityException in while opening links via LocalUriHandler

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -71,25 +71,25 @@ fun ClientSupportScreen() {
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.MATRIX) },
-                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.forum".i18n(),
                 link = BisqLinks.FORUM,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.FORUM) },
-                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.telegram".i18n(),
                 link = BisqLinks.TELEGRAM,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.TELEGRAM) },
-                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.reddit".i18n(),
                 link = BisqLinks.REDDIT,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.REDDIT) },
-                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
         }
 
@@ -103,7 +103,7 @@ fun ClientSupportScreen() {
             text = "mobile.support.wiki".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { supportPresenter.onOpenWebUrl(BisqLinks.BISQ_EASY_WIKI_URL) },
-            onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -121,7 +121,7 @@ fun ClientSupportScreen() {
             text = "mobile.support.troubleShooting.github".i18n(),
             link = reportUrl,
             onClick = { supportPresenter.onOpenWebUrl(reportUrl) },
-            onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -25,6 +25,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
@@ -70,21 +71,25 @@ fun ClientSupportScreen() {
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.MATRIX) },
+                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.forum".i18n(),
                 link = BisqLinks.FORUM,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.FORUM) },
+                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.telegram".i18n(),
                 link = BisqLinks.TELEGRAM,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.TELEGRAM) },
+                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.reddit".i18n(),
                 link = BisqLinks.REDDIT,
                 onClick = { supportPresenter.onOpenWebUrl(BisqLinks.REDDIT) },
+                onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
         }
 
@@ -98,6 +103,7 @@ fun ClientSupportScreen() {
             text = "mobile.support.wiki".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { supportPresenter.onOpenWebUrl(BisqLinks.BISQ_EASY_WIKI_URL) },
+            onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -115,6 +121,7 @@ fun ClientSupportScreen() {
             text = "mobile.support.troubleShooting.github".i18n(),
             link = reportUrl,
             onClick = { supportPresenter.onOpenWebUrl(reportUrl) },
+            onError = { supportPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
@@ -74,7 +74,7 @@ fun TrustedNodeSetupScreen(
         uiState = uiState,
         onAction = presenter::onAction,
         isWorkflow = isWorkflow,
-        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+        onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         topBar =
             if (!isWorkflow) {
                 { TopBar(title = "mobile.trustedNodeSetup.title".i18n()) }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
@@ -43,6 +43,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ConfirmationDialog
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.components.organisms.dialogs.BisqGeneralErrorDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
@@ -73,6 +74,7 @@ fun TrustedNodeSetupScreen(
         uiState = uiState,
         onAction = presenter::onAction,
         isWorkflow = isWorkflow,
+        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         topBar =
             if (!isWorkflow) {
                 { TopBar(title = "mobile.trustedNodeSetup.title".i18n()) }
@@ -88,6 +90,7 @@ fun TrustedNodeSetupContent(
     uiState: TrustedNodeSetupUiState,
     onAction: (TrustedNodeSetupUiAction) -> Unit,
     isWorkflow: Boolean = true,
+    onError: ((Throwable) -> Unit)? = null,
     topBar: @Composable () -> Unit = {},
 ) {
     BisqScaffold(
@@ -102,6 +105,7 @@ fun TrustedNodeSetupContent(
             onAction = onAction,
             isWorkflow = isWorkflow,
             paddingValues = paddingValues,
+            onError = onError,
         )
     }
 
@@ -180,6 +184,7 @@ private fun TrustedNodeSetupMainContent(
     onAction: (TrustedNodeSetupUiAction) -> Unit,
     isWorkflow: Boolean,
     paddingValues: PaddingValues,
+    onError: ((Throwable) -> Unit)?,
 ) {
     val scrollState = rememberScrollState()
 
@@ -361,6 +366,7 @@ private fun TrustedNodeSetupMainContent(
                     "mobile.trustedNodeSetup.help"
                         .i18n("mobile.trustedNodeSetup.help.link".i18n()),
                 link = BisqLinks.BISQ_CONNECT_WIKI_URL,
+                onError = onError,
             )
         }
         BisqGap.V2()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextLinkInteractionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextLinkInteractionUiTest.kt
@@ -1,0 +1,143 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.di.presentationTestModule
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class NoteTextLinkInteractionUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { stopKoin() }
+    }
+
+    private fun webLinkTestModules(
+        settings: SettingsServiceFacade,
+        mainPresenter: MainPresenter,
+    ) = module {
+        single<SettingsServiceFacade> { settings }
+        single<MainPresenter> { mainPresenter }
+    }
+
+    @Test
+    fun `when uri link clicked without confirmation then opens uri`() {
+        val settings = WebLinkDialogSettingsServiceFake(initialShowWebLinkConfirmation = true)
+        val mainPresenter = mockk<MainPresenter>(relaxed = true)
+        every { mainPresenter.navigateToUrl(any()) } returns true
+        startKoin {
+            modules(
+                webLinkTestModules(settings, mainPresenter),
+                module {
+                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+
+        val handler = CapturingUriHandler()
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides handler) {
+                BisqTheme {
+                    NoteText(
+                        notes = "Read docs",
+                        linkText = "Open link",
+                        uri = "https://example.com/note-direct",
+                        openConfirmation = false,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Open link", substring = true).performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(listOf("https://example.com/note-direct"), handler.openedUris)
+    }
+
+    @Test
+    fun `when uri link clicked with confirmation then presenter navigates to url`() {
+        val settings = WebLinkDialogSettingsServiceFake(initialShowWebLinkConfirmation = true)
+        val mainPresenter = mockk<MainPresenter>(relaxed = true)
+        every { mainPresenter.navigateToUrl(any()) } returns true
+
+        val presenterSpy =
+            spyk(WebLinkConfirmationDialogPresenter(settings, mainPresenter))
+
+        startKoin {
+            modules(
+                webLinkTestModules(settings, mainPresenter),
+                module {
+                    single<WebLinkConfirmationDialogPresenter> { presenterSpy }
+                },
+                presentationTestModule,
+            )
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides NoopUriHandler()) {
+                BisqTheme {
+                    NoteText(
+                        notes = "Read docs",
+                        linkText = "Open link",
+                        uri = "https://example.com/note-confirm",
+                        openConfirmation = true,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Open link", substring = true).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) {
+            presenterSpy.navigateToUrl("https://example.com/note-confirm")
+        }
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class NoopUriHandler : UriHandler {
+        override fun openUri(uri: String) {}
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUiSmokeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUiSmokeTest.kt
@@ -1,0 +1,41 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NoteTextUiSmokeTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renders note text with link`() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides NoopUriHandler()) {
+                BisqTheme {
+                    NoteText(
+                        notes = "Read docs",
+                        linkText = "Open link",
+                        uri = "https://example.com",
+                        openConfirmation = false,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Read docs Open link").assertIsDisplayed()
+    }
+
+    private class NoopUriHandler : UriHandler {
+        override fun openUri(uri: String) {}
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUriOpenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUriOpenTest.kt
@@ -1,0 +1,48 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms
+
+import androidx.compose.ui.platform.UriHandler
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NoteTextUriOpenTest {
+    @Test
+    fun `openNoteTextUri returns true on success`() {
+        val handler = CapturingUriHandler()
+
+        val result = openNoteTextUri(handler, "https://example.com", null)
+
+        assertTrue(result)
+        assertEquals(listOf("https://example.com"), handler.openedUris)
+    }
+
+    @Test
+    fun `openNoteTextUri returns false and forwards error`() {
+        val handler = ThrowingUriHandler()
+        val errors = mutableListOf<Throwable>()
+
+        val result =
+            openNoteTextUri(
+                uriHandler = handler,
+                uri = "https://example.com/fail",
+                onError = { throwable -> errors += throwable },
+            )
+
+        assertFalse(result)
+        assertEquals(1, errors.size)
+        assertEquals("forced openUri failure", errors.first().message)
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class ThrowingUriHandler : UriHandler {
+        override fun openUri(uri: String): Unit = throw RuntimeException("forced openUri failure")
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
@@ -35,6 +36,7 @@ import kotlin.test.assertTrue
 class LinkButtonUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+    private lateinit var mainPresenter: MainPresenter
 
     private val dialogTitle get() = "hyperlinks.openInBrowser.attention.headline".i18n()
 
@@ -44,14 +46,19 @@ class LinkButtonUiTest {
         initKoin(showWebLinkConfirmation = true)
     }
 
-    private fun initKoin(showWebLinkConfirmation: Boolean) {
+    private fun initKoin(
+        showWebLinkConfirmation: Boolean,
+        openUrlResult: Boolean = true,
+    ) {
         runCatching { stopKoin() }
+        mainPresenter = mockk(relaxed = true)
+        every { mainPresenter.navigateToUrl(any()) } returns openUrlResult
         val settingsFacade =
             WebLinkDialogSettingsServiceFake(initialShowWebLinkConfirmation = showWebLinkConfirmation)
         startKoin {
             modules(
                 module {
-                    single<MainPresenter> { mockk(relaxed = true) }
+                    single<MainPresenter> { mainPresenter }
                     single<SettingsServiceFacade> { settingsFacade }
                     factory { WebLinkConfirmationDialogPresenter(get(), get()) }
                 },
@@ -170,11 +177,27 @@ class LinkButtonUiTest {
     }
 
     @Test
-    fun `when dialog confirm clicked then opens uri and invokes onClick`() {
-        val capturingUriHandler = CapturingUriHandler()
+    fun `when openConfirmation false and link is blank then invokes onClick without opening uri`() {
         val onClick = mockk<() -> Unit>(relaxed = true)
         setLinkButton(
-            uriHandler = capturingUriHandler,
+            uriHandler = ThrowingUriHandler(),
+            link = "   ",
+            onClick = onClick,
+            openConfirmation = false,
+        )
+
+        composeTestRule.onNodeWithText("Open docs").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) { onClick() }
+        assertNoNodeWithText(dialogTitle)
+    }
+
+    @Test
+    fun `when dialog confirm clicked then opens uri and invokes onClick`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setLinkButton(
+            uriHandler = NoopUriHandler(),
             link = "https://example.com/confirm",
             onClick = onClick,
         )
@@ -185,7 +208,7 @@ class LinkButtonUiTest {
         composeTestRule.waitForIdle()
 
         verify(exactly = 1) { onClick() }
-        assertEquals(listOf("https://example.com/confirm"), capturingUriHandler.openedUris)
+        verify(exactly = 1) { mainPresenter.navigateToUrl("https://example.com/confirm") }
         assertNoNodeWithText(dialogTitle)
     }
 
@@ -225,10 +248,11 @@ class LinkButtonUiTest {
 
     @Test
     fun `when uri open fails then invokes onError and closes dialog without invoking onClick`() {
+        initKoin(showWebLinkConfirmation = true, openUrlResult = false)
         val onClick = mockk<() -> Unit>(relaxed = true)
         val onError = mockk<(Throwable) -> Unit>(relaxed = true)
         setLinkButton(
-            uriHandler = ThrowingUriHandler(),
+            uriHandler = NoopUriHandler(),
             link = "https://example.com/fail",
             onClick = onClick,
             onError = onError,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
@@ -19,6 +19,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.di.presentationTestModule
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.main.MainPresenter
 import org.junit.After
@@ -247,7 +248,7 @@ class LinkButtonUiTest {
     }
 
     @Test
-    fun `when uri open fails then invokes onError and closes dialog without invoking onClick`() {
+    fun `when uri open fails then shows snackbar via main presenter and closes dialog without invoking onClick or composable onError`() {
         initKoin(showWebLinkConfirmation = true, openUrlResult = false)
         val onClick = mockk<() -> Unit>(relaxed = true)
         val onError = mockk<(Throwable) -> Unit>(relaxed = true)
@@ -263,7 +264,8 @@ class LinkButtonUiTest {
         composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
         composeTestRule.waitForIdle()
 
-        verify(exactly = 1) { onError(any()) }
+        verify(exactly = 0) { onError(any()) }
+        verify(exactly = 1) { mainPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) }
         verify(exactly = 0) { onClick() }
         assertNoNodeWithText(dialogTitle)
     }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUriOpenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUriOpenTest.kt
@@ -1,0 +1,48 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms.button
+
+import androidx.compose.ui.platform.UriHandler
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LinkButtonUriOpenTest {
+    @Test
+    fun `tryOpenLinkWithoutConfirmation returns true on success`() {
+        val handler = CapturingUriHandler()
+
+        val result = tryOpenLinkWithoutConfirmation(handler, "https://example.com", null)
+
+        assertTrue(result)
+        assertEquals(listOf("https://example.com"), handler.openedUris)
+    }
+
+    @Test
+    fun `tryOpenLinkWithoutConfirmation returns false and forwards error`() {
+        val handler = ThrowingUriHandler()
+        val errors = mutableListOf<Throwable>()
+
+        val result =
+            tryOpenLinkWithoutConfirmation(
+                uriHandler = handler,
+                link = "https://example.com/fail",
+                onError = { throwable -> errors += throwable },
+            )
+
+        assertFalse(result)
+        assertEquals(1, errors.size)
+        assertEquals("forced openUri failure", errors.first().message)
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class ThrowingUriHandler : UriHandler {
+        override fun openUri(uri: String): Unit = throw RuntimeException("forced openUri failure")
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogTestSupport.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogTestSupport.kt
@@ -78,6 +78,7 @@ internal fun startKoinWithWebLinkDeps(
     permitOpeningBrowser: Boolean = true,
     setPermitResult: Result<Unit> = Result.success(Unit),
     setDontShowAgainResult: Result<Unit> = Result.success(Unit),
+    openUrlResult: Boolean = true,
 ): Pair<SettingsServiceFacade, MainPresenter> {
     runCatching { stopKoin() }
     val showFlow = MutableStateFlow(showWebLinkConfirmation)
@@ -89,6 +90,7 @@ internal fun startKoinWithWebLinkDeps(
     coEvery { facade.setPermitOpeningBrowser(false) } returns setPermitResult
     coEvery { facade.setWebLinkDontShowAgain() } returns setDontShowAgainResult
     val presenter = mockk<MainPresenter>(relaxed = true)
+    every { presenter.navigateToUrl(any()) } returns openUrlResult
     startKoin {
         modules(
             module {
@@ -106,9 +108,11 @@ internal fun startKoinWithWebLinkDeps(
 
 internal fun startKoinWithWebLinkDialogFake(
     fake: WebLinkDialogSettingsServiceFake = WebLinkDialogSettingsServiceFake(),
+    openUrlResult: Boolean = true,
 ): Pair<WebLinkDialogSettingsServiceFake, MainPresenter> {
     runCatching { stopKoin() }
     val presenter = mockk<MainPresenter>(relaxed = true)
+    every { presenter.navigateToUrl(any()) } returns openUrlResult
     startKoin {
         modules(
             module {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -14,16 +14,24 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.di.presentationTestModule
+import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
+import network.bisq.mobile.presentation.main.MainPresenter
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 import kotlin.test.assertEquals
 
 /**
@@ -564,6 +572,14 @@ class WebLinkDialogUiKoinTest {
         verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onError() }
         verify(exactly = 0) { onConfirm() }
+        verify(exactly = 1) {
+            presenter.showSnackbar(
+                "mobile.error.generic".i18n(),
+                SnackbarType.ERROR,
+                SnackbarPosition.BOTTOM,
+                SnackbarDuration.Short,
+            )
+        }
     }
 
     /**
@@ -702,4 +718,50 @@ class WebLinkDialogUiKoinTest {
         }
         composeTestRule.assertNoNodeWithText(headline)
     }
+
+    @Test
+    fun `when confirm clicked while presenter non interactive then skips navigation`() {
+        runCatching { stopKoin() }
+        val fake = WebLinkDialogSettingsServiceFake()
+        val mainPresenter = mockk<MainPresenter>(relaxed = true)
+        every { mainPresenter.navigateToUrl(any()) } returns false
+        startKoin {
+            modules(
+                module {
+                    single<SettingsServiceFacade> { fake }
+                    single<MainPresenter> { mainPresenter }
+                    single { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+        val dialogPresenter =
+            GlobalContext.get().get<WebLinkConfirmationDialogPresenter>()
+        val link = "https://example.com/noninteractive-guard"
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
+            WebLinkConfirmationDialog(
+                link = link,
+                onConfirm = {},
+                onDismiss = {},
+                onError = {},
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        dialogPresenter.setInteractiveFlagForTest(false)
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 0) { mainPresenter.navigateToUrl(any()) }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun BasePresenter.setInteractiveFlagForTest(value: Boolean) {
+    val field =
+        BasePresenter::class.java.getDeclaredField("_isInteractive").apply {
+            isAccessible = true
+        }
+    val flow = field.get(this) as MutableStateFlow<Boolean>
+    flow.value = value
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -65,15 +65,15 @@ class WebLinkDialogUiKoinTest {
     fun `when web link confirmation suppressed and browser permitted then opens uri invokes onConfirm without showing dialog`() {
         // Given
         val link = "https://example.com/auto"
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
-        startKoinWithWebLinkDeps(
-            showWebLinkConfirmation = false,
-            permitOpeningBrowser = true,
-        )
+        val (_, presenter) =
+            startKoinWithWebLinkDeps(
+                showWebLinkConfirmation = false,
+                permitOpeningBrowser = true,
+            )
 
         // When
-        setTestContent(uriHandler) {
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = onConfirm,
@@ -86,8 +86,42 @@ class WebLinkDialogUiKoinTest {
 
         // Then
         composeTestRule.waitForIdle()
-        assertEquals(listOf(link), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onConfirm() }
+        composeTestRule.assertNoNodeWithText("Should not appear")
+    }
+
+    @Test
+    fun `when web link confirmation suppressed and browser permitted but launcher fails then invokes onError and does not invoke onConfirm`() {
+        // Given
+        val link = "https://example.com/auto-fail"
+        val onConfirm = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<() -> Unit>(relaxed = true)
+        val (_, presenter) =
+            startKoinWithWebLinkDeps(
+                showWebLinkConfirmation = false,
+                permitOpeningBrowser = true,
+                openUrlResult = false,
+            )
+
+        // When
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
+            WebLinkConfirmationDialog(
+                link = link,
+                onConfirm = onConfirm,
+                onDismiss = {},
+                onError = onError,
+                headline = "Should not appear",
+                confirmButtonText = "Yes",
+                dismissButtonText = "No",
+            )
+        }
+
+        // Then
+        composeTestRule.waitForIdle()
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
+        verify(exactly = 1) { onError() }
+        verify(exactly = 0) { onConfirm() }
         composeTestRule.assertNoNodeWithText("Should not appear")
     }
 
@@ -343,12 +377,11 @@ class WebLinkDialogUiKoinTest {
     fun `when confirm clicked then persists browser permitted true, opens uri, does not set dont show again and invokes onConfirm`() {
         // Given
         val link = "https://example.com/yes"
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
-        val (facade, _) = startKoinWithWebLinkDeps()
+        val (facade, presenter) = startKoinWithWebLinkDeps()
 
         // When
-        setTestContent(uriHandler) {
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = onConfirm,
@@ -369,7 +402,7 @@ class WebLinkDialogUiKoinTest {
         // Then
         coVerify(exactly = 1) { facade.setPermitOpeningBrowser(true) }
         coVerify(exactly = 0) { facade.setWebLinkDontShowAgain() }
-        assertEquals(listOf(link), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onConfirm() }
     }
 
@@ -377,12 +410,11 @@ class WebLinkDialogUiKoinTest {
     fun `when confirm clicked with dont show again checked then persists browser permitted, persists dont show flag, opens uri and invokes onConfirm`() {
         // Given
         val link = "https://example.com/yes-dsa"
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
-        val (facade, _) = startKoinWithWebLinkDeps()
+        val (facade, presenter) = startKoinWithWebLinkDeps()
 
         // When
-        setTestContent(uriHandler) {
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = onConfirm,
@@ -404,7 +436,7 @@ class WebLinkDialogUiKoinTest {
         // Then
         coVerify(exactly = 1) { facade.setPermitOpeningBrowser(true) }
         coVerify(exactly = 1) { facade.setWebLinkDontShowAgain() }
-        assertEquals(listOf(link), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onConfirm() }
     }
 
@@ -412,7 +444,6 @@ class WebLinkDialogUiKoinTest {
     fun `when set permit opening browser fails on confirm then shows error snackbar still, opens uri and invokes onConfirm`() {
         // Given
         val link = "https://example.com/fail-confirm"
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
         val (facade, presenter) =
             startKoinWithWebLinkDeps(
@@ -420,7 +451,7 @@ class WebLinkDialogUiKoinTest {
             )
 
         // When
-        setTestContent(uriHandler) {
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = onConfirm,
@@ -448,7 +479,7 @@ class WebLinkDialogUiKoinTest {
                 SnackbarDuration.Short,
             )
         }
-        assertEquals(listOf(link), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onConfirm() }
     }
 
@@ -456,7 +487,6 @@ class WebLinkDialogUiKoinTest {
     fun `when set dont show again fails on confirm with dont show checked then shows error snackbar, opens uri and invokes onConfirm`() {
         // Given
         val link = "https://example.com/fail-confirm-dsa"
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
         val (facade, presenter) =
             startKoinWithWebLinkDeps(
@@ -464,7 +494,7 @@ class WebLinkDialogUiKoinTest {
             )
 
         // When
-        setTestContent(uriHandler) {
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = onConfirm,
@@ -494,8 +524,46 @@ class WebLinkDialogUiKoinTest {
                 SnackbarDuration.Short,
             )
         }
-        assertEquals(listOf(link), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onConfirm() }
+    }
+
+    @Test
+    fun `when confirm clicked and launcher fails then invokes onError shows error snackbar and does not invoke onConfirm`() {
+        // Given
+        val link = "https://example.com/yes-fail-open"
+        val onConfirm = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<() -> Unit>(relaxed = true)
+        val (facade, presenter) =
+            startKoinWithWebLinkDeps(
+                openUrlResult = false,
+            )
+
+        // When
+        setTestContent(WebLinkDialogTestFixtures.noopUriHandler) {
+            WebLinkConfirmationDialog(
+                link = link,
+                onConfirm = onConfirm,
+                onDismiss = {},
+                onError = onError,
+                headline = "Headline",
+                headlineLeftIcon = null,
+                message = "Message",
+                confirmButtonText = "Yes",
+                dismissButtonText = "No",
+            )
+        }
+
+        // Action
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        coVerify(exactly = 1) { facade.setPermitOpeningBrowser(true) }
+        verify(exactly = 1) { presenter.navigateToUrl(link) }
+        verify(exactly = 1) { onError() }
+        verify(exactly = 0) { onConfirm() }
     }
 
     /**
@@ -515,14 +583,13 @@ class WebLinkDialogUiKoinTest {
         val confirmButtonText = "Yes"
         val dismissButtonText = "No"
         val fake = WebLinkDialogSettingsServiceFake()
-        val uriHandler = WebLinkDialogCapturingUriHandler()
         val onConfirm = mockk<() -> Unit>(relaxed = true)
-        startKoinWithWebLinkDialogFake(fake)
+        val (_, presenter) = startKoinWithWebLinkDialogFake(fake)
 
         // One setContent per test (Compose rule); drive second navigation by changing link state.
         val linkState = mutableStateOf(link1)
         composeTestRule.setContent {
-            KoinTestHost(uriHandler) {
+            KoinTestHost(WebLinkDialogTestFixtures.noopUriHandler) {
                 key(linkState.value) {
                     WebLinkConfirmationDialog(
                         link = linkState.value,
@@ -547,7 +614,7 @@ class WebLinkDialogUiKoinTest {
         // Then — persisted state matches production semantics
         assertEquals(false, fake.showWebLinkConfirmation.value)
         assertEquals(true, fake.permitOpeningBrowser.value)
-        assertEquals(listOf(link1), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link1) }
         verify(exactly = 1) { onConfirm() }
 
         // When — second link: suppressed confirmation, auto-open
@@ -555,7 +622,7 @@ class WebLinkDialogUiKoinTest {
         composeTestRule.waitForIdle()
 
         // Then
-        assertEquals(listOf(link1, link2), uriHandler.openedUris)
+        verify(exactly = 1) { presenter.navigateToUrl(link2) }
         verify(exactly = 2) { onConfirm() }
         composeTestRule.assertNoNodeWithText(headline)
     }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -130,6 +130,14 @@ class WebLinkDialogUiKoinTest {
         verify(exactly = 1) { presenter.navigateToUrl(link) }
         verify(exactly = 1) { onError() }
         verify(exactly = 0) { onConfirm() }
+        verify(exactly = 1) {
+            presenter.showSnackbar(
+                "mobile.error.cannotOpenUrl".i18n(),
+                SnackbarType.ERROR,
+                SnackbarPosition.BOTTOM,
+                SnackbarDuration.Short,
+            )
+        }
         composeTestRule.assertNoNodeWithText("Should not appear")
     }
 
@@ -574,7 +582,7 @@ class WebLinkDialogUiKoinTest {
         verify(exactly = 0) { onConfirm() }
         verify(exactly = 1) {
             presenter.showSnackbar(
-                "mobile.error.generic".i18n(),
+                "mobile.error.cannotOpenUrl".i18n(),
                 SnackbarType.ERROR,
                 SnackbarPosition.BOTTOM,
                 SnackbarDuration.Short,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtilsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtilsTest.kt
@@ -1,0 +1,59 @@
+package network.bisq.mobile.presentation.common.ui.utils
+
+import androidx.compose.ui.platform.UriHandler
+import kotlinx.coroutines.CancellationException
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class UriHandlerUtilsTest {
+    @Test
+    fun `openUriSafely returns true when open succeeds`() {
+        val handler = CapturingUriHandler()
+
+        val result = handler.openUriSafely("https://example.com")
+
+        assertTrue(result)
+        assertEquals(listOf("https://example.com"), handler.openedUris)
+    }
+
+    @Test
+    fun `openUriSafely returns false and does not throw for regular failures`() {
+        val errors = mutableListOf<Throwable>()
+        val handler = ThrowingUriHandler(RuntimeException("forced"))
+
+        val result = handler.openUriSafely("https://example.com") { throwable -> errors += throwable }
+
+        assertFalse(result)
+        assertEquals(1, errors.size)
+        assertEquals("forced", errors.first().message)
+    }
+
+    @Test
+    fun `openUriSafely rethrows cancellation exception`() {
+        val handler = ThrowingUriHandler(CancellationException("cancelled"))
+
+        try {
+            handler.openUriSafely("https://example.com")
+            fail("Expected CancellationException")
+        } catch (e: CancellationException) {
+            assertEquals("cancelled", e.message)
+        }
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class ThrowingUriHandler(
+        private val throwable: Throwable,
+    ) : UriHandler {
+        override fun openUri(uri: String): Unit = throw throwable
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialogUriOpenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialogUriOpenTest.kt
@@ -27,6 +27,18 @@ class PaymentMethodBackgroundInformationDialogUriOpenTest {
     }
 
     @Test
+    fun `openPaymentMethodBackgroundInfoUri invokes onError when open fails`() {
+        val handler = ThrowingUriHandler()
+        var invocations = 0
+
+        val result =
+            openPaymentMethodBackgroundInfoUri(handler, "https://example.com/fail", onError = { invocations++ })
+
+        assertFalse(result)
+        assertEquals(1, invocations)
+    }
+
+    @Test
     fun `paymentMethodBackgroundHyperlinkInteraction delegates to openPaymentMethodBackgroundInfoUri`() {
         val handler = CapturingUriHandler()
 
@@ -34,6 +46,22 @@ class PaymentMethodBackgroundInformationDialogUriOpenTest {
 
         assertTrue(result)
         assertEquals(listOf("https://example.com/delegate"), handler.openedUris)
+    }
+
+    @Test
+    fun `paymentMethodBackgroundHyperlinkInteraction forwards onError to openPaymentMethodBackgroundInfoUri`() {
+        val handler = ThrowingUriHandler()
+        var invocations = 0
+
+        val result =
+            paymentMethodBackgroundHyperlinkInteraction(
+                handler,
+                "https://example.com/fail",
+                onError = { invocations++ },
+            )
+
+        assertFalse(result)
+        assertEquals(1, invocations)
     }
 
     private class CapturingUriHandler : UriHandler {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialogUriOpenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialogUriOpenTest.kt
@@ -1,0 +1,50 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.ui
+
+import androidx.compose.ui.platform.UriHandler
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PaymentMethodBackgroundInformationDialogUriOpenTest {
+    @Test
+    fun `openPaymentMethodBackgroundInfoUri returns true on success`() {
+        val handler = CapturingUriHandler()
+
+        val result = openPaymentMethodBackgroundInfoUri(handler, "https://example.com")
+
+        assertTrue(result)
+        assertEquals(listOf("https://example.com"), handler.openedUris)
+    }
+
+    @Test
+    fun `openPaymentMethodBackgroundInfoUri returns false on failure`() {
+        val handler = ThrowingUriHandler()
+
+        val result = openPaymentMethodBackgroundInfoUri(handler, "https://example.com/fail")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `paymentMethodBackgroundHyperlinkInteraction delegates to openPaymentMethodBackgroundInfoUri`() {
+        val handler = CapturingUriHandler()
+
+        val result = paymentMethodBackgroundHyperlinkInteraction(handler, "https://example.com/delegate")
+
+        assertTrue(result)
+        assertEquals(listOf("https://example.com/delegate"), handler.openedUris)
+    }
+
+    private class CapturingUriHandler : UriHandler {
+        val openedUris = mutableListOf<String>()
+
+        override fun openUri(uri: String) {
+            openedUris += uri
+        }
+    }
+
+    private class ThrowingUriHandler : UriHandler {
+        override fun openUri(uri: String): Unit = throw RuntimeException("forced openUri failure")
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
@@ -45,23 +47,14 @@ class ReputationWebLinkDialogUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private lateinit var uriHandler: TestUriHandler
+    private lateinit var uriHandler: NoopUriHandler
+    private lateinit var mainPresenter: MainPresenter
 
     @Before
     fun setup() {
         I18nSupport.setLanguage()
-        uriHandler = TestUriHandler()
-
-        startKoin {
-            modules(
-                module {
-                    single<MainPresenter> { mockk(relaxed = true) }
-                    single<SettingsServiceFacade> { WebLinkDialogSettingsServiceFake() }
-                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
-                },
-                presentationTestModule,
-            )
-        }
+        uriHandler = NoopUriHandler()
+        initKoin(openUrlResult = true)
     }
 
     @After
@@ -95,12 +88,12 @@ class ReputationWebLinkDialogUiTest {
         composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
         composeTestRule.waitForIdle()
         assertNoDialog()
-        assertEquals(listOf("https://example.com/confirm"), uriHandler.openedUris)
+        verify(exactly = 1) { mainPresenter.navigateToUrl("https://example.com/confirm") }
     }
 
     @Test
     fun `error callback clears selected link and closes dialog when uri open fails`() {
-        uriHandler.shouldThrow = true
+        initKoin(openUrlResult = false)
         var selectedWebLink by mutableStateOf<String?>(null)
         var errorFlag = false
         var clearedFlag = false
@@ -125,7 +118,7 @@ class ReputationWebLinkDialogUiTest {
         assertNoDialog()
         assertTrue(errorFlag)
         assertFalse(clearedFlag)
-        assertTrue(uriHandler.failureTriggered)
+        verify(exactly = 1) { mainPresenter.navigateToUrl("https://example.com/error") }
     }
 
     private val dialogTitle get() = "hyperlinks.openInBrowser.attention.headline".i18n()
@@ -151,6 +144,22 @@ class ReputationWebLinkDialogUiTest {
         }
     }
 
+    private fun initKoin(openUrlResult: Boolean) {
+        runCatching { stopKoin() }
+        mainPresenter = mockk(relaxed = true)
+        every { mainPresenter.navigateToUrl(any()) } returns openUrlResult
+        startKoin {
+            modules(
+                module {
+                    single<MainPresenter> { mainPresenter }
+                    single<SettingsServiceFacade> { WebLinkDialogSettingsServiceFake() }
+                    factory { WebLinkConfirmationDialogPresenter(get(), get()) }
+                },
+                presentationTestModule,
+            )
+        }
+    }
+
     private fun assertNoDialog() {
         val nodes =
             composeTestRule
@@ -159,17 +168,7 @@ class ReputationWebLinkDialogUiTest {
         assertTrue(nodes.isEmpty(), "Expected dialog to be dismissed")
     }
 
-    private class TestUriHandler : UriHandler {
-        var shouldThrow = false
-        var failureTriggered = false
-        val openedUris = mutableListOf<String>()
-
-        override fun openUri(uri: String) {
-            if (shouldThrow) {
-                failureTriggered = true
-                throw RuntimeException("forced failure")
-            }
-            openedUris += uri
-        }
+    private class NoopUriHandler : UriHandler {
+        override fun openUri(uri: String) {}
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
@@ -74,6 +74,7 @@ class ReputationWebLinkDialogUiTest {
         composeTestRule.onNodeWithContentDescription("dialog_confirm_no").performClick()
         composeTestRule.waitForIdle()
         assertNoDialog()
+        verify(exactly = 0) { mainPresenter.navigateToUrl(any()) }
     }
 
     @Test
@@ -169,6 +170,6 @@ class ReputationWebLinkDialogUiTest {
     }
 
     private class NoopUriHandler : UriHandler {
-        override fun openUri(uri: String) {}
+        override fun openUri(uri: String) = Unit
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -20,6 +21,7 @@ import androidx.compose.ui.text.withLink
 import kotlinx.coroutines.launch
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.openUriSafely
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
 
 // Pass either uri or onLinkClick. Not both
@@ -31,6 +33,7 @@ fun NoteText(
     textAlign: TextAlign = TextAlign.Start,
     openConfirmation: Boolean = false,
     onLinkClick: (() -> Unit)? = null,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
     val clipboard = LocalClipboard.current
@@ -59,7 +62,7 @@ fun NoteText(
                             if (openConfirmation) {
                                 showConfirmDialog = true
                             } else {
-                                uriHandler.openUri(uri)
+                                openNoteTextUri(uriHandler, uri, onError)
                             }
                         },
                     ),
@@ -132,8 +135,6 @@ fun NoteText(
             onConfirm = {
                 if (onLinkClick != null) {
                     onLinkClick()
-                } else if (uri != null) {
-                    uriHandler.openUri(uri)
                 }
                 showConfirmDialog = false
             },
@@ -146,3 +147,9 @@ fun NoteText(
         )
     }
 }
+
+internal fun openNoteTextUri(
+    uriHandler: UriHandler,
+    uri: String,
+    onError: ((Throwable) -> Unit)?,
+): Boolean = uriHandler.openUriSafely(uri) { throwable -> onError?.invoke(throwable) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
@@ -9,12 +9,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
-import kotlinx.coroutines.CancellationException
+import androidx.compose.ui.platform.UriHandler
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.openUriSafely
 
 @Composable
 fun LinkButton(
@@ -49,12 +50,8 @@ fun LinkButton(
                     onClick?.invoke()
                     return@BisqButton
                 }
-                try {
-                    uriHandler.openUri(link)
+                if (tryOpenLinkWithoutConfirmation(uriHandler, link, onError)) {
                     onClick?.invoke()
-                } catch (t: Throwable) {
-                    if (t is CancellationException) throw t
-                    onError?.invoke(t)
                 }
             }
         },
@@ -81,3 +78,9 @@ fun LinkButton(
         )
     }
 }
+
+internal fun tryOpenLinkWithoutConfirmation(
+    uriHandler: UriHandler,
+    link: String,
+    onError: ((Throwable) -> Unit)?,
+): Boolean = uriHandler.openUriSafely(uri = link) { throwable -> onError?.invoke(throwable) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButton.kt
@@ -17,6 +17,8 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.openUriSafely
 
+// TODO: Centralize URL-open logic via UrlLauncher and eliminate LocalUriHandler,
+// So the behavior can be customized per OS and exceptions handled in a single place.
 @Composable
 fun LinkButton(
     text: String,
@@ -73,7 +75,6 @@ fun LinkButton(
             },
             onError = {
                 showConfirmDialog = false
-                onError?.invoke(RuntimeException("Web link confirmation failed"))
             },
         )
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqCheckbox
@@ -31,12 +30,10 @@ fun WebLinkConfirmationDialog(
 ) {
     val presenter: WebLinkConfirmationDialogPresenter = koinInject()
     val clipboard = LocalClipboard.current
-    val uriHandler = LocalUriHandler.current
 
     RememberPresenterLifecycle(presenter, {
         presenter.initialize(
             link = link,
-            uriHandler = uriHandler,
             clipboard = clipboard,
             onConfirm = onConfirm,
             onDismiss = onDismiss,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
 
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.CancellationException
@@ -11,6 +12,7 @@ import kotlinx.coroutines.launch
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
+import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -88,7 +90,13 @@ class WebLinkConfirmationDialogPresenter(
                         dontShowAgain = _uiState.value.dontShowAgain,
                     )
                 }
+                // navigateToUrl returns false when already non-interactive (anti double-tap)
+                // before attempting to open; snapshot before call to tell that apart from a real failure.
+                val interactiveBeforeOpen = isInteractive.value
                 if (!navigateToUrl(uri)) {
+                    if (!interactiveBeforeOpen) {
+                        return@launch
+                    }
                     throw IllegalStateException("Failed to open URI")
                 }
                 userOnConfirm.invoke()
@@ -97,7 +105,7 @@ class WebLinkConfirmationDialogPresenter(
             } catch (throwable: Throwable) {
                 log.e(throwable) { "Failed to open URI from web link confirmation dialog" }
                 userOnError.invoke()
-                showSnackbar("mobile.error.generic".i18n(), type = SnackbarType.ERROR)
+                mainPresenter.showSnackbar("mobile.error.generic".i18n(), SnackbarType.ERROR)
             } finally {
                 if (persist) hideLoading()
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
 
 import androidx.compose.ui.platform.Clipboard
-import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,13 +25,11 @@ class WebLinkConfirmationDialogPresenter(
     private var userOnConfirm: () -> Unit = {}
     private var userOnDismiss: () -> Unit = {}
     private var userOnError: () -> Unit = {}
-    private var currentUriHandler: UriHandler? = null
     private var currentClipboard: Clipboard? = null
     private var activeLink: String = ""
 
     fun initialize(
         link: String,
-        uriHandler: UriHandler,
         clipboard: Clipboard,
         onConfirm: () -> Unit,
         onDismiss: () -> Unit,
@@ -43,7 +40,6 @@ class WebLinkConfirmationDialogPresenter(
         userOnConfirm = onConfirm
         userOnDismiss = onDismiss
         userOnError = onError
-        currentUriHandler = uriHandler
         currentClipboard = clipboard
 
         _uiState.value = WebLinkConfirmationUiState()
@@ -92,7 +88,9 @@ class WebLinkConfirmationDialogPresenter(
                         dontShowAgain = _uiState.value.dontShowAgain,
                     )
                 }
-                currentUriHandler?.openUri(uri)
+                if (!navigateToUrl(uri)) {
+                    throw IllegalStateException("Failed to open URI")
+                }
                 userOnConfirm.invoke()
             } catch (cancellationException: CancellationException) {
                 throw cancellationException

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenter.kt
@@ -105,7 +105,7 @@ class WebLinkConfirmationDialogPresenter(
             } catch (throwable: Throwable) {
                 log.e(throwable) { "Failed to open URI from web link confirmation dialog" }
                 userOnError.invoke()
-                mainPresenter.showSnackbar("mobile.error.generic".i18n(), SnackbarType.ERROR)
+                mainPresenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR)
             } finally {
                 if (persist) hideLoading()
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
@@ -28,6 +28,7 @@ fun ReputationBasedSellerLimitsPopup(
     onRepLinkClick: () -> Unit,
     reputationScore: String,
     maxSellAmount: String,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     BisqDialog(
         horizontalAlignment = Alignment.Start,
@@ -49,6 +50,7 @@ fun ReputationBasedSellerLimitsPopup(
             padding = PaddingValues(horizontal = BisqUIConstants.ScreenPadding, vertical = 8.dp),
             fullWidth = true,
             onClick = onBuildRepLinkClick,
+            onError = onError,
         )
 
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/create_offer/ReputationBasedSellerLimitsPopup.kt
@@ -20,7 +20,9 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Bi
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
+@ExcludeFromCoverage
 @Composable
 fun ReputationBasedSellerLimitsPopup(
     onDismiss: () -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.CancellationException
  */
 fun UriHandler.openUriSafely(
     uri: String,
-    onError: (Throwable) -> Unit = {},
+    onError: (Throwable) -> Unit = { _ -> },
 ): Boolean =
     try {
         openUri(uri)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
@@ -3,6 +3,10 @@ package network.bisq.mobile.presentation.common.ui.utils
 import androidx.compose.ui.platform.UriHandler
 import kotlinx.coroutines.CancellationException
 
+// TODO: Centralize URL-open logic via UrlLauncher and eliminate LocalUriHandler,
+// So the behavior can be customized per OS and exceptions handled in a single place.
+// Ideally override LocalUriHandler so it wraps over UrlLauncher
+
 /**
  * Opens a URI and prevents platform-specific launcher failures (for example SecurityException
  * on Android) from crashing the composable tree.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/UriHandlerUtils.kt
@@ -1,0 +1,24 @@
+package network.bisq.mobile.presentation.common.ui.utils
+
+import androidx.compose.ui.platform.UriHandler
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Opens a URI and prevents platform-specific launcher failures (for example SecurityException
+ * on Android) from crashing the composable tree.
+ *
+ * @return true when the URI was opened, false when opening failed.
+ */
+fun UriHandler.openUriSafely(
+    uri: String,
+    onError: (Throwable) -> Unit = {},
+): Boolean =
+    try {
+        openUri(uri)
+        true
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
+    } catch (e: Exception) {
+        onError(e)
+        false
+    }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/zelle/ZelleFormContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/zelle/ZelleFormContent.kt
@@ -16,11 +16,14 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqTextFieldV0
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.ZelleFormUiAction
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.ui.PaymentMethodBackgroundInformationDialog
 
+@ExcludeFromCoverage
 @Composable
 fun ZellePaymentAccountFormContent(
     presenter: ZelleFormPresenter,
@@ -42,14 +45,19 @@ fun ZellePaymentAccountFormContent(
         uiState = uiState,
         modifier = modifier,
         onAction = presenter::onAction,
+        onHyperlinkOpenError = {
+            presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR)
+        },
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun ZelleFormContent(
     uiState: ZelleFormUiState,
     onAction: (ZelleFormUiAction) -> Unit,
     modifier: Modifier = Modifier,
+    onHyperlinkOpenError: (() -> Unit)? = null,
 ) {
     val isInPreview = LocalInspectionMode.current
     val (showBackgroundInformationDialog, setShowBackgroundInformationDialog) =
@@ -88,6 +96,7 @@ private fun ZelleFormContent(
         PaymentMethodBackgroundInformationDialog(
             bodyText = "paymentAccounts.createAccount.accountData.backgroundOverlay.zelle".i18n(),
             onDismissRequest = { setShowBackgroundInformationDialog(false) },
+            onError = onHyperlinkOpenError,
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -29,6 +30,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.openUriSafely
 
 private val HyperlinkTokenRegex = Regex("\\[HYPERLINK:\\s*([^]]+)]")
 
@@ -102,7 +104,7 @@ private fun LinkifiedBodyText(bodyText: String) {
                                         ),
                                 ),
                             linkInteractionListener = {
-                                uriHandler.openUri(url)
+                                paymentMethodBackgroundHyperlinkInteraction(uriHandler, url)
                             },
                         ),
                     ) {
@@ -128,6 +130,16 @@ private fun LinkifiedBodyText(bodyText: String) {
             ),
     )
 }
+
+internal fun paymentMethodBackgroundHyperlinkInteraction(
+    uriHandler: UriHandler,
+    url: String,
+): Boolean = openPaymentMethodBackgroundInfoUri(uriHandler, url)
+
+internal fun openPaymentMethodBackgroundInfoUri(
+    uriHandler: UriHandler,
+    url: String,
+): Boolean = uriHandler.openUriSafely(url)
 
 @Preview
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/ui/PaymentMethodBackgroundInformationDialog.kt
@@ -30,14 +30,17 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.openUriSafely
 
 private val HyperlinkTokenRegex = Regex("\\[HYPERLINK:\\s*([^]]+)]")
 
+@ExcludeFromCoverage
 @Composable
 fun PaymentMethodBackgroundInformationDialog(
     bodyText: String,
     onDismissRequest: () -> Unit,
+    onError: (() -> Unit)? = null,
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,
@@ -58,7 +61,7 @@ fun PaymentMethodBackgroundInformationDialog(
                         .weight(1f, false)
                         .verticalScroll(rememberScrollState()),
             ) {
-                LinkifiedBodyText(bodyText)
+                LinkifiedBodyText(bodyText = bodyText, onError = onError)
             }
             BisqGap.V1()
             BisqButton(
@@ -71,8 +74,12 @@ fun PaymentMethodBackgroundInformationDialog(
     }
 }
 
+@ExcludeFromCoverage
 @Composable
-private fun LinkifiedBodyText(bodyText: String) {
+private fun LinkifiedBodyText(
+    bodyText: String,
+    onError: (() -> Unit)?,
+) {
     val uriHandler = LocalUriHandler.current
     val text =
         buildAnnotatedString {
@@ -104,7 +111,7 @@ private fun LinkifiedBodyText(bodyText: String) {
                                         ),
                                 ),
                             linkInteractionListener = {
-                                paymentMethodBackgroundHyperlinkInteraction(uriHandler, url)
+                                paymentMethodBackgroundHyperlinkInteraction(uriHandler, url, onError)
                             },
                         ),
                     ) {
@@ -134,12 +141,20 @@ private fun LinkifiedBodyText(bodyText: String) {
 internal fun paymentMethodBackgroundHyperlinkInteraction(
     uriHandler: UriHandler,
     url: String,
-): Boolean = openPaymentMethodBackgroundInfoUri(uriHandler, url)
+    onError: (() -> Unit)? = null,
+): Boolean = openPaymentMethodBackgroundInfoUri(uriHandler, url, onError)
 
 internal fun openPaymentMethodBackgroundInfoUri(
     uriHandler: UriHandler,
     url: String,
-): Boolean = uriHandler.openUriSafely(url)
+    onError: (() -> Unit)? = null,
+): Boolean {
+    val result = uriHandler.openUriSafely(url)
+    if (!result) {
+        onError?.invoke()
+    }
+    return result
+}
 
 @Preview
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.OrderedTextLi
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
@@ -66,6 +67,7 @@ fun TradeGuideProcess() {
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
@@ -13,9 +13,11 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun TradeGuideProcess() {
     val presenter: TradeGuideProcessPresenter = koinInject()
@@ -67,7 +69,7 @@ fun TradeGuideProcess() {
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
@@ -11,6 +11,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.OrderedTextLi
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
@@ -29,6 +30,7 @@ fun TradeGuideSecurity() {
         prevClick = presenter::prevClick,
         nextClick = presenter::securityNextClick,
         learnMoreClick = presenter::navigateSecurityLearnMore,
+        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
     )
 }
 
@@ -37,6 +39,7 @@ fun TradeGuideSecurity() {
     prevClick: () -> Unit,
     nextClick: () -> Unit,
     learnMoreClick: () -> Unit,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     val title = "bisqEasy.tradeGuide.tabs.headline".i18n() + ": " + "bisqEasy.tradeGuide.security".i18n()
 
@@ -71,6 +74,7 @@ fun TradeGuideSecurity() {
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = learnMoreClick,
+            onError = onError,
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
@@ -14,10 +14,12 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun TradeGuideSecurity() {
     val presenter: TradeGuideSecurityPresenter = koinInject()
@@ -29,16 +31,16 @@ fun TradeGuideSecurity() {
         isInteractive = isInteractive,
         prevClick = presenter::prevClick,
         nextClick = presenter::securityNextClick,
-        learnMoreClick = presenter::navigateSecurityLearnMore,
-        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+        onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
     )
 }
 
-@Composable fun TradeGuideSecurityContent(
+@ExcludeFromCoverage
+@Composable
+fun TradeGuideSecurityContent(
     isInteractive: Boolean,
     prevClick: () -> Unit,
     nextClick: () -> Unit,
-    learnMoreClick: () -> Unit,
     onError: ((Throwable) -> Unit)? = null,
 ) {
     val title = "bisqEasy.tradeGuide.tabs.headline".i18n() + ": " + "bisqEasy.tradeGuide.security".i18n()
@@ -73,7 +75,6 @@ fun TradeGuideSecurity() {
         LinkButton(
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
-            onClick = learnMoreClick,
             onError = onError,
         )
     }
@@ -88,7 +89,6 @@ private fun TradeGuideSecurityContentPreview(
             isInteractive = true,
             prevClick = {},
             nextClick = {},
-            learnMoreClick = {},
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurityPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurityPresenter.kt
@@ -15,8 +15,4 @@ class TradeGuideSecurityPresenter(
     fun securityNextClick() {
         navigateTo(NavRoute.TradeGuideProcess)
     }
-
-    fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
-    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
@@ -17,9 +17,11 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun TradeGuideTradeRules() {
     val presenter: TradeGuideTradeRulesPresenter = koinInject()
@@ -65,7 +67,7 @@ fun TradeGuideTradeRules() {
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
@@ -14,6 +14,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.OrderedTextLi
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
@@ -64,6 +65,7 @@ fun TradeGuideTradeRules() {
             "action.learnMore".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.navigateSecurityLearnMore() },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
@@ -14,9 +14,11 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkBu
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun WalletGuideDownload() {
     val presenter: WalletGuideDownloadPresenter = koinInject()
@@ -46,7 +48,7 @@ fun WalletGuideDownload() {
             "bisqEasy.walletGuide.download.link".i18n(),
             link = presenter.blueWalletLink,
             onClick = { presenter.navigateToBlueWallet() },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
@@ -45,6 +46,7 @@ fun WalletGuideDownload() {
             "bisqEasy.walletGuide.download.link".i18n(),
             link = presenter.blueWalletLink,
             onClick = { presenter.navigateToBlueWallet() },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
@@ -22,6 +22,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
@@ -64,12 +65,14 @@ fun WalletGuideReceiving() {
             "bisqEasy.walletGuide.receive.link1".i18n(),
             link = BisqLinks.BLUE_WALLET_TUTORIAL_1_URL,
             onClick = { presenter.navigateToBlueWalletTutorial1() },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link2".i18n(),
             link = BisqLinks.BLUE_WALLET_TUTORIAL_2_URL,
             onClick = { presenter.navigateToBlueWalletTutorial2() },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
@@ -24,9 +24,11 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun WalletGuideReceiving() {
     val presenter: WalletGuideReceivingPresenter = koinInject()
@@ -65,14 +67,14 @@ fun WalletGuideReceiving() {
             "bisqEasy.walletGuide.receive.link1".i18n(),
             link = BisqLinks.BLUE_WALLET_TUTORIAL_1_URL,
             onClick = { presenter.navigateToBlueWalletTutorial1() },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         LinkButton(
             "bisqEasy.walletGuide.receive.link2".i18n(),
             link = BisqLinks.BLUE_WALLET_TUTORIAL_2_URL,
             onClick = { presenter.navigateToBlueWalletTutorial2() },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
@@ -22,6 +22,7 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.components.molecules.ToggleTab
 import network.bisq.mobile.presentation.common.ui.components.molecules.amountSelector.BisqAmountSelector
 import network.bisq.mobile.presentation.common.ui.components.molecules.amountSelector.BisqRangeAmountSelector
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.components.organisms.create_offer.ReputationBasedBuyerLimitsPopup
 import network.bisq.mobile.presentation.common.ui.components.organisms.create_offer.ReputationBasedSellerLimitsPopup
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
@@ -99,6 +100,7 @@ fun CreateOfferAmountScreen() {
         setShowLimitPopup = presenter::setShowLimitPopup,
         onReputationLinkClick = presenter::navigateToReputation,
         onBuildReputationLinkClick = presenter::navigateToBuildReputation,
+        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
     )
 }
 
@@ -145,6 +147,7 @@ fun CreateOfferAmountContent(
     setShowLimitPopup: (Boolean) -> Unit,
     onReputationLinkClick: () -> Unit,
     onBuildReputationLinkClick: () -> Unit,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     val amountTypes = remember { AmountType.entries.toList() }
 
@@ -252,6 +255,7 @@ fun CreateOfferAmountContent(
                 maxSellAmount = reputationBasedMaxSellAmount,
                 onRepLinkClick = onReputationLinkClick,
                 onBuildRepLinkClick = onBuildReputationLinkClick,
+                onError = onError,
             )
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountScreen.kt
@@ -26,11 +26,13 @@ import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarT
 import network.bisq.mobile.presentation.common.ui.components.organisms.create_offer.ReputationBasedBuyerLimitsPopup
 import network.bisq.mobile.presentation.common.ui.components.organisms.create_offer.ReputationBasedSellerLimitsPopup
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator.AmountType
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun CreateOfferAmountScreen() {
     val presenter: CreateOfferAmountPresenter = koinInject()
@@ -100,10 +102,11 @@ fun CreateOfferAmountScreen() {
         setShowLimitPopup = presenter::setShowLimitPopup,
         onReputationLinkClick = presenter::navigateToReputation,
         onBuildReputationLinkClick = presenter::navigateToBuildReputation,
-        onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+        onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 fun CreateOfferAmountContent(
     isBuy: Boolean,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/resources/ResourcesScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/resources/ResourcesScreen.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
@@ -51,7 +52,10 @@ fun ResourcesScreen() {
         BisqHDivider(modifier = dividerModifier)
         BisqGap.V1()
 
-        WebResources(presenter::onAction)
+        WebResources(
+            onAction = presenter::onAction,
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+        )
 
         BisqHDivider(modifier = dividerModifier)
         BisqGap.V1()
@@ -66,7 +70,10 @@ fun ResourcesScreen() {
         BisqHDivider(modifier = dividerModifier)
         BisqGap.V1()
 
-        Legal(presenter::onAction)
+        Legal(
+            onAction = presenter::onAction,
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+        )
     }
 }
 
@@ -96,6 +103,7 @@ private fun Guides(
 @Composable
 private fun WebResources(
     onAction: (ResourcesUiAction) -> Unit,
+    onError: (Throwable) -> Unit,
 ) {
     BisqText.H3Light(
         "support.resources.resources.headline".i18n(),
@@ -105,21 +113,25 @@ private fun WebResources(
         "support.resources.resources.webpage".i18n(),
         link = BisqLinks.WEBPAGE,
         onClick = { onAction(ResourcesUiAction.OnNavigateToUrl(BisqLinks.WEBPAGE)) },
+        onError = onError,
     )
     ResourceWeblink(
         "support.resources.resources.dao".i18n(),
         link = BisqLinks.DAO,
         onClick = { onAction(ResourcesUiAction.OnNavigateToUrl(BisqLinks.DAO)) },
+        onError = onError,
     )
     ResourceWeblink(
         "support.resources.resources.sourceCode".i18n(),
         link = BisqLinks.BISQ_MOBILE_GH,
         onClick = { onAction(ResourcesUiAction.OnNavigateToUrl(BisqLinks.BISQ_MOBILE_GH)) },
+        onError = onError,
     )
     ResourceWeblink(
         "support.resources.resources.community".i18n(),
         link = BisqLinks.MATRIX,
         onClick = { onAction(ResourcesUiAction.OnNavigateToUrl(BisqLinks.MATRIX)) },
+        onError = onError,
     )
 }
 
@@ -162,6 +174,7 @@ private fun DeviceInfo(deviceInfo: String) {
 @Composable
 private fun Legal(
     onAction: (ResourcesUiAction) -> Unit,
+    onError: (Throwable) -> Unit,
 ) {
     BisqText.H3Light(
         "support.resources.legal.headline".i18n(),
@@ -175,6 +188,7 @@ private fun Legal(
         "support.resources.legal.license".i18n(),
         link = BisqLinks.LICENSE,
         onClick = { onAction(ResourcesUiAction.OnNavigateToUrl(BisqLinks.LICENSE)) },
+        onError = onError,
     )
 }
 
@@ -183,11 +197,13 @@ private fun ResourceWeblink(
     text: String,
     link: String,
     onClick: (() -> Unit)? = null,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     LinkButton(
         text,
         link = link,
         onClick = onClick,
+        onError = onError,
         leftIcon = { WebLinkIcon(modifier = Modifier.size(16.dp).alpha(0.5f)) },
         color = BisqTheme.colors.mid_grey20,
         padding =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/resources/ResourcesScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/resources/ResourcesScreen.kt
@@ -26,9 +26,11 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun ResourcesScreen() {
     val presenter: ResourcesPresenter = koinInject()
@@ -54,7 +56,7 @@ fun ResourcesScreen() {
 
         WebResources(
             onAction = presenter::onAction,
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
 
         BisqHDivider(modifier = dividerModifier)
@@ -72,11 +74,12 @@ fun ResourcesScreen() {
 
         Legal(
             onAction = presenter::onAction,
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
     }
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun Guides(
     onAction: (ResourcesUiAction) -> Unit,
@@ -100,6 +103,7 @@ private fun Guides(
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun WebResources(
     onAction: (ResourcesUiAction) -> Unit,
@@ -135,6 +139,7 @@ private fun WebResources(
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun Version(versionInfo: String) {
     BisqText.H3Light(
@@ -153,6 +158,7 @@ private fun Version(versionInfo: String) {
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun DeviceInfo(deviceInfo: String) {
     BisqText.H3Light(
@@ -171,6 +177,7 @@ private fun DeviceInfo(deviceInfo: String) {
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun Legal(
     onAction: (ResourcesUiAction) -> Unit,
@@ -192,6 +199,7 @@ private fun Legal(
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun ResourceWeblink(
     text: String,
@@ -214,6 +222,7 @@ private fun ResourceWeblink(
     )
 }
 
+@ExcludeFromCoverage
 @Composable
 private fun AppLinkButton(
     text: String,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -28,9 +28,11 @@ import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarT
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage
 @Composable
 fun SupportScreen() {
     val presenter: SupportPresenter = koinInject()
@@ -57,25 +59,25 @@ fun SupportScreen() {
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.MATRIX) },
-                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.forum".i18n(),
                 link = BisqLinks.FORUM,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.FORUM) },
-                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.telegram".i18n(),
                 link = BisqLinks.TELEGRAM,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.TELEGRAM) },
-                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.reddit".i18n(),
                 link = BisqLinks.REDDIT,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.REDDIT) },
-                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+                onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
         }
 
@@ -89,7 +91,7 @@ fun SupportScreen() {
             text = "mobile.support.wiki".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.onOpenWebUrl(BisqLinks.BISQ_EASY_WIKI_URL) },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -126,7 +128,7 @@ fun SupportScreen() {
             text = "mobile.support.troubleShooting.github".i18n(),
             link = reportUrl,
             onClick = { presenter.onOpenWebUrl(reportUrl) },
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -166,6 +168,7 @@ fun SupportScreen() {
     }
 }
 
+@ExcludeFromCoverage
 @Composable
 fun SupportWeblink(
     text: String,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -24,6 +24,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
@@ -56,21 +57,25 @@ fun SupportScreen() {
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.MATRIX) },
+                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.forum".i18n(),
                 link = BisqLinks.FORUM,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.FORUM) },
+                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.telegram".i18n(),
                 link = BisqLinks.TELEGRAM,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.TELEGRAM) },
+                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
             SupportWeblink(
                 text = "mobile.support.reddit".i18n(),
                 link = BisqLinks.REDDIT,
                 onClick = { presenter.onOpenWebUrl(BisqLinks.REDDIT) },
+                onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             )
         }
 
@@ -84,6 +89,7 @@ fun SupportScreen() {
             text = "mobile.support.wiki".i18n(),
             link = BisqLinks.BISQ_EASY_WIKI_URL,
             onClick = { presenter.onOpenWebUrl(BisqLinks.BISQ_EASY_WIKI_URL) },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -120,6 +126,7 @@ fun SupportScreen() {
             text = "mobile.support.troubleShooting.github".i18n(),
             link = reportUrl,
             onClick = { presenter.onOpenWebUrl(reportUrl) },
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
             color = BisqTheme.colors.primary,
             padding = PaddingValues(all = BisqUIConstants.Zero),
         )
@@ -164,11 +171,13 @@ fun SupportWeblink(
     text: String,
     link: String,
     onClick: (() -> Unit)? = null,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     LinkButton(
         text,
         link = link,
         onClick = onClick,
+        onError = onError,
         leftIcon = { WebLinkIcon(modifier = Modifier.size(16.dp).alpha(0.5f)) },
         color = BisqTheme.colors.mid_grey20,
         padding =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
@@ -54,6 +54,7 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.info.Info
 import network.bisq.mobile.presentation.common.ui.components.molecules.info.InfoBoxSats
 import network.bisq.mobile.presentation.common.ui.components.molecules.info.InfoRow
 import network.bisq.mobile.presentation.common.ui.components.molecules.info.InfoRowContainer
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
@@ -74,6 +75,7 @@ fun TradeDetailsHeader(presenter: TradeDetailsHeaderPresenter = koinInject()) {
             sessionUiState = sessionUiState,
             userProfileIconProvider = presenter.userProfileIconProvider,
             onAction = presenter::onAction,
+            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
     }
 }
@@ -84,6 +86,7 @@ fun TradeDetailsHeaderContent(
     sessionUiState: TradeDetailsHeaderSessionUiState,
     userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
     onAction: (TradeDetailsHeaderUiAction) -> Unit,
+    onError: ((Throwable) -> Unit)? = null,
 ) {
     val enterTransition =
         remember {
@@ -170,6 +173,7 @@ fun TradeDetailsHeaderContent(
                             forceConfirm = true,
                             padding = PaddingValues(0.dp),
                             modifier = Modifier.defaultMinSize(minHeight = 0.dp),
+                            onError = onError,
                         )
                     }
                 } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeader.kt
@@ -75,7 +75,7 @@ fun TradeDetailsHeader(presenter: TradeDetailsHeaderPresenter = koinInject()) {
             sessionUiState = sessionUiState,
             userProfileIconProvider = presenter.userProfileIconProvider,
             onAction = presenter::onAction,
-            onError = { presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
+            onError = { _ -> presenter.showSnackbar("mobile.error.cannotOpenUrl".i18n(), SnackbarType.ERROR) },
         )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1403

In this related PR (https://github.com/bisq-network/bisq-mobile/pull/1362), we addressed catching the exception thrown by `UrlLauncher` (in both android/ios).

But this bug https://github.com/bisq-network/bisq-mobile/issues/1403, happened because of similar exception when opening URL via `LocalUriHandler` direclty via Composable, as not all Composables has presenters.

Did 2 fixes:
1. WebLinkConfirmationDialog now opens links via navigateToUrl() instead of LocalUriHandler.current, since it has it's presenter. And navigateToUrl() guards against all exception.

2. LocalUriHandler gains openUriSafely() so Composables can open URLs with exceptions caught instead of crashing. NoteText, LinkButton, PaymentMethodBackgroundInformationDialog, now uses `LocalUriHandler.openUriSafely()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added UI and unit tests covering link-click flows, confirmation dialogs, and safe URI-opening across success, failure, and cancellation scenarios.
* **Refactor**
  * Centralized safe URI opening with optional onError callbacks; link-opening now routes through presenter-driven logic.
  * Many UI components now accept onError handlers and display standardized error snackbars when external links fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->