### PR TITLE
Chore/upgrade bisq2 deps to latest

### DIFF
--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -327,7 +327,9 @@ abstract class StripShadedBouncyCastle : TransformAction<TransformParameters.Non
         val output = outputs.file(input.nameWithoutExtension + "-no-bc.jar")
         JarOutputStream(output.outputStream().buffered()).use { jos ->
             JarFile(input).use { jf ->
-                jf.entries().asSequence()
+                jf
+                    .entries()
+                    .asSequence()
                     .filterNot { it.name.startsWith("org/bouncycastle/") }
                     .forEach { entry ->
                         jos.putNextEntry(JarEntry(entry.name))
@@ -360,14 +362,15 @@ class StripShadedBcCompatibility : AttributeCompatibilityRule<Boolean> {
 // no-duplicate-classes. JVM unit tests tolerate duplicate classes (first-found wins), and
 // stamping the attribute on test classpaths excludes project-local artifacts even with a
 // compatibility rule in place (NoClassDefFoundError on the project's own Kotlin output).
-val apkClasspathNames = setOf(
-    "debugCompileClasspath",
-    "debugRuntimeClasspath",
-    "releaseCompileClasspath",
-    "releaseRuntimeClasspath",
-    "profileCompileClasspath",
-    "profileRuntimeClasspath",
-)
+val apkClasspathNames =
+    setOf(
+        "debugCompileClasspath",
+        "debugRuntimeClasspath",
+        "releaseCompileClasspath",
+        "releaseRuntimeClasspath",
+        "profileCompileClasspath",
+        "profileRuntimeClasspath",
+    )
 configurations.matching { it.isCanBeResolved && it.name in apkClasspathNames }.configureEach {
     attributes.attribute(stripShadedBcAttribute, true)
 }

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -1,7 +1,20 @@
 import com.google.protobuf.gradle.proto
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeCompatibilityRule
+import org.gradle.api.attributes.CompatibilityCheckDetails
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -286,10 +299,77 @@ protobuf {
 }
 
 // -------------------- Dependencies --------------------
-// Exclude conflicting jsocks fork from bisq-network to avoid duplicate class errors
-// We use com.github.chimp1984:jsocks instead
+// Exclude conflicting jsocks fork from bisq-network. The canonical jsocks classes are
+// provided transitively via bisq2's tor:jsocks subproject (pulled in by bisq.core.network.network).
 configurations.all {
     exclude(group = "com.github.bisq-network", module = "jsocks")
+}
+
+// net.i2p:router 2.12.0 added post-quantum (MLKEM) support and ships a shaded copy of 60
+// org/bouncycastle/* classes inside its jar. Mobile pulls clean bcprov-jdk18on directly,
+// and Android's R8 fails the build on the duplicate classes. Mobile only enables TOR
+// transport at runtime (see android.conf: supportedTransportTypes = ["TOR"]), so the
+// shaded BC classes are dead code on this platform. Strip them at consume time via a
+// Gradle artifact transform; bisq2 desktop avoids this because the JVM tolerates
+// duplicate classpath classes (first-found wins) where R8 doesn't.
+abstract class StripShadedBouncyCastle : TransformAction<TransformParameters.None> {
+    @get:InputArtifact
+    abstract val inputArtifact: Provider<FileSystemLocation>
+
+    override fun transform(outputs: TransformOutputs) {
+        val input = inputArtifact.get().asFile
+        // Pass through everything except net.i2p:router. Use the Provider-based outputs.file
+        // overload so Gradle wires the input file as the output without copying or relocating.
+        if (!input.name.startsWith("router-")) {
+            outputs.file(inputArtifact)
+            return
+        }
+        val output = outputs.file(input.nameWithoutExtension + "-no-bc.jar")
+        JarOutputStream(output.outputStream().buffered()).use { jos ->
+            JarFile(input).use { jf ->
+                jf.entries().asSequence()
+                    .filterNot { it.name.startsWith("org/bouncycastle/") }
+                    .forEach { entry ->
+                        jos.putNextEntry(JarEntry(entry.name))
+                        if (!entry.isDirectory) {
+                            jf.getInputStream(entry).use { it.copyTo(jos) }
+                        }
+                        jos.closeEntry()
+                    }
+            }
+        }
+    }
+}
+
+val stripShadedBcAttribute = Attribute.of("stripShadedBc", Boolean::class.javaObjectType)
+
+// Producers that don't declare the attribute (e.g. project-local artifacts from Android/Kotlin
+// compile tasks) must remain compatible with consumers that request stripShadedBc = true.
+// Without this rule, requesting the attribute on a classpath silently excludes project artifacts
+// and tests fail with NoClassDefFoundError on the project's own classes.
+class StripShadedBcCompatibility : AttributeCompatibilityRule<Boolean> {
+    override fun execute(details: CompatibilityCheckDetails<Boolean>) {
+        if (details.producerValue == null || details.producerValue == details.consumerValue) {
+            details.compatible()
+        }
+        // Else (producer=false, consumer=true) leave unset so Gradle picks the registered transform.
+    }
+}
+
+// Only the APK runtime/compile classpaths need the transform — that's where R8/D8 enforces
+// no-duplicate-classes. JVM unit tests tolerate duplicate classes (first-found wins), and
+// stamping the attribute on test classpaths excludes project-local artifacts even with a
+// compatibility rule in place (NoClassDefFoundError on the project's own Kotlin output).
+val apkClasspathNames = setOf(
+    "debugCompileClasspath",
+    "debugRuntimeClasspath",
+    "releaseCompileClasspath",
+    "releaseRuntimeClasspath",
+    "profileCompileClasspath",
+    "profileRuntimeClasspath",
+)
+configurations.matching { it.isCanBeResolved && it.name in apkClasspathNames }.configureEach {
+    attributes.attribute(stripShadedBcAttribute, true)
 }
 
 // Force Bisq2 core dependency versions in unit tests to match production
@@ -303,6 +383,20 @@ configurations.matching { it.name.contains("UnitTest") }.configureEach {
 }
 
 dependencies {
+    // Register the BC-strip artifact transform (definition + producer/consumer attribute setup)
+    attributesSchema {
+        attribute(stripShadedBcAttribute) {
+            compatibilityRules.add(StripShadedBcCompatibility::class.java)
+        }
+    }
+    artifactTypes.getByName("jar") {
+        attributes.attribute(stripShadedBcAttribute, false)
+    }
+    registerTransform(StripShadedBouncyCastle::class.java) {
+        from.attribute(stripShadedBcAttribute, false).attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
+        to.attribute(stripShadedBcAttribute, true).attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
+    }
+
     // Project modules
     implementation(project(sharedPresentationModule))
     implementation(project(sharedDomainModule))
@@ -350,7 +444,8 @@ dependencies {
     implementation(libs.bisq.core.network.network.identity)
     implementation(libs.bisq.core.network.socks5.socket.channel)
     implementation(libs.bisq.core.network.i2p)
-    implementation(libs.chimp.jsocks)
+    // jsocks classes are provided transitively by bisq.core.network.network (which depends
+    // on tor:jsocks). Adding com.github.chimp1984:jsocks would duplicate them.
     implementation(libs.failsafe)
     implementation(libs.apache.httpcomponents.httpclient)
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/AndroidApplicationService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/AndroidApplicationService.kt
@@ -187,6 +187,7 @@ class AndroidApplicationService(
             identityService,
             networkService,
             bondedRolesService,
+            UserService.Config.from(getConfig("user")),
         )
     val accountService = AccountService(persistenceService, networkService, userService, bondedRolesService)
     val chatService: ChatService
@@ -269,7 +270,7 @@ class AndroidApplicationService(
         alertNotificationsService =
             AlertNotificationsService(settingsService, bondedRolesService.alertService, AppType.MOBILE_NODE)
 
-        favouriteMarketsService = FavouriteMarketsService(settingsService)
+        favouriteMarketsService = settingsService.favouriteMarketsService
 
         dontShowAgainService = DontShowAgainService(settingsService)
 
@@ -322,7 +323,6 @@ class AndroidApplicationService(
             .thenCompose { result: Boolean? -> supportService.initialize() }
             .thenCompose { result: Boolean? -> tradeService.initialize() }
             .thenCompose { result: Boolean? -> alertNotificationsService.initialize() }
-            .thenCompose { result: Boolean? -> favouriteMarketsService.initialize() }
             .thenCompose { result: Boolean? -> dontShowAgainService.initialize() }
             .orTimeout(STARTUP_TIMEOUT_SEC, TimeUnit.SECONDS)
             .handle { result: Boolean?, throwable: Throwable? ->
@@ -354,10 +354,6 @@ class AndroidApplicationService(
                 .shutdown()
                 .exceptionally { throwable: Throwable -> this.logError(throwable) }
                 .thenCompose { result: Boolean? ->
-                    favouriteMarketsService
-                        .shutdown()
-                        .exceptionally { throwable: Throwable -> this.logError(throwable) }
-                }.thenCompose { result: Boolean? ->
                     alertNotificationsService
                         .shutdown()
                         .exceptionally { throwable: Throwable -> this.logError(throwable) }

--- a/apps/nodeApp/src/main/resources/android.conf
+++ b/apps/nodeApp/src/main/resources/android.conf
@@ -142,6 +142,10 @@ application {
         }
     }
 
+    user = {
+        rateLimitEnabled = true
+    }
+
     network {
         version = 1
 

--- a/apps/nodeApp/src/release/resources/android.conf
+++ b/apps/nodeApp/src/release/resources/android.conf
@@ -140,6 +140,10 @@ application {
         }
     }
 
+    user = {
+        rateLimitEnabled = true
+    }
+
     network {
         version = 1
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 
 # -------------------- Project Specific --------------------
-bisq-core = "2.1.10"
+bisq-core = "2.1.11"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "df6ac6bd384bd186edf838bc595f606b41dedc6a"
+bisq-core-commit = "429b5423d90a4715e0f664e929094f24d261a309"
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing
-bisq-desktop-pairing = "2.1.10"
+bisq-desktop-pairing = "2.1.11"
 # API version is usually same as bisq-core but for more control we keep it separated
 # Retrieved in shared/domain/build.gradle.kts: val bisqApiVersion by extra { findTomlVersion("bisq-api") }
-bisq-api = "2.1.10"
+bisq-api = "2.1.11"
 
 # -------------------- Kotlin & JetBrains --------------------
 kotlin = "2.3.20"


### PR DESCRIPTION
 - depends on https://github.com/bisq-network/bisq2/pull/4789
 - `for-mobile-based-on-2.1.11` is now our dev bisq2 branch
 - connect: no necessary changes, everything is already in api module
 - node: removed jsocks dep in favour of transitive dependency + gradle conflict resolution for jars including BC
 - added comments on gradle changes for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Bisq core libraries to version 2.1.11 with improvements and stability enhancements.
  * Enabled rate limiting in application configuration for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->