### PR TITLE
bugfix/opted_in_android_relayed_notifications_too_many_per_open_trade

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -318,9 +318,19 @@ class BisqFirebaseMessagingService :
 
             internal fun fromTitle(title: String): NotificationCategory {
                 val lower = title.lowercase()
+                // Chat is checked first because trade-private chat titles (built by
+                // bisq2 `ChatNotificationService#createNotification`) embed the
+                // channel navigation path e.g. "Alice (Bisq Easy → Open Trades → Bob)"
+                // — they match BOTH "chat" / "message" semantics and "trade" /
+                // "open trades" keywords. Without this ordering, trade-private chats
+                // were mislabelled as `TRADE_UPDATE` and shared the generic banner
+                // with actual state-transition pushes.
+                // The explicit `payload.category` (set by bisq2 since #1450) bypasses
+                // this entirely; the heuristic is only the backward-compat fallback
+                // for older trusted nodes that don't populate `category` yet.
                 return when {
+                    lower.contains("chat") || lower.contains("message") -> CHAT_MESSAGE
                     lower.contains("trade") || lower.contains("payment") || lower.contains("btc") -> TRADE_UPDATE
-                    lower.contains("message") || lower.contains("chat") -> CHAT_MESSAGE
                     lower.contains("offer") -> OFFER_UPDATE
                     else -> GENERAL
                 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
@@ -155,7 +155,7 @@ class ClientApplicationLifecycleServiceTest {
         }
 
     @Test
-    fun `activate starts foreground notification service in power-user combo (relayed on AND keep-connected on)`() =
+    fun `activate starts FG service and suppresses local delivery in power-user combo (relayed on AND keep-connected on)`() =
         runTest {
             order.clear()
             coEvery { settingsRepository.fetch() } returns
@@ -166,11 +166,16 @@ class ClientApplicationLifecycleServiceTest {
 
             service.activate()
 
-            // Power-user combo: FCM acts as backstop for killed-app delivery AND the
-            // local FG service keeps the WebSocket alive while the app is backgrounded
-            // (snappy reopens, real-time trade chat). FG service MUST start.
+            // Power-user combo: FG service MUST run to keep the WS connection alive
+            // in background (this is the whole point of the keep-connected toggle —
+            // fast app resumes, live trade chat). The FG service is decoupled from
+            // local notification posting: local delivery is SUPPRESSED because the
+            // relay (FCM/APNs) handles user-facing notifications, so the FG service
+            // hosts only the WS without arming the notification observers. See
+            // bisq-mobile#1450.
             assertEquals(true, order.contains("notification.start"))
             assertEquals("notification.start", order.first())
+            io.mockk.coVerify { openTradesNotificationService.setLocalDeliverySuppressed(true) }
         }
 
     @Test
@@ -193,22 +198,23 @@ class ClientApplicationLifecycleServiceTest {
         }
 
     /**
-     * Verifies the runtime suppressor job — the [combine]+[onEach] pipeline that
-     * mirrors `relayed × keepConnected × osPermission` into
-     * [OpenTradesNotificationService.setLocalDeliverySuppressed]. The bootstrap-path
-     * tests above only cover the cold-start gate; this one closes the loop on
-     * runtime state changes.
+     * Verifies the runtime orchestrator job — the [combine]+[onEach] pipeline that
+     * mirrors `relayed × keepConnected × osPermission` into TWO independent
+     * decisions:
+     *  - [OpenTradesNotificationService.setKeepProcessAlive] (FG service lifecycle)
+     *  - [OpenTradesNotificationService.setLocalDeliverySuppressed] (notification posting)
      *
-     * The suppressor runs on `pushModeScope` (Dispatchers.Default), which is not
+     * The orchestrator runs on `pushModeScope` (Dispatchers.Default), which is not
      * controlled by `runTest`'s virtual scheduler, so we use MockK's `coVerify(timeout = …)`
      * to wait for the side-effect rather than driving virtual time.
      *
-     * Note: `distinctUntilChanged` means transitions that don't flip the computed
-     * `suppressed` boolean emit nothing — that's a deliberate idempotence guarantee
-     * worth covering, hence the final "no extra emission" assertion.
+     * `distinctUntilChanged` operates on the whole [ClientApplicationLifecycleService.PushOrchestrationState]
+     * pair, so when *either* component changes, BOTH method calls fire (the orchestrator
+     * is idempotent per-method, so a no-op call is fine). State C is the regression we
+     * fixed: relayed=true + keep=true now correctly keeps FG alive.
      */
     @Test
-    fun `suppressor job mirrors truth table when relayed and keep-connected change at runtime`() =
+    fun `orchestrator mirrors truth table when relayed and keep-connected change at runtime`() =
         runTest {
             order.clear()
             val relayedFlow = MutableStateFlow(false)
@@ -221,47 +227,78 @@ class ClientApplicationLifecycleServiceTest {
 
             service.activate()
 
-            // State A: relayed=false → NOT suppressed (today's default, FG service runs).
-            coVerify(timeout = 2_000) { openTradesNotificationService.setLocalDeliverySuppressed(false) }
-
-            // State B: relayed=true, keep=false → suppressed (today's pure relayed mode).
-            relayedFlow.value = true
-            coVerify(timeout = 2_000) { openTradesNotificationService.setLocalDeliverySuppressed(true) }
-
-            // State C: relayed=true, keep=true → NOT suppressed (power-user combo).
-            // This is the second time `false` is emitted (after A), so `exactly = 2`.
-            settingsFlow.value = settingsFlow.value.copy(keepConnectedInBackground = true)
+            // State A: relayed=false → FG ON, NOT suppressed (default mode, local posts).
+            // Note: BOTH the bootstrap path (`maybeLaunchForegroundNotificationService`)
+            // AND the orchestrator's initial combine emission fire with the same values
+            // on activate(), so each method is called TWICE at State A. The service
+            // methods are idempotent so the double-call is a no-op past the first one.
             coVerify(timeout = 2_000, exactly = 2) {
                 openTradesNotificationService.setLocalDeliverySuppressed(false)
             }
+            coVerify(timeout = 2_000, exactly = 2) {
+                openTradesNotificationService.setKeepProcessAlive(true)
+            }
 
-            // State D: relayed flipped back off while keep is still true. Computed
-            // `suppressed` is still false (same as C), so distinctUntilChanged must
-            // NOT emit again — call count for `false` stays at 2, not 3.
-            relayedFlow.value = false
-            coVerify(timeout = 1_000, exactly = 1) {
+            // State B: relayed=true, keep=false → FG OFF, suppressed (pure relayed mode).
+            relayedFlow.value = true
+            coVerify(timeout = 2_000) { openTradesNotificationService.setLocalDeliverySuppressed(true) }
+            coVerify(timeout = 2_000) { openTradesNotificationService.setKeepProcessAlive(false) }
+
+            // State C: relayed=true, keep=true → FG ON (regression fix — was OFF before
+            // bisq-mobile#1450 follow-up). Local delivery stays suppressed because the
+            // relay handles user-facing notifications, but the FG service runs to keep
+            // the WS alive in background for fast resume and live trade chat.
+            // The orchestrator's `distinctUntilChanged` operates on the whole
+            // `PushOrchestrationState` data class — when ONE component changes (keep
+            // here) BOTH method calls fire, even though setLocalDeliverySuppressed(true)
+            // matches state B's value. Cumulative counts from A+B+C:
+            //   setLocalDeliverySuppressed(true): 2 (B + C)
+            //   setKeepProcessAlive(true):        3 (2× A + C)
+            settingsFlow.value = settingsFlow.value.copy(keepConnectedInBackground = true)
+            coVerify(timeout = 2_000, exactly = 3) {
+                openTradesNotificationService.setKeepProcessAlive(true)
+            }
+            coVerify(timeout = 2_000, exactly = 2) {
                 openTradesNotificationService.setLocalDeliverySuppressed(true)
             }
-            coVerify(timeout = 1_000, exactly = 2) {
+
+            // State D: relayed=false, keep=true → FG ON, NOT suppressed (back to default
+            // local mode; the keep-connected toggle is hidden in UI when relayed is off
+            // but the stored value stays). Same FG/suppression VALUES as State A but
+            // distinctUntilChanged fires because the data class differs from State C.
+            // Cumulative counts after A+B+C+D:
+            //   setLocalDeliverySuppressed(false): 3 (2× A + D)
+            //   setKeepProcessAlive(true):        4 (2× A + C + D)
+            //   setKeepProcessAlive(false):       1 (B only — sanity-check the
+            //                                        "stop FG" path stayed scoped to State B)
+            relayedFlow.value = false
+            coVerify(timeout = 2_000, exactly = 3) {
                 openTradesNotificationService.setLocalDeliverySuppressed(false)
+            }
+            coVerify(timeout = 2_000, exactly = 4) {
+                openTradesNotificationService.setKeepProcessAlive(true)
+            }
+            coVerify(timeout = 1_000, exactly = 1) {
+                openTradesNotificationService.setKeepProcessAlive(false)
             }
         }
 
     @Test
-    fun `suppressor job suppresses local delivery when OS notification permission is revoked`() =
+    fun `orchestrator stops FG and suppresses local delivery when OS notification permission is revoked`() =
         runTest {
             order.clear()
             val relayedFlow = MutableStateFlow(false)
             val settingsFlow = MutableStateFlow(Settings(keepConnectedInBackground = false))
             every { pushNotificationServiceFacade.isPushNotificationsEnabled } returns relayedFlow
             every { settingsRepository.data } returns settingsFlow
-            // Permission denied: there's nothing useful to deliver locally; suppress regardless
-            // of the relayed/keep-connected combo.
+            // Permission denied: there's nothing useful to deliver locally; suppress AND
+            // shut FG down regardless of the relayed/keep-connected combo.
             coEvery { notificationController.hasPermission() } returns false
 
             service.activate()
 
             coVerify(timeout = 2_000) { openTradesNotificationService.setLocalDeliverySuppressed(true) }
+            coVerify(timeout = 2_000) { openTradesNotificationService.setKeepProcessAlive(false) }
         }
 
     @Test
@@ -337,6 +374,12 @@ class ClientApplicationLifecycleServiceTest {
         }
 
     private fun configureActivationTracking() {
+        // The bootstrap path now calls `setKeepProcessAlive(true)` directly (see
+        // `ClientApplicationLifecycleService.maybeLaunchForegroundNotificationService`)
+        // instead of the legacy `startService()` alias. Track that call. Only the
+        // `true` argument is recorded — `false` is the "skip" case and is asserted
+        // via `order.contains("notification.start") == false`.
+        io.mockk.every { openTradesNotificationService.setKeepProcessAlive(true) } answers { order += "notification.start" }
         io.mockk.every { openTradesNotificationService.startService() } answers { order += "notification.start" }
         coEvery { apiAccessService.activate() } answers { order += "apiAccess.activate" }
         coEvery { applicationBootstrapFacade.activate() } answers { order += "bootstrap.activate" }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
@@ -156,6 +156,31 @@ class BisqFirebaseMessagingServiceTest {
     }
 
     @Test
+    fun `fromTitle prefers chat over trade keywords when both are present`() {
+        // Pins the defensive keyword ordering in `fromTitle`: titles that match
+        // BOTH the chat/message bucket and the trade/payment/btc bucket must
+        // resolve to CHAT_MESSAGE. If the order is ever flipped back (trade-first),
+        // this test fails — a chat in a trade context would silently be labelled
+        // as a generic trade update again, recreating the bisq-mobile#1450 symptom
+        // for older trusted nodes that don't yet populate `category`.
+        //
+        // The explicit-category path (`fromPayload`) is the real fix for the
+        // production trade-private chat title pattern; this ordering hygiene is
+        // for backward-compat with older bisq2 versions that don't set category.
+        listOf(
+            "Trade chat update",
+            "Payment message received",
+            "BTC chat from peer",
+        ).forEach { title ->
+            assertEquals(
+                BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE,
+                BisqFirebaseMessagingService.NotificationCategory.fromTitle(title),
+                "chat keyword must win over trade keyword for title: $title",
+            )
+        }
+    }
+
+    @Test
     fun `fromPayload classifies trade-private chat titles as CHAT_MESSAGE when backend sets explicit category`() {
         // Regression for bisq-mobile#1450 categorisation bug. The bisq2
         // `ChatNotificationService#createNotification` builds trade-private chat

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
@@ -156,6 +156,53 @@ class BisqFirebaseMessagingServiceTest {
     }
 
     @Test
+    fun `fromPayload classifies trade-private chat titles as CHAT_MESSAGE when backend sets explicit category`() {
+        // Regression for bisq-mobile#1450 categorisation bug. The bisq2
+        // `ChatNotificationService#createNotification` builds trade-private chat
+        // titles as `"{userName} ({channelNavigationPath})"` where the path is
+        // e.g. `"Bisq Easy → Open Trades → {peer}"`. That string matches the
+        // "trade" / "open trades" keywords in `fromTitle` but contains NO chat
+        // keyword to grab onto — so a title-only heuristic genuinely cannot
+        // disambiguate a peer's chat from a trade-state push.
+        //
+        // The fix is the explicit `category` field populated by bisq2's
+        // `ChatNotification#getCategory` returning `chat_message`, which the
+        // `fromPayload` path prefers over the title heuristic.
+        listOf(
+            "Alice (Bisq Easy → Open Trades → Bob)",
+            "alice (bisq easy - open trades - bob)",
+        ).forEach { title ->
+            val payload =
+                BisqFirebaseMessagingService.NotificationPayload(
+                    id = "channel.msg",
+                    title = title,
+                    message = "hello",
+                    category = "chat_message",
+                )
+            assertEquals(
+                BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE,
+                BisqFirebaseMessagingService.NotificationCategory.fromPayload(payload),
+                "trade-private chat with explicit category should resolve to CHAT_MESSAGE: $title",
+            )
+        }
+    }
+
+    @Test
+    fun `fromTitle returns TRADE_UPDATE for trade-private chat titles when category is absent (backward compat with old nodes)`() {
+        // Documents the genuine limitation of the title heuristic for the chat
+        // case described above — kept as a regression so anyone tightening the
+        // heuristic in the future understands why the backend `category` field
+        // is the only reliable signal. Older trusted nodes (pre-#1450) that
+        // don't populate `category` will still mislabel chats as TRADE_UPDATE
+        // — that's the cost of backward compat; the route deep-link still
+        // lands the user on the trade list either way.
+        assertEquals(
+            BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+            BisqFirebaseMessagingService.NotificationCategory.fromTitle("Alice (Bisq Easy → Open Trades → Bob)"),
+        )
+    }
+
+    @Test
     fun `fromTitle classifies offer keyword as OFFER_UPDATE`() {
         assertEquals(
             BisqFirebaseMessagingService.NotificationCategory.OFFER_UPDATE,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
@@ -195,63 +195,83 @@ class ClientApplicationLifecycleService(
         val keepConnectedInBackground = settings.keepConnectedInBackground
         val notificationPermissionGranted = notificationController.hasPermission()
         if (getPlatformInfo().type == PlatformType.ANDROID) {
-            when {
-                pushNotificationsEnabled && !keepConnectedInBackground ->
-                    log.i {
-                        "Skipping foreground notification service start " +
-                            "(relayed mode on, keep-connected off)"
-                    }
+            // The foreground service has two independent purposes (see
+            // [OpenTradesNotificationService.setKeepProcessAlive] kdoc):
+            //   1. Keep the process + WS alive in background (driven by
+            //      `keepConnectedInBackground`, useful even in pure-relayed mode).
+            //   2. Host the local-delivery observers that post trade-state /
+            //      chat notifications via `notify(...)`.
+            // Suppression (purpose 2) is now separate from FG-service start
+            // (purpose 1) — see [launchForegroundNotificationServiceSuppressorJob].
+            val keepProcessAlive =
+                notificationPermissionGranted && (!pushNotificationsEnabled || keepConnectedInBackground)
+            val localDeliverySuppressed = pushNotificationsEnabled || !notificationPermissionGranted
 
-                !notificationPermissionGranted ->
-                    log.i {
-                        "Skipping foreground notification service start " +
-                            "(POST_NOTIFICATIONS permission not granted — nothing useful to deliver)"
-                    }
+            // Set suppression first so that if the FG service starts and the
+            // app transitions straight to background, observers see the
+            // correct suppressed flag at registration time.
+            openTradesNotificationService.setLocalDeliverySuppressed(localDeliverySuppressed)
 
-                else -> {
-                    log.i {
-                        "Starting foreground notification service " +
-                            "(relayed=$pushNotificationsEnabled, keepConnected=$keepConnectedInBackground, " +
-                            "permission granted)"
-                    }
-                    openTradesNotificationService.startService()
+            if (keepProcessAlive) {
+                log.i {
+                    "Starting foreground notification service " +
+                        "(relayed=$pushNotificationsEnabled, keepConnected=$keepConnectedInBackground, " +
+                        "suppressed=$localDeliverySuppressed)"
+                }
+                openTradesNotificationService.setKeepProcessAlive(true)
+            } else {
+                log.i {
+                    "Skipping foreground notification service start " +
+                        "(relayed=$pushNotificationsEnabled, keepConnected=$keepConnectedInBackground, " +
+                        "permission=$notificationPermissionGranted) — nothing for the FG service to do"
                 }
             }
         }
     }
 
     /**
-     * Enables/disables the foreground notification service based on user preferences + permissions.
+     * Orchestrates two independent decisions on every relevant settings/permission change:
      *
-     * Three inputs decide whether the local foreground delivery should be suppressed:
+     *  1. **Foreground service** ([OpenTradesNotificationService.setKeepProcessAlive]) —
+     *     should the Android FG service run? The FG service keeps the process + WS alive
+     *     in background, and hosts the local-delivery observers when those are active.
+     *  2. **Local notification posting** ([OpenTradesNotificationService.setLocalDeliverySuppressed]) —
+     *     should the local observers post `notify(...)` calls? Suppressed when the relay
+     *     handles delivery, to avoid duplicate notifications. See bisq-mobile#1450.
+     *
+     * Three inputs drive both decisions:
      *  - relayed-push opt-in (from the push-notifications facade)
-     *  - "keep connected in background" sub-setting (from settings; Android-only; only
-     *    meaningful when relayed is on, but read unconditionally — gating happens via the
-     *    truth table below)
+     *  - "keep connected in background" sub-setting (Android-only; only user-visible when
+     *    relayed is on, but read unconditionally)
      *  - OS POST_NOTIFICATIONS permission (queried directly from the OS each tick)
      *
-     * Truth table (with permission granted):
+     * Truth table:
      *
-     *   relayed=false, keep=*       → not suppressed (today's default; FG service runs)
-     *   relayed=true,  keep=false   → suppressed (today's relayed mode; FCM-only)
-     *   relayed=true,  keep=true    → not suppressed (power-user combo; FG keeps WS alive,
-     *                                                 FCM is the backstop for killed app)
+     *   relayed  keep  perm |  FG service  |  local delivery
+     *   -------- ----- ---- |  ----------- |  --------------
+     *   off      *     yes  |  RUN         |  post (default mode)
+     *   off      *     no   |  off         |  suppressed (nothing to deliver)
+     *   on       off   yes  |  off         |  suppressed (pure relayed mode)
+     *   on       off   no   |  off         |  suppressed
+     *   on       on    yes  |  RUN         |  suppressed (FG keeps WS alive; relay posts)
+     *   on       on    no   |  off         |  suppressed (no permission overrides keep)
      *
-     * Permission denied always suppresses regardless — there's nothing useful to deliver.
+     * `keepConnected` no longer doubles notification delivery — the relay (bisq-relay
+     * → FCM/APNs) has no awareness of the client's WS state and pushes for every mobile-
+     * eligible event regardless. If `keepConnected=true` also armed the local observers,
+     * every event would fire twice: rich local notification + generic relay notification.
+     * `keepConnected` retains its WS-lifecycle role (FG service runs) but the local
+     * observers stay suppressed.
      *
-     * `settingsRepository.data` is observed for two reasons: (a) it carries the
-     * `keepConnectedInBackground` value, (b) it acts as a "something changed, re-evaluate"
-     * trigger for the OS permission re-check. The OS query inside the transform is
-     * `ContextCompat.checkSelfPermission` on Android — cheap to call. `distinctUntilChanged`
-     * keeps `setLocalDeliverySuppressed` idempotent.
+     * Suppression is set BEFORE keep-alive on each emission so that observers see the
+     * correct flag at registration time when the FG service is being started fresh.
      *
      * Catches the runtime transitions the bootstrap gate misses:
      *  - User flips the relayed-push toggle in Settings.
      *  - User flips the keep-connected sub-toggle in Settings.
-     *  - User grants POST_NOTIFICATIONS via the dashboard explainer (the dashboard's
-     *    `LaunchedEffect` writes the new state into `settingsRepository`, which triggers a
-     *    re-evaluation here that picks up the now-`true` OS truth).
-     *  - User revokes permission via system Settings and returns to the dashboard; same path.
+     *  - User grants/revokes POST_NOTIFICATIONS — the dashboard's `LaunchedEffect` writes
+     *    the new state into `settingsRepository`, which triggers a re-evaluation here that
+     *    picks up the now-current OS truth.
      */
     private fun launchForegroundNotificationServiceSuppressorJob() {
         pushModeOrchestrationJob?.cancel()
@@ -262,10 +282,19 @@ class ClientApplicationLifecycleService(
             ) { relayed, settings ->
                 val keepConnected = settings.keepConnectedInBackground
                 val osGranted = notificationController.hasPermission()
-                (relayed && !keepConnected) || !osGranted
+                PushOrchestrationState(
+                    keepProcessAlive = osGranted && (!relayed || keepConnected),
+                    localDeliverySuppressed = relayed || !osGranted,
+                )
             }.distinctUntilChanged()
-                .onEach { suppressed ->
-                    openTradesNotificationService.setLocalDeliverySuppressed(suppressed)
+                .onEach { state ->
+                    openTradesNotificationService.setLocalDeliverySuppressed(state.localDeliverySuppressed)
+                    openTradesNotificationService.setKeepProcessAlive(state.keepProcessAlive)
                 }.launchIn(pushModeScope)
     }
+
+    private data class PushOrchestrationState(
+        val keepProcessAlive: Boolean,
+        val localDeliverySuppressed: Boolean,
+    )
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
@@ -1,0 +1,136 @@
+package network.bisq.mobile.presentation.common.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.service.ForegroundDetector
+import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.notification.ForegroundServiceController
+import network.bisq.mobile.presentation.common.notification.NotificationController
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Direct unit tests for the foreground-service-vs-local-delivery state machine on
+ * [OpenTradesNotificationService] — the seam where bisq-mobile#1450's regression lived.
+ *
+ * Why this lives separately from [OpenTradesNotificationServiceStateTest]: that suite
+ * focuses on the trade-state notify(…) decisions; this one focuses on the lifecycle
+ * decoupling between [OpenTradesNotificationService.setKeepProcessAlive] (controls the
+ * Android FG service) and [OpenTradesNotificationService.setLocalDeliverySuppressed]
+ * (controls whether observers post notifications). The previous regression was caused
+ * by these two concerns being tangled in a single method — without a direct test for
+ * the decoupled contract, only an indirect test via `ClientApplicationLifecycleService`
+ * caught the bug. This suite pins the decoupled contract so a future re-tangle fails
+ * a unit test rather than a manual test on device.
+ */
+class OpenTradesNotificationServiceLifecycleTest {
+    private lateinit var notificationController: NotificationController
+    private lateinit var foregroundServiceController: ForegroundServiceController
+    private lateinit var tradesServiceFacade: TradesServiceFacade
+    private lateinit var userProfileServiceFacade: UserProfileServiceFacade
+    private lateinit var appForegroundController: ForegroundDetector
+    private lateinit var service: OpenTradesNotificationService
+
+    @BeforeTest
+    fun setup() {
+        I18nSupport.initialize("en")
+
+        notificationController = mockk(relaxed = true)
+        foregroundServiceController = mockk(relaxed = true)
+
+        tradesServiceFacade = mockk(relaxed = true)
+        every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+
+        userProfileServiceFacade = mockk(relaxed = true)
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+
+        appForegroundController = mockk(relaxed = true)
+        // Foreground=true at setup means the lifecycle observer won't try to register
+        // background flow observers — keeps the tests focused on the FG service /
+        // suppression seam rather than the BG observer-registration path.
+        every { appForegroundController.isForeground } returns MutableStateFlow(true)
+
+        service =
+            OpenTradesNotificationService(
+                notificationController = notificationController,
+                foregroundServiceController = foregroundServiceController,
+                tradesServiceFacade = tradesServiceFacade,
+                userProfileServiceFacade = userProfileServiceFacade,
+                appForegroundController = appForegroundController,
+            )
+    }
+
+    @Test
+    fun `setKeepProcessAlive true starts the foreground service when not running`() =
+        runTest {
+            service.setKeepProcessAlive(true)
+
+            verify(exactly = 1) { foregroundServiceController.startService() }
+            verify(exactly = 0) { foregroundServiceController.stopService() }
+        }
+
+    @Test
+    fun `setKeepProcessAlive false stops the foreground service when running`() =
+        runTest {
+            service.setKeepProcessAlive(true)
+
+            service.setKeepProcessAlive(false)
+
+            verify(exactly = 1) { foregroundServiceController.startService() }
+            verify(exactly = 1) { foregroundServiceController.stopService() }
+        }
+
+    @Test
+    fun `setKeepProcessAlive is idempotent — repeated same-value calls are no-ops`() =
+        runTest {
+            // True → true → true should call startService exactly once.
+            service.setKeepProcessAlive(true)
+            service.setKeepProcessAlive(true)
+            service.setKeepProcessAlive(true)
+            verify(exactly = 1) { foregroundServiceController.startService() }
+            verify(exactly = 0) { foregroundServiceController.stopService() }
+
+            // False → false → false (after returning to stopped) should call stopService
+            // exactly once total, not three times.
+            service.setKeepProcessAlive(false)
+            service.setKeepProcessAlive(false)
+            verify(exactly = 1) { foregroundServiceController.stopService() }
+        }
+
+    @Test
+    fun `setLocalDeliverySuppressed does NOT touch the foreground service`() =
+        runTest {
+            // This is the regression-pin for bisq-mobile#1450. Before the fix,
+            // `setLocalDeliverySuppressed(true)` ALSO stopped the FG service. That
+            // killed the keep-connected-in-background mode for users running
+            // relayed+keepConnected=on. The decoupled contract: suppression only
+            // gates `notify(…)` / observer registration. FG lifecycle is owned
+            // by `setKeepProcessAlive`.
+            service.setKeepProcessAlive(true)
+
+            service.setLocalDeliverySuppressed(true)
+            service.setLocalDeliverySuppressed(false)
+            service.setLocalDeliverySuppressed(true)
+
+            verify(exactly = 1) { foregroundServiceController.startService() }
+            verify(exactly = 0) { foregroundServiceController.stopService() }
+        }
+
+    @Test
+    fun `startService is a backward-compatible alias for setKeepProcessAlive true`() =
+        runTest {
+            // `startService()` is still called by the nodeApp's lifecycle service
+            // (which doesn't differentiate between FG lifecycle and local notification
+            // posting — local IS the only path on the node app). Verify it stays
+            // wired to FG-start so the nodeApp keeps working without changes.
+            service.startService()
+
+            verify(exactly = 1) { foregroundServiceController.startService() }
+            verify(exactly = 0) { foregroundServiceController.stopService() }
+        }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
@@ -91,56 +91,81 @@ class OpenTradesNotificationService(
      * Starts the foreground service immediately. Should be called during app initialization
      * before any heavy work to avoid ForegroundServiceDidNotStartInTimeException.
      *
-     * No-op when local delivery is suppressed (relayed notifications enabled, or OS
-     * notification permission denied). Keeping the service alive in those cases would
-     * either compete with the relayed path or run with no user-visible effect.
+     * Thin alias for [setKeepProcessAlive] with `true` — kept for backward compatibility
+     * with callers (e.g. the nodeApp lifecycle service) that don't differentiate between
+     * "keep process alive" and "post local notifications", which are independent on the
+     * client app.
      */
     fun startService() {
-        if (isLocalDeliverySuppressed) {
-            log.d { "Local delivery is suppressed — skipping local foreground service start" }
-            return
-        }
-        if (!isServiceStarted) {
-            log.i { "Starting foreground service on app initialization" }
+        setKeepProcessAlive(true)
+    }
+
+    /**
+     * Controls whether the Android foreground service is running, independent of whether
+     * local notifications should post. Decoupled from [setLocalDeliverySuppressed]
+     * because the foreground service has two distinct purposes:
+     *
+     *  1. Keep the process (and the WebSocket connection) alive while the app is
+     *     backgrounded — useful for "keep-connected-in-background" even when the
+     *     relayed (FCM/APNs) path is the sole notification channel.
+     *  2. Host the [registerObservers] background flow observers that fire
+     *     `notify(...)` calls for local trade-state / chat events.
+     *
+     * On the client app, purpose 1 may apply WITHOUT purpose 2 (relayed mode + keep
+     * connected on). On the nodeApp both apply together since there's no relay.
+     *
+     *  - `true`  → starts the FG service if not already running.
+     *  - `false` → stops the FG service AND unregisters observers (no process means
+     *              no observers can run usefully). Used when the user opts into pure
+     *              relayed mode (no keep-connected) or has revoked notification
+     *              permission entirely.
+     *
+     * Idempotent.
+     */
+    fun setKeepProcessAlive(keepAlive: Boolean) {
+        if (isServiceStarted == keepAlive) return
+        if (keepAlive) {
+            log.i { "Starting foreground service (keep process alive)" }
             foregroundServiceController.startService()
             isServiceStarted = true
         } else {
-            log.d { "Foreground service already started" }
+            log.i { "Stopping foreground service — process no longer needs to stay alive" }
+            scope.launch { unregisterObservers() }
+            foregroundServiceController.stopService()
+            isServiceStarted = false
         }
     }
 
     /**
-     * Suppresses or resumes the local foreground delivery path. Drives mutual
-     * exclusivity between local and relayed (FCM/APNs) modes, and is also
-     * called when the OS-level notification permission flips so that we don't
-     * keep the FG service running with no permission to post notifications.
+     * Suppresses or resumes local notification posting. Controls observer
+     * registration (so peer-chat / trade-state observers don't fire `notify(...)`
+     * calls that would duplicate the relayed path) but does NOT touch the
+     * foreground service lifecycle — that's [setKeepProcessAlive]'s job.
      *
-     *  - `true`  → stops the local foreground service and prevents the
-     *              lifecycle observer from re-arming background flow
-     *              observers. Used when the relayed path handles delivery, or
-     *              when the OS has revoked / not granted POST_NOTIFICATIONS.
-     *  - `false` → starts the local foreground service. Used when the user
-     *              has the default (local) mode AND has granted notification
-     *              permission.
+     *  - `true`  → unregisters observers and prevents the lifecycle observer
+     *              from re-arming them on the next background transition. Used
+     *              when the relayed path handles delivery, or when the OS has
+     *              revoked / not granted POST_NOTIFICATIONS.
+     *  - `false` → flag-flip only. The lifecycle observer will register
+     *              observers on the next background transition.
      *
-     * Idempotent — repeated calls with the same value are a no-op.
+     * Idempotent. Safe to call independently of [setKeepProcessAlive]:
+     *  - keep=true,  suppressed=true  → FG runs (WS alive), no local notifications.
+     *  - keep=true,  suppressed=false → FG runs, observers post locally (default).
+     *  - keep=false, suppressed=true  → fully off (pure relayed mode without
+     *                                   keep-connected, or permission denied).
+     *  - keep=false, suppressed=false → not a meaningful combination — without
+     *                                   FG, observers can't outlive the process,
+     *                                   so the suppression flag has no effect.
      */
     fun setLocalDeliverySuppressed(suppressed: Boolean) {
         if (isLocalDeliverySuppressed == suppressed) return
         isLocalDeliverySuppressed = suppressed
         if (suppressed) {
-            log.i { "Suppressing local foreground delivery — stopping foreground service" }
+            log.i { "Suppressing local notification posting — unregistering observers" }
             scope.launch { unregisterObservers() }
-            foregroundServiceController.stopService()
-            isServiceStarted = false
         } else {
-            log.i { "Resuming local foreground delivery — starting foreground service" }
-            if (!isServiceStarted) {
-                foregroundServiceController.startService()
-                isServiceStarted = true
-            }
-            // The lifecycle observer will (re-)register flow observers next time
-            // the app moves to background — no need to register them here.
+            log.i { "Resuming local notification posting — observers will re-arm on next background transition" }
         }
     }
 


### PR DESCRIPTION
 - resolves #1450 
 - depends on https://github.com/bisq-network/bisq2/pull/4797
 - avoid FG service reposting already managed by relayed mechanism notifications
 - fix regression bug preventing foreground service to start when keep alive is selected
 - fix bug showing a chat message generic message as a trade message
 - improve docs + tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification categorization so chat messages are no longer miscategorized as trade updates.
  * More consistent background behavior: foreground keep-alive and local notification suppression are now handled separately, reducing missed or duplicate notifications and improving connection persistence when enabled.

* **Tests**
  * Added coverage for chat-vs-trade notification precedence and for the new foreground/suppression lifecycle behaviors, including backward-compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->