### PR TITLE
bugfix/dsym_reported_ios_crash_fix

### DIFF
--- a/iosClient/embed_libtor.sh
+++ b/iosClient/embed_libtor.sh
@@ -59,3 +59,42 @@ else
     exit 1
 fi
 
+# Generate a UUID-matched dSYM bundle for LibTor.
+#
+# kmp-tor-resource ships a stripped LibTor binary with no DWARF debug info, so
+# Xcode does not produce a dSYM for it automatically. Without a UUID-matched
+# dSYM, App Store Connect / Xcode Organizer flags crash reports with a
+# "Missing dSYM" warning and refuses to symbolicate the surrounding non-LibTor
+# frames (Kotlin/Native, Swift) cleanly. See issue #1404.
+#
+# Running dsymutil on the stripped binary produces a dSYM bundle with the
+# correct UUID and the dynamic symbol table. This is enough to clear the
+# warning and unblock symbolication of the rest of the stack. Internal LibTor
+# functions remain unsymbolicated (would require building LibTor from source
+# upstream — tracked separately).
+if [ "${DEBUG_INFORMATION_FORMAT}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM_FOLDER_PATH}" ]; then
+    echo "🪪 Generating UUID-matched dSYM for LibTor.framework..."
+
+    EMBEDDED_BINARY="${DEST_FRAMEWORKS}/LibTor.framework/LibTor"
+    DSYM_OUTPUT="${DWARF_DSYM_FOLDER_PATH}/LibTor.framework.dSYM"
+
+    mkdir -p "${DWARF_DSYM_FOLDER_PATH}"
+    rm -rf "${DSYM_OUTPUT}"
+
+    # dsymutil prints a benign "no debug symbols in executable" warning for
+    # stripped binaries but still emits a valid dSYM bundle. Don't fail on it.
+    if dsymutil "${EMBEDDED_BINARY}" -o "${DSYM_OUTPUT}"; then
+        BINARY_UUID="$(dwarfdump --uuid "${EMBEDDED_BINARY}" 2>/dev/null | awk '{print $2; exit}')"
+        DSYM_UUID="$(dwarfdump --uuid "${DSYM_OUTPUT}" 2>/dev/null | awk '{print $2; exit}')"
+        if [ -n "${BINARY_UUID}" ] && [ "${BINARY_UUID}" = "${DSYM_UUID}" ]; then
+            echo "✅ LibTor dSYM generated at: ${DSYM_OUTPUT} (UUID ${DSYM_UUID})"
+        else
+            echo "⚠️  LibTor dSYM UUID mismatch (binary=${BINARY_UUID}, dsym=${DSYM_UUID})"
+        fi
+    else
+        echo "⚠️  dsymutil failed for LibTor — continuing without dSYM (crash reports will show 'Missing dSYM' for LibTor)"
+    fi
+else
+    echo "ℹ️  Skipping LibTor dSYM generation (DEBUG_INFORMATION_FORMAT=${DEBUG_INFORMATION_FORMAT:-unset})"
+fi
+


### PR DESCRIPTION
 - fixes #1404 
 - contribs to #1437 
 - prevent dsym symbolic links crashes when embedding tor into iOS builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS device build process with automated debug symbol generation and validation to ensure consistency between binaries and debug information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq-mobile/pull/1439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->