### PR TITLE
Implement other crypto account (BSQ,ETH,etc) flow

### DIFF
--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/account/crypto/OtherCryptoAssetAccountDto.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/account/crypto/OtherCryptoAssetAccountDto.kt
@@ -2,13 +2,12 @@ package network.bisq.mobile.data.model.account.crypto
 
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.data.model.account.PaymentAccountDto
-import network.bisq.mobile.data.model.account.PaymentRailDto
 
 @Serializable
 data class OtherCryptoAssetAccountDto(
     override val accountName: String,
     override val accountPayload: OtherCryptoAssetAccountPayloadDto,
-    override val paymentRail: PaymentRailDto = CryptoPaymentRailDto.OTHER_CRYPTO_ASSET,
+    override val paymentRail: CryptoPaymentRailDto = CryptoPaymentRailDto.OTHER_CRYPTO_ASSET,
     override val creationDate: String? = null,
     override val tradeLimitInfo: String? = null,
     override val tradeDuration: String? = null,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/MoneroAccountDetailContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/MoneroAccountDetailContentUiTest.kt
@@ -78,16 +78,16 @@ class MoneroAccountDetailContentUiTest {
             .assertCountEquals(0)
         composeTestRule
             .onNodeWithText("paymentAccounts.crypto.address.xmr.mainAddresses".i18n())
-            .assertIsDisplayed()
+            .assertExists()
         composeTestRule
             .onNodeWithText("paymentAccounts.crypto.address.xmr.privateViewKey".i18n())
-            .assertIsDisplayed()
+            .assertExists()
         composeTestRule
             .onNodeWithText("paymentAccounts.crypto.address.xmr.accountIndex".i18n())
-            .assertIsDisplayed()
+            .assertExists()
         composeTestRule
             .onNodeWithText("paymentAccounts.crypto.address.xmr.initialSubAddressIndex".i18n())
-            .assertIsDisplayed()
+            .assertExists()
         composeTestRule
             .onAllNodesWithText("89ABCDE...", substring = true)
             .assertCountEquals(1)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/OtherCryptoAssetAccountDetailContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/OtherCryptoAssetAccountDetailContentUiTest.kt
@@ -1,0 +1,136 @@
+package network.bisq.mobile.presentation.create_payment_account.account_review.ui
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccountPayload
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OtherCryptoAssetAccountDetailContentUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setTestContent(account: OtherCryptoAssetAccount) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    OtherCryptoAssetAccountDetailContent(
+                        account = account,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when auto conf supported and enabled then crypto rows and details section are shown`() {
+        setTestContent(
+            account =
+                sampleAccount(
+                    supportAutoConf = true,
+                    isAutoConf = true,
+                    creationDate = "2025-04-01",
+                    tradeLimitInfo = "5000.00",
+                    tradeDuration = "4 days",
+                ),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("ETH").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Ethereum").assertIsDisplayed()
+        composeTestRule.onNodeWithText("paymentAccounts.crypto.address.address".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("paymentAccounts.crypto.address.isInstant".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("paymentAccounts.crypto.address.autoConf.use".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("paymentAccounts.crypto.address.autoConf.numConfirmations".i18n()).assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.tradeLimit".i18n())
+            .assertCountEquals(1)
+    }
+
+    @Test
+    fun `when auto conf not supported then auto conf rows are hidden`() {
+        setTestContent(
+            account = sampleAccount(supportAutoConf = false, isAutoConf = true),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.numConfirmations".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n())
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `when details metadata missing then details section fields are hidden`() {
+        setTestContent(
+            account =
+                sampleAccount(
+                    supportAutoConf = true,
+                    isAutoConf = false,
+                    creationDate = null,
+                    tradeLimitInfo = null,
+                    tradeDuration = null,
+                ),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.accountCreationDate".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.tradeLimit".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.tradeDuration".i18n())
+            .assertCountEquals(0)
+    }
+
+    private fun sampleAccount(
+        supportAutoConf: Boolean,
+        isAutoConf: Boolean,
+        creationDate: String? = null,
+        tradeLimitInfo: String? = null,
+        tradeDuration: String? = null,
+    ): OtherCryptoAssetAccount =
+        OtherCryptoAssetAccount(
+            accountName = "My Ethereum Account",
+            accountPayload =
+                OtherCryptoAssetAccountPayload(
+                    address = "0x1234567890abcdef1234567890abcdef12345678",
+                    isInstant = true,
+                    isAutoConf = isAutoConf,
+                    autoConfNumConfirmations = 2,
+                    autoConfMaxTradeAmount = 1,
+                    autoConfExplorerUrls = "https://explorer.example.com",
+                    currencyCode = "ETH",
+                    currencyName = "Ethereum",
+                    supportAutoConf = supportAutoConf,
+                ),
+            creationDate = creationDate,
+            tradeLimitInfo = tradeLimitInfo,
+            tradeDuration = tradeDuration,
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/crypto/CommonCryptoFormSectionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/crypto/CommonCryptoFormSectionUiTest.kt
@@ -1,0 +1,196 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.CryptoAccountFormUiAction
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class CommonCryptoFormSectionUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setTestContent(
+        cryptoUiState: CryptoAccountFormUiState,
+        showAddress: Boolean,
+        showAutoConf: Boolean,
+        onAction: (AccountFormUiAction) -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    CommonCryptoFormSection(
+                        cryptoUiState = cryptoUiState,
+                        onAction = onAction,
+                        showAddress = showAddress,
+                        showAutoConf = showAutoConf,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when address enabled then address field is shown`() {
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(),
+            showAddress = true,
+            showAutoConf = false,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.address".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when address hidden then address field is not rendered`() {
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(),
+            showAddress = false,
+            showAutoConf = false,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.address".i18n())
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `when auto conf enabled and state true then auto conf fields are shown`() {
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(isAutoConf = true),
+            showAddress = true,
+            showAutoConf = true,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.numConfirmations".i18n())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.explorerUrls".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when auto conf hidden then auto conf controls are not rendered`() {
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(isAutoConf = true),
+            showAddress = true,
+            showAutoConf = false,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.numConfirmations".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.explorerUrls".i18n())
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `when address typed then emits address change action`() {
+        val typedAddress = "0xABCDEF"
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(),
+            showAddress = true,
+            showAutoConf = false,
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.address.prompt".i18n())
+            .performTextInput(typedAddress)
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnAddressChange(typedAddress), capturedAction)
+    }
+
+    @Test
+    fun `when instant clicked then emits instant toggle action`() {
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(isInstant = false),
+            showAddress = true,
+            showAutoConf = false,
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.isInstant".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnIsInstantChange(true), capturedAction)
+    }
+
+    @Test
+    fun `when auto conf clicked then emits auto conf toggle action`() {
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            cryptoUiState = sampleCryptoUiState(isAutoConf = false),
+            showAddress = true,
+            showAutoConf = true,
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnIsAutoConfChange(true), capturedAction)
+    }
+
+    private fun sampleCryptoUiState(
+        isInstant: Boolean = false,
+        isAutoConf: Boolean = false,
+    ): CryptoAccountFormUiState =
+        CryptoAccountFormUiState(
+            addressEntry = DataEntry(value = ""),
+            isInstant = isInstant,
+            isAutoConf = isAutoConf,
+            autoConfNumConfirmationsEntry = DataEntry(value = "2"),
+            autoConfMaxTradeAmountEntry = DataEntry(value = "1"),
+            autoConfExplorerUrlsEntry = DataEntry(value = "https://explorer.example.com"),
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormContentUiTest.kt
@@ -1,0 +1,185 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.model.account.PaymentTypeVO
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.CryptoAccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormUiState
+import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class OtherCryptoFormContentUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setTestContent(
+        uiState: OtherCryptoFormUiState,
+        paymentMethod: CryptoPaymentMethodVO,
+        onAction: (AccountFormUiAction) -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    OtherCryptoFormContent(
+                        uiState = uiState,
+                        paymentMethod = paymentMethod,
+                        onAction = onAction,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when rendered then address and instant controls are shown`() {
+        setTestContent(
+            uiState = sampleUiState(),
+            paymentMethod = samplePaymentMethod(supportAutoConf = false),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.address".i18n())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.isInstant".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when payment method supports auto conf then auto conf switch is shown`() {
+        setTestContent(
+            uiState = sampleUiState(),
+            paymentMethod = samplePaymentMethod(supportAutoConf = true),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when payment method does not support auto conf then auto conf controls are hidden`() {
+        setTestContent(
+            uiState = sampleUiState(),
+            paymentMethod = samplePaymentMethod(supportAutoConf = false),
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodesWithText("paymentAccounts.crypto.address.autoConf.numConfirmations".i18n())
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `when address typed then emits address change action`() {
+        val typedAddress = "0xFEEDBEEF"
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            uiState = sampleUiState(),
+            paymentMethod = samplePaymentMethod(supportAutoConf = false),
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.address.prompt".i18n())
+            .performTextInput(typedAddress)
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnAddressChange(typedAddress), capturedAction)
+    }
+
+    @Test
+    fun `when instant clicked then emits instant change action`() {
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            uiState = sampleUiState(isInstant = false),
+            paymentMethod = samplePaymentMethod(supportAutoConf = false),
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.isInstant".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnIsInstantChange(true), capturedAction)
+    }
+
+    @Test
+    fun `when auto conf supported and clicked then emits auto conf change action`() {
+        var capturedAction: AccountFormUiAction? = null
+
+        setTestContent(
+            uiState = sampleUiState(isAutoConf = false),
+            paymentMethod = samplePaymentMethod(supportAutoConf = true),
+            onAction = { action -> capturedAction = action },
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText("paymentAccounts.crypto.address.autoConf.use".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assertEquals(CryptoAccountFormUiAction.OnIsAutoConfChange(true), capturedAction)
+    }
+
+    private fun sampleUiState(
+        isInstant: Boolean = false,
+        isAutoConf: Boolean = false,
+    ): OtherCryptoFormUiState =
+        OtherCryptoFormUiState(
+            crypto =
+                CryptoAccountFormUiState(
+                    addressEntry = DataEntry(value = ""),
+                    isInstant = isInstant,
+                    isAutoConf = isAutoConf,
+                    autoConfNumConfirmationsEntry = DataEntry(value = "2"),
+                    autoConfMaxTradeAmountEntry = DataEntry(value = "1"),
+                    autoConfExplorerUrlsEntry = DataEntry(value = "https://explorer.example.com"),
+                ),
+        )
+
+    private fun samplePaymentMethod(supportAutoConf: Boolean): CryptoPaymentMethodVO =
+        CryptoPaymentMethodVO(
+            paymentType = PaymentTypeVO.ETH,
+            code = "ETH",
+            name = "Ethereum",
+            supportAutoConf = supportAutoConf,
+            tradeLimitInfo = EMPTY_STRING,
+            tradeDuration = EMPTY_STRING,
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormPresenterTest.kt
@@ -1,0 +1,211 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.model.account.PaymentTypeVO
+import network.bisq.mobile.presentation.common.test_utils.TestCoroutineJobsManager
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.CryptoAccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OtherCryptoFormPresenterTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var mainPresenter: MainPresenter
+    private lateinit var presenter: OtherCryptoFormPresenter
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        mainPresenter = mockk(relaxed = true)
+
+        startKoin {
+            modules(
+                module {
+                    single<NavigationManager> { mockk(relaxed = true) }
+                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
+                    single<GlobalUiManager> { mockk(relaxed = true) }
+                },
+            )
+        }
+
+        presenter = OtherCryptoFormPresenter(mainPresenter = mainPresenter)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        try {
+            stopKoin()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `when crypto actions are dispatched then crypto ui state updates`() =
+        runTest(testDispatcher) {
+            // When
+            presenter.onAction(CryptoAccountFormUiAction.OnAddressChange("0xABCDEF"))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsInstantChange(true))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(true))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange("2"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange("1"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange("https://explorer.eth"))
+
+            // Then
+            val state = presenter.uiState.value.crypto
+            assertEquals("0xABCDEF", state.addressEntry.value)
+            assertTrue(state.isInstant)
+            assertTrue(state.isAutoConf)
+            assertEquals("2", state.autoConfNumConfirmationsEntry.value)
+            assertEquals("1", state.autoConfMaxTradeAmountEntry.value)
+            assertEquals("https://explorer.eth", state.autoConfExplorerUrlsEntry.value)
+        }
+
+    @Test
+    fun `when next clicked before initialize then no effect is emitted`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter.onAction(AccountFormUiAction.OnUniqueAccountNameChange("ETH Account"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAddressChange("0x123456"))
+
+            // When
+            val effectDeferred = async { presenter.effect.first() }
+            presenter.onAction(AccountFormUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            // Then
+            assertFalse(effectDeferred.isCompleted)
+            effectDeferred.cancel()
+        }
+
+    @Test
+    fun `when next clicked with invalid entries then no navigation effect is emitted and errors are set`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter.initialize(samplePaymentMethod())
+            presenter.onAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAddressChange("   "))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(true))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange("0"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange("0"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange("x"))
+
+            // When
+            val effectDeferred = async { presenter.effect.first() }
+            presenter.onAction(AccountFormUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            // Then
+            assertFalse(effectDeferred.isCompleted)
+            effectDeferred.cancel()
+
+            val state = presenter.uiState.value
+            assertTrue(presenter.uniqueAccountNameEntry.value.errorMessage != null)
+            assertTrue(state.crypto.addressEntry.errorMessage != null)
+            assertTrue(state.crypto.autoConfNumConfirmationsEntry.errorMessage != null)
+            assertTrue(state.crypto.autoConfMaxTradeAmountEntry.errorMessage != null)
+            assertTrue(state.crypto.autoConfExplorerUrlsEntry.errorMessage != null)
+        }
+
+    @Test
+    fun `when next clicked with valid auto conf enabled entries then emits account payload`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter.initialize(samplePaymentMethod())
+            presenter.onAction(AccountFormUiAction.OnUniqueAccountNameChange("  ETH Account  "))
+            presenter.onAction(CryptoAccountFormUiAction.OnAddressChange("  0xABC123  "))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsInstantChange(true))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(true))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange(" 2 "))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange(" 1 "))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange("  https://explorer.eth  "))
+
+            // When
+            val effectDeferred = async { presenter.effect.first() }
+            presenter.onAction(AccountFormUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            // Then
+            val effect = effectDeferred.await()
+            assertTrue(effect is OtherCryptoFormEffect.NavigateToNextScreen)
+
+            val account = effect.account
+            assertEquals("ETH Account", account.accountName)
+            val payload = account.accountPayload
+            assertEquals("0xABC123", payload.address)
+            assertTrue(payload.isInstant)
+            assertEquals(true, payload.isAutoConf)
+            assertEquals(2, payload.autoConfNumConfirmations)
+            assertEquals(1L, payload.autoConfMaxTradeAmount)
+            assertEquals("https://explorer.eth", payload.autoConfExplorerUrls)
+            assertEquals("ETH", payload.currencyCode)
+            assertEquals("Ethereum", payload.currencyName)
+            assertTrue(payload.supportAutoConf)
+            assertEquals("5000.00", account.tradeLimitInfo)
+            assertEquals("4 days", account.tradeDuration)
+            assertNull(account.creationDate)
+        }
+
+    @Test
+    fun `when next clicked with auto conf disabled then auto conf payload fields are null`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter.initialize(samplePaymentMethod())
+            presenter.onAction(AccountFormUiAction.OnUniqueAccountNameChange("ETH No AutoConf"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAddressChange("0xNOAUTO"))
+            presenter.onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(false))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange("2"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange("1"))
+            presenter.onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange("https://ignored.explorer"))
+
+            // When
+            val effectDeferred = async { presenter.effect.first() }
+            presenter.onAction(AccountFormUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            // Then
+            val effect = effectDeferred.await()
+            assertTrue(effect is OtherCryptoFormEffect.NavigateToNextScreen)
+
+            val payload = effect.account.accountPayload
+            assertEquals(false, payload.isAutoConf)
+            assertNull(payload.autoConfNumConfirmations)
+            assertNull(payload.autoConfMaxTradeAmount)
+            assertNull(payload.autoConfExplorerUrls)
+        }
+
+    private fun samplePaymentMethod(): CryptoPaymentMethodVO =
+        CryptoPaymentMethodVO(
+            paymentType = PaymentTypeVO.ETH,
+            code = "ETH",
+            name = "Ethereum",
+            supportAutoConf = true,
+            tradeLimitInfo = "5000.00",
+            tradeDuration = "4 days",
+        )
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PaymentsPresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PaymentsPresentationModule.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.common.di
 import network.bisq.mobile.presentation.create_payment_account.CreatePaymentAccountPresenter
 import network.bisq.mobile.presentation.create_payment_account.account_review.PaymentAccountReviewPresenter
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.monero.MoneroFormPresenter
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto.OtherCryptoFormPresenter
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.zelle.ZelleFormPresenter
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.crypto.SelectCryptoPaymentMethodPresenter
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.fiat.SelectFiatPaymentMethodPresenter
@@ -19,4 +20,5 @@ val paymentsPresentationModule =
 
         factory { ZelleFormPresenter(get()) }
         factory { MoneroFormPresenter(get()) }
+        factory { OtherCryptoFormPresenter(get()) }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/PaymentAccountReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/PaymentAccountReviewScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.crypto.MoneroAccount
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
 import network.bisq.mobile.domain.model.account.fiat.ZelleAccount
 import network.bisq.mobile.domain.model.account.fiat.ZelleAccountPayload
 import network.bisq.mobile.i18n.i18n
@@ -24,6 +25,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.MoneroAccountDetailContent
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.OtherCryptoAssetAccountDetailContent
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.ZelleAccountDetailContent
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.AccountDetailFieldRow
 import network.bisq.mobile.presentation.create_payment_account.ui.UnsupportedAccountState
@@ -85,6 +87,9 @@ fun PaymentAccountReviewContent(
 
                 is MoneroAccount ->
                     MoneroAccountDetailContent(paymentAccount)
+
+                is OtherCryptoAssetAccount ->
+                    OtherCryptoAssetAccountDetailContent(paymentAccount)
 
                 else -> UnsupportedAccountState(modifier = Modifier.fillMaxWidth())
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/MoneroAccountDetailContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/MoneroAccountDetailContent.kt
@@ -2,26 +2,24 @@ package network.bisq.mobile.presentation.create_payment_account.account_review.u
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.domain.model.account.crypto.MoneroAccount
 import network.bisq.mobile.domain.model.account.crypto.MoneroAccountPayload
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.model.account.PaymentTypeVO
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.AccountDetailDetailsSection
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.AccountDetailFieldRow
-import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.PaymentAccountTypeIcon
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoAccountDetailHeader
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoAutoConfDetailRows
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoCommonDetailRows
 
 @Composable
 fun MoneroAccountDetailContent(
@@ -35,40 +33,30 @@ fun MoneroAccountDetailContent(
         color = BisqTheme.colors.dark_grey40,
     ) {
         Column {
-            Row(
-                modifier =
-                    Modifier
-                        .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
-                        .padding(BisqUIConstants.ScreenPadding)
-                        .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
-            ) {
-                PaymentAccountTypeIcon(
-                    paymentType = PaymentTypeVO.XMR,
-                    size = BisqUIConstants.ScreenPadding2X,
-                )
-                Column {
-                    BisqText.BaseRegular(account.accountPayload.currencyName)
-                    BisqText.BaseRegularGrey(account.accountPayload.currencyCode)
-                }
-            }
+            CryptoAccountDetailHeader(
+                paymentType = PaymentTypeVO.XMR,
+                currencyName = payload.currencyName,
+                currencyCode = payload.currencyCode,
+            )
 
             Column(
                 modifier = Modifier.padding(BisqUIConstants.ScreenPadding),
                 verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
             ) {
-                if (!payload.useSubAddresses) {
-                    AccountDetailFieldRow(
-                        label = "paymentAccounts.crypto.address.address".i18n(),
-                        value = payload.address,
+                CryptoCommonDetailRows(
+                    address = payload.address,
+                    isInstant = payload.isInstant,
+                    showAddress = !payload.useSubAddresses,
+                )
+
+                if (payload.supportAutoConf) {
+                    CryptoAutoConfDetailRows(
+                        isAutoConf = payload.isAutoConf == true,
+                        autoConfNumConfirmations = payload.autoConfNumConfirmations,
+                        autoConfMaxTradeAmount = payload.autoConfMaxTradeAmount,
+                        autoConfExplorerUrls = payload.autoConfExplorerUrls,
                     )
                 }
-
-                AccountDetailFieldRow(
-                    label = "paymentAccounts.crypto.address.isInstant".i18n(),
-                    value = if (payload.isInstant) "state.enabled".i18n() else "state.disabled".i18n(),
-                )
 
                 AccountDetailFieldRow(
                     label = "paymentAccounts.crypto.address.xmr.useSubAddresses.switch".i18n(),
@@ -105,35 +93,6 @@ fun MoneroAccountDetailContent(
                             label = "paymentAccounts.crypto.address.xmr.subAddress".i18n(),
                             value = it,
                         )
-                    }
-                }
-
-                if (account.accountPayload.supportAutoConf) {
-                    val isAutoConf = payload.isAutoConf == true
-                    AccountDetailFieldRow(
-                        label = "paymentAccounts.crypto.address.autoConf.use".i18n(),
-                        value = if (isAutoConf) "state.enabled".i18n() else "state.disabled".i18n(),
-                    )
-
-                    if (isAutoConf) {
-                        payload.autoConfNumConfirmations?.let {
-                            AccountDetailFieldRow(
-                                label = "paymentAccounts.crypto.address.autoConf.numConfirmations".i18n(),
-                                value = it.toString(),
-                            )
-                        }
-                        payload.autoConfMaxTradeAmount?.let {
-                            AccountDetailFieldRow(
-                                label = "paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n(),
-                                value = it.toString(),
-                            )
-                        }
-                        payload.autoConfExplorerUrls?.let {
-                            AccountDetailFieldRow(
-                                label = "paymentAccounts.crypto.address.autoConf.explorerUrls".i18n(),
-                                value = it,
-                            )
-                        }
                     }
                 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/OtherCryptoAssetAccountDetailContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/OtherCryptoAssetAccountDetailContent.kt
@@ -1,0 +1,99 @@
+package network.bisq.mobile.presentation.create_payment_account.account_review.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccountPayload
+import network.bisq.mobile.presentation.common.model.account.getPaymentTypeVOFromCryptoCurrencyCode
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.AccountDetailDetailsSection
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoAccountDetailHeader
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoAutoConfDetailRows
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.CryptoCommonDetailRows
+
+@Composable
+fun OtherCryptoAssetAccountDetailContent(
+    account: OtherCryptoAssetAccount,
+) {
+    val payload = account.accountPayload
+    val paymentType = remember { getPaymentTypeVOFromCryptoCurrencyCode(payload.currencyCode) }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(BisqUIConstants.BorderRadius),
+        color = BisqTheme.colors.dark_grey40,
+    ) {
+        Column {
+            CryptoAccountDetailHeader(
+                paymentType = paymentType,
+                currencyName = payload.currencyName,
+                currencyCode = payload.currencyCode,
+            )
+
+            Column(
+                modifier = Modifier.padding(BisqUIConstants.ScreenPadding),
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+            ) {
+                CryptoCommonDetailRows(
+                    address = payload.address,
+                    isInstant = payload.isInstant,
+                    showAddress = true,
+                )
+
+                if (payload.supportAutoConf) {
+                    CryptoAutoConfDetailRows(
+                        isAutoConf = payload.isAutoConf == true,
+                        autoConfNumConfirmations = payload.autoConfNumConfirmations,
+                        autoConfMaxTradeAmount = payload.autoConfMaxTradeAmount,
+                        autoConfExplorerUrls = payload.autoConfExplorerUrls,
+                    )
+                }
+
+                AccountDetailDetailsSection(
+                    creationDate = account.creationDate,
+                    tradeLimitInfo = account.tradeLimitInfo,
+                    tradeDuration = account.tradeDuration,
+                )
+            }
+        }
+    }
+}
+
+private val previewAccount =
+    OtherCryptoAssetAccount(
+        accountName = "My Ethereum Account",
+        accountPayload =
+            OtherCryptoAssetAccountPayload(
+                address = "0x1234567890abcdef1234567890abcdef12345678",
+                isInstant = true,
+                isAutoConf = true,
+                autoConfNumConfirmations = 2,
+                autoConfMaxTradeAmount = 1,
+                autoConfExplorerUrls = "https://explorer.example.com",
+                currencyCode = "ETH",
+                currencyName = "Ethereum",
+                supportAutoConf = true,
+            ),
+        creationDate = null,
+        tradeLimitInfo = null,
+        tradeDuration = null,
+    )
+
+@Preview
+@Composable
+private fun OtherCryptoAssetAccountDetailContentPreview() {
+    BisqTheme.Preview {
+        OtherCryptoAssetAccountDetailContent(
+            account = previewAccount,
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoAccountDetailHeader.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoAccountDetailHeader.kt
@@ -1,0 +1,70 @@
+package network.bisq.mobile.presentation.create_payment_account.account_review.ui.core
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import network.bisq.mobile.presentation.common.model.account.PaymentTypeVO
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.settings.payment_accounts_musig.ui.PaymentAccountTypeIcon
+
+@Composable
+fun CryptoAccountDetailHeader(
+    paymentType: PaymentTypeVO?,
+    currencyName: String,
+    currencyCode: String,
+) {
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
+                .padding(BisqUIConstants.ScreenPadding)
+                .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+    ) {
+        paymentType?.let {
+            PaymentAccountTypeIcon(
+                paymentType = it,
+                size = BisqUIConstants.ScreenPadding2X,
+            )
+        }
+        Column {
+            BisqText.BaseRegular(currencyCode)
+            BisqText.BaseRegularGrey(currencyName)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CryptoAccountDetailHeader_WithIconPreview() {
+    BisqTheme.Preview {
+        CryptoAccountDetailHeader(
+            paymentType = PaymentTypeVO.XMR,
+            currencyName = "Monero",
+            currencyCode = "XMR",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CryptoAccountDetailHeader_WithoutIconPreview() {
+    BisqTheme.Preview {
+        CryptoAccountDetailHeader(
+            paymentType = null,
+            currencyName = "Ethereum",
+            currencyCode = "ETH",
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoAutoConfDetailRows.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoAutoConfDetailRows.kt
@@ -1,0 +1,38 @@
+package network.bisq.mobile.presentation.create_payment_account.account_review.ui.core
+
+import androidx.compose.runtime.Composable
+import network.bisq.mobile.i18n.i18n
+
+@Composable
+fun CryptoAutoConfDetailRows(
+    isAutoConf: Boolean,
+    autoConfNumConfirmations: Int?,
+    autoConfMaxTradeAmount: Long?,
+    autoConfExplorerUrls: String?,
+) {
+    AccountDetailFieldRow(
+        label = "paymentAccounts.crypto.address.autoConf.use".i18n(),
+        value = if (isAutoConf) "state.enabled".i18n() else "state.disabled".i18n(),
+    )
+
+    if (isAutoConf) {
+        autoConfNumConfirmations?.let {
+            AccountDetailFieldRow(
+                label = "paymentAccounts.crypto.address.autoConf.numConfirmations".i18n(),
+                value = it.toString(),
+            )
+        }
+        autoConfMaxTradeAmount?.let {
+            AccountDetailFieldRow(
+                label = "paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n(),
+                value = it.toString(),
+            )
+        }
+        autoConfExplorerUrls?.let {
+            AccountDetailFieldRow(
+                label = "paymentAccounts.crypto.address.autoConf.explorerUrls".i18n(),
+                value = it,
+            )
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoCommonDetailRows.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/account_review/ui/core/CryptoCommonDetailRows.kt
@@ -1,0 +1,23 @@
+package network.bisq.mobile.presentation.create_payment_account.account_review.ui.core
+
+import androidx.compose.runtime.Composable
+import network.bisq.mobile.i18n.i18n
+
+@Composable
+fun CryptoCommonDetailRows(
+    address: String,
+    isInstant: Boolean,
+    showAddress: Boolean,
+) {
+    if (showAddress) {
+        AccountDetailFieldRow(
+            label = "paymentAccounts.crypto.address.address".i18n(),
+            value = address,
+        )
+    }
+
+    AccountDetailFieldRow(
+        label = "paymentAccounts.crypto.address.isInstant".i18n(),
+        value = if (isInstant) "state.enabled".i18n() else "state.disabled".i18n(),
+    )
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/PaymentAccountFormScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/PaymentAccountFormScreen.kt
@@ -34,6 +34,8 @@ import network.bisq.mobile.presentation.create_payment_account.payment_account_f
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.monero.MoneroFormPresenter
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.monero.MoneroPaymentAccountFormContent
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto.OtherCryptoFormPresenter
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto.OtherCryptoPaymentAccountFormContent
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.zelle.ZelleFormPresenter
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.zelle.ZellePaymentAccountFormContent
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
@@ -126,7 +128,14 @@ fun PaymentAccountFormContent(
                         paymentType = paymentMethod.paymentType,
                         size = BisqUIConstants.ScreenPadding2X,
                     )
-                    BisqText.BaseRegularGrey(paymentMethod.name)
+                    if (paymentMethod is CryptoPaymentMethodVO) {
+                        Column {
+                            BisqText.BaseRegular(paymentMethod.code)
+                            BisqText.BaseRegularGrey(paymentMethod.name)
+                        }
+                    } else {
+                        BisqText.BaseRegularGrey(paymentMethod.name)
+                    }
                 }
             }
 
@@ -179,6 +188,30 @@ private fun PaymentMethodFormContent(
                 )
             } else {
                 UnsupportedAccountState(modifier = modifier.fillMaxWidth())
+            }
+        }
+
+        PaymentTypeVO.BSQ,
+        PaymentTypeVO.LTC,
+        PaymentTypeVO.ETH,
+        PaymentTypeVO.ETC,
+        PaymentTypeVO.LBTC,
+        PaymentTypeVO.LNBTC,
+        PaymentTypeVO.GRIN,
+        PaymentTypeVO.ZEC,
+        PaymentTypeVO.DOGE,
+        -> {
+            val presenter = methodPresenter as? OtherCryptoFormPresenter
+            val cryptoPaymentMethod = paymentMethod as? CryptoPaymentMethodVO
+            if (presenter != null && cryptoPaymentMethod != null) {
+                OtherCryptoPaymentAccountFormContent(
+                    presenter = presenter,
+                    onNavigateToNextScreen = onNavigateToNextScreen,
+                    paymentMethod = cryptoPaymentMethod,
+                    modifier = modifier,
+                )
+            } else {
+                UnsupportedAccountState(modifier = modifier)
             }
         }
 
@@ -261,5 +294,15 @@ private fun rememberMethodPresenter(paymentMethod: PaymentMethodVO): AccountForm
     when (paymentMethod.paymentType) {
         PaymentTypeVO.ZELLE -> RememberPresenterLifecycleBackStackAware<ZelleFormPresenter>()
         PaymentTypeVO.XMR -> RememberPresenterLifecycleBackStackAware<MoneroFormPresenter>()
+        PaymentTypeVO.BSQ,
+        PaymentTypeVO.LTC,
+        PaymentTypeVO.ETH,
+        PaymentTypeVO.ETC,
+        PaymentTypeVO.LBTC,
+        PaymentTypeVO.LNBTC,
+        PaymentTypeVO.GRIN,
+        PaymentTypeVO.ZEC,
+        PaymentTypeVO.DOGE,
+        -> RememberPresenterLifecycleBackStackAware<OtherCryptoFormPresenter>()
         else -> null
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/crypto/CommonCryptoFormSection.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/crypto/CommonCryptoFormSection.kt
@@ -1,0 +1,150 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqSwitch
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqTextFieldV0
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.CryptoAccountFormUiAction
+
+@Composable
+fun CommonCryptoFormSection(
+    cryptoUiState: CryptoAccountFormUiState,
+    onAction: (AccountFormUiAction) -> Unit,
+    showAddress: Boolean,
+    showAutoConf: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        if (showAddress) {
+            BisqTextFieldV0(
+                value = cryptoUiState.addressEntry.value,
+                onValueChange = { onAction(CryptoAccountFormUiAction.OnAddressChange(it)) },
+                label = "paymentAccounts.crypto.address.address".i18n(),
+                placeholder =
+                    "paymentAccounts.crypto.address.address.prompt".i18n(),
+                isError = cryptoUiState.addressEntry.errorMessage != null,
+                bottomMessage = cryptoUiState.addressEntry.errorMessage,
+                singleLine = true,
+            )
+        }
+
+        BisqSwitch(
+            checked = cryptoUiState.isInstant,
+            modifier = Modifier.padding(top = 12.dp),
+            label = "paymentAccounts.crypto.address.isInstant".i18n(),
+            onSwitch = { onAction(CryptoAccountFormUiAction.OnIsInstantChange(it)) },
+        )
+
+        if (showAutoConf) {
+            BisqSwitch(
+                checked = cryptoUiState.isAutoConf,
+                modifier = Modifier.padding(top = 12.dp),
+                label = "paymentAccounts.crypto.address.autoConf.use".i18n(),
+                onSwitch = { onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(it)) },
+            )
+
+            if (cryptoUiState.isAutoConf) {
+                BisqTextFieldV0(
+                    modifier = Modifier.padding(top = 12.dp),
+                    value = cryptoUiState.autoConfNumConfirmationsEntry.value,
+                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange(it)) },
+                    label = "paymentAccounts.crypto.address.autoConf.numConfirmations".i18n(),
+                    placeholder = "paymentAccounts.crypto.address.autoConf.numConfirmations.prompt".i18n(),
+                    isError = cryptoUiState.autoConfNumConfirmationsEntry.errorMessage != null,
+                    bottomMessage = cryptoUiState.autoConfNumConfirmationsEntry.errorMessage,
+                    singleLine = true,
+                )
+
+                BisqTextFieldV0(
+                    modifier = Modifier.padding(top = 12.dp),
+                    value = cryptoUiState.autoConfMaxTradeAmountEntry.value,
+                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange(it)) },
+                    label = "paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n(),
+                    placeholder = "paymentAccounts.crypto.address.autoConf.maxTradeAmount.prompt".i18n(),
+                    isError = cryptoUiState.autoConfMaxTradeAmountEntry.errorMessage != null,
+                    bottomMessage = cryptoUiState.autoConfMaxTradeAmountEntry.errorMessage,
+                    singleLine = true,
+                )
+
+                BisqTextFieldV0(
+                    modifier = Modifier.padding(top = 12.dp),
+                    value = cryptoUiState.autoConfExplorerUrlsEntry.value,
+                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange(it)) },
+                    label = "paymentAccounts.crypto.address.autoConf.explorerUrls".i18n(),
+                    placeholder = "paymentAccounts.crypto.address.autoConf.explorerUrls.prompt".i18n(),
+                    isError = cryptoUiState.autoConfExplorerUrlsEntry.errorMessage != null,
+                    bottomMessage =
+                        cryptoUiState.autoConfExplorerUrlsEntry.errorMessage
+                            ?: "paymentAccounts.crypto.address.autoConf.explorerUrls.help".i18n(),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CommonCryptoFormSection_DefaultPreview() {
+    BisqTheme.Preview {
+        CommonCryptoFormSection(
+            cryptoUiState =
+                CryptoAccountFormUiState(
+                    addressEntry = DataEntry(value = "0x1234567890abcdef1234567890abcdef12345678"),
+                    isInstant = true,
+                    isAutoConf = false,
+                ),
+            onAction = {},
+            showAddress = true,
+            showAutoConf = false,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CommonCryptoFormSection_AutoConfEnabledPreview() {
+    BisqTheme.Preview {
+        CommonCryptoFormSection(
+            cryptoUiState =
+                CryptoAccountFormUiState(
+                    addressEntry = DataEntry(value = "0x1234567890abcdef1234567890abcdef12345678"),
+                    isInstant = false,
+                    isAutoConf = true,
+                    autoConfNumConfirmationsEntry = DataEntry(value = "2"),
+                    autoConfMaxTradeAmountEntry = DataEntry(value = "1"),
+                    autoConfExplorerUrlsEntry = DataEntry(value = "https://explorer.example.com"),
+                ),
+            onAction = {},
+            showAddress = true,
+            showAutoConf = true,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CommonCryptoFormSection_AddressHiddenPreview() {
+    BisqTheme.Preview {
+        CommonCryptoFormSection(
+            cryptoUiState =
+                CryptoAccountFormUiState(
+                    isInstant = false,
+                    isAutoConf = true,
+                    autoConfNumConfirmationsEntry = DataEntry(value = "3"),
+                    autoConfMaxTradeAmountEntry = DataEntry(value = "1000"),
+                    autoConfExplorerUrlsEntry = DataEntry(value = "https://hidden-address.example"),
+                ),
+            onAction = {},
+            showAddress = false,
+            showAutoConf = true,
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/monero/MoneroFormContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/monero/MoneroFormContent.kt
@@ -20,12 +20,12 @@ import network.bisq.mobile.presentation.common.ui.utils.DataEntry
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
-import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.CryptoAccountFormUiAction
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.MoneroFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CommonCryptoFormSection
 import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormUiState
 import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
 
-private const val MONERO_SUB_ADDRESSES_ENABLED =
+private val moneroSubAddressesEnabled =
     false // TODO: remove once bisq2 issue https://github.com/bisq-network/bisq2/issues/4682 is resolved
 
 @Composable
@@ -66,28 +66,15 @@ fun MoneroFormContent(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        if (!uiState.useSubAddresses) {
-            BisqTextFieldV0(
-                value = uiState.crypto.addressEntry.value,
-                onValueChange = { onAction(CryptoAccountFormUiAction.OnAddressChange(it)) },
-                label = "paymentAccounts.crypto.address.address".i18n(),
-                placeholder =
-                    "paymentAccounts.crypto.address.address.prompt".i18n(),
-                isError = uiState.crypto.addressEntry.errorMessage != null,
-                bottomMessage = uiState.crypto.addressEntry.errorMessage,
-                singleLine = true,
-            )
-        }
-
-        BisqSwitch(
-            checked = uiState.crypto.isInstant,
-            modifier = Modifier.padding(top = 12.dp),
-            label = "paymentAccounts.crypto.address.isInstant".i18n(),
-            onSwitch = { onAction(CryptoAccountFormUiAction.OnIsInstantChange(it)) },
+        CommonCryptoFormSection(
+            cryptoUiState = uiState.crypto,
+            onAction = onAction,
+            showAddress = !uiState.useSubAddresses,
+            showAutoConf = moneroSubAddressesEnabled && paymentMethod.supportAutoConf,
         )
 
         // This feature is disabled for now until we get this fixed in Bisq2
-        if (MONERO_SUB_ADDRESSES_ENABLED) {
+        if (moneroSubAddressesEnabled) {
             BisqSwitch(
                 checked = uiState.useSubAddresses,
                 modifier = Modifier.padding(top = 12.dp),
@@ -147,52 +134,6 @@ fun MoneroFormContent(
                     readOnly = true,
                     label = "paymentAccounts.crypto.address.xmr.subAddress".i18n(),
                     singleLine = true,
-                )
-            }
-        }
-
-        // This feature is disabled for now until we get this fixed in Bisq2
-        if (paymentMethod.supportAutoConf && MONERO_SUB_ADDRESSES_ENABLED) {
-            BisqSwitch(
-                checked = uiState.crypto.isAutoConf,
-                modifier = Modifier.padding(top = 12.dp),
-                label = "paymentAccounts.crypto.address.autoConf.use".i18n(),
-                onSwitch = { onAction(CryptoAccountFormUiAction.OnIsAutoConfChange(it)) },
-            )
-
-            if (uiState.crypto.isAutoConf) {
-                BisqTextFieldV0(
-                    modifier = Modifier.padding(top = 12.dp),
-                    value = uiState.crypto.autoConfNumConfirmationsEntry.value,
-                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfNumConfirmationsChange(it)) },
-                    label = "paymentAccounts.crypto.address.autoConf.numConfirmations".i18n(),
-                    placeholder = "paymentAccounts.crypto.address.autoConf.numConfirmations.prompt".i18n(),
-                    isError = uiState.crypto.autoConfNumConfirmationsEntry.errorMessage != null,
-                    bottomMessage = uiState.crypto.autoConfNumConfirmationsEntry.errorMessage,
-                    singleLine = true,
-                )
-
-                BisqTextFieldV0(
-                    modifier = Modifier.padding(top = 12.dp),
-                    value = uiState.crypto.autoConfMaxTradeAmountEntry.value,
-                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfMaxTradeAmountChange(it)) },
-                    label = "paymentAccounts.crypto.address.autoConf.maxTradeAmount".i18n(),
-                    placeholder = "paymentAccounts.crypto.address.autoConf.maxTradeAmount.prompt".i18n(),
-                    isError = uiState.crypto.autoConfMaxTradeAmountEntry.errorMessage != null,
-                    bottomMessage = uiState.crypto.autoConfMaxTradeAmountEntry.errorMessage,
-                    singleLine = true,
-                )
-
-                BisqTextFieldV0(
-                    modifier = Modifier.padding(top = 12.dp),
-                    value = uiState.crypto.autoConfExplorerUrlsEntry.value,
-                    onValueChange = { onAction(CryptoAccountFormUiAction.OnAutoConfExplorerUrlsChange(it)) },
-                    label = "paymentAccounts.crypto.address.autoConf.explorerUrls".i18n(),
-                    placeholder = "paymentAccounts.crypto.address.autoConf.explorerUrls.prompt".i18n(),
-                    isError = uiState.crypto.autoConfExplorerUrlsEntry.errorMessage != null,
-                    bottomMessage =
-                        uiState.crypto.autoConfExplorerUrlsEntry.errorMessage
-                            ?: "paymentAccounts.crypto.address.autoConf.explorerUrls.help".i18n(),
                 )
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormContent.kt
@@ -1,0 +1,121 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import network.bisq.mobile.domain.model.account.PaymentAccount
+import network.bisq.mobile.presentation.common.model.account.PaymentTypeVO
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.action.AccountFormUiAction
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CommonCryptoFormSection
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormUiState
+import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
+
+@Composable
+fun OtherCryptoPaymentAccountFormContent(
+    presenter: OtherCryptoFormPresenter,
+    paymentMethod: CryptoPaymentMethodVO,
+    onNavigateToNextScreen: (PaymentAccount) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uiState by presenter.uiState.collectAsState()
+    val currentOnNavigate by rememberUpdatedState(onNavigateToNextScreen)
+
+    LaunchedEffect(presenter, paymentMethod) {
+        presenter.initialize(paymentMethod)
+    }
+
+    LaunchedEffect(presenter) {
+        presenter.effect.collect { effect ->
+            when (effect) {
+                is OtherCryptoFormEffect.NavigateToNextScreen -> currentOnNavigate(effect.account)
+            }
+        }
+    }
+
+    OtherCryptoFormContent(
+        uiState = uiState,
+        paymentMethod = paymentMethod,
+        onAction = presenter::onAction,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun OtherCryptoFormContent(
+    uiState: OtherCryptoFormUiState,
+    paymentMethod: CryptoPaymentMethodVO,
+    onAction: (AccountFormUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        CommonCryptoFormSection(
+            cryptoUiState = uiState.crypto,
+            onAction = onAction,
+            showAddress = true,
+            showAutoConf = paymentMethod.supportAutoConf,
+        )
+    }
+}
+
+private fun previewPaymentMethod(
+    supportAutoConf: Boolean,
+): CryptoPaymentMethodVO =
+    CryptoPaymentMethodVO(
+        paymentType = PaymentTypeVO.ETH,
+        code = "ETH",
+        name = "Ethereum",
+        supportAutoConf = supportAutoConf,
+        tradeLimitInfo = EMPTY_STRING,
+        tradeDuration = EMPTY_STRING,
+    )
+
+@Preview
+@Composable
+private fun OtherCryptoFormContentPreview_DefaultPreview() {
+    BisqTheme.Preview {
+        OtherCryptoFormContent(
+            uiState =
+                OtherCryptoFormUiState(
+                    crypto =
+                        CryptoAccountFormUiState(
+                            addressEntry = DataEntry(value = "0x1234567890abcdef1234567890abcdef12345678"),
+                            isInstant = true,
+                            isAutoConf = false,
+                        ),
+                ),
+            paymentMethod = previewPaymentMethod(supportAutoConf = false),
+            onAction = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OtherCryptoFormContentPreview_AutoConfEnabledPreview() {
+    BisqTheme.Preview {
+        OtherCryptoFormContent(
+            uiState =
+                OtherCryptoFormUiState(
+                    crypto =
+                        CryptoAccountFormUiState(
+                            addressEntry = DataEntry(value = "0x1234567890abcdef1234567890abcdef12345678"),
+                            isInstant = false,
+                            isAutoConf = true,
+                            autoConfNumConfirmationsEntry = DataEntry(value = "2"),
+                            autoConfMaxTradeAmountEntry = DataEntry(value = "1"),
+                            autoConfExplorerUrlsEntry = DataEntry(value = "https://explorer.example.com"),
+                        ),
+                ),
+            paymentMethod = previewPaymentMethod(supportAutoConf = true),
+            onAction = {},
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormEffect.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormEffect.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
+
+sealed interface OtherCryptoFormEffect {
+    data class NavigateToNextScreen(
+        val account: OtherCryptoAssetAccount,
+    ) : OtherCryptoFormEffect
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormPresenter.kt
@@ -1,0 +1,113 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccountPayload
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormPresenter
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormUiState
+import network.bisq.mobile.presentation.create_payment_account.select_payment_method.model.CryptoPaymentMethodVO
+import network.bisq.mobile.presentation.main.MainPresenter
+
+open class OtherCryptoFormPresenter(
+    mainPresenter: MainPresenter,
+) : CryptoAccountFormPresenter(mainPresenter) {
+    private val _uiState = MutableStateFlow(OtherCryptoFormUiState())
+    override val uiState: StateFlow<OtherCryptoFormUiState> = _uiState.asStateFlow()
+
+    private val _effect = MutableSharedFlow<OtherCryptoFormEffect>()
+    val effect = _effect.asSharedFlow()
+
+    lateinit var paymentMethod: CryptoPaymentMethodVO
+
+    fun initialize(paymentMethod: CryptoPaymentMethodVO) {
+        this.paymentMethod = paymentMethod
+    }
+
+    override fun updateCryptoUiState(transform: (CryptoAccountFormUiState) -> CryptoAccountFormUiState) {
+        _uiState.update { it.copy(crypto = transform(it.crypto)) }
+    }
+
+    override fun onNextClick() {
+        if (!::paymentMethod.isInitialized) {
+            return
+        }
+
+        val validatedState =
+            _uiState.updateAndGet { current ->
+                current.copy(
+                    crypto =
+                        validateCryptoAutoConfState(current.crypto).copy(
+                            addressEntry = current.crypto.addressEntry.validate(),
+                        ),
+                )
+            }
+
+        val validatedAccountName = validateUniqueAccountNameEntry()
+        val isValid =
+            validatedAccountName.isValid &&
+                validatedState.crypto.addressEntry.isValid &&
+                isCryptoAutoConfStateValid(validatedState.crypto)
+
+        if (!isValid) {
+            return
+        }
+
+        val payload =
+            OtherCryptoAssetAccountPayload(
+                address =
+                    validatedState.crypto.addressEntry.value
+                        .trim(),
+                isInstant = validatedState.crypto.isInstant,
+                isAutoConf = validatedState.crypto.isAutoConf,
+                autoConfNumConfirmations =
+                    if (validatedState.crypto.isAutoConf) {
+                        validatedState.crypto.autoConfNumConfirmationsEntry.value
+                            .trim()
+                            .toIntOrNull()
+                    } else {
+                        null
+                    },
+                autoConfMaxTradeAmount =
+                    if (validatedState.crypto.isAutoConf) {
+                        validatedState.crypto.autoConfMaxTradeAmountEntry.value
+                            .trim()
+                            .toLongOrNull()
+                    } else {
+                        null
+                    },
+                autoConfExplorerUrls =
+                    if (validatedState.crypto.isAutoConf) {
+                        validatedState.crypto.autoConfExplorerUrlsEntry.value
+                            .trim()
+                            .ifBlank { null }
+                    } else {
+                        null
+                    },
+                currencyCode = paymentMethod.code,
+                currencyName = paymentMethod.name,
+                supportAutoConf = paymentMethod.supportAutoConf,
+            )
+
+        presenterScope.launch {
+            _effect.emit(
+                OtherCryptoFormEffect.NavigateToNextScreen(
+                    account =
+                        OtherCryptoAssetAccount(
+                            accountName = uniqueAccountNameEntry.value.value.trim(),
+                            accountPayload = payload,
+                            creationDate = null,
+                            tradeLimitInfo = paymentMethod.tradeLimitInfo,
+                            tradeDuration = paymentMethod.tradeDuration,
+                        ),
+                ),
+            )
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/create_payment_account/payment_account_form/form/other_crypto/OtherCryptoFormUiState.kt
@@ -1,0 +1,8 @@
+package network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.other_crypto
+
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.AccountFormUiState
+import network.bisq.mobile.presentation.create_payment_account.payment_account_form.form.crypto.CryptoAccountFormUiState
+
+data class OtherCryptoFormUiState(
+    val crypto: CryptoAccountFormUiState = CryptoAccountFormUiState(),
+) : AccountFormUiState

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/detail/PaymentAccountMusigDetailScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/payment_accounts_musig/detail/PaymentAccountMusigDetailScreen.kt
@@ -17,6 +17,8 @@ import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.PaymentAccountPayload
 import network.bisq.mobile.domain.model.account.crypto.MoneroAccount
 import network.bisq.mobile.domain.model.account.crypto.MoneroAccountPayload
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccount
+import network.bisq.mobile.domain.model.account.crypto.OtherCryptoAssetAccountPayload
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.ZelleAccount
 import network.bisq.mobile.domain.model.account.fiat.ZelleAccountPayload
@@ -33,6 +35,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.MoneroAccountDetailContent
+import network.bisq.mobile.presentation.create_payment_account.account_review.ui.OtherCryptoAssetAccountDetailContent
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.UserDefinedAccountDetailContent
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.ZelleAccountDetailContent
 import network.bisq.mobile.presentation.create_payment_account.account_review.ui.core.AccountDetailFieldRow
@@ -104,6 +107,9 @@ fun PaymentAccountMusigDetailContent(
 
                             is UserDefinedFiatAccount ->
                                 UserDefinedAccountDetailContent(paymentAccount)
+
+                            is OtherCryptoAssetAccount ->
+                                OtherCryptoAssetAccountDetailContent(paymentAccount)
 
                             else -> UnsupportedAccountState(modifier = Modifier.fillMaxSize())
                         }
@@ -194,6 +200,23 @@ private val previewUnsupportedAccount =
         override val tradeDuration: String? = null
     }
 
+private val previewOtherCryptoAccount =
+    OtherCryptoAssetAccount(
+        accountName = "My Ethereum Account",
+        accountPayload =
+            OtherCryptoAssetAccountPayload(
+                address = "0x1234567890abcdef1234567890abcdef12345678",
+                isInstant = true,
+                isAutoConf = false,
+                currencyCode = "ETH",
+                currencyName = "Ethereum",
+                supportAutoConf = true,
+            ),
+        creationDate = null,
+        tradeLimitInfo = null,
+        tradeDuration = null,
+    )
+
 @Preview
 @Composable
 private fun PaymentAccountMusigDetail_ZelleLoadedPreview() {
@@ -218,6 +241,22 @@ private fun PaymentAccountMusigDetail_MoneroLoadedPreview() {
             uiState =
                 PaymentAccountMusigDetailUiState(
                     paymentAccount = previewMoneroAccount,
+                    isAccountMissing = false,
+                ),
+            onAction = {},
+            topBar = { PreviewTopBar() },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PaymentAccountMusigDetail_OtherCryptoLoadedPreview() {
+    BisqTheme.Preview {
+        PaymentAccountMusigDetailContent(
+            uiState =
+                PaymentAccountMusigDetailUiState(
+                    paymentAccount = previewOtherCryptoAccount,
                     isAccountMissing = false,
                 ),
             onAction = {},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and managing "other crypto" payment accounts (BSQ, LTC, ETH, ETC, LBTC, LNBTC, GRIN, ZEC, DOGE).
  * Enhanced crypto account forms with auto-configuration controls.
  * Introduced shared crypto payment account UI components for improved consistency across account types.

* **Tests**
  * Comprehensive test suites for crypto account forms, presenters, and detail views.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq-mobile/pull/1422)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->