### PR TITLE
Release/anode 0.6.0

### DIFF
--- a/apps/nodeApp/proguard-rules.pro
+++ b/apps/nodeApp/proguard-rules.pro
@@ -366,3 +366,18 @@
 -assumenosideeffects class bisq.offer.protobuf.** {
     *** getSerializedSize(...);
 }
+
+## Tink (com.google.crypto.tink) — used transitively for EncryptedSharedPreferences /
+## push-notification-key encryption. Tink ships an unused KeysDownloader utility that
+## references google-http-client + joda-time; those are not on our classpath because
+## we never call KeysDownloader. R8 fails the build on the unresolved references unless
+## we explicitly tell it to ignore them.
+-dontwarn com.google.api.client.http.GenericUrl
+-dontwarn com.google.api.client.http.HttpHeaders
+-dontwarn com.google.api.client.http.HttpRequest
+-dontwarn com.google.api.client.http.HttpRequestFactory
+-dontwarn com.google.api.client.http.HttpResponse
+-dontwarn com.google.api.client.http.HttpTransport
+-dontwarn com.google.api.client.http.javanet.NetHttpTransport
+-dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
+-dontwarn org.joda.time.Instant

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.10.0
 
 node.name=Bisq Easy
-node.android.version=0.5.3
+node.android.version=0.6.0
 
 client.name=Bisq Connect
 client.android.version=0.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.10.0
 
 node.name=Bisq Easy
-node.android.version=0.6.0
+node.android.version=0.6.1
 
 client.name=Bisq Connect
 client.android.version=0.4.1
@@ -42,7 +42,7 @@ client.ios.version=0.4.1
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=30
 client.android.version.code=23
-node.android.version.code=41
+node.android.version.code=42
 
 # Networking
 


### PR DESCRIPTION
 - contribs to #1427
 - fix release proguard setup related to recent changes to be able to generate release buikds
 - updated metadata and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app version to 0.6.1 (version code bumped to 42).
  * Enhanced build configuration for improved dependency handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq-mobile/pull/1429)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->