### PR TITLE
Release/anode 0.7.0

### DIFF
--- a/apps/nodeApp/proguard-rules.pro
+++ b/apps/nodeApp/proguard-rules.pro
@@ -381,3 +381,29 @@
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport
 -dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
 -dontwarn org.joda.time.Instant
+
+## bisq2 2.1.11 transitive deps (Apache HttpClient5, Apache Commons, Jersey, Swagger,
+## gRPC-Netty-shaded) reference JDK-only and optional classes that don't exist on
+## Android. None are reachable at runtime on the node app:
+##  - MethodHandleProxies / AnnotatedParameterizedType / InaccessibleObjectException
+##    — JDK-only reflection APIs used by Apache Commons Lang3 dynamic proxies and
+##    Jersey/Swagger WADL generators. The node app doesn't expose REST surfaces, so
+##    none of those code paths run.
+##  - jdk.net.ExtendedSocketOptions / jdk.net.Sockets — Sun-internal socket option
+##    APIs used by HttpClient5; the library falls back gracefully when absent.
+##  - org.apache.commons.compress.compressors.* — optional content-codec for
+##    HttpClient5; falls back to gzip/deflate when commons-compress isn't on the
+##    classpath. We don't depend on it transitively.
+##  - org.osgi.annotation.bundle.Export — compile-time annotation only, never
+##    referenced at runtime. Pulled in by shaded gRPC-Netty's JCTools package-info.
+## Rules mirror the R8-generated missing_rules.txt verbatim.
+-dontwarn java.lang.invoke.MethodHandleProxies
+-dontwarn java.lang.reflect.AnnotatedParameterizedType
+-dontwarn java.lang.reflect.InaccessibleObjectException
+-dontwarn jdk.net.ExtendedSocketOptions
+-dontwarn jdk.net.Sockets
+-dontwarn org.apache.commons.compress.compressors.CompressorException
+-dontwarn org.apache.commons.compress.compressors.CompressorInputStream
+-dontwarn org.apache.commons.compress.compressors.CompressorOutputStream
+-dontwarn org.apache.commons.compress.compressors.CompressorStreamFactory
+-dontwarn org.osgi.annotation.bundle.Export

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.10.0
 
 node.name=Bisq Easy
-node.android.version=0.7.0
+node.android.version=0.7.1
 
 client.name=Bisq Connect
 client.android.version=0.4.2
@@ -42,7 +42,7 @@ client.ios.version=0.4.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=41
 client.android.version.code=24
-node.android.version.code=42
+node.android.version.code=43
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.10.0
 
 node.name=Bisq Easy
-node.android.version=0.6.1
+node.android.version=0.7.0
 
 client.name=Bisq Connect
 client.android.version=0.4.2


### PR DESCRIPTION
 - fix proguard setup regarding bisq2 jars changes
 - update metadata and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android node app version to 0.7.1
  * Enhanced build configuration for third-party dependency compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->