### PR TITLE
chore: add reconnect benchmark scripts and client connectivity docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ captures
 .cxx
 local.properties
 xcuserdata
+debug/
 
 spot.xml
 hs_err_pid*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ captures
 .cxx
 local.properties
 xcuserdata
-debug/
+/debug/
 
 spot.xml
 hs_err_pid*

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
@@ -92,7 +92,7 @@ class ClientConnectivityService(
     }
 
     /**
-     * Starts monitoring connectivity every given period (ms). Default is 10 seconds.
+     * Starts monitoring connectivity every given period (ms). Default is 5 seconds ([PERIOD]).
      * @param period of time in ms to check connectivity
      * @param startDelay to delay the first check, default to 5 secs
      */

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
@@ -1,0 +1,182 @@
+# Client connectivity
+
+HTTP → WebSocket → health-monitor stack for the client app.
+
+Source of truth is the code. Update this file whenever connectivity behaviour changes so reviewers can skim the diff here for a high-level picture of what changed.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `httpclient/HttpClientService.kt` | Settings-driven `HttpClient` lifecycle; `recreateClient()` for iOS recovery |
+| `httpclient/HttpClientSettings.kt` | Tor proxy defaults; iOS maps proxy host `127.0.0.1` → `localhost` |
+| `utils/PlatformAbstractions.{android,ios}.kt` | `createHttpClient()`, TLS/proxy wiring |
+| `websocket/WebSocketClientService.kt` | WS factory, subscriptions, reconnect/recreate orchestration |
+| `websocket/WebSocketClientImpl.kt` | Connect, listen, request/response, reconnect backoff |
+| `websocket/WebSocketClient.kt` | Connect timeouts: 15s clearnet / 60s `.onion` |
+| `service/network/ClientConnectivityService.kt` | Health polling, UI `ConnectivityStatus` |
+| `data/.../ConnectivityService.kt` | Shared `ConnectivityStatus` enum (status values only) |
+
+```text
+Settings + Tor ──► HttpClientService ──► httpClientChangedFlow
+                              │
+                              ▼
+                   WebSocketClientService ──► WebSocketClientImpl
+                              │
+                              ▼
+                   ClientConnectivityService ──► ConnectivityStatus (UI)
+```
+
+---
+
+## Flow 1 — Initial connect
+
+```text
+Settings / Tor port change
+        │
+        ▼
+HttpClientService ──► createHttpClient() ──► httpClientChangedFlow
+        │
+        ▼
+WebSocketClientService.updateWebSocketClient()
+        │
+        ├─ currentClient != null AND settings == previousSettings
+        │       └─► return (keep live client; duplicate httpClientChangedFlow)
+        │
+        ├─ proxy mode changed (Tor ↔ clearnet) ──► cancel stateCollectionJob
+        │
+        ▼
+dispose prior client (if any) ──► _connectionState = Disconnected
+        │
+        ├─ sessionId or clientId blank ──► return (pairing; no new WS yet)
+        │
+        ▼
+new WebSocketClientImpl + currentClientSettings = settings
+        │
+        ▼
+collect webSocketClientStatus ──► proactive connect(determineTimeout(host))
+        │
+        ▼
+connect() [connectionMutex]
+        ├─ already Connected ─────────────────────────────► return
+        ▼
+webSocketSession(/websocket + SESSION_ID/CLIENT_ID headers)
+        ├─ fail ───────────────────────────────────────────► Disconnected(error)
+        ▼
+withTimeout(remainingTime after WS handshake)
+        GET /api/v1/settings/version (API compatibility)
+        ├─ 401/403 ──► UnauthorizedApiAccessException
+        ├─ incompatible version ──► IncompatibleHttpApiVersionException
+        ▼
+Connected ──► applySubscriptions()
+```
+
+Note: The pairing path runs after dispose — it does not keep an old WS. Any material settings change (including new `sessionId` after pairing) goes through dispose + new client; there is no credentials-only in-place update.
+
+External callers (`ClientApplicationBootstrapFacade`, `TrustedNodeSetupUseCase`) can also trigger a connect via `WebSocketClientService.connect()` directly. This path awaits a live client via `currentClient.filterNotNull()` then calls `WebSocketClientImpl.connect(determineTimeout(host))`; it does not go through `updateWebSocketClient()`.
+
+---
+
+## Flow 2 — Health monitor (every 5s)
+
+`ClientConnectivityService.startMonitoring()` — default 5s period, 5s delay before first check.
+
+```text
+checkConnectivity() loop
+        │
+        ├─ !isConnected() OR connectionUntrusted
+        │       ├─ !isConnected()
+        │       │       ├─ triggerReconnect() if not already connected at WCS layer
+        │       │       └─ iOS: 12 consecutive cycles ──► forceClientRecreation()
+        │       │
+        │       └─ isConnected() but untrusted (prior health check failed)
+        │               ├─ health check pass ──► restore trust, derive status
+        │               └─ health check fail ──► forceReconnect(); iOS may forceClientRecreation()
+        │
+        └─ connected and trusted
+                ├─ health check pass ──► derive status
+                └─ health check fail ──► connectionUntrusted=true, forceReconnect()
+
+Status derivation (when health check passes):
+        failed subscription topics ──► CONNECTED_WITH_LIMITATIONS
+        avg RTT > 500ms (≥4 samples) ──► REQUESTING_INVENTORY
+        else ──► CONNECTED_AND_DATA_RECEIVED
+
+On unhandled errors in checkConnectivity ──► DISCONNECTED
+```
+
+Health check = `GET /api/v1/settings/version` via WS REST proxy (`sendHealthCheck`, `TIMEOUT` = 5s). Sent with `awaitConnection = false`: if the WS is already disconnected the check returns `false` immediately without waiting for reconnect. 401/403 in the response body throw `UnauthorizedApiAccessException` (Flow 4).
+
+The base `ConnectivityService` does not time out `RECONNECTING`; `ClientConnectivityService` and error handling move status when connectivity is restored or lost.
+
+---
+
+## Flow 3 — Reconnect & iOS force recreation
+
+```text
+reconnect()  [CCS triggerReconnect/forceReconnect | WCS on abnormal disconnect]
+        │
+        ├─ already reconnecting AND connect phase > 30s ──► cancel stuck reconnectJob
+        ├─ already reconnecting, not stuck ─────────────► return (no parallel reconnect)
+        ▼
+doDisconnect() ──► exponential backoff (2s × 2^n, cap 10s)
+        ▼
+reconnectAttempts >= 5 ? ──► Disconnected(MaximumRetryReached); counter reset; end job
+        │                      (CCS may triggerReconnect() later for a fresh 5-attempt cycle)
+        ▼
+connect(min(determineTimeout(host), 30s))   // 30s cap even for 60s Tor hosts
+        │
+        ├─ success ──► Connected
+        ├─ retryable error ──► reconnect() again (invokeOnCompletion, same job)
+        └─ 401 / bad API version ──► stop auto-retry in this job
+
+WCS triggerReconnect(): only calls reconnect() when WCS reports not connected.
+
+iOS forceClientRecreation() (CCS after 12 failed cycles):
+        dispose WS ──► cancel state collector ──► HttpClientService.recreateClient()
+        ──► httpClientChangedFlow ──► updateWebSocketClient() ──► new client + connect()
+```
+
+Constants (`WebSocketClientImpl`): `STALE_RECONNECT_THRESHOLD_MS` = 30s; `MAX_RECONNECT_ATTEMPTS` = 5; `RECONNECT_CONNECT_TIMEOUT` = 30s.
+
+Details omitted here: WCS also calls `reconnect()` from its status collector on some disconnects, and skips others via `shouldAttemptReconnect()` (see `WebSocketClientService.kt`).
+
+---
+
+## Flow 4 — Session renewal vs revocation
+
+401/403 from health check or API version step → `UnauthorizedApiAccessException`.
+
+```text
+Health check 401/403 OR WS disconnect with UnauthorizedApiAccessException
+        ▼
+attemptSessionRenewal() [30s cooldown; needs SessionService + SensitiveSettingsRepository]
+        ├─ success ──► settingsRepo.update(sessionId) ──► httpClientChangedFlow ──► new WS
+        └─ renewal 401/403 ──► clear creds, disposeClient(), clientRevoked=true ──► pairing UI
+
+CCS on health-check 401: attemptSessionRenewal() — NOT forceReconnect() (stale sessionId).
+```
+
+---
+
+## Rules & gotchas
+
+1. 401 → session renewal, not force reconnect on the health-check path.
+2. `connectionUntrusted` — after a failed health check, `isConnected()` alone is not trusted (half-open TCP, e.g. desktop RST).
+3. `triggerReconnect` vs `forceReconnect` — former only if not connected; latter always runs `reconnect()` (stale TCP while status says connected).
+4. Proxy mode change (`isTorProxy` / `externalProxyUrl`) — cancel state collector before disposing the old client.
+5. Identical `HttpClientSettings` — skip WS replacement (avoids churn during Tor startup duplicates).
+6. Pairing — blank `sessionId`/`clientId` skips WS creation until credentials exist.
+7. iOS `CancellationException` on disconnect — reconnect only when cause message contains `"Socket is not connected"`; other cancellations are not auto-retried.
+8. iOS SIGSEGV guard — extract `requestId` from raw JSON before deserializing sealed WS messages.
+9. `unSubscribe()` — not implemented (logs warning).
+10. Demo — host `demo.bisq:21` → `WebSocketClientDemo` (`WebSocketClientFactory`).
+
+### Platform differences (Android vs iOS)
+
+| | Android (OkHttp) | iOS (Darwin) |
+|--|------------------|--------------|
+| Dead TCP detection | More reliable | Often needs health checks |
+| Stuck reconnect recovery | `triggerReconnect` / backoff | + `forceClientRecreation()` after 12×5s failures |
+| Tor SOCKS in settings | `127.0.0.1:port` as configured | `127.0.0.1` normalized to `localhost` in `HttpClientSettings` |
+| HTTP client hard reset | `disposeClient()` / settings-driven recreate | `recreateClient()` closes and re-emits settings |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,88 @@
+# Scripts
+
+## Bisq2 reconnect timing (optional)
+
+These bash scripts measure timing between Bisq desktop (`Bisq2.app`) restarts and mobile client log markers (WebSocket connect). They are macOS-only (`open`, `~/Library/Application Support/Bisq2/`).
+
+| Script | Role |
+|--------|------|
+| [`reconnect-bench-android.sh`](reconnect-bench-android.sh) | Android: tails desktop log + `adb logcat` while cycling Bisq2 |
+| [`reconnect-bench-ios.sh`](reconnect-bench-ios.sh) | iOS Simulator: tails desktop log + `simctl log stream` |
+| [`reconnect-bench-dual.sh`](reconnect-bench-dual.sh) | Android + iOS Simulator together: one Bisq2 restart per round, both mobile captures in parallel |
+
+Requirements: Bash, [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`), Bisq2 desktop installed. Android scripts need `adb` (exactly one connected device/emulator, or set `ANDROID_SERIAL`). iOS scripts need Xcode Command Line Tools (`xcrun`); they use Simulator log streaming, not USB device capture by default. The combined script needs both `adb` and a booted iOS Simulator.
+
+Artifacts default to `debug/<timestamped-folder>/` under the repository root when the script lives in a git clone (that tree is gitignored). Default folder names:
+
+- Android: `reconnect-bench-android-<timestamp>-<git-short>`
+- iOS: `reconnect-bench-ios-<timestamp>-<git-short>`
+- Combined: `reconnect-bench-dual-<timestamp>-<git-short>`
+
+Override with `OUT_DIR`. Environment variables are documented in each script header (`APP_PATH`, `BISQ_LOG`, timeouts, `IOS_*`, `ANDROID_SERIAL`, etc.).
+
+If the primary desktop log (`BISQ_LOG`, default `~/Library/Application Support/Bisq2/bisq.log`) is missing, all scripts fall back to `bisq_1.log` in the same directory.
+
+### Round sequence (matches the scripts)
+
+Each round repeats the steps below.
+
+**Timestamps:** t1 is recorded when `ApplicationService initialized` appears in the desktop log. t2 is when the platform’s WS success marker appears in the mobile log. Duration is `t2 − t1` in whole seconds.
+
+**When t1/t2/duration are set:**
+
+- **Android / iOS (single-platform):** `t1` is recorded when Bisq init succeeds; `t2` and `duration_seconds` only when the mobile WS wait also succeeds. On any timeout, `RoundN.log` and `summary.csv` still record `status` (e.g. `bisq-init-timeout`, `adb-connect-timeout`, `ios-connect-timeout`) with `<missing>` for timestamps that were not captured.
+- **Combined:** `t1` is set if Bisq init succeeds. Each platform gets its own `t2` and duration from `t1` when that side’s WS marker appears within `CONNECT_TIMEOUT_SEC` (measured from the start of the mobile wait). Round `status` is `success` only when **both** platforms connect; otherwise partial `t2`/duration values may be present with `adb-connect-timeout`, `ios-connect-timeout`, or `adb-ios-connect-timeout`.
+
+**Inter-round delay:** If the round succeeded and more rounds remain, the script sleeps `SLEEP_AFTER_CONNECT_SEC` (default 30; set `0` to skip) **before** stopping mobile log capture. For the combined script, “success” means both Android and iOS connected.
+
+#### [`reconnect-bench-android.sh`](reconnect-bench-android.sh) (Android)
+
+1. Snapshot `bisq_start_line` (line count of the desktop `BISQ_LOG` file before this round’s restart).
+2. Clear logcat buffers (`adb logcat -b all -c`, twice), sleep 1s, log a post-clear dump line count.
+3. Start background capture: `adb logcat -b all -v time` → `RoundN.adb.log` (runs for the rest of the round).
+4. Kill Bisq2 desktop (`pkill -x Bisq2`).
+5. Sleep `SLEEP_BEFORE_OPEN` seconds (default 45).
+6. Open Bisq2 (`open "$APP_PATH"`).
+7. Wait (poll desktop log from `bisq_start_line`, with baseline reset if the log rotates) for `ApplicationService initialized` — record t1, and set `adb_start_line_for_wait` to the current line count of `RoundN.adb.log` (mobile matching starts after noise before t1).
+8. If that succeeded: wait (poll new lines in `RoundN.adb.log` from that offset) for `WS connected successfully` — record t2 and duration (bounded by `ADB_CONNECT_TIMEOUT_SEC`, default 300). If another round follows and this round succeeded, sleep `SLEEP_AFTER_CONNECT_SEC` while logcat keeps running.
+9. Stop the logcat background process; clear logcat buffers again (same as step 2).
+10. Write `RoundN.log`: metadata and matched lines, then the full `RoundN.adb.log` contents under `===== adb logcat slice =====`.
+11. Append one row to `summary.csv` (`round,node_start_timestamp,app_connect_timestamp,duration_seconds,status`).
+
+After all rounds, print `summary.csv` path and the logs directory.
+
+#### [`reconnect-bench-ios.sh`](reconnect-bench-ios.sh) (iOS Simulator)
+
+1. Snapshot `bisq_start_line` (line count of the desktop `BISQ_LOG` file before this round’s restart).
+2. Start background capture: `xcrun simctl spawn "$IOS_SIM_DEVICE" log stream …` → `RoundN.ios.log` (predicate/process as configured; default filters on process `Bisq Connect`).
+3. Kill Bisq2 desktop (`pkill -x Bisq2`).
+4. Sleep `SLEEP_BEFORE_OPEN` seconds (default 45).
+5. Open Bisq2 (`open "$APP_PATH"`).
+6. Wait (poll desktop log from `bisq_start_line`, with baseline reset if the log rotates) for `ApplicationService initialized` — record t1, and set `ios_start_line_for_wait` to the current line count of `RoundN.ios.log` (mobile matching starts after noise before t1).
+7. If that succeeded: wait (poll new lines in `RoundN.ios.log` from that offset) for `IOS_WS_MARKER_REGEX` (default includes `WS connected successfully` and CFNetwork hints) — record t2 and duration (bounded by `IOS_CONNECT_TIMEOUT_SEC`, default 300). If another round follows and this round succeeded, sleep `SLEEP_AFTER_CONNECT_SEC` while the log stream keeps running.
+8. Stop the `log stream` background process.
+9. Write `RoundN.log`: metadata and matched lines, then the full `RoundN.ios.log` contents under `===== ios log stream slice =====`.
+10. Append one row to `summary.csv` (`round,node_start_timestamp,app_connect_timestamp,duration_seconds,status`).
+
+After all rounds, print `summary.csv` path and the logs directory.
+
+#### [`reconnect-bench-dual.sh`](reconnect-bench-dual.sh) (Android + iOS Simulator)
+
+One Bisq2 restart per round while **both** mobile captures run. Same clear/start/stop patterns as the single-platform scripts for each side.
+
+1. Snapshot `bisq_start_line`.
+2. Clear logcat buffers (same as Android script).
+3. Start background capture: `adb logcat -b all -v time` → `RoundN.adb.log`.
+4. Start background capture: `xcrun simctl spawn … log stream` → `RoundN.ios.log` (same options as the iOS script).
+5. Kill Bisq2 desktop (`pkill -x Bisq2`).
+6. Sleep `SLEEP_BEFORE_OPEN` seconds (default 45).
+7. Open Bisq2 (`open "$APP_PATH"`).
+8. Wait for `ApplicationService initialized` — record t1; set `adb_start_line_for_wait` and `ios_start_line_for_wait` from the current line counts of `RoundN.adb.log` and `RoundN.ios.log`.
+9. If that succeeded: poll **both** logs in parallel until each platform’s WS marker appears or `CONNECT_TIMEOUT_SEC` (default 300) elapses for that side — record `t2_android`, `t2_ios`, and separate durations from t1. If another round follows and **both** connected, sleep `SLEEP_AFTER_CONNECT_SEC` while captures keep running.
+10. Stop adb logcat and the iOS log stream; clear logcat buffers again.
+11. Write `RoundN.log`: **metadata and match lines only** (full mobile logs are **not** inlined). Paths to `RoundN.adb.log` and `RoundN.ios.log` are listed in the metadata.
+12. Append one row to `summary.csv` (`round,t1_bisq_initialized,t2_android_ws,t2_ios_ws,android_duration_seconds,ios_duration_seconds,status`).
+
+After all rounds, print `summary.csv` path and the logs directory.
+
+**WS markers (combined script):** Android uses `WS connected successfully` in logcat; iOS uses `IOS_WS_MARKER_REGEX` (same defaults as the iOS-only script).

--- a/scripts/reconnect-bench-android.sh
+++ b/scripts/reconnect-bench-android.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bisq2 desktop ↔ Android client reconnect timing (macOS).
+#
+# Prerequisites:
+#   - macOS (uses `open`, ~/Library/Application Support/Bisq2/, default APP_PATH)
+#   - bash, ripgrep (`rg`), Android platform-tools (`adb`) on PATH
+#   - Bisq2 desktop installed; Android device or emulator attached (see adb note below)
+#
+# Working directory: if this script lives inside a git clone, cwd is set to the repo root
+# so default OUT_DIR lands in <repo>/debug/ (that folder is gitignored).
+#
+# Environment (all optional unless noted):
+#   APP_PATH              Bisq2.app bundle (default /Applications/Bisq2.app)
+#   BISQ_LOG              Desktop bisq log file to tail for "ApplicationService initialized"
+#   OUT_DIR               Output directory (default ./debug/reconnect-bench-android-<timestamp>-<git-short>)
+#   SLEEP_BEFORE_OPEN     Seconds between kill and reopen (default 45)
+#   SLEEP_AFTER_CONNECT_SEC  After WS connect succeeds, seconds to wait before the next round
+#                            when more rounds remain (default 30; set 0 to skip)
+#   BISQ_INIT_TIMEOUT_SEC Seconds to wait for desktop init marker (default 180)
+#   ADB_CONNECT_TIMEOUT_SEC  Seconds to wait for "WS connected successfully" in logcat (default 300)
+#   ANDROID_SERIAL        When multiple adb devices exist, set to the target UDID (adb devices).
+#
+# Round sequence (numbered steps): see scripts/README.md section "Round sequence".
+#
+# Usage: ./scripts/reconnect-bench-android.sh [ROUNDS]
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(git -C "$_SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -n "$_REPO_ROOT" ]]; then
+  cd "$_REPO_ROOT"
+fi
+_BENCH_GIT_HASH="$(git rev-parse --short=8 HEAD 2>/dev/null || true)"
+_BENCH_GIT_HASH="${_BENCH_GIT_HASH:-unknown}"
+unset _SCRIPT_DIR _REPO_ROOT
+
+ROUNDS="${1:-1}"
+APP_PATH="${APP_PATH:-/Applications/Bisq2.app}"
+BISQ_LOG="${BISQ_LOG:-$HOME/Library/Application Support/Bisq2/bisq.log}"
+SLEEP_BEFORE_OPEN="${SLEEP_BEFORE_OPEN:-45}"
+SLEEP_AFTER_CONNECT_SEC="${SLEEP_AFTER_CONNECT_SEC:-30}"
+BISQ_INIT_TIMEOUT_SEC="${BISQ_INIT_TIMEOUT_SEC:-180}"
+ADB_CONNECT_TIMEOUT_SEC="${ADB_CONNECT_TIMEOUT_SEC:-300}"
+OUT_DIR="${OUT_DIR:-$PWD/debug/reconnect-bench-android-$(date +%Y%m%d-%H%M%S)-${_BENCH_GIT_HASH}}"
+
+adb_cmd() {
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    command adb -s "$ANDROID_SERIAL" "$@"
+  else
+    command adb "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}. ${hint}" >&2
+    exit 1
+  fi
+}
+
+ensure_adb_device() {
+  local st count
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    st="$(adb_cmd get-state 2>/dev/null || true)"
+    if [[ "$st" != "device" ]]; then
+      echo "adb: device ANDROID_SERIAL=${ANDROID_SERIAL} is not ready (state=${st:-missing})." >&2
+      exit 1
+    fi
+    return 0
+  fi
+  count="$(adb_cmd devices 2>/dev/null | awk '$2 == "device" { c++ } END { print c + 0 }')"
+  if [[ "$count" -eq 0 ]]; then
+    echo "adb: no device in 'device' state. Connect hardware or start an emulator; accept USB debugging if prompted." >&2
+    exit 1
+  fi
+  if [[ "$count" -gt 1 ]]; then
+    echo "adb: multiple devices/emulators connected (${count}). Set ANDROID_SERIAL to one UDID (see: adb devices)." >&2
+    exit 1
+  fi
+}
+
+if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -lt 1 ]]; then
+  echo "ROUNDS must be a positive integer, got: $ROUNDS" >&2
+  exit 1
+fi
+
+require_cmd rg "Install ripgrep (e.g. brew install ripgrep)."
+require_cmd adb "Install Android platform-tools and ensure adb is on PATH."
+
+ensure_adb_device
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "APP_PATH is not a directory (expecting a macOS .app bundle): $APP_PATH" >&2
+  echo "Set APP_PATH to your Bisq2.app location." >&2
+  exit 1
+fi
+
+if [[ ! -f "$BISQ_LOG" ]]; then
+  fallback_log="${HOME}/Library/Application Support/Bisq2/bisq_1.log"
+  if [[ -f "$fallback_log" ]]; then
+    BISQ_LOG="$fallback_log"
+  else
+    echo "Bisq log file not found: $BISQ_LOG (fallback missing: $fallback_log)" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$OUT_DIR"
+SUMMARY_CSV="$OUT_DIR/summary.csv"
+echo "round,node_start_timestamp,app_connect_timestamp,duration_seconds,status" > "$SUMMARY_CSV"
+
+log_step() {
+  echo "[$(date '+%H:%M:%S')] $*" >&2
+}
+
+cleanup_adb_tail() {
+  local pid="${1:-}"
+  if [[ -n "$pid" ]]; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+ADB_LOGCAT_PID=""
+on_exit() {
+  cleanup_adb_tail "$ADB_LOGCAT_PID"
+  ADB_LOGCAT_PID=""
+}
+trap on_exit EXIT INT TERM
+
+clear_adb_logcat() {
+  log_step "Round ${CURRENT_ROUND}: clearing adb logcat buffers with 'adb logcat -b all -c'"
+  adb_cmd logcat -b all -c
+  # Repeat once to reduce chance of buffer race with in-flight lines.
+  adb_cmd logcat -b all -c
+  sleep 1
+  local post_clear_lines
+  post_clear_lines="$(adb_cmd logcat -b all -d | wc -l | tr -d ' ')"
+  log_step "Round ${CURRENT_ROUND}: post-clear adb dump line count=${post_clear_lines}"
+}
+
+wait_for_bisq_initialized() {
+  local start_line="$1"
+  local deadline=$(( $(date +%s) + BISQ_INIT_TIMEOUT_SEC ))
+  local wait_start_epoch
+  wait_start_epoch="$(date +%s)"
+  local last_report_epoch
+  last_report_epoch="$wait_start_epoch"
+  local baseline_reset_logged="false"
+
+  while (( $(date +%s) <= deadline )); do
+    local now_epoch
+    now_epoch="$(date +%s)"
+    local current_line_count
+    current_line_count="$(wc -l < "$BISQ_LOG" || echo "$start_line")"
+
+    # Bisq may rotate/truncate log files during restart. If the file shrank,
+    # reset baseline so we continue scanning the new file content.
+    if (( current_line_count < start_line )); then
+      if [[ "$baseline_reset_logged" == "false" ]]; then
+        log_step "Round ${CURRENT_ROUND}: detected Bisq log truncation/rotation (start_line=${start_line}, current_line_count=${current_line_count}), resetting baseline to 0"
+        baseline_reset_logged="true"
+      fi
+      start_line=0
+    fi
+
+    local line
+    line="$(sed -n "$((start_line + 1)),\$p" "$BISQ_LOG" | rg -m1 "ApplicationService initialized" || true)"
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      local new_lines="$((current_line_count - start_line))"
+      local elapsed="$((now_epoch - wait_start_epoch))"
+      log_step "Round ${CURRENT_ROUND}: waiting Bisq init... elapsed=${elapsed}s bisq_lines_total=${current_line_count} bisq_new_lines=${new_lines} baseline_start_line=${start_line}"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_adb_connected() {
+  local adb_log_file="$1"
+  local start_line="${2:-0}"
+  local deadline=$(( $(date +%s) + ADB_CONNECT_TIMEOUT_SEC ))
+  local wait_start_epoch
+  wait_start_epoch="$(date +%s)"
+  local last_report_epoch
+  last_report_epoch="$wait_start_epoch"
+
+  while (( $(date +%s) <= deadline )); do
+    local now_epoch
+    now_epoch="$(date +%s)"
+    local line
+    # Only lines after t1 (adb snapshot at Bisq init): full-file rg could match earlier noise.
+    line="$(sed -n "$((start_line + 1)),\$p" "$adb_log_file" | rg -m1 "WS connected successfully" || true)"
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      local elapsed="$((now_epoch - wait_start_epoch))"
+      log_step "Round ${CURRENT_ROUND}: waiting adb WS connect... elapsed=${elapsed}s search_start_line=${start_line}"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+for round in $(seq 1 "$ROUNDS"); do
+  echo "=== Round $round / $ROUNDS ==="
+  CURRENT_ROUND="$round"
+  local_round_file="$OUT_DIR/Round${round}.log"
+  local_adb_file="$OUT_DIR/Round${round}.adb.log"
+
+  round_start_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+  bisq_start_line="$(wc -l < "$BISQ_LOG" || echo 0)"
+  adb_pid=""
+  bisq_line=""
+  adb_line=""
+  adb_start_line_for_wait="0"
+  t1_epoch=""
+  t2_epoch=""
+  t1_iso=""
+  t2_iso=""
+  duration_sec=""
+  round_status="success"
+
+  clear_adb_logcat
+  adb_cmd logcat -b all -v time > "$local_adb_file" 2>&1 &
+  adb_pid="$!"
+  ADB_LOGCAT_PID="$adb_pid"
+
+  # Kill Bisq2, wait, reopen (README steps 4–6).
+  log_step "Round $round: killing Bisq2"
+  pkill -x Bisq2 >/dev/null 2>&1 || true
+  log_step "Round $round: sleeping ${SLEEP_BEFORE_OPEN}s before relaunch"
+  sleep "$SLEEP_BEFORE_OPEN"
+  log_step "Round $round: opening Bisq2 app"
+  open "$APP_PATH"
+
+  # Wait for "ApplicationService initialized" and capture t1 (README step 7).
+  log_step "Round $round: monitoring Bisq log file: $BISQ_LOG"
+  log_step "Round $round: waiting for Bisq log marker \"ApplicationService initialized\""
+  if bisq_line="$(wait_for_bisq_initialized "$bisq_start_line")"; then
+    t1_epoch="$(date +%s)"
+    t1_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+    adb_start_line_for_wait="$(wc -l < "$local_adb_file" | tr -d ' ')"
+    log_step "Round $round: captured t1=$t1_iso"
+  else
+    round_status="bisq-init-timeout"
+    log_step "Round $round: timeout waiting for Bisq initialization marker"
+  fi
+
+  # Wait for adb WS success and capture t2 (README step 8).
+  if [[ "$round_status" == "success" ]]; then
+    log_step "Round $round: waiting up to ${ADB_CONNECT_TIMEOUT_SEC}s for \"WS connected successfully\" (search starts after adb_line>${adb_start_line_for_wait})"
+    if adb_line="$(wait_for_adb_connected "$local_adb_file" "$adb_start_line_for_wait")"; then
+      t2_epoch="$(date +%s)"
+      t2_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+      duration_sec="$((t2_epoch - t1_epoch))"
+      log_step "Round $round: captured t2=$t2_iso duration=${duration_sec}s"
+      if [[ "$round" -lt "$ROUNDS" ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" =~ ^[0-9]+$ ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" -gt 0 ]]; then
+        log_step "Round $round: sleeping ${SLEEP_AFTER_CONNECT_SEC}s after WS connect before next round"
+        sleep "$SLEEP_AFTER_CONNECT_SEC"
+      fi
+    else
+      round_status="adb-connect-timeout"
+      log_step "Round $round: timeout waiting for adb WS connect marker"
+    fi
+  fi
+
+  cleanup_adb_tail "$adb_pid"
+  ADB_LOGCAT_PID=""
+  clear_adb_logcat
+
+  {
+    echo "round: $round"
+    echo "status: $round_status"
+    echo "round_start: $round_start_iso"
+    if [[ -n "$t1_iso" ]]; then
+      echo "t1_bisq_initialized: $t1_iso"
+    else
+      echo "t1_bisq_initialized: <missing>"
+    fi
+    if [[ -n "$t2_iso" ]]; then
+      echo "t2_ws_connected: $t2_iso"
+    else
+      echo "t2_ws_connected: <missing>"
+    fi
+    if [[ -n "$duration_sec" ]]; then
+      echo "duration_seconds: $duration_sec"
+    else
+      echo "duration_seconds: <missing>"
+    fi
+    echo "adb_connect_timeout_seconds: $ADB_CONNECT_TIMEOUT_SEC"
+    if [[ -n "$bisq_line" ]]; then
+      echo "bisq_match: $bisq_line"
+    else
+      echo "bisq_match: <missing>"
+    fi
+    if [[ -n "$adb_line" ]]; then
+      echo "adb_match: $adb_line"
+    else
+      echo "adb_match: <missing>"
+    fi
+    echo
+    echo "===== adb logcat slice ====="
+    cat "$local_adb_file"
+  } > "$local_round_file"
+
+  if [[ "$round_status" == "success" ]]; then
+    echo "Round $round completed in ${duration_sec}s."
+  else
+    echo "Round $round ended with status: $round_status"
+  fi
+  node_start_ts="${t1_iso:-<missing>}"
+  app_connect_ts="${t2_iso:-<missing>}"
+  duration_value="${duration_sec:-<missing>}"
+  printf "%s,%s,%s,%s,%s\n" \
+    "$round" \
+    "$node_start_ts" \
+    "$app_connect_ts" \
+    "$duration_value" \
+    "$round_status" >> "$SUMMARY_CSV"
+  echo "Saved: $local_round_file"
+  echo "Updated: $SUMMARY_CSV"
+  echo
+done
+
+echo "Summary CSV: $SUMMARY_CSV"
+echo "Done. Logs directory: $OUT_DIR"

--- a/scripts/reconnect-bench-dual.sh
+++ b/scripts/reconnect-bench-dual.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bisq2 desktop ↔ Android + iOS (Simulator) reconnect timing in one run (macOS).
+#
+# Artifacts per round: RoundN.log (metadata + match lines only), RoundN.adb.log, RoundN.ios.log
+# (full captures; not inlined into RoundN.log).
+# One Bisq2 restart per round while both captures run (same clear/start/stop patterns as the single-platform scripts).
+#
+# After desktop "ApplicationService initialized" (t1), polls BOTH mobile logs until each platform's
+# WS success marker appears (or that platform's timeout). Durations are seconds from t1 to each t2.
+#
+# Prerequisites: same as running the Android and iOS scripts separately (adb + booted simulator,
+# Bisq2.app, bash, rg). Do not modify the single-platform scripts; this file is standalone.
+#
+# Environment (optional):
+#   Same as reconnect-bench-android.sh: APP_PATH, BISQ_LOG, OUT_DIR, SLEEP_BEFORE_OPEN,
+#   SLEEP_AFTER_CONNECT_SEC, BISQ_INIT_TIMEOUT_SEC, ANDROID_SERIAL
+#   CONNECT_TIMEOUT_SEC   Per-platform WS wait after t1, seconds (default 300; Android + iOS)
+#   Same as reconnect-bench-ios.sh: IOS_WS_MARKER, IOS_WS_MARKER_REGEX,
+#   IOS_SIM_DEVICE, IOS_APP_PROCESS, IOS_LOG_PREDICATE, IOS_LOG_LEVEL, IOS_WS_FAILURE_MARKER
+#
+# Usage: ./scripts/reconnect-bench-dual.sh [ROUNDS]
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(git -C "$_SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -n "$_REPO_ROOT" ]]; then
+  cd "$_REPO_ROOT"
+fi
+_BENCH_GIT_HASH="$(git rev-parse --short=8 HEAD 2>/dev/null || true)"
+_BENCH_GIT_HASH="${_BENCH_GIT_HASH:-unknown}"
+unset _SCRIPT_DIR _REPO_ROOT
+
+ROUNDS="${1:-1}"
+APP_PATH="${APP_PATH:-/Applications/Bisq2.app}"
+BISQ_LOG="${BISQ_LOG:-$HOME/Library/Application Support/Bisq2/bisq.log}"
+SLEEP_BEFORE_OPEN="${SLEEP_BEFORE_OPEN:-45}"
+SLEEP_AFTER_CONNECT_SEC="${SLEEP_AFTER_CONNECT_SEC:-30}"
+BISQ_INIT_TIMEOUT_SEC="${BISQ_INIT_TIMEOUT_SEC:-180}"
+CONNECT_TIMEOUT_SEC="${CONNECT_TIMEOUT_SEC:-300}"
+IOS_WS_MARKER="${IOS_WS_MARKER:-WS connected successfully}"
+IOS_WS_MARKER_REGEX="${IOS_WS_MARKER_REGEX:-${IOS_WS_MARKER}|Connection [0-9]+: connected successfully|received response, status 101}"
+IOS_SIM_DEVICE="${IOS_SIM_DEVICE:-booted}"
+IOS_APP_PROCESS="${IOS_APP_PROCESS:-Bisq Connect}"
+IOS_LOG_PREDICATE="${IOS_LOG_PREDICATE:-}"
+IOS_LOG_LEVEL="${IOS_LOG_LEVEL:-debug}"
+IOS_WS_FAILURE_MARKER="${IOS_WS_FAILURE_MARKER:-WS connection failed to connect|Exception occurred whilst listening for WS messages}"
+OUT_DIR="${OUT_DIR:-$PWD/debug/reconnect-bench-dual-$(date +%Y%m%d-%H%M%S)-${_BENCH_GIT_HASH}}"
+
+adb_cmd() {
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    command adb -s "$ANDROID_SERIAL" "$@"
+  else
+    command adb "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}. ${hint}" >&2
+    exit 1
+  fi
+}
+
+ensure_adb_device() {
+  local st count
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    st="$(adb_cmd get-state 2>/dev/null || true)"
+    if [[ "$st" != "device" ]]; then
+      echo "adb: device ANDROID_SERIAL=${ANDROID_SERIAL} is not ready (state=${st:-missing})." >&2
+      exit 1
+    fi
+    return 0
+  fi
+  count="$(adb_cmd devices 2>/dev/null | awk '$2 == "device" { c++ } END { print c + 0 }')"
+  if [[ "$count" -eq 0 ]]; then
+    echo "adb: no device in 'device' state. Connect hardware or start an emulator." >&2
+    exit 1
+  fi
+  if [[ "$count" -gt 1 ]]; then
+    echo "adb: multiple devices connected (${count}). Set ANDROID_SERIAL (see: adb devices)." >&2
+    exit 1
+  fi
+}
+
+if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -lt 1 ]]; then
+  echo "ROUNDS must be a positive integer, got: $ROUNDS" >&2
+  exit 1
+fi
+
+require_cmd rg "Install ripgrep (e.g. brew install ripgrep)."
+require_cmd adb "Install Android platform-tools and ensure adb is on PATH."
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "xcrun not found; install Xcode command line tools first." >&2
+  exit 1
+fi
+
+ensure_adb_device
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "APP_PATH is not a directory (expecting a macOS .app bundle): $APP_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$BISQ_LOG" ]]; then
+  fallback_log="${HOME}/Library/Application Support/Bisq2/bisq_1.log"
+  if [[ -f "$fallback_log" ]]; then
+    BISQ_LOG="$fallback_log"
+  else
+    echo "Bisq log file not found: $BISQ_LOG (fallback missing: $fallback_log)" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$OUT_DIR"
+SUMMARY_CSV="$OUT_DIR/summary.csv"
+echo "round,t1_bisq_initialized,t2_android_ws,t2_ios_ws,android_duration_seconds,ios_duration_seconds,status" > "$SUMMARY_CSV"
+
+log_step() {
+  echo "[$(date '+%H:%M:%S')] $*" >&2
+}
+
+cleanup_pid() {
+  local pid="${1:-}"
+  if [[ -n "$pid" ]]; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+ADB_LOGCAT_PID=""
+IOS_STREAM_PID=""
+on_exit() {
+  cleanup_pid "$ADB_LOGCAT_PID"
+  ADB_LOGCAT_PID=""
+  cleanup_pid "$IOS_STREAM_PID"
+  IOS_STREAM_PID=""
+}
+trap on_exit EXIT INT TERM
+
+clear_adb_logcat() {
+  log_step "Round ${CURRENT_ROUND}: clearing adb logcat buffers with 'adb logcat -b all -c'"
+  adb_cmd logcat -b all -c
+  adb_cmd logcat -b all -c
+  sleep 1
+  local post_clear_lines
+  post_clear_lines="$(adb_cmd logcat -b all -d | wc -l | tr -d ' ')"
+  log_step "Round ${CURRENT_ROUND}: post-clear adb dump line count=${post_clear_lines}"
+}
+
+start_ios_log_stream() {
+  local out_file="$1"
+  local stream_pid=""
+  local effective_predicate="$IOS_LOG_PREDICATE"
+
+  if [[ -z "$effective_predicate" && -n "$IOS_APP_PROCESS" ]]; then
+    effective_predicate="process == \"$IOS_APP_PROCESS\""
+  fi
+
+  if [[ -n "$effective_predicate" ]]; then
+    xcrun simctl spawn "$IOS_SIM_DEVICE" log stream --style compact --level "$IOS_LOG_LEVEL" --predicate "$effective_predicate" > "$out_file" 2>&1 &
+  else
+    xcrun simctl spawn "$IOS_SIM_DEVICE" log stream --style compact --level "$IOS_LOG_LEVEL" > "$out_file" 2>&1 &
+  fi
+  stream_pid="$!"
+  sleep 1
+  if ! kill -0 "$stream_pid" >/dev/null 2>&1; then
+    echo "Failed to start iOS log stream. Is an iOS simulator booted?" >&2
+    return 1
+  fi
+  printf '%s\n' "$stream_pid"
+}
+
+wait_for_bisq_initialized() {
+  local start_line="$1"
+  local deadline=$(( $(date +%s) + BISQ_INIT_TIMEOUT_SEC ))
+  local wait_start_epoch last_report_epoch baseline_reset_logged
+  wait_start_epoch="$(date +%s)"
+  last_report_epoch="$wait_start_epoch"
+  baseline_reset_logged="false"
+
+  while (( $(date +%s) <= deadline )); do
+    local now_epoch current_line_count line
+    now_epoch="$(date +%s)"
+    current_line_count="$(wc -l < "$BISQ_LOG" || echo "$start_line")"
+
+    if (( current_line_count < start_line )); then
+      if [[ "$baseline_reset_logged" == "false" ]]; then
+        log_step "Round ${CURRENT_ROUND}: Bisq log truncated/rotated, resetting baseline to 0"
+        baseline_reset_logged="true"
+      fi
+      start_line=0
+    fi
+
+    line="$(sed -n "$((start_line + 1)),\$p" "$BISQ_LOG" | rg -m1 "ApplicationService initialized" || true)"
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      log_step "Round ${CURRENT_ROUND}: waiting Bisq init... elapsed=$((now_epoch - wait_start_epoch))s bisq_lines=${current_line_count}"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# After t1, poll both log files until each marker is found or that side's deadline.
+# Sets: t2_adb_epoch, t2_ios_epoch, adb_line, ios_line, mobile_wait_status
+wait_for_both_mobile_ws() {
+  local adb_log="$1" adb_sl="$2" ios_log="$3" ios_sl="$4"
+  local wait_start now_epoch last_report_epoch
+  wait_start="$(date +%s)"
+  last_report_epoch="$wait_start"
+  local adb_dead ios_dead
+  adb_dead=$((wait_start + CONNECT_TIMEOUT_SEC))
+  ios_dead=$((wait_start + CONNECT_TIMEOUT_SEC))
+
+  t2_adb_epoch=""
+  t2_ios_epoch=""
+  adb_line=""
+  ios_line=""
+
+  while true; do
+    now_epoch="$(date +%s)"
+
+    if [[ -z "$t2_adb_epoch" ]]; then
+      local hit
+      hit="$(sed -n "$((adb_sl + 1)),\$p" "$adb_log" | rg -m1 "WS connected successfully" || true)"
+      if [[ -n "$hit" ]]; then
+        t2_adb_epoch="$now_epoch"
+        adb_line="$hit"
+        log_step "Round ${CURRENT_ROUND}: Android WS marker captured"
+      fi
+    fi
+
+    if [[ -z "$t2_ios_epoch" ]]; then
+      local hit_ios
+      hit_ios="$(sed -n "$((ios_sl + 1)),\$p" "$ios_log" | rg -m1 "$IOS_WS_MARKER_REGEX" || true)"
+      if [[ -n "$hit_ios" ]]; then
+        t2_ios_epoch="$now_epoch"
+        ios_line="$hit_ios"
+        log_step "Round ${CURRENT_ROUND}: iOS WS marker captured"
+      fi
+    fi
+
+    if [[ -n "$t2_adb_epoch" && -n "$t2_ios_epoch" ]]; then
+      mobile_wait_status="success"
+      return 0
+    fi
+
+    local adb_fin ios_fin
+    adb_fin=false
+    ios_fin=false
+    [[ -n "$t2_adb_epoch" || "$now_epoch" -gt "$adb_dead" ]] && adb_fin=true
+    [[ -n "$t2_ios_epoch" || "$now_epoch" -gt "$ios_dead" ]] && ios_fin=true
+
+    if [[ "$adb_fin" == true && "$ios_fin" == true ]]; then
+      if [[ -n "$t2_adb_epoch" && -z "$t2_ios_epoch" ]]; then
+        mobile_wait_status="ios-connect-timeout"
+      elif [[ -z "$t2_adb_epoch" && -n "$t2_ios_epoch" ]]; then
+        mobile_wait_status="adb-connect-timeout"
+      else
+        mobile_wait_status="adb-ios-connect-timeout"
+      fi
+      return 1
+    fi
+
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      local adb_line_count total_ios app_new marker_hits failure_hits
+      adb_line_count="$(wc -l < "$adb_log" | tr -d ' ')"
+      total_ios="$(wc -l < "$ios_log" | tr -d ' ')"
+      app_new="$(sed -n "$((ios_sl + 1)),\$p" "$ios_log" | rg -c "$IOS_APP_PROCESS\\[[0-9]+:" || true)"
+      marker_hits="$(sed -n "$((ios_sl + 1)),\$p" "$ios_log" | rg -c "$IOS_WS_MARKER_REGEX" || true)"
+      failure_hits="$(rg -c "$IOS_WS_FAILURE_MARKER" "$ios_log" || true)"
+      log_step "Round ${CURRENT_ROUND}: waiting mobile WS... adb_lines=${adb_line_count} ios_lines=${total_ios} ios_app_new_lines=${app_new:-0} ios_marker_hits=${marker_hits:-0} ios_failure_hits=${failure_hits:-0} have_android=$([[ -n "$t2_adb_epoch" ]] && echo yes || echo no) have_ios=$([[ -n "$t2_ios_epoch" ]] && echo yes || echo no)"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+}
+
+CURRENT_ROUND=0
+
+for round in $(seq 1 "$ROUNDS"); do
+  echo "=== Round $round / $ROUNDS (Android + iOS) ==="
+  CURRENT_ROUND="$round"
+  local_round_file="$OUT_DIR/Round${round}.log"
+  local_adb_file="$OUT_DIR/Round${round}.adb.log"
+  local_ios_file="$OUT_DIR/Round${round}.ios.log"
+
+  round_start_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+  bisq_start_line="$(wc -l < "$BISQ_LOG" || echo 0)"
+  t2_adb_epoch=""
+  t2_ios_epoch=""
+  adb_line=""
+  ios_line=""
+  adb_pid=""
+  ios_pid=""
+  bisq_line=""
+  t1_epoch=""
+  t1_iso=""
+  t2_adb_iso=""
+  t2_ios_iso=""
+  dur_adb=""
+  dur_ios=""
+  round_status="success"
+  adb_start_line_for_wait="0"
+  ios_start_line_for_wait="0"
+
+  clear_adb_logcat
+
+  adb_cmd logcat -b all -v time > "$local_adb_file" 2>&1 &
+  adb_pid="$!"
+  ADB_LOGCAT_PID="$adb_pid"
+
+  log_step "Round $round: starting iOS log stream (device=${IOS_SIM_DEVICE})"
+  ios_pid="$(start_ios_log_stream "$local_ios_file")"
+  IOS_STREAM_PID="$ios_pid"
+  log_step "Round $round: iOS log stream pid=$ios_pid, adb logcat pid=$adb_pid"
+
+  log_step "Round $round: killing Bisq2"
+  pkill -x Bisq2 >/dev/null 2>&1 || true
+  log_step "Round $round: sleeping ${SLEEP_BEFORE_OPEN}s before relaunch"
+  sleep "$SLEEP_BEFORE_OPEN"
+  log_step "Round $round: opening Bisq2 app"
+  open "$APP_PATH"
+
+  log_step "Round $round: waiting for Bisq \"ApplicationService initialized\""
+  if bisq_line="$(wait_for_bisq_initialized "$bisq_start_line")"; then
+    t1_epoch="$(date +%s)"
+    t1_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+    adb_start_line_for_wait="$(wc -l < "$local_adb_file" | tr -d ' ')"
+    ios_start_line_for_wait="$(wc -l < "$local_ios_file" | tr -d ' ')"
+    log_step "Round $round: t1=$t1_iso adb_search_line=${adb_start_line_for_wait} ios_search_line=${ios_start_line_for_wait}"
+  else
+    round_status="bisq-init-timeout"
+    log_step "Round $round: timeout waiting for Bisq initialization marker"
+  fi
+
+  mobile_wait_status="skipped"
+  if [[ "$round_status" == "success" ]]; then
+    log_step "Round $round: waiting Android and iOS WS markers from t1 (≤${CONNECT_TIMEOUT_SEC}s each)"
+    if wait_for_both_mobile_ws "$local_adb_file" "$adb_start_line_for_wait" "$local_ios_file" "$ios_start_line_for_wait"; then
+      round_status="success"
+    else
+      round_status="$mobile_wait_status"
+    fi
+  fi
+
+  if [[ "$round_status" == "success" ]]; then
+    t2_adb_iso="$(date -r "$t2_adb_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
+    t2_ios_iso="$(date -r "$t2_ios_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
+    dur_adb="$((t2_adb_epoch - t1_epoch))"
+    dur_ios="$((t2_ios_epoch - t1_epoch))"
+    log_step "Round $round: t2_android=$t2_adb_iso duration=${dur_adb}s | t2_ios=$t2_ios_iso duration=${dur_ios}s"
+    if [[ "$round" -lt "$ROUNDS" ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" =~ ^[0-9]+$ ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" -gt 0 ]]; then
+      log_step "Round $round: sleeping ${SLEEP_AFTER_CONNECT_SEC}s before next round"
+      sleep "$SLEEP_AFTER_CONNECT_SEC"
+    fi
+  else
+    if [[ -n "${t2_adb_epoch:-}" ]]; then
+      t2_adb_iso="$(date -r "$t2_adb_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || true)"
+      dur_adb="$((t2_adb_epoch - t1_epoch))"
+    fi
+    if [[ -n "${t2_ios_epoch:-}" ]]; then
+      t2_ios_iso="$(date -r "$t2_ios_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || true)"
+      dur_ios="$((t2_ios_epoch - t1_epoch))"
+    fi
+    log_step "Round $round: ended status=$round_status"
+  fi
+
+  cleanup_pid "$adb_pid"
+  ADB_LOGCAT_PID=""
+  cleanup_pid "$ios_pid"
+  IOS_STREAM_PID=""
+  clear_adb_logcat
+
+  {
+    echo "round: $round"
+    echo "status: $round_status"
+    echo "round_start: $round_start_iso"
+    echo "t1_bisq_initialized: ${t1_iso:-<missing>}"
+    echo "t2_android_ws: ${t2_adb_iso:-<missing>}"
+    echo "t2_ios_ws: ${t2_ios_iso:-<missing>}"
+    echo "duration_android_seconds: ${dur_adb:-<missing>}"
+    echo "duration_ios_seconds: ${dur_ios:-<missing>}"
+    echo "connect_timeout_seconds: $CONNECT_TIMEOUT_SEC"
+    echo "ios_ws_marker_regex: $IOS_WS_MARKER_REGEX"
+    if [[ -n "${bisq_line:-}" ]]; then echo "bisq_match: $bisq_line"; else echo "bisq_match: <missing>"; fi
+    if [[ -n "${adb_line:-}" ]]; then echo "adb_match: $adb_line"; else echo "adb_match: <missing>"; fi
+    if [[ -n "${ios_line:-}" ]]; then echo "ios_match: $ios_line"; else echo "ios_match: <missing>"; fi
+    echo
+    echo "android_log_file: $(basename "$local_adb_file")"
+    echo "ios_log_file: $(basename "$local_ios_file")"
+    echo "android_log_path: $local_adb_file"
+    echo "ios_log_path: $local_ios_file"
+  } > "$local_round_file"
+
+  printf "%s,%s,%s,%s,%s,%s,%s\n" \
+    "$round" \
+    "${t1_iso:-<missing>}" \
+    "${t2_adb_iso:-<missing>}" \
+    "${t2_ios_iso:-<missing>}" \
+    "${dur_adb:-<missing>}" \
+    "${dur_ios:-<missing>}" \
+    "$round_status" >> "$SUMMARY_CSV"
+
+  echo "Saved: $local_round_file + $(basename "$local_adb_file") + $(basename "$local_ios_file")"
+  echo "Updated: $SUMMARY_CSV"
+  echo
+done
+
+echo "Summary CSV: $SUMMARY_CSV"
+echo "Done. Logs directory: $OUT_DIR"

--- a/scripts/reconnect-bench-ios.sh
+++ b/scripts/reconnect-bench-ios.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bisq2 desktop ↔ iOS client reconnect timing (macOS, iOS Simulator).
+#
+# Prerequisites:
+#   - macOS (uses `open`, ~/Library/Application Support/Bisq2/, default APP_PATH)
+#   - bash, ripgrep (`rg`), Xcode Command Line Tools (`xcrun`)
+#   - Bisq2 desktop installed; a booted iOS Simulator (or device UDID for simctl — see IOS_SIM_DEVICE)
+#
+# This script uses `xcrun simctl spawn … log stream`; it does not attach log capture for a USB
+# physical iPhone the way macOS Console / `log stream` for a plugged-in device would. For physical
+# devices, capture logs through Xcode or Console and compare timestamps manually, or extend this script.
+#
+# Working directory: if this script lives inside a git clone, cwd is set to the repo root
+# so default OUT_DIR lands in <repo>/debug/ (that folder is gitignored).
+#
+# Environment (all optional unless noted):
+#   APP_PATH              Bisq2.app bundle (default /Applications/Bisq2.app)
+#   BISQ_LOG              Desktop bisq log file for "ApplicationService initialized"
+#   OUT_DIR               Output directory (default ./debug/reconnect-bench-ios-<timestamp>-<git-short>)
+#   SLEEP_BEFORE_OPEN     Seconds between kill and reopen (default 45)
+#   SLEEP_AFTER_CONNECT_SEC  After WS connect succeeds, seconds to wait before the next round
+#                            when more rounds remain (default 30; set 0 to skip)
+#   BISQ_INIT_TIMEOUT_SEC Seconds to wait for desktop init marker (default 180)
+#   IOS_CONNECT_TIMEOUT_SEC  Seconds to wait for WS success markers in sim logs (default 300)
+#   IOS_WS_MARKER         Primary substring marker for success (default "WS connected successfully")
+#   IOS_WS_MARKER_REGEX   Regex passed to rg for success (default combines marker + CFNetwork hints)
+#   IOS_SIM_DEVICE        simctl target: "booted" or a simulator UDID (default booted)
+#   IOS_APP_PROCESS       Process name as shown in Simulator logs (default "Bisq Connect")
+#   IOS_LOG_PREDICATE     If set, used as `log stream --predicate` instead of process-based default
+#   IOS_LOG_LEVEL         Argument for log stream --level (default debug; info omits debug messages)
+#   IOS_WS_FAILURE_MARKER Regex for failure hints in heartbeat logs (optional diagnostics)
+#
+# Round sequence (numbered steps): see scripts/README.md section "Round sequence".
+#
+# Usage: ./scripts/reconnect-bench-ios.sh [ROUNDS]
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(git -C "$_SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -n "$_REPO_ROOT" ]]; then
+  cd "$_REPO_ROOT"
+fi
+_BENCH_GIT_HASH="$(git rev-parse --short=8 HEAD 2>/dev/null || true)"
+_BENCH_GIT_HASH="${_BENCH_GIT_HASH:-unknown}"
+unset _SCRIPT_DIR _REPO_ROOT
+
+ROUNDS="${1:-1}"
+APP_PATH="${APP_PATH:-/Applications/Bisq2.app}"
+BISQ_LOG="${BISQ_LOG:-$HOME/Library/Application Support/Bisq2/bisq.log}"
+SLEEP_BEFORE_OPEN="${SLEEP_BEFORE_OPEN:-45}"
+SLEEP_AFTER_CONNECT_SEC="${SLEEP_AFTER_CONNECT_SEC:-30}"
+BISQ_INIT_TIMEOUT_SEC="${BISQ_INIT_TIMEOUT_SEC:-180}"
+IOS_CONNECT_TIMEOUT_SEC="${IOS_CONNECT_TIMEOUT_SEC:-300}"
+IOS_WS_MARKER="${IOS_WS_MARKER:-WS connected successfully}"
+IOS_WS_MARKER_REGEX="${IOS_WS_MARKER_REGEX:-${IOS_WS_MARKER}|Connection [0-9]+: connected successfully|received response, status 101}"
+IOS_SIM_DEVICE="${IOS_SIM_DEVICE:-booted}" # e.g. "booted" or specific UDID
+IOS_APP_PROCESS="${IOS_APP_PROCESS:-Bisq Connect}" # process label shown in iOS logs
+IOS_LOG_PREDICATE="${IOS_LOG_PREDICATE:-}" # optional override; if empty we default to app-process predicate
+IOS_LOG_LEVEL="${IOS_LOG_LEVEL:-debug}"
+IOS_WS_FAILURE_MARKER="${IOS_WS_FAILURE_MARKER:-WS connection failed to connect|Exception occurred whilst listening for WS messages}"
+OUT_DIR="${OUT_DIR:-$PWD/debug/reconnect-bench-ios-$(date +%Y%m%d-%H%M%S)-${_BENCH_GIT_HASH}}"
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}. ${hint}" >&2
+    exit 1
+  fi
+}
+
+if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -lt 1 ]]; then
+  echo "ROUNDS must be a positive integer, got: $ROUNDS" >&2
+  exit 1
+fi
+
+require_cmd rg "Install ripgrep (e.g. brew install ripgrep)."
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "APP_PATH is not a directory (expecting a macOS .app bundle): $APP_PATH" >&2
+  echo "Set APP_PATH to your Bisq2.app location." >&2
+  exit 1
+fi
+
+if [[ ! -f "$BISQ_LOG" ]]; then
+  fallback_log="${HOME}/Library/Application Support/Bisq2/bisq_1.log"
+  if [[ -f "$fallback_log" ]]; then
+    BISQ_LOG="$fallback_log"
+  else
+    echo "Bisq log file not found: $BISQ_LOG (fallback missing: $fallback_log)" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "xcrun not found; install Xcode command line tools first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+SUMMARY_CSV="$OUT_DIR/summary.csv"
+echo "round,node_start_timestamp,app_connect_timestamp,duration_seconds,status" > "$SUMMARY_CSV"
+
+log_step() {
+  echo "[$(date '+%H:%M:%S')] $*" >&2
+}
+
+cleanup_ios_tail() {
+  local pid="${1:-}"
+  if [[ -n "$pid" ]]; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+IOS_STREAM_PID=""
+on_exit() {
+  cleanup_ios_tail "$IOS_STREAM_PID"
+  IOS_STREAM_PID=""
+}
+trap on_exit EXIT INT TERM
+
+start_ios_log_stream() {
+  local out_file="$1"
+  local stream_pid=""
+  local effective_predicate="$IOS_LOG_PREDICATE"
+
+  if [[ -z "$effective_predicate" && -n "$IOS_APP_PROCESS" ]]; then
+    effective_predicate="process == \"$IOS_APP_PROCESS\""
+  fi
+
+  if [[ -n "$effective_predicate" ]]; then
+    xcrun simctl spawn "$IOS_SIM_DEVICE" log stream --style compact --level "$IOS_LOG_LEVEL" --predicate "$effective_predicate" > "$out_file" 2>&1 &
+  else
+    xcrun simctl spawn "$IOS_SIM_DEVICE" log stream --style compact --level "$IOS_LOG_LEVEL" > "$out_file" 2>&1 &
+  fi
+  stream_pid="$!"
+  sleep 1
+  if ! kill -0 "$stream_pid" >/dev/null 2>&1; then
+    echo "Failed to start iOS log stream. Is an iOS simulator/device booted?" >&2
+    return 1
+  fi
+  printf '%s\n' "$stream_pid"
+}
+
+wait_for_bisq_initialized() {
+  local start_line="$1"
+  local deadline=$(( $(date +%s) + BISQ_INIT_TIMEOUT_SEC ))
+  local wait_start_epoch
+  wait_start_epoch="$(date +%s)"
+  local last_report_epoch
+  last_report_epoch="$wait_start_epoch"
+  local baseline_reset_logged="false"
+
+  while (( $(date +%s) <= deadline )); do
+    local now_epoch
+    now_epoch="$(date +%s)"
+    local current_line_count
+    current_line_count="$(wc -l < "$BISQ_LOG" || echo "$start_line")"
+
+    if (( current_line_count < start_line )); then
+      if [[ "$baseline_reset_logged" == "false" ]]; then
+        log_step "Round ${CURRENT_ROUND}: detected Bisq log truncation/rotation (start_line=${start_line}, current_line_count=${current_line_count}), resetting baseline to 0"
+        baseline_reset_logged="true"
+      fi
+      start_line=0
+    fi
+
+    local line
+    line="$(sed -n "$((start_line + 1)),\$p" "$BISQ_LOG" | rg -m1 "ApplicationService initialized" || true)"
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      local new_lines="$((current_line_count - start_line))"
+      local elapsed="$((now_epoch - wait_start_epoch))"
+      log_step "Round ${CURRENT_ROUND}: waiting Bisq init... elapsed=${elapsed}s bisq_lines_total=${current_line_count} bisq_new_lines=${new_lines} baseline_start_line=${start_line}"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_ios_connected() {
+  local ios_log_file="$1"
+  local start_line="${2:-0}"
+  local deadline=$(( $(date +%s) + IOS_CONNECT_TIMEOUT_SEC ))
+  local wait_start_epoch
+  wait_start_epoch="$(date +%s)"
+  local last_report_epoch
+  last_report_epoch="$wait_start_epoch"
+
+  while (( $(date +%s) <= deadline )); do
+    local now_epoch
+    now_epoch="$(date +%s)"
+    local line
+    line="$(sed -n "$((start_line + 1)),\$p" "$ios_log_file" | rg -m1 "$IOS_WS_MARKER_REGEX" || true)"
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    if (( now_epoch - last_report_epoch >= 5 )); then
+      local elapsed="$((now_epoch - wait_start_epoch))"
+      local total_lines
+      local app_lines
+      local app_new_lines
+      local marker_hits
+      local failure_hits
+      total_lines="$(wc -l < "$ios_log_file" || echo 0)"
+      app_lines="$(rg -c "$IOS_APP_PROCESS\\[[0-9]+:" "$ios_log_file" || true)"
+      app_new_lines="$(sed -n "$((start_line + 1)),\$p" "$ios_log_file" | rg -c "$IOS_APP_PROCESS\\[[0-9]+:" || true)"
+      marker_hits="$(sed -n "$((start_line + 1)),\$p" "$ios_log_file" | rg -c "$IOS_WS_MARKER_REGEX" || true)"
+      failure_hits="$(rg -c "$IOS_WS_FAILURE_MARKER" "$ios_log_file" || true)"
+      log_step "Round ${CURRENT_ROUND}: waiting iOS WS connect... elapsed=${elapsed}s marker_regex='${IOS_WS_MARKER_REGEX}' ios_lines=${total_lines} app_lines=${app_lines:-0} app_new_lines=${app_new_lines:-0} marker_hits=${marker_hits:-0} failure_hits=${failure_hits:-0} search_start_line=${start_line}"
+      last_report_epoch="$now_epoch"
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+for round in $(seq 1 "$ROUNDS"); do
+  echo "=== Round $round / $ROUNDS ==="
+  CURRENT_ROUND="$round"
+  local_round_file="$OUT_DIR/Round${round}.log"
+  local_ios_file="$OUT_DIR/Round${round}.ios.log"
+
+  round_start_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+  bisq_start_line="$(wc -l < "$BISQ_LOG" || echo 0)"
+  ios_pid=""
+  bisq_line=""
+  ios_line=""
+  t1_epoch=""
+  t2_epoch=""
+  t1_iso=""
+  t2_iso=""
+  duration_sec=""
+  round_status="success"
+  ios_start_line_for_wait="0"
+
+  log_step "Round $round: starting iOS log stream (device=${IOS_SIM_DEVICE})"
+  ios_pid="$(start_ios_log_stream "$local_ios_file")"
+  IOS_STREAM_PID="$ios_pid"
+  log_step "Round $round: iOS log stream pid=$ios_pid"
+
+  log_step "Round $round: killing Bisq2"
+  pkill -x Bisq2 >/dev/null 2>&1 || true
+
+  log_step "Round $round: sleeping ${SLEEP_BEFORE_OPEN}s before relaunch"
+  sleep "$SLEEP_BEFORE_OPEN"
+
+  log_step "Round $round: opening Bisq2 app"
+  open "$APP_PATH"
+
+  log_step "Round $round: monitoring Bisq log file: $BISQ_LOG"
+  log_step "Round $round: waiting for Bisq log marker \"ApplicationService initialized\""
+  if bisq_line="$(wait_for_bisq_initialized "$bisq_start_line")"; then
+    t1_epoch="$(date +%s)"
+    t1_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+    ios_start_line_for_wait="$(wc -l < "$local_ios_file" || echo 0)"
+    log_step "Round $round: captured t1=$t1_iso"
+  else
+    round_status="bisq-init-timeout"
+    log_step "Round $round: timeout waiting for Bisq initialization marker"
+  fi
+
+  if [[ "$round_status" == "success" ]]; then
+    log_step "Round $round: waiting up to ${IOS_CONNECT_TIMEOUT_SEC}s for iOS marker regex \"${IOS_WS_MARKER_REGEX}\" (search starts at ios_line>${ios_start_line_for_wait})"
+    if ios_line="$(wait_for_ios_connected "$local_ios_file" "$ios_start_line_for_wait")"; then
+      t2_epoch="$(date +%s)"
+      t2_iso="$(date '+%Y-%m-%d %H:%M:%S')"
+      duration_sec="$((t2_epoch - t1_epoch))"
+      log_step "Round $round: captured t2=$t2_iso duration=${duration_sec}s"
+      if [[ "$round" -lt "$ROUNDS" ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" =~ ^[0-9]+$ ]] && [[ "${SLEEP_AFTER_CONNECT_SEC:-0}" -gt 0 ]]; then
+        log_step "Round $round: sleeping ${SLEEP_AFTER_CONNECT_SEC}s after WS connect before next round"
+        sleep "$SLEEP_AFTER_CONNECT_SEC"
+      fi
+    else
+      round_status="ios-connect-timeout"
+      log_step "Round $round: timeout waiting for iOS WS connect marker"
+    fi
+  fi
+
+  cleanup_ios_tail "$ios_pid"
+
+  {
+    echo "round: $round"
+    echo "status: $round_status"
+    echo "round_start: $round_start_iso"
+    if [[ -n "$t1_iso" ]]; then
+      echo "t1_bisq_initialized: $t1_iso"
+    else
+      echo "t1_bisq_initialized: <missing>"
+    fi
+    if [[ -n "$t2_iso" ]]; then
+      echo "t2_ws_connected: $t2_iso"
+    else
+      echo "t2_ws_connected: <missing>"
+    fi
+    if [[ -n "$duration_sec" ]]; then
+      echo "duration_seconds: $duration_sec"
+    else
+      echo "duration_seconds: <missing>"
+    fi
+    echo "ios_connect_timeout_seconds: $IOS_CONNECT_TIMEOUT_SEC"
+    echo "ios_ws_marker: $IOS_WS_MARKER"
+    if [[ -n "$bisq_line" ]]; then
+      echo "bisq_match: $bisq_line"
+    else
+      echo "bisq_match: <missing>"
+    fi
+    if [[ -n "$ios_line" ]]; then
+      echo "ios_match: $ios_line"
+    else
+      echo "ios_match: <missing>"
+    fi
+    echo
+    echo "===== ios log stream slice ====="
+    cat "$local_ios_file"
+  } > "$local_round_file"
+
+  if [[ "$round_status" == "success" ]]; then
+    echo "Round $round completed in ${duration_sec}s."
+  else
+    echo "Round $round ended with status: $round_status"
+  fi
+  node_start_ts="${t1_iso:-<missing>}"
+  app_connect_ts="${t2_iso:-<missing>}"
+  duration_value="${duration_sec:-<missing>}"
+  printf "%s,%s,%s,%s,%s\n" \
+    "$round" \
+    "$node_start_ts" \
+    "$app_connect_ts" \
+    "$duration_value" \
+    "$round_status" >> "$SUMMARY_CSV"
+  echo "Saved: $local_round_file"
+  echo "Updated: $SUMMARY_CSV"
+  echo
+done
+
+echo "Summary CSV: $SUMMARY_CSV"
+echo "Done. Logs directory: $OUT_DIR"


### PR DESCRIPTION
PR1 of breaking down of https://github.com/bisq-network/bisq-mobile/pull/1445 into small chunks

This is just a baseline PR to capture logs of main branch, so as to compare future PRs against these logs.

Apart from above reason, added these to this PR:
 - Added three bash scripts that automate Bisq desktop restart cycles and measure how long the mobile client takes to reconnect.
 - Added connectivity.md — a living doc of the HTTP → WebSocket → health-monitor stack - so with future PR's, it's easy to see the diff of this file to understand what changed, at a high level.

Because of uncertainity of the this multi-round tor testing (as mentioned at https://github.com/bisq-network/bisq-mobile/pull/1445#issuecomment-4606338511), it's better to compare the logs of further PRs, against the logs of this PR, rather than comparing the timings in summary.csv.

In every further PR, I will provide this log comparison info.
For example, NSURLSession zombie tasks hanging for ~120s, will be part of the logs, captured here. In the PR, that addresses this issue, those logs won't appear. And I will mention that in those PRs. But timing wise, we might not see improvements, for reasons stated at https://github.com/bisq-network/bisq-mobile/pull/1445#issuecomment-4606338511.

Summary.csv:

round | t1_bisq_initialized | t2_android_ws | t2_ios_ws | android_duration_seconds | ios_duration_seconds | status
-- | -- | -- | -- | -- | -- | --
1 | 2026-06-03 13:19:59 | 2026-06-03 13:20:17 | 2026-06-03 13:21:28 | 18 | 89 | success
2 | 2026-06-03 13:23:11 | 2026-06-03 13:24:16 | 2026-06-03 13:24:17 | 65 | 66 | success
3 | 2026-06-03 13:26:00 | 2026-06-03 13:29:11 | <missing> | 191 | <missing> | ios-connect-timeout
4 | 2026-06-03 13:32:15 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
5 | 2026-06-03 13:38:28 | 2026-06-03 13:38:39 | 2026-06-03 13:38:47 | 11 | 19 | success
6 | 2026-06-03 13:40:32 | 2026-06-03 13:40:47 | 2026-06-03 13:41:30 | 15 | 58 | success
7 | 2026-06-03 13:43:14 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
8 | 2026-06-03 13:49:27 | 2026-06-03 13:49:46 | 2026-06-03 13:51:55 | 19 | 148 | success
9 | 2026-06-03 13:53:38 | 2026-06-03 13:56:06 | <missing> | 148 | <missing> | ios-connect-timeout
10 | 2026-06-03 13:59:54 | 2026-06-03 14:01:51 | <missing> | 117 | <missing> | ios-connect-timeout
11 | 2026-06-03 14:06:08 | 2026-06-03 14:07:09 | 2026-06-03 14:07:29 | 61 | 81 | success
12 | 2026-06-03 14:09:14 | 2026-06-03 14:09:24 | 2026-06-03 14:10:40 | 10 | 86 | success
13 | 2026-06-03 14:12:22 | 2026-06-03 14:12:57 | 2026-06-03 14:12:41 | 35 | 19 | success
14 | 2026-06-03 14:14:40 | 2026-06-03 14:15:29 | 2026-06-03 14:14:55 | 49 | 15 | success
15 | 2026-06-03 14:17:11 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
16 | 2026-06-03 14:23:23 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
17 | 2026-06-03 14:29:37 | 2026-06-03 14:29:56 | 2026-06-03 14:31:12 | 19 | 95 | success
18 | 2026-06-03 14:32:52 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
19 | 2026-06-03 14:39:03 | 2026-06-03 14:39:59 | 2026-06-03 14:40:41 | 56 | 98 | success
20 | 2026-06-03 14:42:22 | 2026-06-03 14:43:28 | 2026-06-03 14:42:36 | 66 | 14 | success
21 | 2026-06-03 14:45:10 | <missing> | 2026-06-03 14:45:31 | <missing> | 21 | adb-connect-timeout
22 | 2026-06-03 14:51:28 | <missing> | 2026-06-03 14:51:44 | <missing> | 16 | adb-connect-timeout
23 | 2026-06-03 14:57:45 | <missing> | 2026-06-03 14:58:17 | <missing> | 32 | adb-connect-timeout
24 | 2026-06-03 15:04:01 | 2026-06-03 15:06:45 | 2026-06-03 15:04:39 | 164 | 38 | success
25 | 2026-06-03 15:08:34 | 2026-06-03 15:09:04 | 2026-06-03 15:09:06 | 30 | 32 | success
26 | 2026-06-03 15:10:48 | 2026-06-03 15:11:02 | 2026-06-03 15:12:44 | 14 | 116 | success
27 | 2026-06-03 15:14:30 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
28 | 2026-06-03 15:20:42 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
29 | 2026-06-03 15:26:55 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
30 | 2026-06-03 15:33:09 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
31 | 2026-06-03 15:39:22 | 2026-06-03 15:41:26 | 2026-06-03 15:42:57 | 124 | 215 | success
32 | 2026-06-03 15:44:44 | 2026-06-03 15:45:14 | 2026-06-03 15:47:31 | 30 | 167 | success
33 | 2026-06-03 15:49:13 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
34 | 2026-06-03 15:55:26 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
35 | 2026-06-03 16:01:39 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
36 | 2026-06-03 16:07:51 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
37 | 2026-06-03 16:14:07 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
38 | 2026-06-03 16:20:18 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
39 | 2026-06-03 16:26:30 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
40 | 2026-06-03 16:32:43 | 2026-06-03 16:37:36 | 2026-06-03 16:37:31 | 293 | 288 | success
41 | 2026-06-03 16:39:17 | <missing> | 2026-06-03 16:43:32 | <missing> | 255 | adb-connect-timeout
42 | 2026-06-03 16:45:29 | 2026-06-03 16:48:15 | <missing> | 166 | <missing> | ios-connect-timeout
43 | 2026-06-03 16:51:42 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
44 | 2026-06-03 16:57:52 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
45 | 2026-06-03 17:04:04 | 2026-06-03 17:06:40 | 2026-06-03 17:08:18 | 156 | 254 | success
46 | 2026-06-03 17:10:09 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
47 | 2026-06-03 17:16:21 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
48 | 2026-06-03 17:22:32 | <missing> | <missing> | <missing> | <missing> | adb-ios-connect-timeout
49 | 2026-06-03 17:28:46 | 2026-06-03 17:29:00 | 2026-06-03 17:28:58 | 14 | 12 | success
50 | 2026-06-03 17:30:41 | 2026-06-03 17:31:55 | 2026-06-03 17:31:59 | 74 | 78 | success

Full logs:
[reconnect-bench-dual-20260603-131847-599fe18c.zip](https://github.com/user-attachments/files/28553737/reconnect-bench-dual-20260603-131847-599fe18c.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added client connectivity architecture specification

* **Chores**
  * Added reconnection benchmarking scripts for Android and iOS platforms
  * Updated `.gitignore` to exclude debug directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->