### PR TITLE
Remove isInteractive pattern from some screens

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
@@ -190,7 +190,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.deleteAccount(account.accountName) }
-            verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
+            verify(exactly = 2) { globalUiManager.scheduleShowLoading() }
             verify(exactly = 1) { globalUiManager.hideLoading() }
             verify(exactly = 1) { navigationManager.navigateBack(any()) }
             assertFalse(presenter.uiState.value.showDeleteConfirmationDialog)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
@@ -30,6 +30,7 @@ import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -106,6 +107,7 @@ class ClientSplashPresenterNavigationTest {
                             get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
                         }
                     }
+                    single<GlobalUiManager> { GlobalUiManager(testDispatcher) }
                     single<NavigationManager> { navigationManager }
                 },
             )

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -167,6 +167,7 @@ mobile.bisqEasy.tradeWizard.market.headline.buyer=In which currency do you want 
 mobile.bisqEasy.tradeWizard.market.headline.seller=In which currency do you want to get paid?
 mobile.bisqEasy.tradeWizard.market.title=Currency
 mobile.bisqEasy.tradeWizard.market.subTitle=Choose your trade currency
+mobile.bisqEasy.tradeWizard.market.select.error=Please select a currency
 mobile.bisqEasy.tradeWizard.price.title=What is your trade price?
 mobile.bisqEasy.tradeWizard.price.subTitle=This can be defined as a percentage price which floats with the market price or fixed price.
 mobile.bisqEasy.tradeWizard.price.tradePrice.type.percentage=Percentage

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.utils.UrlLauncher
@@ -34,7 +33,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BasePresenterTest {
@@ -60,7 +58,7 @@ class BasePresenterTest {
                             get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
                         }
                     }
-                    single<NavigationManager> { io.mockk.mockk(relaxed = true) }
+                    single<NavigationManager> { mockk(relaxed = true) }
                     single { globalUiManager }
                 },
             )
@@ -209,7 +207,7 @@ class BasePresenterTest {
     }
 
     @Test
-    fun `navigateToUrl returns false and restores interactivity when URL launcher throws`() {
+    fun `navigateToUrl returns false and clears loading when URL launcher throws`() {
         val urlLauncher = mockk<UrlLauncher>()
         coEvery { urlLauncher.openUrl(any()) } throws IllegalStateException("unexpected")
         mainPresenter =
@@ -222,9 +220,8 @@ class BasePresenterTest {
         val result = runBlocking { presenter.navigateToUrlAwait("https://bisq.network") }
 
         assertFalse(result)
-        assertFalse(presenter.isInteractive.value)
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertTrue(presenter.isInteractive.value)
+        assertFalse(globalUiManager.isLoadingBlocking.value)
+        assertFalse(globalUiManager.showLoadingDialog.value)
         coVerify(exactly = 1) { urlLauncher.openUrl("https://bisq.network") }
         verify(exactly = 1) {
             globalUiManager.showSnackbar(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLockTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLockTest.kt
@@ -1,0 +1,137 @@
+package network.bisq.mobile.presentation.common.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class InitialScreenInteractionLockTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @After
+    fun tearDown() {
+        composeTestRule.mainClock.autoAdvance = true
+    }
+
+    private fun setTestContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    content()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when rendered then content is displayed`() {
+        setTestContent {
+            InitialScreenInteractionLock {
+                Text("Locked content")
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Locked content").assertIsDisplayed()
+    }
+
+    @Test
+    fun `when clicked before delay ends then click is blocked`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+
+        setTestContent {
+            TestLockContent(
+                lockDurationMillis = 250L,
+                onClick = { clickCount++ },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BUTTON_TEXT).performTouchInput { click() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, clickCount)
+    }
+
+    @Test
+    fun `when clicked after delay ends then click is handled`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+
+        setTestContent {
+            TestLockContent(
+                lockDurationMillis = 250L,
+                onClick = { clickCount++ },
+            )
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(251L)
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BUTTON_TEXT).performTouchInput { click() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Test
+    fun `when delay is zero then click is handled immediately`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+
+        setTestContent {
+            TestLockContent(
+                lockDurationMillis = 0L,
+                onClick = { clickCount++ },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BUTTON_TEXT).performTouchInput { click() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Composable
+    private fun TestLockContent(
+        lockDurationMillis: Long,
+        onClick: () -> Unit,
+    ) {
+        InitialScreenInteractionLock(lockDurationMillis = lockDurationMillis) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Button(onClick = onClick) {
+                    Text(BUTTON_TEXT)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val BUTTON_TEXT = "Tap action"
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -9,30 +9,21 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.flow.MutableStateFlow
-import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.di.presentationTestModule
-import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
-import network.bisq.mobile.presentation.main.MainPresenter
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.koin.core.context.GlobalContext
-import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import kotlin.test.assertEquals
 
 /**
@@ -729,48 +720,25 @@ class WebLinkDialogUiKoinTest {
     }
 
     @Test
-    fun `when confirm clicked while presenter non interactive then skips navigation`() {
-        runCatching { stopKoin() }
-        val fake = WebLinkDialogSettingsServiceFake()
-        val mainPresenter = mockk<MainPresenter>(relaxed = true)
-        coEvery { mainPresenter.navigateToUrlWithLauncher(any()) } returns false
-        startKoin {
-            modules(
-                module {
-                    single<SettingsServiceFacade> { fake }
-                    single<MainPresenter> { mainPresenter }
-                    single { WebLinkConfirmationDialogPresenter(get(), get()) }
-                },
-                presentationTestModule,
-            )
-        }
-        val dialogPresenter =
-            GlobalContext.get().get<WebLinkConfirmationDialogPresenter>()
-        val link = "https://example.com/noninteractive-guard"
+    fun `when confirm clicked and launcher fails then attempts navigation and invokes onError`() {
+        val link = "https://example.com/launcher-fails"
+        val onError = mockk<() -> Unit>(relaxed = true)
+        val (_, mainPresenter) = startKoinWithWebLinkDialogFake(openUrlResult = false)
+
         setTestContent(WebLinkDialogTestFixtures.noopExternalUrlOpener) {
             WebLinkConfirmationDialog(
                 link = link,
                 onConfirm = {},
                 onDismiss = {},
-                onError = {},
+                onError = onError,
             )
         }
 
         composeTestRule.waitForIdle()
-        dialogPresenter.setInteractiveFlagForTest(false)
         composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
         composeTestRule.waitForIdle()
 
-        coVerify(exactly = 0) { mainPresenter.navigateToUrlWithLauncher(any()) }
+        coVerify(exactly = 1) { mainPresenter.navigateToUrlWithLauncher(link) }
+        verify(exactly = 1) { onError() }
     }
-}
-
-@Suppress("UNCHECKED_CAST")
-private fun BasePresenter.setInteractiveFlagForTest(value: Boolean) {
-    val field =
-        BasePresenter::class.java.getDeclaredField("_isInteractive").apply {
-            isAccessible = true
-        }
-    val flow = field.get(this) as MutableStateFlow<Boolean>
-    flow.value = value
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -1,16 +1,22 @@
 package network.bisq.mobile.presentation.offer.create_offer
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.model.BatteryOptimizationState
 import network.bisq.mobile.data.model.PermissionState
@@ -74,6 +80,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -865,6 +872,49 @@ class CreateOfferReviewPresenterTest {
                 "but was: '${reviewPresenter.priceDetails}'"
         }
     }
+
+    /**
+     * Rapid double-tap on "Publish offer" must trigger the underlying createOffer
+     * only once. Disabling the button via the StateFlow alone has a recomposition
+     * window where a second tap can land before the UI redraws — compareAndSet
+     * closes that window.
+     */
+    @Test
+    fun `rapid double-tap on onCreateOffer triggers createOffer only once`() =
+        runTest(testDispatcher) {
+            val marketUSD = MarketVOFactory.USD
+            val staleMarketPrice = with(PriceQuoteVOFactory) { fromPrice(100000.0, marketUSD) }
+            val currentMarketItem = makeMarketPriceItem(marketUSD, 105000.0)
+            val prices = mutableMapOf(marketUSD to currentMarketItem)
+            val settingsRepo = FakeSettingsRepository()
+            val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
+
+            mockkStatic(
+                "network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt",
+            )
+            every { getScreenWidthDp() } returns 480
+
+            val mainPresenter = makeMainPresenter()
+            val createOfferCoordinator = spyk(makeCreateOfferCoordinator(marketPriceServiceFacade))
+            // Suspend the underlying create so the guard is observable across the second tap.
+            coEvery { createOfferCoordinator.createOffer() } coAnswers {
+                delay(Long.MAX_VALUE)
+                Result.success("never")
+            }
+
+            createOfferCoordinator.createOfferModel =
+                buildModelWithPercentagePricing(marketUSD, staleMarketPrice, 0.10)
+
+            val reviewPresenter = CreateOfferReviewPresenter(mainPresenter, createOfferCoordinator)
+            reviewPresenter.onViewAttached()
+
+            reviewPresenter.onCreateOffer()
+            reviewPresenter.onCreateOffer()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { createOfferCoordinator.createOffer() }
+            assertFalse(reviewPresenter.isCreateOfferBtnEnabled.value)
+        }
 
     @Test
     fun `when demo mode then onCreateOffer returns early without calling createOffer`() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferReviewPresenterTest.kt
@@ -1,0 +1,230 @@
+package network.bisq.mobile.presentation.offer.take_offer
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.CoinVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.replicated.common.network.AddressByTransportTypeMapVO
+import network.bisq.mobile.data.replicated.network.identity.NetworkIdVO
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideRangeAmountSpecVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationDto
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.replicated.security.keys.PubKeyVO
+import network.bisq.mobile.data.replicated.security.keys.PublicKeyVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.data.service.trades.TakeOfferStatus
+import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.presentation.offer.take_offer.review.TakeOfferReviewPresenter
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TakeOfferReviewPresenterTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        startKoin {
+            modules(
+                module {
+                    single { CoroutineExceptionHandlerSetup() }
+                    factory<CoroutineJobsManager> {
+                        DefaultCoroutineJobsManager().apply {
+                            get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
+                        }
+                    }
+                    single<NavigationManager> { mockk(relaxed = true) }
+                    single { GlobalUiManager() }
+                },
+            )
+        }
+        I18nSupport.initialize("en")
+        // MainPresenter.init touches a platform-specific helper transitively; stub it.
+        mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+        every { getScreenWidthDp() } returns 480
+    }
+
+    @AfterTest
+    fun tearDown() {
+        try {
+            stopKoin()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    /**
+     * Rapid double-tap on the "Take offer" button must trigger the underlying
+     * [TakeOfferCoordinator.takeOffer] only once. The atomic compareAndSet guard
+     * is the structural protection — the progress dialog alone is not modal enough,
+     * especially on the android node app where the API returns near-instantly.
+     */
+    @Test
+    fun `rapid double-tap on onTakeOffer triggers underlying takeOffer only once`() =
+        runTest(testDispatcher) {
+            val fixture = makeFixture()
+            fixture.presenter.onTakeOffer()
+            fixture.presenter.onTakeOffer()
+            advanceUntilIdle()
+            coVerify(exactly = 1) { fixture.coordinator.takeOffer() }
+        }
+
+    /**
+     * After an error arrives on the error flow, the guard must be released so the
+     * user can retry. The progress dialog must also be hidden (without this fix,
+     * an error left the dialog up indefinitely).
+     */
+    @Test
+    fun `error path releases guard and hides progress dialog`() =
+        runTest(testDispatcher) {
+            val fixture = makeFixture()
+            fixture.presenter.onTakeOffer()
+            advanceUntilIdle()
+            assertTrue(fixture.presenter.showTakeOfferProgressDialog.value, "progress dialog should be up before error")
+
+            fixture.errorFlow.value = "boom"
+            advanceUntilIdle()
+
+            assertFalse(fixture.presenter.showTakeOfferProgressDialog.value, "progress dialog should be hidden after error")
+
+            // Retry should now succeed
+            fixture.presenter.onTakeOffer()
+            advanceUntilIdle()
+            coVerify(exactly = 2) { fixture.coordinator.takeOffer() }
+        }
+
+    /**
+     * Once SUCCESS arrives, the guard must stay engaged — the user is meant to leave
+     * the screen via the success dialog. Resetting the guard would expose the button
+     * again if the success dialog were dismissed unexpectedly.
+     */
+    @Test
+    fun `success path keeps guard engaged so a subsequent tap is ignored`() =
+        runTest(testDispatcher) {
+            val fixture = makeFixture()
+            fixture.presenter.onTakeOffer()
+            advanceUntilIdle()
+
+            fixture.statusFlow.value = TakeOfferStatus.SUCCESS
+            advanceUntilIdle()
+
+            assertTrue(fixture.presenter.showTakeOfferSuccessDialog.value, "success dialog should be up")
+            assertFalse(fixture.presenter.showTakeOfferProgressDialog.value, "progress dialog should be down")
+
+            // Phantom tap after success — must be ignored.
+            fixture.presenter.onTakeOffer()
+            advanceUntilIdle()
+            coVerify(exactly = 1) { fixture.coordinator.takeOffer() }
+        }
+
+    // ---- fixture ----
+
+    private data class Fixture(
+        val presenter: TakeOfferReviewPresenter,
+        val coordinator: TakeOfferCoordinator,
+        val statusFlow: MutableStateFlow<TakeOfferStatus?>,
+        val errorFlow: MutableStateFlow<String?>,
+    )
+
+    private fun makeFixture(): Fixture {
+        val marketPriceServiceFacade = mockk<MarketPriceServiceFacade>(relaxed = true)
+        every { marketPriceServiceFacade.findMarketPriceItem(any()) } returns null
+
+        val coordinator = mockk<TakeOfferCoordinator>(relaxed = true)
+        every { coordinator.takeOfferModel } returns makeTakeOfferModel()
+
+        val statusFlow = MutableStateFlow<TakeOfferStatus?>(null)
+        val errorFlow = MutableStateFlow<String?>(null)
+        coEvery { coordinator.takeOffer() } returns TakeOfferFlowResult(statusFlow, errorFlow)
+
+        val presenter =
+            TakeOfferReviewPresenter(
+                MainPresenterTestFactory.create(),
+                marketPriceServiceFacade,
+                coordinator,
+            )
+        return Fixture(presenter, coordinator, statusFlow, errorFlow)
+    }
+
+    private fun makeTakeOfferModel(): TakeOfferCoordinator.TakeOfferModel {
+        val market = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
+        val amountSpec = QuoteSideRangeAmountSpecVO(minAmount = 10_0000L, maxAmount = 100_0000L)
+        val priceSpec = FixPriceSpecVO(with(PriceQuoteVOFactory) { fromPrice(100_00L, market) })
+        val makerNetworkId =
+            NetworkIdVO(
+                AddressByTransportTypeMapVO(mapOf()),
+                PubKeyVO(PublicKeyVO("pub"), keyId = "key", hash = "hash", id = "id"),
+            )
+        val offer =
+            BisqEasyOfferVO(
+                id = "offer-1",
+                date = 0L,
+                makerNetworkId = makerNetworkId,
+                direction = DirectionEnum.BUY,
+                market = market,
+                amountSpec = amountSpec,
+                priceSpec = priceSpec,
+                protocolTypes = emptyList(),
+                baseSidePaymentMethodSpecs = emptyList(),
+                quoteSidePaymentMethodSpecs = emptyList(),
+                offerOptions = emptyList(),
+                supportedLanguageCodes = emptyList(),
+            )
+        val dto =
+            OfferItemPresentationDto(
+                bisqEasyOffer = offer,
+                isMyOffer = false,
+                userProfile = createMockUserProfile("Alice"),
+                formattedDate = "",
+                formattedQuoteAmount = "",
+                formattedBaseAmount = "",
+                formattedPrice = "",
+                formattedPriceSpec = "",
+                quoteSidePaymentMethods = listOf("SEPA"),
+                baseSidePaymentMethods = listOf("BTC"),
+                reputationScore = ReputationScoreVO(0, 0.0, 0),
+            )
+        val priceQuote = with(PriceQuoteVOFactory) { fromPrice(100_00L, market) }
+        return TakeOfferCoordinator.TakeOfferModel().apply {
+            offerItemPresentationVO = OfferItemPresentationModel(dto)
+            originalPriceQuote = priceQuote
+            this.priceQuote = priceQuote
+            quoteAmount = with(FiatVOFactory) { fromFaceValue(50.0, "USD") }
+            baseAmount = with(CoinVOFactory) { fromFaceValue(0.0005, "BTC") }
+            quoteSidePaymentMethod = "SEPA"
+            baseSidePaymentMethod = "MAIN_CHAIN"
+        }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.TestCoroutineJobsManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
@@ -68,6 +69,7 @@ class OfferbookPresenterTradeRestrictionTest {
                 module {
                     factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
                     single<NavigationManager> { NoopNavigationManager() }
+                    single { GlobalUiManager(testDispatcher) }
                 },
             )
         }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenterNavigationTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenterNavigationTest.kt
@@ -22,6 +22,7 @@ import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -96,6 +97,7 @@ class SplashPresenterNavigationTest {
                         }
                     }
                     single<NavigationManager> { navigationManager }
+                    single { GlobalUiManager(testDispatcher) }
                 },
             )
         }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
@@ -24,6 +24,7 @@ import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.TestCoroutineJobsManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
@@ -56,6 +57,7 @@ class TabContainerPresenterTradeRestrictionTest {
                 module {
                     factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
                     single<NavigationManager> { NoopNavigationManager() }
+                    single { GlobalUiManager(testDispatcher) }
                 },
             )
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -377,13 +377,12 @@ abstract class BasePresenter(
      * For the [Boolean] result inside a coroutine, use [navigateToUrlAwait].
      */
     open fun navigateToUrl(url: String) {
-        if (!_isInteractive.value) return
-        disableInteractive()
+        showLoading()
         presenterScope.launch {
             try {
                 mainPresenterForUrlNavigation()?.navigateToUrlWithLauncher(url)
             } finally {
-                enableInteractive()
+                hideLoading()
             }
         }
     }
@@ -393,12 +392,11 @@ abstract class BasePresenter(
      * succeeded. Use from coroutines when the [Boolean] matters (e.g. web-link confirmation flow).
      */
     open suspend fun navigateToUrlAwait(url: String): Boolean {
-        if (!_isInteractive.value) return false
-        disableInteractive()
+        showLoading()
         return try {
             mainPresenterForUrlNavigation()?.navigateToUrlWithLauncher(url) ?: false
         } finally {
-            enableInteractive()
+            hideLoading()
         }
     }
 
@@ -419,20 +417,20 @@ abstract class BasePresenter(
         destination: NavRoute,
         customSetup: (NavOptionsBuilder) -> Unit = {},
     ) {
-        disableInteractive()
+        showLoading()
         navigationManager.navigate(
             destination,
             customSetup,
         ) {
-            enableInteractive()
+            hideLoading()
         }
     }
 
     protected fun navigateBack() {
         log.d { "Navigating back" }
-        disableInteractive()
+        showLoading()
         navigationManager.navigateBack {
-            enableInteractive()
+            hideLoading()
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLock.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLock.kt
@@ -1,0 +1,56 @@
+package network.bisq.mobile.presentation.common.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import kotlinx.coroutines.delay
+
+@Composable
+fun InitialScreenInteractionLock(
+    modifier: Modifier = Modifier,
+    lockDurationMillis: Long = 250L,
+    content: @Composable () -> Unit,
+) {
+    val isPreview = LocalInspectionMode.current
+    var isLocked by remember(lockDurationMillis, isPreview) {
+        mutableStateOf(lockDurationMillis > 0L && !isPreview)
+    }
+
+    if (!isPreview) {
+        LaunchedEffect(lockDurationMillis) {
+            if (lockDurationMillis > 0L) {
+                isLocked = true
+                delay(lockDurationMillis)
+            }
+            isLocked = false
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        content()
+
+        if (isLocked) {
+            Box(
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent()
+                                }
+                            }
+                        }.clearAndSetSemantics { },
+            )
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
@@ -20,7 +20,6 @@ fun TradeGuideProcess() {
     val presenter: TradeGuideProcessPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val isInteractive by presenter.isInteractive.collectAsState()
     val title = "bisqEasy.tradeGuide.tabs.headline".i18n() + ": " + "bisqEasy.tradeGuide.process".i18n()
 
     MultiScreenWizardScaffold(
@@ -30,7 +29,6 @@ fun TradeGuideProcess() {
         prevOnClick = presenter::prevClick,
         nextOnClick = presenter::processNextClick,
         horizontalAlignment = Alignment.Start,
-        isInteractive = isInteractive,
     ) {
         BisqText.H3Light("bisqEasy.tradeGuide.process.headline".i18n())
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
@@ -1,8 +1,6 @@
 package network.bisq.mobile.presentation.guide.trade_guide
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.tooling.preview.Preview
 import network.bisq.mobile.i18n.i18n
@@ -22,10 +20,7 @@ fun TradeGuideSecurity() {
     val presenter: TradeGuideSecurityPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val isInteractive by presenter.isInteractive.collectAsState()
-
     TradeGuideSecurityContent(
-        isInteractive = isInteractive,
         prevClick = presenter::prevClick,
         nextClick = presenter::securityNextClick,
     )
@@ -33,7 +28,6 @@ fun TradeGuideSecurity() {
 
 @Composable
 fun TradeGuideSecurityContent(
-    isInteractive: Boolean,
     prevClick: () -> Unit,
     nextClick: () -> Unit,
 ) {
@@ -46,7 +40,6 @@ fun TradeGuideSecurityContent(
         prevOnClick = prevClick,
         nextOnClick = nextClick,
         horizontalAlignment = Alignment.Start,
-        isInteractive = isInteractive,
     ) {
         BisqText.H3Light("bisqEasy.tradeGuide.security.headline".i18n())
 
@@ -79,7 +72,6 @@ private fun TradeGuideSecurityContentPreview(
 ) {
     BisqTheme.Preview(language = language) {
         TradeGuideSecurityContent(
-            isInteractive = true,
             prevClick = {},
             nextClick = {},
         )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
@@ -26,7 +26,6 @@ fun TradeGuideTradeRules() {
 
     val userAgreed by presenter.tradeRulesConfirmed.collectAsState()
     var localUserAgreed by remember(userAgreed) { mutableStateOf(userAgreed) }
-    val isInteractive by presenter.isInteractive.collectAsState()
 
     val title = "bisqEasy.tradeGuide.tabs.headline".i18n() + ": " + "bisqEasy.tradeGuide.rules".i18n()
 
@@ -39,7 +38,6 @@ fun TradeGuideTradeRules() {
         nextButtonText = "mobile.action.finish".i18n(),
         nextDisabled = !localUserAgreed,
         horizontalAlignment = Alignment.Start,
-        isInteractive = isInteractive,
         showJumpToBottom = true,
     ) {
         BisqText.H3Light("bisqEasy.tradeGuide.rules.headline".i18n())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketPresenter.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.OfferFlowPresenter
@@ -45,17 +46,6 @@ class CreateOfferMarketPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
-
-        // wait for market items to be ready
-        disableInteractive()
-        presenterScope.launch {
-            offersServiceFacade.offerbookMarketItems.collect { markets ->
-                if (markets.isNotEmpty()) {
-                    enableInteractive()
-                }
-            }
-        }
-
         observeGlobalMarketPrices()
     }
 
@@ -132,6 +122,8 @@ class CreateOfferMarketPresenter(
     fun onNext() {
         if (isValid()) {
             navigateNext()
+        } else {
+            showSnackbar("mobile.bisqEasy.tradeWizard.market.select.error".i18n(), type = SnackbarType.ERROR)
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/market/CreateOfferMarketScreen.kt
@@ -29,7 +29,6 @@ fun CreateOfferMarketScreen() {
 
     val searchText by presenter.searchText.collectAsState()
     val filteredMarketList by presenter.marketListItemWithNumOffers.collectAsState()
-    val isInteractive by presenter.isInteractive.collectAsState()
     val selectedMarketItem by presenter.selectedMarketItem.collectAsState()
 
     MultiScreenWizardScaffold(
@@ -40,7 +39,6 @@ fun CreateOfferMarketScreen() {
         nextOnClick = { presenter.onNext() },
         useStaticScaffold = true,
         horizontalAlignment = Alignment.Start,
-        isInteractive = isInteractive,
         showUserAvatar = false,
         closeAction = true,
         onConfirmedClose = presenter::onClose,
@@ -59,7 +57,7 @@ fun CreateOfferMarketScreen() {
 
         BisqGap.V1()
 
-        if (isInteractive) {
+        if (filteredMarketList.isNotEmpty()) {
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewPresenter.kt
@@ -250,7 +250,13 @@ class CreateOfferReviewPresenter(
             showSnackbar("mobile.demo.action.disabled".i18n(), type = SnackbarType.ERROR)
             return
         }
-        _isCreateOfferBtnEnabled.value = false
+        // Atomic guard against rapid-fire taps. Disabling the button via the
+        // StateFlow alone has a recomposition window where a second tap can land
+        // before the UI redraws. compareAndSet ensures only the first call proceeds.
+        if (!_isCreateOfferBtnEnabled.compareAndSet(expect = true, update = false)) {
+            log.w { "onCreateOffer called while a publish is already in progress; ignoring" }
+            return
+        }
         showLoading()
         presenterScope.launch {
             try {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewPresenter.kt
@@ -46,8 +46,6 @@ class CreateOfferReviewPresenter(
     var formattedBaseRangeMaxAmount: String = ""
     var isRangeOffer: Boolean = false
 
-    override val blockInteractivityOnAttached: Boolean = true
-
     private val _isCreateOfferBtnEnabled = MutableStateFlow(true)
     val isCreateOfferBtnEnabled = _isCreateOfferBtnEnabled.asStateFlow()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/review/CreateOfferReviewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.InitialScreenInteractionLock
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
@@ -34,147 +35,152 @@ fun CreateOfferReviewOfferScreen() {
 
     val isCreateOfferBtnEnabled by presenter.isCreateOfferBtnEnabled.collectAsState()
 
-    MultiScreenWizardScaffold(
-        "bisqEasy.tradeWizard.review.headline.maker".i18n(),
-        stepIndex = if (createCoordinator.skipCurrency) 6 else 7,
-        stepsLength = if (createCoordinator.skipCurrency) 6 else 7,
-        prevOnClick = { presenter.onBack() },
-        nextDisabled = !isCreateOfferBtnEnabled,
-        nextButtonText = "bisqEasy.tradeWizard.review.nextButton.createOffer".i18n(),
-        nextOnClick = { presenter.onCreateOffer() },
-        showUserAvatar = false,
-        closeAction = true,
-        onConfirmedClose = presenter::onClose,
-    ) {
-        BisqGap.V1()
-        Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)) {
-            InfoBox(
-                label = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
-                value = presenter.headLine,
-            )
-            if (presenter.isRangeOffer) {
-                if (presenter.direction == DirectionEnum.BUY) {
-                    InfoBoxCurrency(
-                        label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
-                        value = presenter.amountToPay,
-                    )
-                    InfoBox(
-                        label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
-                        valueComposable = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                BtcSatsText(
-                                    formattedBtcAmountValue = presenter.formattedBaseRangeMinAmount,
-                                    noCode = true,
-                                    textStyle = BisqTheme.typography.h6Regular,
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                                BisqGap.H1()
-                                BisqText.H6Light("–", modifier = Modifier.alignByBaseline())
-                                BisqGap.H1()
-                                BtcSatsText(
-                                    formattedBtcAmountValue = presenter.formattedBaseRangeMaxAmount,
-                                    noCode = true,
-                                    textStyle = BisqTheme.typography.h6Regular,
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                                BisqGap.HHalf()
-                                BisqText.BaseRegularGrey(
-                                    "BTC",
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                            }
-                        },
-                    )
-                } else {
-                    InfoBoxCurrency(
-                        label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
-                        value = presenter.amountToReceive,
-                    )
-                    InfoBox(
-                        label = "bisqEasy.tradeWizard.review.toSend".i18n().uppercase(),
-                        valueComposable = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                BtcSatsText(
-                                    presenter.formattedBaseRangeMinAmount,
-                                    noCode = true,
-                                    textStyle = BisqTheme.typography.h6Regular,
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                                BisqGap.H1()
-                                BisqText.H6Light("–", modifier = Modifier.alignByBaseline())
-                                BisqGap.H1()
-                                BtcSatsText(
-                                    presenter.formattedBaseRangeMaxAmount,
-                                    noCode = true,
-                                    textStyle = BisqTheme.typography.h6Regular,
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                                BisqGap.HHalf()
-                                BisqText.BaseRegularGrey(
-                                    "BTC",
-                                    modifier = Modifier.alignByBaseline(),
-                                )
-                            }
-                        },
-                    )
-                }
-            } else {
-                if (presenter.direction == DirectionEnum.BUY) {
-                    InfoRowContainer {
+    // This final review step is locked briefly to prevent fast repeated taps from creating the offer
+    // before the user has reviewed it. A deeper fix is harder because the controls are wrapped inside
+    // MultiScreenWizardScaffold.
+    InitialScreenInteractionLock {
+        MultiScreenWizardScaffold(
+            "bisqEasy.tradeWizard.review.headline.maker".i18n(),
+            stepIndex = if (createCoordinator.skipCurrency) 6 else 7,
+            stepsLength = if (createCoordinator.skipCurrency) 6 else 7,
+            prevOnClick = { presenter.onBack() },
+            nextDisabled = !isCreateOfferBtnEnabled,
+            nextButtonText = "bisqEasy.tradeWizard.review.nextButton.createOffer".i18n(),
+            nextOnClick = { presenter.onCreateOffer() },
+            showUserAvatar = false,
+            closeAction = true,
+            onConfirmedClose = presenter::onClose,
+        ) {
+            BisqGap.V1()
+            Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding2X)) {
+                InfoBox(
+                    label = "bisqEasy.tradeState.header.direction".i18n().uppercase(),
+                    value = presenter.headLine,
+                )
+                if (presenter.isRangeOffer) {
+                    if (presenter.direction == DirectionEnum.BUY) {
                         InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
                             value = presenter.amountToPay,
                         )
-                        InfoBoxSats(
+                        InfoBox(
                             label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
-                            value = presenter.amountToReceive,
+                            valueComposable = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    BtcSatsText(
+                                        formattedBtcAmountValue = presenter.formattedBaseRangeMinAmount,
+                                        noCode = true,
+                                        textStyle = BisqTheme.typography.h6Regular,
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                    BisqGap.H1()
+                                    BisqText.H6Light("–", modifier = Modifier.alignByBaseline())
+                                    BisqGap.H1()
+                                    BtcSatsText(
+                                        formattedBtcAmountValue = presenter.formattedBaseRangeMaxAmount,
+                                        noCode = true,
+                                        textStyle = BisqTheme.typography.h6Regular,
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                    BisqGap.HHalf()
+                                    BisqText.BaseRegularGrey(
+                                        "BTC",
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                }
+                            },
                         )
-                    }
-                } else {
-                    InfoRowContainer {
-                        InfoBoxSats(
-                            label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
-                            value = presenter.amountToPay,
-                        )
+                    } else {
                         InfoBoxCurrency(
                             label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
                             value = presenter.amountToReceive,
                         )
+                        InfoBox(
+                            label = "bisqEasy.tradeWizard.review.toSend".i18n().uppercase(),
+                            valueComposable = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    BtcSatsText(
+                                        presenter.formattedBaseRangeMinAmount,
+                                        noCode = true,
+                                        textStyle = BisqTheme.typography.h6Regular,
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                    BisqGap.H1()
+                                    BisqText.H6Light("–", modifier = Modifier.alignByBaseline())
+                                    BisqGap.H1()
+                                    BtcSatsText(
+                                        presenter.formattedBaseRangeMaxAmount,
+                                        noCode = true,
+                                        textStyle = BisqTheme.typography.h6Regular,
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                    BisqGap.HHalf()
+                                    BisqText.BaseRegularGrey(
+                                        "BTC",
+                                        modifier = Modifier.alignByBaseline(),
+                                    )
+                                }
+                            },
+                        )
+                    }
+                } else {
+                    if (presenter.direction == DirectionEnum.BUY) {
+                        InfoRowContainer {
+                            InfoBoxCurrency(
+                                label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
+                                value = presenter.amountToPay,
+                            )
+                            InfoBoxSats(
+                                label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
+                                value = presenter.amountToReceive,
+                            )
+                        }
+                    } else {
+                        InfoRowContainer {
+                            InfoBoxSats(
+                                label = "bisqEasy.tradeWizard.review.toPay".i18n().uppercase(),
+                                value = presenter.amountToPay,
+                            )
+                            InfoBoxCurrency(
+                                label = "bisqEasy.tradeWizard.review.toReceive".i18n().uppercase(),
+                                value = presenter.amountToReceive,
+                            )
+                        }
                     }
                 }
+
+                BisqHDivider()
+
+                InfoBox(
+                    label = "bisqEasy.tradeWizard.review.priceDescription.maker".i18n(),
+                    valueComposable = {
+                        Row(
+                            verticalAlignment = Alignment.Bottom,
+                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            BisqText.H6Light(presenter.formattedPrice)
+                            BisqGap.HQuarter()
+                            BisqText.BaseLightGrey(presenter.marketCodes)
+                        }
+                    },
+                    subvalue = presenter.priceDetails,
+                )
+
+                InfoBox(
+                    label = "bisqEasy.tradeWizard.review.paymentMethodDescription.fiat".i18n(), // Fiat payment method
+                    value = presenter.quoteSidePaymentMethodDisplayString,
+                )
+                InfoBox(
+                    label = "bisqEasy.tradeWizard.review.paymentMethodDescription.btc".i18n(), // Bitcoin settlement method
+                    value = presenter.baseSidePaymentMethodDisplayString,
+                )
+
+                InfoBox(
+                    label = "bisqEasy.tradeWizard.review.feeDescription".i18n(),
+                    value = presenter.fee,
+                    subvalue = presenter.feeDetails,
+                )
             }
-
-            BisqHDivider()
-
-            InfoBox(
-                label = "bisqEasy.tradeWizard.review.priceDescription.maker".i18n(),
-                valueComposable = {
-                    Row(
-                        verticalAlignment = Alignment.Bottom,
-                        horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    ) {
-                        BisqText.H6Light(presenter.formattedPrice)
-                        BisqGap.HQuarter()
-                        BisqText.BaseLightGrey(presenter.marketCodes)
-                    }
-                },
-                subvalue = presenter.priceDetails,
-            )
-
-            InfoBox(
-                label = "bisqEasy.tradeWizard.review.paymentMethodDescription.fiat".i18n(), // Fiat payment method
-                value = presenter.quoteSidePaymentMethodDisplayString,
-            )
-            InfoBox(
-                label = "bisqEasy.tradeWizard.review.paymentMethodDescription.btc".i18n(), // Bitcoin settlement method
-                value = presenter.baseSidePaymentMethodDisplayString,
-            )
-
-            InfoBox(
-                label = "bisqEasy.tradeWizard.review.feeDescription".i18n(),
-                value = presenter.fee,
-                subvalue = presenter.feeDetails,
-            )
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
@@ -48,8 +48,6 @@ class TakeOfferReviewPresenter(
     var takersDirection: DirectionEnum
     lateinit var priceDetails: String
 
-    override val blockInteractivityOnAttached: Boolean = true
-
     private var takeOfferModel: TakeOfferCoordinator.TakeOfferModel
 
     // We pass that to the domain, which updates the state while take offer is in progress, so that we can show the status
@@ -77,6 +75,7 @@ class TakeOfferReviewPresenter(
                 log.i { "takeOfferStatus: $it" }
                 if (it == TakeOfferStatus.SUCCESS) {
                     setShowTakeOfferSuccessDialog(true)
+                    setShowTakeOfferProgressDialog(false)
                 }
             }
         }
@@ -131,8 +130,6 @@ class TakeOfferReviewPresenter(
 
     fun onTakeOffer() {
         setShowTakeOfferProgressDialog(true)
-        disableInteractive()
-
         presenterScope.launch {
             try {
                 if (isDemo()) {
@@ -152,9 +149,7 @@ class TakeOfferReviewPresenter(
                 log.e("Take offer failed", e)
                 takeOfferErrorMessage.value =
                     e.message ?: ("mobile.takeOffer.failedWithException".i18n(e.toString().truncate(50)))
-            } finally {
                 setShowTakeOfferProgressDialog(false)
-                enableInteractive()
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewPresenter.kt
@@ -69,6 +69,13 @@ class TakeOfferReviewPresenter(
         _showTakeOfferSuccessDialog.value = value
     }
 
+    // Atomic guard against rapid-fire taps on the "Take offer" button. The progress
+    // dialog is the visible signal, but its modality is not enough on its own —
+    // touches can land before the dialog renders, especially on the android node
+    // app where the API returns near-instantly. compareAndSet ensures only the
+    // first tap proceeds; subsequent taps short-circuit until SUCCESS / error.
+    private val isTakingOffer = MutableStateFlow(false)
+
     init {
         presenterScope.launch {
             takeOfferStatus.collect {
@@ -76,6 +83,9 @@ class TakeOfferReviewPresenter(
                 if (it == TakeOfferStatus.SUCCESS) {
                     setShowTakeOfferSuccessDialog(true)
                     setShowTakeOfferProgressDialog(false)
+                    // Keep isTakingOffer = true on success: the user moves on via
+                    // the success dialog. Resetting could re-expose the button if
+                    // the dialog were dismissed unexpectedly.
                 }
             }
         }
@@ -84,6 +94,10 @@ class TakeOfferReviewPresenter(
             takeOfferErrorMessage.drop(1).collect {
                 log.e { "takeOfferErrorMessage: $it" }
                 showSnackbar(it ?: "mobile.takeOffer.unexpectedError".i18n(), type = SnackbarType.ERROR)
+                // Error path: hide the progress dialog (otherwise it stays up forever)
+                // and release the guard so the user can retry.
+                setShowTakeOfferProgressDialog(false)
+                isTakingOffer.value = false
             }
         }
 
@@ -129,27 +143,32 @@ class TakeOfferReviewPresenter(
     }
 
     fun onTakeOffer() {
+        if (isDemo()) {
+            showSnackbar("mobile.demo.action.disabled".i18n(), type = SnackbarType.ERROR)
+            return
+        }
+        if (!isTakingOffer.compareAndSet(expect = false, update = true)) {
+            log.w { "onTakeOffer called while a take is already in progress; ignoring" }
+            return
+        }
         setShowTakeOfferProgressDialog(true)
         presenterScope.launch {
             try {
-                if (isDemo()) {
-                    showSnackbar("mobile.demo.action.disabled".i18n(), type = SnackbarType.ERROR)
-                } else {
-                    val (statusFlow, errorFlow) = takeOfferCoordinator.takeOffer()
+                val (statusFlow, errorFlow) = takeOfferCoordinator.takeOffer()
 
-                    // The stateFlow objects are set in the ioScope in the service. Thus we need to map them to the presenterScope.
-                    presenterScope.launch {
-                        statusFlow.collect { takeOfferStatus.value = it }
-                    }
-                    presenterScope.launch {
-                        errorFlow.collect { takeOfferErrorMessage.value = it }
-                    }
+                // The stateFlow objects are set in the ioScope in the service. Thus we need to map them to the presenterScope.
+                presenterScope.launch {
+                    statusFlow.collect { takeOfferStatus.value = it }
+                }
+                presenterScope.launch {
+                    errorFlow.collect { takeOfferErrorMessage.value = it }
                 }
             } catch (e: Exception) {
                 log.e("Take offer failed", e)
                 takeOfferErrorMessage.value =
                     e.message ?: ("mobile.takeOffer.failedWithException".i18n(e.toString().truncate(50)))
                 setShowTakeOfferProgressDialog(false)
+                isTakingOffer.value = false
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/review/TakeOfferReviewScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.InitialScreenInteractionLock
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
@@ -40,7 +41,6 @@ fun TakeOfferReviewTradeScreen() {
 
     val showProgressDialog by presenter.showTakeOfferProgressDialog.collectAsState()
     val showSuccessDialog by presenter.showTakeOfferSuccessDialog.collectAsState()
-    val isInteractive by presenter.isInteractive.collectAsState()
 
     val takeOffer = takeOfferCoordinator.takeOfferModel
     var stepIndex = 1
@@ -54,29 +54,33 @@ fun TakeOfferReviewTradeScreen() {
         stepIndex++
     }
 
-    TakeOfferReviewContent(
-        headLine = presenter.headLine,
-        takersDirection = presenter.takersDirection,
-        amountToPay = presenter.amountToPay,
-        amountToReceive = presenter.amountToReceive,
-        price = presenter.price,
-        marketCodes = presenter.marketCodes,
-        priceDetails = presenter.priceDetails,
-        quoteSidePaymentMethodDisplayString = presenter.quoteSidePaymentMethodDisplayString,
-        baseSidePaymentMethodDisplayString = presenter.baseSidePaymentMethodDisplayString,
-        fee = presenter.fee,
-        feeDetails = presenter.feeDetails,
-        isSmallScreen = presenter::isSmallScreen,
-        stepIndex = stepIndex,
-        stepsLength = takeOfferCoordinator.totalSteps,
-        showProgressDialog = showProgressDialog,
-        showSuccessDialog = showSuccessDialog,
-        isInteractive = isInteractive,
-        onBack = presenter::onBack,
-        onTakeOffer = presenter::onTakeOffer,
-        onClose = presenter::onClose,
-        onGoToOpenTrades = presenter::onGoToOpenTrades,
-    )
+    // This final review step is locked briefly to prevent fast repeated taps from creating the offer
+    // before the user has reviewed it. A deeper fix is harder because the controls are wrapped inside
+    // MultiScreenWizardScaffold.
+    InitialScreenInteractionLock {
+        TakeOfferReviewContent(
+            headLine = presenter.headLine,
+            takersDirection = presenter.takersDirection,
+            amountToPay = presenter.amountToPay,
+            amountToReceive = presenter.amountToReceive,
+            price = presenter.price,
+            marketCodes = presenter.marketCodes,
+            priceDetails = presenter.priceDetails,
+            quoteSidePaymentMethodDisplayString = presenter.quoteSidePaymentMethodDisplayString,
+            baseSidePaymentMethodDisplayString = presenter.baseSidePaymentMethodDisplayString,
+            fee = presenter.fee,
+            feeDetails = presenter.feeDetails,
+            isSmallScreen = presenter::isSmallScreen,
+            stepIndex = stepIndex,
+            stepsLength = takeOfferCoordinator.totalSteps,
+            showProgressDialog = showProgressDialog,
+            showSuccessDialog = showSuccessDialog,
+            onBack = presenter::onBack,
+            onTakeOffer = presenter::onTakeOffer,
+            onClose = presenter::onClose,
+            onGoToOpenTrades = presenter::onGoToOpenTrades,
+        )
+    }
 }
 
 @ExcludeFromCoverage
@@ -98,7 +102,6 @@ fun TakeOfferReviewContent(
     stepsLength: Int,
     showProgressDialog: Boolean,
     showSuccessDialog: Boolean,
-    isInteractive: Boolean,
     onBack: () -> Unit,
     onTakeOffer: () -> Unit,
     onClose: () -> Unit,
@@ -111,7 +114,6 @@ fun TakeOfferReviewContent(
         prevOnClick = onBack,
         nextButtonText = "bisqEasy.takeOffer.review.takeOffer".i18n(),
         nextOnClick = onTakeOffer,
-        isInteractive = isInteractive,
         shouldBlurBg = showProgressDialog || showSuccessDialog,
         showUserAvatar = false,
         closeAction = true,
@@ -253,7 +255,6 @@ private fun TakeOfferReviewScreen_Buyer_Preview() {
             stepsLength = 4,
             showProgressDialog = false,
             showSuccessDialog = false,
-            isInteractive = true,
             onBack = {},
             onTakeOffer = {},
             onClose = {},
@@ -283,7 +284,6 @@ private fun TakeOfferReviewScreen_Seller_Preview() {
             stepsLength = 4,
             showProgressDialog = false,
             showSuccessDialog = false,
-            isInteractive = true,
             onBack = {},
             onTakeOffer = {},
             onClose = {},
@@ -313,7 +313,6 @@ private fun TakeOfferReviewScreen_SmallScreen_Buyer_Preview() {
             stepsLength = 4,
             showProgressDialog = false,
             showSuccessDialog = false,
-            isInteractive = true,
             onBack = {},
             onTakeOffer = {},
             onClose = {},
@@ -343,7 +342,6 @@ private fun TakeOfferReviewScreen_SmallScreen_Seller_Preview() {
             stepsLength = 4,
             showProgressDialog = false,
             showSuccessDialog = false,
-            isInteractive = true,
             onBack = {},
             onTakeOffer = {},
             onClose = {},
@@ -373,7 +371,6 @@ private fun TakeOfferReviewScreen_WithProgressDialog_Preview() {
             stepsLength = 4,
             showProgressDialog = true,
             showSuccessDialog = false,
-            isInteractive = false,
             onBack = {},
             onTakeOffer = {},
             onClose = {},
@@ -403,7 +400,6 @@ private fun TakeOfferReviewScreen_WithSuccessDialog_Preview() {
             stepsLength = 4,
             showProgressDialog = false,
             showSuccessDialog = true,
-            isInteractive = false,
             onBack = {},
             onTakeOffer = {},
             onClose = {},


### PR DESCRIPTION
This partially resolves: https://github.com/bisq-network/bisq-mobile/issues/1245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interaction-lock component to briefly block rapid taps on critical offer review screens (create/take offer review).

* **Improvements**
  * Updated URL navigation to consistently show the global loading overlay during handoff and always hide it afterward.
  * Improved URL launcher failure behavior to reliably follow the dialog error flow.
  * Reduced reliance on presenter-side interactivity flags across multiple trade wizard flows.
  * Added a new localized string for market selection validation.

* **Tests**
  * Updated and expanded unit/UI tests, including Compose timing coverage for the interaction lock and refreshed global UI loading expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->