### PR TITLE
Feature/prod ready opt in analytics with settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Please refer to [this README](shared/presentation/src/commonMain/kotlin/network/
  - Some Apple M chips have trouble with cocoapods, follow [this guide](https://stackoverflow.com/questions/64901180/how-to-run-cocoapods-on-apple-silicon-m1/66556339#66556339) to fix it
  - On MacOS: non-homebrew versions of Ruby will cause problems
  - On MacOS: If Gradle sync fails with "Gradle not found" error, you may need to install gradle with `homebrew` and then run `gradle wrapper` on the root. Then reopen Android Studio and try syncing again.
+ - **iOS link errors with `kniprot_cocoapods_Sentry0_*` "symbol multiply defined"**: stale cinterop incremental cache after Kotlin changes near the Sentry cocoapods boundary. Recovery: `./gradlew :apps:clientApp:clean`, then Xcode → Product → Clean Build Folder, then rebuild. Cascading Swift errors (`MainPresenter`/`Koin_coreQualifier` not in scope, etc.) are downstream of this — fixing the link error fixes them too.
 
 ### Initial Project Structure
 

--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -144,19 +144,11 @@ kotlin {
         // required, otherwise cinterop crashes with
         //   IllegalArgumentException: 'SentryMechanismMeta' is going to be declared twice
         //
-        // TODO: revisit iOS Sentry Cocoa pruning. Unlike Android (where
-        // R8 const-folds `if (BuildConfig.ANALYTICS_ENABLED)` and prunes the
-        // SDK from release builds with the flag off), this pod() declaration
-        // statically links Sentry.framework into the iOS binary regardless of
-        // whether any Kotlin code references it. ~few-hundred-KB binary cost
-        // when analyticsEnabled=false. Options for a follow-up:
-        //   1. Gate this declaration on resolveProperty("feature.analyticsEnabled")
-        //      (cleanest, but requires gating the Sentry-KMP dependency too so
-        //      cinterop bindings don't try to compile against missing types)
-        //   2. Move SentryAnalyticsService.kt into a separate source set
-        //      that's only included when the flag is on
-        //   3. Accept as cost-of-iOS — events go over Tor anyway when the user
-        //      opts in, so the binary surface is exercised in production then.
+        // Sentry Cocoa is statically linked into every iOS build. Aligns with
+        // the Android side now too — both platforms ship the SDK linked but
+        // inert until the user-settings toggle is flipped ON. Trade-off: a
+        // few hundred KB binary cost in exchange for end users getting a
+        // ready-to-flip release build (no rebuild needed to enable).
         pod("Sentry") {
             version = "8.58.2"
             extraOpts += listOf("-compiler-option", "-fmodules")

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
@@ -42,13 +42,11 @@ val androidClientDomainModule =
             ClientPushNotificationServiceFacade(get(), get(), get(), get(), get())
         }
 
-        // Native Sentry SDK initializer — only bound when analytics is enabled
-        // at build time. The factory itself uses sentry-android-core types, so
-        // gating the binding lets R8 prune SentryJavaNativeSentryInitializer
-        // (and the Sentry-KMP SDK it touches) from analytics-disabled release
-        // builds. Verified empirically by grepping the release APK for the
-        // class name — see [[project_analytics_phase0_plan]].
-        if (BuildConfig.ANALYTICS_ENABLED) {
-            single<NativeSentryInitializer> { SentryJavaNativeSentryInitializer() }
-        }
+        // Native Sentry SDK initializer. Unconditionally bound — release builds
+        // ship the SDK linked and inert; the user-settings toggle + dev gate are
+        // the runtime gates. The previous build-time gate that allowed R8 to
+        // prune Sentry-KMP is gone (verified historic empty grep:
+        // `unzip -l <release.apk> | grep sentry`). We accept a few-hundred-KB
+        // cost in exchange for ship-ready release builds.
+        single<NativeSentryInitializer> { SentryJavaNativeSentryInitializer() }
     }

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
@@ -71,8 +71,8 @@ val androidClientPresentationModule =
                 get(), // notificationController
                 get(), // analyticsService
                 get(), // analyticsBootstrapConfig
-                getOrNull(), // bufferedAnalyticsService — only bound when ANALYTICS_ENABLED
-                getOrNull(), // analyticsSocksPortProvider — only bound when ANALYTICS_ENABLED
+                getOrNull(), // bufferedAnalyticsService — always bound now (dev + user-settings gates at runtime)
+                getOrNull(), // analyticsSocksPortProvider — always bound now (dev + user-settings gates at runtime)
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -109,9 +109,9 @@ import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
-import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
 import network.bisq.mobile.domain.analytics.SentryAnalyticsService
 import network.bisq.mobile.domain.model.PlatformType
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import okio.Path.Companion.toPath
 import org.koin.core.qualifier.named
@@ -209,58 +209,69 @@ val clientDomainModule =
         }
 
         // Opt-in analytics (issue #525). Two locks gate emission:
-        //  1. Build-time: ANALYTICS_ENABLED=false → NoOpAnalyticsService is
-        //     bound and R8 prunes Sentry-KMP AND BufferedAnalyticsService from
-        //     release artifacts entirely (verified via
-        //     `unzip -l <release.apk> | grep -E 'sentry|Buffered'` = empty).
-        //  2. Runtime: `runtimeOptInProvider` below is checked on every emit.
-        //     For first tests we tie it to the same BuildConfig flag — double-lock,
-        //     no information leakage if (1) ever gets bypassed by a refactor.
-        //     TODO swap `{ BuildConfig.ANALYTICS_ENABLED }` for
-        //     `{ get<SettingsRepository>().analyticsEnabled.value }` once the
-        //     Settings UI toggle ships.
+        //  1. Dev-only build gate: `BuildConfig.ANALYTICS_DEV_ENABLED`. In RELEASE
+        //     builds this is always true (forced at BuildConfig generation time);
+        //     in DEBUG builds it reads `feature.analyticsDevEnabled` from
+        //     gradle/local.properties (default false). Protects production
+        //     GlitchTip from being polluted by developer test events while
+        //     guaranteeing end users get a ready-to-flip release build.
+        //  2. User-facing runtime gate: `SettingsRepository.analyticsEnabled`.
+        //     This is THE switch a user controls from the Settings UI — default
+        //     OFF. Checked on every emit; flipping it ON in a release build
+        //     starts emission immediately, no rebuild required.
         //
-        // When enabled, BufferedAnalyticsService wraps SentryAnalyticsService:
-        // events fired before the Sentry SDK is ready (e.g. during Tor
-        // bootstrap) sit in an in-memory bounded buffer and drain when the
-        // lifecycle service calls onSentryReady(). The same instance is bound
-        // BOTH as AnalyticsService (for general use) AND as
+        // We ALWAYS bind SentryAnalyticsService now (no R8 pruning) — the
+        // tradeoff is a few hundred KB of Sentry-KMP linked into release builds,
+        // but the SDK stays inert until both gates pass + Tor is ready. The
+        // upside is end users don't need a special build to enable analytics.
+        //
+        // BufferedAnalyticsService wraps SentryAnalyticsService: events fired
+        // before the Sentry SDK is ready (e.g. during Tor bootstrap) sit in an
+        // in-memory bounded buffer and drain when the lifecycle service calls
+        // onSentryReady(). Bound BOTH as AnalyticsService AND as
         // BufferedAnalyticsService (so ApplicationLifecycleService can call
-        // onSentryReady() on the concrete type) — see Koin's double-binding
-        // pattern below.
-        if (BuildConfig.ANALYTICS_ENABLED) {
-            // SOCKS port source: kmp-tor. Suspends until the user pairs an
-            // onion trusted node and `TrustedNodeSetupUseCase` starts Tor.
-            // On a LAN/clearnet trusted node this never resolves — events
-            // sit in the buffer and evict by FIFO with no clearnet leak.
-            single<AnalyticsSocksPortProvider> { KmpTorSocksPortProvider(get()) }
-            single {
-                BufferedAnalyticsService(
-                    downstream =
-                        SentryAnalyticsService(
-                            nativeInitializer = get(),
-                            runtimeOptInProvider = { BuildConfig.ANALYTICS_ENABLED },
-                        ),
-                    // Independent scope so the buffer's periodic flusher survives
-                    // any individual feature-scope cancellation. SupervisorJob so
-                    // a single failed enqueue doesn't kill the flusher.
-                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-                )
-            }
-            single<AnalyticsService> { get<BufferedAnalyticsService>() }
-        } else {
-            single<AnalyticsService> { NoOpAnalyticsService }
-            // Intentionally NO BufferedAnalyticsService binding here — the
-            // lifecycle service uses getOrNull<BufferedAnalyticsService>(),
-            // which returns null and skips the onSentryReady() call.
+        // onSentryReady() on the concrete type).
+        //
+        // SOCKS port source: kmp-tor. Suspends until the user pairs an onion
+        // trusted node and `TrustedNodeSetupUseCase` starts Tor. On a LAN /
+        // clearnet trusted node this never resolves — events sit in the buffer
+        // and evict by FIFO with no clearnet leak.
+        single<AnalyticsSocksPortProvider> { KmpTorSocksPortProvider(get()) }
+        single {
+            // Independent scope so the buffer's periodic flusher survives any
+            // individual feature-scope cancellation. SupervisorJob so a single
+            // failed enqueue doesn't kill the flusher. Reused for the
+            // settings-derived analyticsEnabled StateFlow so its hot-share
+            // lives exactly as long as the BufferedAnalyticsService instance.
+            val analyticsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val settingsRepository = get<SettingsRepository>()
+            // Hot StateFlow view of `Settings.analyticsEnabled`. Backed by
+            // DataStore so a settings flip from any UI surface propagates
+            // immediately to this `.value` read in the runtime gate.
+            val analyticsEnabledFlow = settingsRepository.analyticsEnabledIn(analyticsScope)
+            BufferedAnalyticsService(
+                downstream =
+                    SentryAnalyticsService(
+                        nativeInitializer = get(),
+                        // Two gates AND'd together:
+                        //  1) Dev-only build flag — release builds const-fold
+                        //     this to true at BuildConfig generation time.
+                        //  2) User-settings toggle — flipped from Settings UI.
+                        // Both must be true for the SDK to emit anything.
+                        runtimeOptInProvider = {
+                            BuildConfig.ANALYTICS_DEV_ENABLED && analyticsEnabledFlow.value
+                        },
+                    ),
+                scope = analyticsScope,
+            )
         }
+        single<AnalyticsService> { get<BufferedAnalyticsService>() }
         // Per-platform analytics bootstrap config. The Connect app ships a
         // separate GlitchTip project for Android (id=3) and iOS (id=4); the
         // right DSN is selected at runtime from the platform. `IS_DEBUG`
-        // splits debug-mode opt-in events (tagged "development") from any
-        // future production rollout ("production"). For intial work only debug
-        // builds with `feature.analyticsEnabled=true` in local.properties
-        // emit anything.
+        // splits debug-mode events (tagged "development") from release events
+        // ("production"). Debug builds need both feature.analyticsDevEnabled=true
+        // in local.properties AND the user-settings toggle ON to emit.
         single<AnalyticsBootstrapConfig> {
             val dsn =
                 when (getPlatformInfo().type) {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
@@ -75,6 +75,7 @@ class ClientApplicationLifecycleService(
         analyticsBootstrapConfig,
         bufferedAnalyticsService,
         analyticsSocksPortProvider,
+        settingsRepository,
     ) {
     /**
      * Dedicated scope for the local-vs-relayed orchestration job. Kept separate

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -67,21 +67,17 @@ val iosClientDomainModule =
                 get(), // notificationController
                 get(), // analyticsService
                 get(), // analyticsBootstrapConfig
-                getOrNull(), // bufferedAnalyticsService — only bound when ANALYTICS_ENABLED
-                getOrNull(), // analyticsSocksPortProvider — only bound when ANALYTICS_ENABLED
+                getOrNull(), // bufferedAnalyticsService — always bound now (dev + user-settings gates at runtime)
+                getOrNull(), // analyticsSocksPortProvider — always bound now (dev + user-settings gates at runtime)
             )
         }
         single<UrlLauncher> { IOSUrlLauncher() }
         single<VersionProvider> { ClientVersionProvider() }
 
-        // Native Sentry SDK initializer — only bound when analytics is enabled
-        // at build time. Unlike Android (where R8 prunes the Sentry-KMP classes
-        // outright), iOS still statically links Sentry.framework via the pod()
-        // declaration in clientApp/build.gradle.kts — but no Kotlin code paths
-        // reference it when this binding is absent, so it stays inert.
-        // TODO: gate the pod() declaration too (see clientApp/build.gradle.kts
-        // for iOS pruning options).
-        if (BuildConfig.ANALYTICS_ENABLED) {
-            single<NativeSentryInitializer> { SentryCocoaNativeSentryInitializer() }
-        }
+        // Native Sentry SDK initializer. Unconditionally bound — the
+        // user-settings toggle + dev gate are the runtime gates. iOS already
+        // statically links Sentry.framework via the pod() declaration in
+        // clientApp/build.gradle.kts regardless; the SDK stays inert until
+        // SentryAnalyticsService.init() runs (gated by both lock layers).
+        single<NativeSentryInitializer> { SentryCocoaNativeSentryInitializer() }
     }

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/analytics/SentryCocoaNativeSentryInitializer.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/analytics/SentryCocoaNativeSentryInitializer.kt
@@ -92,6 +92,7 @@ class SentryCocoaNativeSentryInitializer :
         isDebug: Boolean,
         socksProxyHost: String?,
         socksProxyPort: Int?,
+        runtimeOptInProvider: () -> Boolean,
     ) {
         Sentry.initWithPlatformOptions { options ->
             // Identity / build-time config
@@ -100,7 +101,7 @@ class SentryCocoaNativeSentryInitializer :
             options.releaseName = release
             options.debug = isDebug
 
-            setupPrivacy(options, redactor)
+            setupPrivacy(options, redactor, runtimeOptInProvider)
             setupTransport(options, socksProxyHost, socksProxyPort)
         }
         log.d {
@@ -115,6 +116,7 @@ class SentryCocoaNativeSentryInitializer :
     private fun setupPrivacy(
         options: cocoapods.Sentry.SentryOptions,
         redactor: AnalyticsRedactor,
+        runtimeOptInProvider: () -> Boolean,
     ) {
         options.sendDefaultPii = false
 
@@ -134,10 +136,20 @@ class SentryCocoaNativeSentryInitializer :
         options.enableCoreDataTracing = false
         options.attachStacktrace = false
 
-        // beforeSend is defence in depth — see [applyMinimalPayloadContract].
+        // beforeSend serves TWO purposes:
+        //  1. Defence in depth scrubbing — see [applyMinimalPayloadContract].
+        //  2. THE opt-in gate for SDK auto-captures (Crash, Watchdog, etc.)
+        //     that ship through this callback rather than our explicit
+        //     [SentryAnalyticsService.track] / [captureException] gates.
+        //     Returning null drops the event at the SDK level so an opted-out
+        //     user never leaks a crash report or session.
         options.beforeSend = { event ->
-            event?.let { applyMinimalPayloadContract(it, redactor) }
-            event
+            if (!runtimeOptInProvider()) {
+                null
+            } else {
+                event?.let { applyMinimalPayloadContract(it, redactor) }
+                event
+            }
         }
     }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -36,9 +36,9 @@ import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
 import network.bisq.mobile.domain.analytics.NativeSentryInitializer
-import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
 import network.bisq.mobile.domain.analytics.SentryAnalyticsService
 import network.bisq.mobile.domain.analytics.SentryJavaNativeSentryInitializer
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.utils.AndroidDeviceInfoProvider
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
@@ -121,35 +121,34 @@ val androidNodeDomainModule =
         single { NodeApplicationBootstrapFacade(get(), get()) } bind ApplicationBootstrapFacade::class
 
         // Opt-in analytics (issue #525). Same shape as clientApp's binding —
-        // see ClientDomainModule for the full double-lock rationale plus the
-        // BufferedAnalyticsService double-binding pattern.
-        // Node app sends to the bisq-easy-node-android GlitchTip project (DSN
-        // from gradle.properties / local.properties).
-        if (BuildNodeConfig.ANALYTICS_ENABLED) {
-            single<NativeSentryInitializer> { SentryJavaNativeSentryInitializer() }
-            // SOCKS port source: bisq2's embedded NetworkService. The node app's
-            // KmpTorService binding is NEVER started (its startTor() is only
-            // called from the Connect-side TrustedNodeSetupUseCase) — so we
-            // must NOT wire KmpTorSocksPortProvider here or analytics would
-            // suspend forever waiting on a Tor instance nobody ever starts.
-            single<AnalyticsSocksPortProvider> { Bisq2SocksPortProvider(get()) }
-            single {
-                BufferedAnalyticsService(
-                    downstream =
-                        SentryAnalyticsService(
-                            nativeInitializer = get(),
-                            runtimeOptInProvider = { BuildNodeConfig.ANALYTICS_ENABLED },
-                        ),
-                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-                )
-            }
-            single<AnalyticsService> { get<BufferedAnalyticsService>() }
-        } else {
-            single<AnalyticsService> { NoOpAnalyticsService }
-            // Intentionally NO BufferedAnalyticsService binding here — the
-            // lifecycle service uses getOrNull<BufferedAnalyticsService>(),
-            // which returns null and skips the onSentryReady() call.
+        // see ClientDomainModule for the full double-lock rationale (dev gate
+        // + user-settings gate) and the BufferedAnalyticsService double-binding
+        // pattern. Node app sends to the bisq-easy-node-android GlitchTip
+        // project (DSN from gradle.properties / local.properties).
+        single<NativeSentryInitializer> { SentryJavaNativeSentryInitializer() }
+        // SOCKS port source: bisq2's embedded NetworkService. The node app's
+        // KmpTorService binding is NEVER started (its startTor() is only
+        // called from the Connect-side TrustedNodeSetupUseCase) — so we must
+        // NOT wire KmpTorSocksPortProvider here or analytics would suspend
+        // forever waiting on a Tor instance nobody ever starts.
+        single<AnalyticsSocksPortProvider> { Bisq2SocksPortProvider(get()) }
+        single {
+            // See ClientDomainModule for the matching pattern + rationale.
+            val analyticsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val settingsRepository = get<SettingsRepository>()
+            val analyticsEnabledFlow = settingsRepository.analyticsEnabledIn(analyticsScope)
+            BufferedAnalyticsService(
+                downstream =
+                    SentryAnalyticsService(
+                        nativeInitializer = get(),
+                        runtimeOptInProvider = {
+                            BuildNodeConfig.ANALYTICS_DEV_ENABLED && analyticsEnabledFlow.value
+                        },
+                    ),
+                scope = analyticsScope,
+            )
         }
+        single<AnalyticsService> { get<BufferedAnalyticsService>() }
         single<AnalyticsBootstrapConfig> {
             AnalyticsBootstrapConfig(
                 dsn = BuildNodeConfig.ANALYTICS_DSN,
@@ -225,8 +224,9 @@ val androidNodeDomainModule =
                 get(),
                 get(), // analyticsService
                 get(), // analyticsBootstrapConfig
-                getOrNull(), // bufferedAnalyticsService — only bound when ANALYTICS_ENABLED
-                getOrNull(), // analyticsSocksPortProvider — only bound when ANALYTICS_ENABLED
+                getOrNull(), // bufferedAnalyticsService — always bound now (dev + user-settings gates at runtime)
+                getOrNull(), // analyticsSocksPortProvider — always bound now (dev + user-settings gates at runtime)
+                get<SettingsRepository>(), // pre-warm DataStore before flipping onSentryReady — see ApplicationLifecycleService
             )
         } bind ApplicationLifecycleService::class
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -27,6 +27,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.restartProcess
 import network.bisq.mobile.node.common.domain.service.network.NodeConnectivityService
 import network.bisq.mobile.node.common.domain.utils.AndroidMemoryReportService
@@ -63,6 +64,7 @@ class NodeApplicationLifecycleService(
     analyticsBootstrapConfig: AnalyticsBootstrapConfig,
     bufferedAnalyticsService: BufferedAnalyticsService? = null,
     analyticsSocksPortProvider: AnalyticsSocksPortProvider? = null,
+    settingsRepository: SettingsRepository? = null,
 ) : ApplicationLifecycleService(
         applicationBootstrapFacade,
         kmpTorService,
@@ -70,6 +72,7 @@ class NodeApplicationLifecycleService(
         analyticsBootstrapConfig,
         bufferedAnalyticsService,
         analyticsSocksPortProvider,
+        settingsRepository,
     ) {
     fun restartForRestoreDataDirectory(view: Any?) {
         val activity =

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/service/offers/NodeOffersServiceFacadeIntegrationTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/service/offers/NodeOffersServiceFacadeIntegrationTest.kt
@@ -61,6 +61,10 @@ class NodeOffersServiceFacadeIntegrationTest {
         override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {}
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) {}
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) {}
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) {}
     }
 
     private fun buildDto(

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,14 +62,19 @@ kover.diff.coverage.minimum=80
 # Feature (client app only)
 feature.muSigEnabled=false
 
-# Opt-in analytics (issue #525). Build-time gate for the analytics SDK.
-# - false (default): NoOp analytics binding; Sentry-KMP is on the classpath but
-#   never initialized. Production builds ship with this off. R8 prunes the SDK
-#   from release APKs when this stays false.
-# - true: SentryAnalyticsService is bound. The user's RUNTIME opt-in still gates
-#   actual emission (TODO wire SettingsRepository.analyticsEnabled).
-# Override in local.properties for dev verification (for now).
-feature.analyticsEnabled=false
+# Opt-in analytics (issue #525). DEV-ONLY override — debug builds only.
+# - false (default): debug builds will NEVER emit events even if a developer
+#   accidentally toggles the user-facing settings switch ON. Protects the
+#   production GlitchTip from being polluted by dev test traffic.
+# - true: debug builds RESPECT the user-facing settings toggle. Set this in
+#   local.properties when actively testing analytics end-to-end on a dev build.
+#
+# RELEASE BUILDS IGNORE THIS PROPERTY. They always honour the user's settings
+# toggle (default OFF for the user too). End users get a ready-to-flip build:
+# enabling the toggle in Settings starts emitting immediately, no rebuild
+# required. The trade-off is that Sentry-KMP is linked into every release
+# (a few hundred KB), but stays inert until the user opts in.
+feature.analyticsDevEnabled=false
 
 # GlitchTip DSNs. PUBLIC values per Sentry's threat model (only the public key is here, no token).
 #   Project IDs:

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -31,7 +31,7 @@ version = project.findProperty("shared.version") as String
 // overrides any property if you need to setup for example local networking"
 // below, we load it once here and prefer it over gradle.properties.
 //
-// Used for: feature.analyticsEnabled, analytics.dsn.*, feature.muSigEnabled,
+// Used for: feature.analyticsDevEnabled, analytics.dsn.*, feature.muSigEnabled,
 // bisq.isDebug, and any future per-developer override. Never commit
 // local.properties — it is gitignored.
 val devLocalProperties: Properties =
@@ -115,19 +115,32 @@ buildConfig {
             "MU_SIG_ENABLED",
             muSigEnabled,
         )
-        // Analytics build-time gate (issue #525). See gradle.properties for the
-        // full opt-in story. Strict parse: refuses anything that isn't a literal
-        // "true"/"false" — silent coercion on a privacy-sensitive switch is a
-        // foot-gun we explicitly want to avoid. Read via resolveProperty so
-        // local.properties takes precedence over gradle.properties.
-        val analyticsEnabled =
-            resolveProperty("feature.analyticsEnabled")
-                ?.let { value ->
-                    value.toBooleanStrictOrNull()
-                        ?: error("feature.analyticsEnabled must be 'true' or 'false', got '$value'")
-                }
-                ?: false
-        buildConfigField("ANALYTICS_ENABLED", analyticsEnabled)
+        // Analytics dev-only override (issue #525). See gradle.properties for the
+        // full opt-in story. This is NOT the user-facing gate — that lives in
+        // SettingsRepository.analyticsEnabled and is honoured by every build.
+        //
+        // What this flag does: in DEBUG builds, when false, prevents Sentry from
+        // emitting even if the user-settings toggle is ON. Protects production
+        // GlitchTip from being polluted by developer test events. In RELEASE
+        // builds, this is forced TRUE — end users get a ready-to-flip build.
+        //
+        // Strict parse: refuses anything that isn't literal "true"/"false" —
+        // silent coercion on a privacy-sensitive switch is a foot-gun we
+        // explicitly want to avoid. Read via resolveProperty so local.properties
+        // takes precedence over gradle.properties.
+        val analyticsDevEnabled =
+            if (!isDebugBuild) {
+                // Release builds always honour the user-settings toggle.
+                true
+            } else {
+                resolveProperty("feature.analyticsDevEnabled")
+                    ?.let { value ->
+                        value.toBooleanStrictOrNull()
+                            ?: error("feature.analyticsDevEnabled must be 'true' or 'false', got '$value'")
+                    }
+                    ?: false
+            }
+        buildConfigField("ANALYTICS_DEV_ENABLED", analyticsDevEnabled)
         // DSNs are public per Sentry's threat model — the public key alone
         // cannot read data, only post. Empty default = effectively disabled.
         // Connect's BuildConfig holds both Android + iOS DSNs; the runtime
@@ -152,18 +165,23 @@ buildConfig {
         buildConfigField("BISQ_CORE_VERSION", bisqCoreVersion)
         // Note: Update when updating kmp-tor lib
         buildConfigField("TOR_VERSION", "0.4.8.17") // is TOR DAEMON version
-        // Analytics build-time gate (issue #525). See client BuildConfig above for
-        // the rationale; the Node app gets its own DSN pointing at GlitchTip
-        // project id=2 (bisq-easy-node-android). Read via resolveProperty so
-        // local.properties takes precedence over gradle.properties.
-        val nodeAnalyticsEnabled =
-            resolveProperty("feature.analyticsEnabled")
-                ?.let { value ->
-                    value.toBooleanStrictOrNull()
-                        ?: error("feature.analyticsEnabled must be 'true' or 'false', got '$value'")
-                }
-                ?: false
-        buildConfigField("ANALYTICS_ENABLED", nodeAnalyticsEnabled)
+        // Analytics dev-only override (issue #525). See client BuildConfig above
+        // for the full rationale. Node app gets its own DSN pointing at GlitchTip
+        // project id=2 (bisq-easy-node-android). Same semantics: release builds
+        // always honour the user-settings toggle; debug builds need this flag
+        // true to actually emit (dev safety against polluting prod GlitchTip).
+        val nodeAnalyticsDevEnabled =
+            if (!isDebugBuild) {
+                true
+            } else {
+                resolveProperty("feature.analyticsDevEnabled")
+                    ?.let { value ->
+                        value.toBooleanStrictOrNull()
+                            ?: error("feature.analyticsDevEnabled must be 'true' or 'false', got '$value'")
+                    }
+                    ?: false
+            }
+        buildConfigField("ANALYTICS_DEV_ENABLED", nodeAnalyticsDevEnabled)
         buildConfigField(
             "ANALYTICS_DSN",
             resolveProperty("analytics.dsn.node.android").orEmpty(),
@@ -248,11 +266,13 @@ kotlin {
             implementation(libs.kphonenumber)
             api(libs.okio) // api to allow platform specific path conversion for kmp-tor
 
-            // Opt-in analytics SDK (issue #525). Always on the classpath so the
-            // DI module can switch between NoOp and Sentry-backed implementations
-            // at runtime based on BuildConfig.ANALYTICS_ENABLED. R8 prunes the
-            // SDK classes from release builds when ANALYTICS_ENABLED=false since
-            // SentryAnalyticsService is then never referenced.
+            // Opt-in analytics SDK (issue #525). Always on the classpath AND
+            // always bound in DI now — the SDK ships linked into every release
+            // build but stays inert until both runtime gates pass: the dev-only
+            // BuildConfig.ANALYTICS_DEV_ENABLED (always true in release) AND
+            // SettingsRepository.analyticsEnabled (default OFF, user-controlled).
+            // Trade-off: a few hundred KB binary cost in exchange for end users
+            // getting a ready-to-flip release build (no rebuild needed to enable).
             implementation(libs.sentry.kotlin.multiplatform)
 
             configurations.all {

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/analytics/SentryJavaNativeSentryInitializer.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/analytics/SentryJavaNativeSentryInitializer.kt
@@ -67,6 +67,7 @@ class SentryJavaNativeSentryInitializer :
         isDebug: Boolean,
         socksProxyHost: String?,
         socksProxyPort: Int?,
+        runtimeOptInProvider: () -> Boolean,
     ) {
         Sentry.initWithPlatformOptions { options ->
             // Identity / build-time config
@@ -75,7 +76,7 @@ class SentryJavaNativeSentryInitializer :
             options.release = release
             options.isDebug = isDebug
 
-            setupPrivacy(options, redactor)
+            setupPrivacy(options, redactor, runtimeOptInProvider)
             setupTransport(options, socksProxyHost, socksProxyPort)
         }
         log.d {
@@ -95,6 +96,7 @@ class SentryJavaNativeSentryInitializer :
     internal fun setupPrivacy(
         options: io.sentry.android.core.SentryAndroidOptions,
         redactor: AnalyticsRedactor,
+        runtimeOptInProvider: () -> Boolean = { true },
     ) {
         // Defaults that block whole categories of auto-attached data.
         options.isSendDefaultPii = false
@@ -121,12 +123,21 @@ class SentryJavaNativeSentryInitializer :
         options.isEnableNdk = false
         options.isAnrEnabled = false
 
-        // beforeSend is defence in depth on top of the killswitches above.
-        // Each killswitch can be a no-op on a future Sentry version (e.g. a
-        // new integration that attaches similar data) — the scrubber is the
-        // last gate before the wire.
+        // beforeSend serves TWO purposes:
+        //  1. Defence in depth on top of the killswitches above — each
+        //     killswitch can be a no-op on a future Sentry version (e.g. a
+        //     new integration that attaches similar data); the scrubber here
+        //     is the last gate before the wire.
+        //  2. THE opt-in gate for SDK auto-captures. The SDK auto-installs
+        //     UncaughtExceptionHandler etc. that ship events through this
+        //     callback — NOT through our [SentryAnalyticsService.track] /
+        //     [captureException] gates. Returning null when the user is
+        //     opted out drops those events at the SDK level. Without this,
+        //     an opted-out user whose app crashes would still ship the
+        //     crash to GlitchTip.
         options.beforeSend =
             SentryOptions.BeforeSendCallback { event, _ ->
+                if (!runtimeOptInProvider()) return@BeforeSendCallback null
                 applyMinimalPayloadContract(event, redactor)
                 event
             }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/SentryJavaNativeSentryInitializerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/SentryJavaNativeSentryInitializerTest.kt
@@ -508,4 +508,79 @@ class SentryJavaNativeSentryInitializerTest {
         assertNull(event.contexts.runtime)
         assertNull(event.contexts.gpu)
     }
+
+    // ============ beforeSend OPT-IN GATE (Option B) ============
+
+    @Test
+    fun `beforeSend returns null when runtimeOptInProvider returns false - drops SDK auto-captures`() {
+        // The load-bearing privacy invariant from Option B (issue #525):
+        // when the user is opted out, the SDK's own pipelines (Uncaught-
+        // ExceptionHandler crashes, ActivityLifecycle, etc.) ship envelopes
+        // through beforeSend — NOT through SentryAnalyticsService.track().
+        // Without this gate, an opted-out user whose app crashes would still
+        // leak the crash report.
+        val options = SentryAndroidOptions()
+        SentryJavaNativeSentryInitializer().setupPrivacy(
+            options = options,
+            redactor = AnalyticsRedactor(),
+            runtimeOptInProvider = { false }, // user opted OUT
+        )
+        val callback = assertNotNull(options.beforeSend)
+
+        val event = SentryEvent()
+        val result = callback.execute(event, io.sentry.Hint())
+
+        assertNull(
+            result,
+            "beforeSend MUST return null when opted-out — Sentry drops the envelope at SDK level, no wire traffic",
+        )
+    }
+
+    @Test
+    fun `beforeSend forwards the event when runtimeOptInProvider returns true`() {
+        // Symmetric to the opted-out test: when opted in, the gate is open
+        // and beforeSend returns the event (after scrubbing).
+        val options = SentryAndroidOptions()
+        SentryJavaNativeSentryInitializer().setupPrivacy(
+            options = options,
+            redactor = AnalyticsRedactor(),
+            runtimeOptInProvider = { true }, // user opted IN
+        )
+        val callback = assertNotNull(options.beforeSend)
+
+        val event = SentryEvent()
+        val result = callback.execute(event, io.sentry.Hint())
+
+        assertEquals(event, result, "beforeSend MUST return the event when opted-in — SDK ships it")
+    }
+
+    @Test
+    fun `beforeSend consults the provider on EVERY call - flipping opt-in mid-session takes effect immediately`() {
+        // Captures-by-reference contract: the provider lambda is invoked fresh
+        // on every event, not snapshotted at init time. This is what makes
+        // toggle-off-after-init work — Sentry stays loaded but stops emitting
+        // the instant the user flips the switch in Settings.
+        var consented = true
+        val options = SentryAndroidOptions()
+        SentryJavaNativeSentryInitializer().setupPrivacy(
+            options = options,
+            redactor = AnalyticsRedactor(),
+            runtimeOptInProvider = { consented },
+        )
+        val callback = assertNotNull(options.beforeSend)
+
+        // First event: opted in → shipped.
+        assertNotNull(callback.execute(SentryEvent(), io.sentry.Hint()))
+
+        // User flips toggle OFF mid-session.
+        consented = false
+        assertNull(
+            callback.execute(SentryEvent(), io.sentry.Hint()),
+            "beforeSend must re-read the provider on every call, not cache",
+        )
+
+        // User flips back ON.
+        consented = true
+        assertNotNull(callback.execute(SentryEvent(), io.sentry.Hint()))
+    }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryImplTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryImplTest.kt
@@ -223,4 +223,60 @@ class SettingsRepositoryImplTest {
             assertEquals(true, afterMarketUpdate.showChatRulesWarnBox) // preserved
             assertEquals("BTC/EUR", afterMarketUpdate.selectedMarketCode)
         }
+
+    // ============ Opt-in analytics (issue #525) ============
+    //
+    // These pins matter because the DI module's runtimeOptInProvider reads
+    // these settings on every analytics emit. If the persistence path
+    // regresses, the SDK silently keeps using the stale value — which would
+    // either suppress events the user enabled (annoying) or worse, emit when
+    // they didn't (privacy contract violation).
+
+    @Test
+    fun `setAnalyticsEnabled should update analyticsEnabled flag without touching other fields`() =
+        runTest {
+            val updateSlot = slot<suspend (Settings) -> Settings>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns Settings()
+
+            val originalSettings =
+                Settings(
+                    firstLaunch = false,
+                    analyticsEnabled = false,
+                    analyticsPromptSeen = true,
+                    selectedMarketCode = "BTC/EUR",
+                )
+
+            repository.setAnalyticsEnabled(true)
+
+            coVerify { mockDataStore.updateData(any()) }
+            val updated = updateSlot.captured(originalSettings)
+            assertEquals(true, updated.analyticsEnabled)
+            // Sibling fields preserved
+            assertEquals(true, updated.analyticsPromptSeen)
+            assertEquals(false, updated.firstLaunch)
+            assertEquals("BTC/EUR", updated.selectedMarketCode)
+        }
+
+    @Test
+    fun `setAnalyticsPromptSeen should update analyticsPromptSeen flag without touching analyticsEnabled`() =
+        runTest {
+            // Critical: the welcome carousel marks the prompt as seen via
+            // "Don't ask again" WITHOUT enabling analytics. If this setter
+            // ever flipped analyticsEnabled as a side effect, a user who
+            // declined the prompt would start emitting events anyway.
+            val updateSlot = slot<suspend (Settings) -> Settings>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns Settings()
+
+            val originalSettings =
+                Settings(
+                    analyticsEnabled = false,
+                    analyticsPromptSeen = false,
+                )
+
+            repository.setAnalyticsPromptSeen(true)
+
+            val updated = updateSlot.captured(originalSettings)
+            assertEquals(true, updated.analyticsPromptSeen)
+            assertEquals(false, updated.analyticsEnabled, "promptSeen flip must NOT enable analytics — privacy contract")
+        }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/Settings.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/Settings.kt
@@ -17,6 +17,15 @@ data class Settings(
     val marketFilter: MarketFilter = MarketFilter.All,
     val dontShowAgainHyperlinksOpenInBrowser: Boolean = false,
     val cookiePermitOpeningBrowser: Boolean = false,
+    // Opt-in analytics (issue #525). The actual emission gate consulted on
+    // every track/captureException via `runtimeOptInProvider` in DI. Default
+    // OFF — privacy contract is opt-in, never opt-out.
+    val analyticsEnabled: Boolean = false,
+    // Has the welcome carousel's analytics page been resolved (either via
+    // "Enable" or "Don't ask again")? When false, the dashboard promo will
+    // include the analytics page; once true, it never auto-prompts again
+    // (user can still flip the toggle manually from Settings).
+    val analyticsPromptSeen: Boolean = false,
 )
 
 @Serializable

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/SettingsRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/SettingsRepositoryImpl.kt
@@ -90,4 +90,16 @@ open class SettingsRepositoryImpl(
             it.copy(cookiePermitOpeningBrowser = value)
         }
     }
+
+    override suspend fun setAnalyticsEnabled(value: Boolean) {
+        settingsStore.updateData {
+            it.copy(analyticsEnabled = value)
+        }
+    }
+
+    override suspend fun setAnalyticsPromptSeen(value: Boolean) {
+        settingsStore.updateData {
+            it.copy(analyticsPromptSeen = value)
+        }
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -1,6 +1,9 @@
 package network.bisq.mobile.data.service.bootstrap
 
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.service.BaseService
 import network.bisq.mobile.data.service.network.KmpTorService
@@ -10,6 +13,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
 import network.bisq.mobile.domain.model.PlatformType
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.killProcess
 import network.bisq.mobile.domain.utils.restartProcess
 
@@ -18,15 +22,21 @@ abstract class ApplicationLifecycleService(
     private val kmpTorService: KmpTorService,
     private val analyticsService: AnalyticsService,
     private val analyticsBootstrapConfig: AnalyticsBootstrapConfig,
-    // Optional — wired by Koin (`getOrNull`) when ANALYTICS_ENABLED is true.
-    // null in production builds with analytics disabled (NoOpAnalyticsService bound)
-    // and in test fixtures that don't care about the readiness signal.
+    // Optional — always bound now in production DI; null only in test fixtures
+    // that don't care about the readiness signal (see TestApplicationLifecycleService).
     private val bufferedAnalyticsService: BufferedAnalyticsService? = null,
-    // Optional — wired by Koin (`getOrNull`) when ANALYTICS_ENABLED is true.
-    // Per-app: ClientApp wraps KmpTorService, NodeApp polls bisq2's NetworkService.
-    // null when analytics is disabled at build time — `bootstrapAnalytics()`
-    // then skips entirely.
+    // Optional — always bound now in production DI (per-app: ClientApp wraps
+    // KmpTorService, NodeApp polls bisq2's NetworkService). null only in test
+    // fixtures; `bootstrapAnalytics()` then skips entirely.
     private val analyticsSocksPortProvider: AnalyticsSocksPortProvider? = null,
+    // Optional — always bound in production DI. Pre-warmed in
+    // [bootstrapAnalytics] before flipping onSentryReady so the DI's
+    // hot StateFlow gate (`analyticsEnabledIn`) has its real value before
+    // any track() call runs through it. Without this, a fast first-frame
+    // dashboard view could race the StateFlow's initial emission and the
+    // event would be silently dropped at the runtime gate. See PR #1473
+    // discussion + diagnostic logs in [SentryAnalyticsService.isReadyToEmit].
+    private val settingsRepository: SettingsRepository? = null,
 ) : BaseService() {
     private val isTerminating = atomic<Boolean>(false)
 
@@ -80,13 +90,35 @@ abstract class ApplicationLifecycleService(
         // on the critical path.
         serviceScope.launch {
             try {
-                log.i { "Analytics: waiting for Tor SOCKS port (suspends until available)" }
-                // No timeout — if Tor never comes up (clearnet trusted node on
-                // the client, or a node app that fails Tor bootstrap), this
-                // suspends forever. The bounded BufferedAnalyticsService FIFO
-                // eviction guarantees memory safety; the privacy contract
-                // guarantees we never leak via clearnet because Sentry is
-                // simply never initialized.
+                // (1) Wait until the user opts in. NEVER load Sentry's SDK
+                //     into the process until the user explicitly agrees —
+                //     prevents the auto-installed integrations (Uncaught-
+                //     ExceptionHandler, ActivityLifecycle, Watchdog, etc.)
+                //     from being registered at all. If the user never opts
+                //     in, this suspends forever and Sentry is never loaded.
+                //
+                //     Note: SettingsRepository is typed nullable for test
+                //     fixtures. Without it we can't honour the opt-in
+                //     contract — fail loudly via early return rather than
+                //     silently behaving as opted-in.
+                val settingsRepo = settingsRepository
+                if (settingsRepo == null) {
+                    log.w { "Analytics: SettingsRepository not bound — refusing to init Sentry (opt-in cannot be verified)" }
+                    return@launch
+                }
+                log.i { "Analytics: waiting for the user opt-in toggle" }
+                settingsRepo.data
+                    .map { it.analyticsEnabled }
+                    .filter { it }
+                    .first()
+                log.i { "Analytics: opt-in confirmed; waiting for Tor SOCKS port" }
+                // (2) Wait for Tor. No timeout — if Tor never comes up
+                //     (clearnet trusted node on the client, or a node app
+                //     that fails Tor bootstrap), this suspends forever. The
+                //     bounded BufferedAnalyticsService FIFO eviction
+                //     guarantees memory safety; the privacy contract
+                //     guarantees we never leak via clearnet because Sentry
+                //     is simply never initialized.
                 val socksPort = provider.awaitSocksPort()
                 analyticsService.init(
                     dsn = analyticsBootstrapConfig.dsn,
@@ -98,9 +130,13 @@ abstract class ApplicationLifecycleService(
                 )
                 // Flip the buffer's readiness flag and trigger an immediate
                 // drain of any events that fired between presenter wiring and
-                // now. Null when analytics is disabled at build time (NoOp is
-                // bound, there's nothing to flush). Safe to call multiple
+                // now. Null only in test fixtures. Safe to call multiple
                 // times — the method is idempotent (atomic CAS internally).
+                //
+                // No pre-warm needed here: the `filter { it }.first()` above
+                // already proved DataStore has emitted at least one value
+                // where `analyticsEnabled == true`, so the DI module's hot
+                // StateFlow gate reflects reality before any track call.
                 bufferedAnalyticsService?.onSentryReady()
                 log.i { "Analytics: Sentry initialized over Tor (SOCKS5 $LOOPBACK_SOCKS_HOST:$socksPort)" }
             } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsService.kt
@@ -3,17 +3,18 @@ package network.bisq.mobile.domain.analytics
 /**
  * Opt-in analytics surface for Bisq Mobile (issue #525).
  *
- * Two layers of gating must both be true for any event to leave the device:
+ * Two layers of gating must BOTH be true for any event to leave the device:
  *
- *  1. **Build-time gate** — `BuildConfig.ANALYTICS_ENABLED`. When false the DI
- *     graph binds [NoOpAnalyticsService] and Sentry-KMP isn't even loaded.
- *     Production builds ship with this OFF. A contributor's fresh clone sends
- *     nothing.
- *  2. **Runtime gate** — the user's explicit opt-in. The DI module wires the
- *     provider to `{ BuildConfig.ANALYTICS_ENABLED }` initially (same source
- *     as the build-time gate, doubly-locked); a follow-up swaps this for
- *     `{ settingsRepository.analyticsEnabled.value }` once the Settings UI
- *     toggle ships. Default at the user level is OFF.
+ *  1. **Dev-only build gate** — `BuildConfig.ANALYTICS_DEV_ENABLED`. In RELEASE
+ *     builds this is hardcoded to true at BuildConfig generation time. In DEBUG
+ *     builds it reads `feature.analyticsDevEnabled` from gradle/local.properties
+ *     (default false), letting contributors keep their dev builds silent even
+ *     if they toggle the user setting ON for testing. Protects the production
+ *     GlitchTip from being polluted by dev test traffic.
+ *  2. **User-facing runtime gate** — `SettingsRepository.analyticsEnabled`.
+ *     The user-controlled switch in the Settings UI. Default OFF. Checked on
+ *     every emit; flipping it ON in a release build starts emission
+ *     immediately, no rebuild required.
  *
  * The API surface is deliberately narrow:
  *  - [init] is called once during app bootstrap.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/NativeSentryInitializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/NativeSentryInitializer.kt
@@ -39,6 +39,14 @@ package network.bisq.mobile.domain.analytics
  * @see DefaultSentryClient
  */
 interface NativeSentryInitializer {
+    /**
+     * @param runtimeOptInProvider cheap synchronous lambda the platform's
+     *   `beforeSend` MUST consult before letting any event reach the wire.
+     *   Returning false drops the event entirely (including auto-captured
+     *   crashes from UncaughtExceptionHandler / ActivityLifecycle), giving
+     *   the user-settings toggle authority over the SDK's own pipelines —
+     *   not just our manual `track()` / `captureException()` callsites.
+     */
     fun init(
         dsn: String,
         environment: String,
@@ -47,5 +55,6 @@ interface NativeSentryInitializer {
         isDebug: Boolean,
         socksProxyHost: String?,
         socksProxyPort: Int?,
+        runtimeOptInProvider: () -> Boolean,
     )
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/NoOpAnalyticsService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/NoOpAnalyticsService.kt
@@ -1,17 +1,16 @@
 package network.bisq.mobile.domain.analytics
 
 /**
- * The [AnalyticsService] implementation bound when `BuildConfig.ANALYTICS_ENABLED`
- * is false — i.e. in every production build and every contributor fresh-clone
- * build. By construction, when this implementation is wired:
+ * Inert [AnalyticsService] implementation. Used as the default for test
+ * fixtures (see `TestApplicationLifecycleService`) and as a safe substitute in
+ * code paths that don't care about analytics emission. Never bound in
+ * production DI — both apps always bind [SentryAnalyticsService] now; the two
+ * runtime gates (dev-only build flag + user-settings toggle) handle suppression.
  *
- *  - Sentry-KMP is not loaded (build-time gate, see DI module).
+ * By construction, when this implementation is wired:
+ *  - Sentry-KMP is never touched.
  *  - No DSN is dialled, no network traffic is generated.
  *  - All calls return [Unit] without observable side effects.
- *
- * Existing because the rest of the codebase calls `analyticsService.track(...)`
- * unconditionally — having an injectable no-op avoids sprinkling `if`s at every
- * call site and keeps the contract identical between gated and ungated builds.
  */
 object NoOpAnalyticsService : AnalyticsService {
     // Each body has an explicit `Unit` statement so kover sees at least one

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/SentryAnalyticsService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/SentryAnalyticsService.kt
@@ -4,12 +4,12 @@ import kotlinx.atomicfu.atomic
 import network.bisq.mobile.domain.utils.Logging
 
 /**
- * The Sentry-backed [AnalyticsService]. Bound only when the build-time gate
- * (`BuildConfig.ANALYTICS_ENABLED`) is true; otherwise the DI module wires
- * [NoOpAnalyticsService] and this class is never instantiated. R8 then prunes
- * both this class and the Sentry-KMP SDK from release builds.
+ * The Sentry-backed [AnalyticsService]. Always bound by the DI module — the
+ * runtime gates ([runtimeOptInProvider] below) control emission, not whether
+ * the class exists. Release builds ship Sentry-KMP linked in but inert until
+ * the user-settings toggle is flipped ON.
  *
- * Two runtime guards on top of the build-time gate:
+ * Two runtime guards:
  *
  *  1. **Init guard.** [init] is idempotent — Sentry-KMP keeps internal state
  *     and a second `Sentry.init` is undefined; we silently no-op the second
@@ -17,15 +17,11 @@ import network.bisq.mobile.domain.utils.Logging
  *     a typo destination).
  *  2. **Runtime opt-in gate.** Every emit checks [runtimeOptInProvider]
  *     immediately before calling into the SDK. **Defaults to `{ false }` —
- *     callers MUST pass a provider explicitly to enable emission.** This is
- *     defence in depth: the DI module's build-time check already gates
- *     construction, and the secure-by-default lambda here ensures any future
- *     bypass of that gate (a refactor, a test fixture, a new platform binding)
- *     can't silently start emitting events. Initial work wires the DI modules to
- *     pass `{ BuildConfig.ANALYTICS_ENABLED }` — same source as the build-time
- *     gate, doubly-locked. TODO swap that for
- *     `{ settingsRepository.analyticsEnabled.value }` once the Settings UI
- *     toggle ships.
+ *     callers MUST pass a provider explicitly to enable emission.** Production
+ *     wiring combines `BuildConfig.ANALYTICS_DEV_ENABLED` (dev safety) AND
+ *     `SettingsRepository.analyticsEnabled.value` (user-facing) — both gates
+ *     must be true for the SDK to fire. See `ClientDomainModule` /
+ *     `NodeDomainModule` for the exact binding.
  *
  * @param sentryClient Indirection over Sentry-KMP for test substitution. See
  *  [DefaultSentryClient] for the production wiring.
@@ -47,10 +43,9 @@ class SentryAnalyticsService internal constructor(
      * a platform-specific [NativeSentryInitializer]) and passing it here.
      *
      * Takes the runtime opt-in source explicitly so the caller's intent
-     * (and what gates emission) is visible at the binding site. Initial work
-     * wires this to `{ BuildConfig.ANALYTICS_ENABLED }`; TODO swap to
-     * `{ settingsRepository.analyticsEnabled.value }` once the Settings UI
-     * toggle ships.
+     * (and what gates emission) is visible at the binding site. Production
+     * wiring is `{ BuildConfig.ANALYTICS_DEV_ENABLED && settingsRepository.analyticsEnabled.value }`
+     * — see `ClientDomainModule` / `NodeDomainModule`.
      */
     constructor(
         nativeInitializer: NativeSentryInitializer,
@@ -88,7 +83,22 @@ class SentryAnalyticsService internal constructor(
                 }
                 null to null
             }
-        sentryClient.init(dsn, environment, release, redactor, isDebug, effectiveHost, effectivePort)
+        // Thread the runtime opt-in provider into the native SDK init so the
+        // platform's beforeSend can drop ALL events when the user is opted out
+        // — including SDK auto-captures (UncaughtExceptionHandler crashes,
+        // ActivityLifecycle, etc.) that don't pass through our [track] /
+        // [captureException] gates. Without this, an opted-out user whose
+        // app crashes would still ship the crash to GlitchTip.
+        sentryClient.init(
+            dsn,
+            environment,
+            release,
+            redactor,
+            isDebug,
+            effectiveHost,
+            effectivePort,
+            runtimeOptInProvider,
+        )
         log.d {
             if (effectiveHost != null) {
                 "Sentry initialized with SOCKS proxy at $effectiveHost:$effectivePort"
@@ -99,7 +109,7 @@ class SentryAnalyticsService internal constructor(
     }
 
     override fun track(event: AnalyticsEvent) {
-        if (!isReadyToEmit()) return
+        if (!isReadyToEmit(event.name)) return
         log.d { "Sentry: Tracking event $event" }
         sentryClient.captureMessage(event.name)
     }
@@ -113,12 +123,28 @@ class SentryAnalyticsService internal constructor(
     override fun trackImmediate(event: AnalyticsEvent) = track(event)
 
     override fun captureException(throwable: Throwable) {
-        if (!isReadyToEmit()) return
+        if (!isReadyToEmit("exception:${throwable::class.simpleName}")) return
         log.w { "Sentry: Tracking exception ${throwable.message}" }
         sentryClient.captureException(throwable)
     }
 
     override fun captureExceptionImmediate(throwable: Throwable) = captureException(throwable)
 
-    private fun isReadyToEmit(): Boolean = initialized.value && runtimeOptInProvider()
+    /**
+     * Both gates must be true. On a `false`, log WHY — silent drops here used
+     * to be a debugging nightmare (the upstream [BufferedAnalyticsService]
+     * sees no exception and happily logs "forwarded direct", but the event
+     * never actually reaches the SDK).
+     */
+    private fun isReadyToEmit(reason: String): Boolean {
+        val init = initialized.value
+        val optedIn = runtimeOptInProvider()
+        if (!init || !optedIn) {
+            log.d {
+                "Sentry: dropping '$reason' — initialized=$init, runtimeOptInProvider=$optedIn"
+            }
+            return false
+        }
+        return true
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/SentryClient.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/SentryClient.kt
@@ -21,6 +21,10 @@ internal interface SentryClient {
      *  - `beforeSend` runs the [AnalyticsRedactor] over message + exception
      *    text as a defence-in-depth layer for whatever made it past the
      *    sealed-event API.
+     *  - `beforeSend` ALSO consults [runtimeOptInProvider] and drops the event
+     *    when it returns false — this is the only gate that catches the SDK's
+     *    auto-installed pipelines (UncaughtExceptionHandler, ActivityLifecycle,
+     *    etc.) when a user opts out AFTER init has happened.
      *  - SOCKS5 proxy when [socksProxyHost] + [socksProxyPort] are non-null —
      *    required for production where the GlitchTip server lives on a Tor
      *    hidden service.
@@ -39,6 +43,7 @@ internal interface SentryClient {
         isDebug: Boolean,
         socksProxyHost: String? = null,
         socksProxyPort: Int? = null,
+        runtimeOptInProvider: () -> Boolean,
     )
 
     /**
@@ -76,6 +81,7 @@ internal class DefaultSentryClient(
         isDebug: Boolean,
         socksProxyHost: String?,
         socksProxyPort: Int?,
+        runtimeOptInProvider: () -> Boolean,
     ) {
         nativeInitializer.init(
             dsn = dsn,
@@ -85,6 +91,7 @@ internal class DefaultSentryClient(
             isDebug = isDebug,
             socksProxyHost = socksProxyHost,
             socksProxyPort = socksProxyPort,
+            runtimeOptInProvider = runtimeOptInProvider,
         )
     }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/repository/SettingsRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/repository/SettingsRepository.kt
@@ -1,7 +1,12 @@
 package network.bisq.mobile.domain.repository
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.data.model.BatteryOptimizationState
 import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.model.Settings
@@ -34,4 +39,20 @@ interface SettingsRepository {
     suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean)
 
     suspend fun setPermitOpeningBrowser(value: Boolean)
+
+    suspend fun setAnalyticsEnabled(value: Boolean)
+
+    suspend fun setAnalyticsPromptSeen(value: Boolean)
+
+    /**
+     * Returns a hot [StateFlow] of [Settings.analyticsEnabled] sharing in the
+     * given [scope]. The DI module passes its long-lived buffer scope here so
+     * the analytics SDK's synchronous `runtimeOptInProvider` can read
+     * `.value` without suspending. Default is `false` (matches privacy
+     * contract: never emit until proven opted-in).
+     */
+    fun analyticsEnabledIn(scope: CoroutineScope): StateFlow<Boolean> =
+        data
+            .map { it.analyticsEnabled }
+            .stateIn(scope, SharingStarted.Eagerly, false)
 }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -114,6 +114,15 @@ mobile.pushNotifications.settings.subtitle=Receive trade alerts when the app is 
 mobile.pushNotifications.settings.iosOnlyOption=On iOS, this is the only way to receive notifications when the app is not running.
 mobile.pushNotifications.settings.learnMoreLink=How this works and what is shared →
 mobile.pushNotifications.settings.disabledWarning=You may miss trade messages while the app is closed.
+# Settings — opt-in analytics section (issue #525). Privacy contract is default OFF; user-controlled.
+mobile.settings.analytics.title=Crash & usage reporting
+mobile.settings.analytics.toggleLabel=Help improve Bisq Mobile
+mobile.settings.analytics.subtitle=Send anonymous crash reports and basic usage metrics so we can fix bugs faster.
+mobile.settings.analytics.info.tor=Routed over Tor — your IP is never exposed
+mobile.settings.analytics.info.noPii=No personal information, accounts, or device IDs
+mobile.settings.analytics.info.noTrade=No trade details, amounts, addresses, or messages
+mobile.settings.analytics.info.retention=Auto-deleted after 90 days on a self-hosted server
+mobile.settings.analytics.learnMore=Learn what we collect and what we don't →
 # Settings — keep-connected-in-background sub-setting (Android Connect only, only visible when relayed is enabled)
 mobile.pushNotifications.settings.keepConnected.toggleLabel=Keep connected in background
 mobile.pushNotifications.settings.keepConnected.subtitle=Trades and chats update in real-time, and the app opens instantly from notifications. Without this, expect a few seconds to reconnect when you open the app from a push. Costs more battery and shows a persistent system notification while active.

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/DefaultSentryClientTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/DefaultSentryClientTest.kt
@@ -41,6 +41,8 @@ class DefaultSentryClientTest {
             private set
         var lastSocksPort: Int? = null
             private set
+        var lastRuntimeOptInProvider: (() -> Boolean)? = null
+            private set
 
         override fun init(
             dsn: String,
@@ -50,6 +52,7 @@ class DefaultSentryClientTest {
             isDebug: Boolean,
             socksProxyHost: String?,
             socksProxyPort: Int?,
+            runtimeOptInProvider: () -> Boolean,
         ) {
             initCalls++
             lastDsn = dsn
@@ -59,6 +62,7 @@ class DefaultSentryClientTest {
             lastIsDebug = isDebug
             lastSocksHost = socksProxyHost
             lastSocksPort = socksProxyPort
+            lastRuntimeOptInProvider = runtimeOptInProvider
         }
     }
 
@@ -73,6 +77,7 @@ class DefaultSentryClientTest {
         val redactor = AnalyticsRedactor()
         val client = DefaultSentryClient(native)
 
+        val providerStub: () -> Boolean = { true }
         client.init(
             dsn = "http://abc@onion-host/3",
             environment = "production",
@@ -81,6 +86,7 @@ class DefaultSentryClientTest {
             isDebug = false,
             socksProxyHost = "127.0.0.1",
             socksProxyPort = 9050,
+            runtimeOptInProvider = providerStub,
         )
 
         assertEquals(1, native.initCalls)
@@ -91,6 +97,11 @@ class DefaultSentryClientTest {
         assertEquals(false, native.lastIsDebug)
         assertEquals("127.0.0.1", native.lastSocksHost)
         assertEquals(9050, native.lastSocksPort)
+        assertEquals(
+            providerStub,
+            native.lastRuntimeOptInProvider,
+            "must forward the SAME runtimeOptInProvider lambda — replacing it breaks the beforeSend opt-in gate",
+        )
     }
 
     @Test
@@ -112,6 +123,7 @@ class DefaultSentryClientTest {
             redactor = AnalyticsRedactor(),
             isDebug = true,
             // socksProxyHost + socksProxyPort omitted — exercise the defaults.
+            runtimeOptInProvider = { true },
         )
 
         assertEquals(1, native.initCalls)
@@ -136,6 +148,7 @@ class DefaultSentryClientTest {
             isDebug = true,
             socksProxyHost = null,
             socksProxyPort = null,
+            runtimeOptInProvider = { true },
         )
 
         assertEquals(1, native.initCalls)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/SentryAnalyticsServiceTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/SentryAnalyticsServiceTest.kt
@@ -21,6 +21,7 @@ class SentryAnalyticsServiceTest {
         var lastIsDebug: Boolean? = null
         var lastSocksHost: String? = null
         var lastSocksPort: Int? = null
+        var lastRuntimeOptInProvider: (() -> Boolean)? = null
         val capturedMessages = mutableListOf<String>()
         val capturedExceptions = mutableListOf<Throwable>()
 
@@ -32,6 +33,7 @@ class SentryAnalyticsServiceTest {
             isDebug: Boolean,
             socksProxyHost: String?,
             socksProxyPort: Int?,
+            runtimeOptInProvider: () -> Boolean,
         ) {
             initCalls++
             lastDsn = dsn
@@ -40,6 +42,7 @@ class SentryAnalyticsServiceTest {
             lastIsDebug = isDebug
             lastSocksHost = socksProxyHost
             lastSocksPort = socksProxyPort
+            lastRuntimeOptInProvider = runtimeOptInProvider
         }
 
         override fun captureMessage(message: String) {
@@ -310,10 +313,10 @@ class SentryAnalyticsServiceTest {
     fun `DI-friendly public constructor accepts a NativeSentryInitializer plus runtimeOptInProvider`() {
         // Pins the contract for the constructor used by every DI module
         // (ClientDomainModule + NodeDomainModule pass `get<NativeSentryInitializer>()`
-        // plus `{ BuildConfig.ANALYTICS_ENABLED }`). Construction must not throw
-        // and must NOT actually invoke the native initializer (init is lazy —
-        // only fires when init() is called). This catches any refactor that
-        // eagerly calls into the SDK at construction time.
+        // plus `{ ANALYTICS_DEV_ENABLED && settingsRepository.analyticsEnabled.value }`).
+        // Construction must not throw and must NOT actually invoke the native
+        // initializer (init is lazy — only fires when init() is called). This
+        // catches any refactor that eagerly calls into the SDK at construction time.
         var consented = false
         var nativeInitCalls = 0
         val recordingNative =
@@ -326,6 +329,7 @@ class SentryAnalyticsServiceTest {
                     isDebug: Boolean,
                     socksProxyHost: String?,
                     socksProxyPort: Int?,
+                    runtimeOptInProvider: () -> Boolean,
                 ) {
                     nativeInitCalls++
                 }
@@ -359,5 +363,46 @@ class SentryAnalyticsServiceTest {
 
         assertTrue(client.capturedMessages.isEmpty(), "default provider must deny track()")
         assertTrue(client.capturedExceptions.isEmpty(), "default provider must deny captureException()")
+    }
+
+    // ============ OPT-IN GATE FORWARDING ============
+    //
+    // The init must forward the SAME `runtimeOptInProvider` to the underlying
+    // SentryClient so the platform's `beforeSend` can drop SDK-auto-captured
+    // events (UncaughtExceptionHandler crashes, ActivityLifecycle events,
+    // etc.) when the user is opted out. Without this, the gate only catches
+    // OUR manual track() / captureException() calls — auto-captured events
+    // bypass it entirely and leak post-opt-out.
+
+    @Test
+    fun `init forwards the runtimeOptInProvider to the SentryClient`() {
+        // Pins the load-bearing contract for Option B (PR #1474 follow-up):
+        // the same lambda the service uses to gate its own emit paths must
+        // ALSO be threaded into the native init so beforeSend can refuse
+        // events at the SDK level. Identity check (===), not equality.
+        var consented = true
+        val providerLambda: () -> Boolean = { consented }
+        val (service, client) = newService(optedIn = true)
+        // Replace with a fresh instance whose provider we control by reference.
+        val taggedService =
+            SentryAnalyticsService(
+                sentryClient = client,
+                runtimeOptInProvider = providerLambda,
+            )
+
+        taggedService.init("http://abc@localhost:8000/3", "development", "0.4.1", isDebug = true)
+
+        assertEquals(1, client.initCalls)
+        assertEquals(
+            providerLambda,
+            client.lastRuntimeOptInProvider,
+            "SentryAnalyticsService.init MUST forward the same runtimeOptInProvider — beforeSend uses it as the SDK-level opt-in gate",
+        )
+        // Bonus: mutating `consented` via the lambda reaches the forwarded
+        // lambda too (i.e. it's captured-by-reference, not snapshotted).
+        consented = false
+        assertEquals(false, client.lastRuntimeOptInProvider?.invoke())
+        // Silence the unused warning on the test-helper service.
+        assertEquals(client, client.also { service.track(AnalyticsEvent.ScreenViewed.Dashboard) })
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceBootstrapTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceBootstrapTest.kt
@@ -7,11 +7,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import org.junit.After
@@ -158,9 +161,10 @@ class ApplicationLifecycleServiceBootstrapTest {
     }
 
     @Test
-    fun `initialize forwards every AnalyticsBootstrapConfig value to AnalyticsService_init when SOCKS port is up`() {
+    fun `initialize forwards every AnalyticsBootstrapConfig value to AnalyticsService_init when opted-in AND SOCKS port is up`() {
         val analytics = RecordingAnalyticsService()
         val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
         val config =
             AnalyticsBootstrapConfig(
                 dsn = "http://abc@onion-host/3",
@@ -173,11 +177,12 @@ class ApplicationLifecycleServiceBootstrapTest {
                 analyticsService = analytics,
                 analyticsBootstrapConfig = config,
                 analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
             )
 
         runCatching { service.initialize() }
 
-        assertEquals(1, analytics.initCalls, "AnalyticsService.init must be called exactly once when SOCKS is up")
+        assertEquals(1, analytics.initCalls, "AnalyticsService.init must be called exactly once when opted-in + SOCKS up")
         assertEquals(config.dsn, analytics.lastDsn)
         assertEquals(config.environment, analytics.lastEnvironment)
         assertEquals(config.release, analytics.lastRelease)
@@ -196,6 +201,7 @@ class ApplicationLifecycleServiceBootstrapTest {
         // leaking the user's IP to whatever clearnet exit it hit.
         val analytics = RecordingAnalyticsService()
         val provider = FakeSocksPortProvider(CompletableDeferred()) // never completes
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
         val service =
             TestApplicationLifecycleService(
                 analyticsService = analytics,
@@ -207,6 +213,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                         isDebug = false,
                     ),
                 analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
             )
 
         runCatching { service.initialize() }
@@ -253,6 +260,7 @@ class ApplicationLifecycleServiceBootstrapTest {
         val boom = RuntimeException("Sentry-KMP refused to dial")
         val analytics = RecordingAnalyticsService(throwOnInit = boom)
         val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
         val service =
             TestApplicationLifecycleService(
                 analyticsService = analytics,
@@ -264,6 +272,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                         isDebug = false,
                     ),
                 analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
             )
 
         val outcome = runCatching { service.initialize() }
@@ -294,6 +303,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                 flushIntervalMs = 0L,
             )
         val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
         val service =
             TestApplicationLifecycleService(
                 analyticsService = buffered,
@@ -306,6 +316,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                     ),
                 bufferedAnalyticsService = buffered,
                 analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
             )
 
         // Pre-condition: not ready before initialize.
@@ -332,6 +343,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                 flushIntervalMs = 0L,
             )
         val provider = FakeSocksPortProvider(CompletableDeferred()) // never completes
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
         val service =
             TestApplicationLifecycleService(
                 analyticsService = buffered,
@@ -344,11 +356,198 @@ class ApplicationLifecycleServiceBootstrapTest {
                     ),
                 bufferedAnalyticsService = buffered,
                 analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
             )
 
         runCatching { service.initialize() }
 
         assertEquals(0, analytics.initCalls)
         assertEquals(false, buffered.isReady, "Buffer must NOT be flipped to ready when Sentry was never initialized")
+    }
+
+    // ============ OPTION B — Defer init until first opt-in ============
+
+    @Test
+    fun `initialize waits for analyticsEnabled=true BEFORE calling Sentry init - opted-out users never load the SDK`() {
+        // THE Option B privacy invariant: a user who never opts in must NEVER
+        // see Sentry's SDK loaded into the process. UncaughtExceptionHandler
+        // installed, native libs (libsentry.so, libsentry-android.so) loaded,
+        // ActivityLifecycle integration registered, cache dirs created — ALL
+        // bypassed until the user explicitly agrees. Verified empirically:
+        // `nativeloader Load /.../libsentry.so` log line never appears for
+        // opted-out users.
+        val analytics = RecordingAnalyticsService()
+        val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = false)))
+        val service =
+            TestApplicationLifecycleService(
+                analyticsService = analytics,
+                analyticsBootstrapConfig =
+                    AnalyticsBootstrapConfig(
+                        dsn = "http://abc@onion-host/3",
+                        environment = "production",
+                        release = "test",
+                        isDebug = false,
+                    ),
+                analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
+            )
+
+        runCatching { service.initialize() }
+
+        assertEquals(0, analytics.initCalls, "Sentry init must NOT run while user is opted-out")
+        assertNull(analytics.lastDsn, "DSN must never reach the SDK pre-opt-in")
+    }
+
+    @Test
+    fun `initialize triggers Sentry init when user flips opt-in to true mid-session`() {
+        // The reactive flip-on path: user defers consent at launch, then
+        // changes their mind. The lifecycle's `filter { it }.first()` must
+        // observe that transition and proceed to init. Without this, a user
+        // who opts in via Settings AFTER launch would never get analytics
+        // unless they restart the app.
+        val analytics = RecordingAnalyticsService()
+        val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsFlow = MutableStateFlow(Settings(analyticsEnabled = false))
+        val settingsRepo = TestSettingsRepository(settingsFlow)
+        val service =
+            TestApplicationLifecycleService(
+                analyticsService = analytics,
+                analyticsBootstrapConfig =
+                    AnalyticsBootstrapConfig(
+                        dsn = "http://abc@onion-host/3",
+                        environment = "production",
+                        release = "test",
+                        isDebug = false,
+                    ),
+                analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
+            )
+
+        runCatching { service.initialize() }
+        assertEquals(0, analytics.initCalls, "pre-condition: opted-out → no init")
+
+        // User flips toggle ON in Settings.
+        settingsFlow.value = settingsFlow.value.copy(analyticsEnabled = true)
+
+        assertEquals(1, analytics.initCalls, "opt-in flip must trigger Sentry init")
+    }
+
+    @Test
+    fun `initialize refuses to init Sentry when SettingsRepository is not bound - fails closed`() {
+        // Defence in depth: if production DI somehow forgot to bind
+        // SettingsRepository (refactor bug, module misconfiguration), we must
+        // NOT silently default to "init Sentry anyway". That would
+        // effectively force-enable analytics for everyone — catastrophic for
+        // the opt-in contract. Fail closed, log loud.
+        val analytics = RecordingAnalyticsService()
+        val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val service =
+            TestApplicationLifecycleService(
+                analyticsService = analytics,
+                analyticsBootstrapConfig =
+                    AnalyticsBootstrapConfig(
+                        dsn = "http://abc@onion-host/3",
+                        environment = "production",
+                        release = "test",
+                        isDebug = false,
+                    ),
+                analyticsSocksPortProvider = provider,
+                settingsRepository = null, // explicit: misconfiguration scenario
+            )
+
+        runCatching { service.initialize() }
+
+        assertEquals(0, analytics.initCalls, "no SettingsRepository → MUST NOT init Sentry")
+    }
+
+    /**
+     * Minimal [SettingsRepository] stand-in that lets the test control when
+     * `data` emits. Used by the pre-warm contract test below. We don't reach
+     * for mockk here because the SettingsRepository interface has many
+     * methods and the test only cares about `data` emissions.
+     */
+    private class TestSettingsRepository(
+        private val flow: MutableStateFlow<Settings> = MutableStateFlow(Settings()),
+    ) : SettingsRepository {
+        override val data = flow
+
+        override suspend fun setFirstLaunch(value: Boolean) {}
+
+        override suspend fun setShowChatRulesWarnBox(value: Boolean) {}
+
+        override suspend fun setSelectedMarketCode(value: String) {}
+
+        override suspend fun setNotificationPermissionState(
+            value: network.bisq.mobile.data.model.PermissionState,
+        ) {}
+
+        override suspend fun setBatteryOptimizationPermissionState(
+            value: network.bisq.mobile.data.model.BatteryOptimizationState,
+        ) {}
+
+        override suspend fun update(transform: suspend (t: Settings) -> Settings) {
+            flow.value = transform(flow.value)
+        }
+
+        override suspend fun clear() {}
+
+        override suspend fun setMarketSortBy(value: network.bisq.mobile.data.model.market.MarketSortBy) {}
+
+        override suspend fun setMarketFilter(value: network.bisq.mobile.data.model.market.MarketFilter) {}
+
+        override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {}
+
+        override suspend fun setPermitOpeningBrowser(value: Boolean) {}
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) {
+            flow.value = flow.value.copy(analyticsEnabled = value)
+        }
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) {
+            flow.value = flow.value.copy(analyticsPromptSeen = value)
+        }
+    }
+
+    @Test
+    fun `init + onSentryReady fire only after the opt-in flip is observed in Settings`() {
+        // Pins the ordering: under Option B, the lifecycle waits for the
+        // settings flow to emit `analyticsEnabled=true` BEFORE calling init
+        // BEFORE calling onSentryReady. So the buffer's "ready" flag must
+        // ONLY flip after both the opt-in flip and SDK init complete.
+        //
+        // This also implicitly handles the StateFlow pre-warm we previously
+        // hand-coded: by the time `filter { it }.first()` resolves, DataStore
+        // has emitted at least once with the truthy value, so the DI module's
+        // `analyticsEnabledIn` StateFlow has its real value. The race window
+        // we hit on the node app on 2026-06-11 is gone.
+        val analytics = RecordingAnalyticsService()
+        val buffered =
+            BufferedAnalyticsService(
+                downstream = analytics,
+                scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob()),
+                flushIntervalMs = 0L,
+            )
+        val provider = FakeSocksPortProvider(CompletableDeferred(9050))
+        val settingsRepo = TestSettingsRepository(MutableStateFlow(Settings(analyticsEnabled = true)))
+        val service =
+            TestApplicationLifecycleService(
+                analyticsService = buffered,
+                analyticsBootstrapConfig =
+                    AnalyticsBootstrapConfig(
+                        dsn = "http://abc@onion-host/3",
+                        environment = "production",
+                        release = "test",
+                        isDebug = false,
+                    ),
+                bufferedAnalyticsService = buffered,
+                analyticsSocksPortProvider = provider,
+                settingsRepository = settingsRepo,
+            )
+
+        runCatching { service.initialize() }
+
+        assertEquals(1, analytics.initCalls)
+        assertEquals(true, buffered.isReady, "Buffer ready flips only after opt-in flip + init + onSentryReady")
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/TestApplicationLifecycleService.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/TestApplicationLifecycleService.kt
@@ -9,6 +9,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
 import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
+import network.bisq.mobile.domain.repository.SettingsRepository
 
 /**
  * Lightweight reusable ApplicationLifecycleService for unit tests.
@@ -24,6 +25,7 @@ class TestApplicationLifecycleService(
         AnalyticsBootstrapConfig(dsn = "", environment = "test", release = "test", isDebug = false),
     bufferedAnalyticsService: BufferedAnalyticsService? = null,
     analyticsSocksPortProvider: AnalyticsSocksPortProvider? = null,
+    settingsRepository: SettingsRepository? = null,
 ) : ApplicationLifecycleService(
         applicationBootstrapFacade,
         kmpTorService,
@@ -31,6 +33,7 @@ class TestApplicationLifecycleService(
         analyticsBootstrapConfig,
         bufferedAnalyticsService,
         analyticsSocksPortProvider,
+        settingsRepository,
     ) {
     override suspend fun activateServiceFacades() {}
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -130,6 +130,10 @@ class CreateOfferPricePresenterTest {
         override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {}
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) {}
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) {}
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) {}
     }
 
     private class FakeMarketPriceServiceFacade(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -139,6 +139,10 @@ class CreateOfferReviewPresenterTest {
         override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {}
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) {}
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) {}
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) {}
     }
 
     private class FakeMarketPriceServiceFacade(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -136,6 +136,10 @@ class TakeOfferCoordinatorTest {
         override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {}
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) {}
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) {}
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) {}
     }
 
     private class FakeMarketPriceServiceFacade(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
@@ -1094,4 +1094,70 @@ class SettingsPresenterTest {
 
             assertFalse(flow.value.keepConnectedInBackground)
         }
+
+    // ============ Opt-in analytics (issue #525) ============
+
+    @Test
+    fun `OnAnalyticsToggle on persists analyticsEnabled=true AND analyticsPromptSeen=true`() =
+        runTest(testDispatcher) {
+            // The promptSeen flip matters: the welcome carousel keys off it to
+            // decide whether to auto-prompt. Once the user has engaged from
+            // Settings (either direction), the carousel should not auto-prompt
+            // them again.
+            val flow = wireSettingsRepositoryUpdate(Settings(analyticsEnabled = false, analyticsPromptSeen = false))
+            coEvery { settingsServiceFacade.getSettings() } returns Result.success(sampleSettings)
+
+            presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(SettingsUiAction.OnAnalyticsToggle(true))
+            advanceUntilIdle()
+
+            assertTrue(flow.value.analyticsEnabled, "toggle ON must persist analyticsEnabled=true")
+            assertTrue(flow.value.analyticsPromptSeen, "engaging from Settings must mark prompt as seen — suppresses carousel auto-prompt")
+        }
+
+    @Test
+    fun `OnAnalyticsToggle off persists analyticsEnabled=false AND analyticsPromptSeen=true`() =
+        runTest(testDispatcher) {
+            // User who turns analytics OFF from Settings has also "seen" the
+            // prompt — auto-carousel must not pester them.
+            val flow = wireSettingsRepositoryUpdate(Settings(analyticsEnabled = true, analyticsPromptSeen = false))
+            coEvery { settingsServiceFacade.getSettings() } returns Result.success(sampleSettings)
+
+            presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(SettingsUiAction.OnAnalyticsToggle(false))
+            advanceUntilIdle()
+
+            assertFalse(flow.value.analyticsEnabled)
+            assertTrue(flow.value.analyticsPromptSeen)
+        }
+
+    @Test
+    fun `analyticsEnabled state reflects repository value via observeAnalyticsEnabled`() =
+        runTest(testDispatcher) {
+            // Pins the read-side observer. A flip from anywhere (carousel,
+            // welcome flow, factory reset) must propagate into the Settings
+            // screen state so the toggle visually matches reality.
+            val flow = wireSettingsRepositoryUpdate(Settings(analyticsEnabled = false))
+            coEvery { settingsServiceFacade.getSettings() } returns Result.success(sampleSettings)
+
+            presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+            assertFalse(presenter.uiState.value.analyticsEnabled)
+
+            // Simulate an external write (e.g. the welcome carousel).
+            flow.value = flow.value.copy(analyticsEnabled = true)
+            advanceUntilIdle()
+            assertTrue(presenter.uiState.value.analyticsEnabled)
+
+            flow.value = flow.value.copy(analyticsEnabled = false)
+            advanceUntilIdle()
+            assertFalse(presenter.uiState.value.analyticsEnabled)
+        }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
@@ -19,4 +19,5 @@ object BisqLinks {
     const val BISQ_AI = "https://ai.bisq.network"
     const val BISQ_CONNECT_WIKI_URL = "https://github.com/bisq-network/bisq-mobile/wiki/How-to-use-Bisq-Connect"
     const val BISQ_CONNECT_PUSH_NOTIFICATIONS_WIKI_URL = "https://github.com/bisq-network/bisq-mobile/wiki/Push-Notifications-Android"
+    const val BISQ_MOBILE_ANALYTICS_WIKI_URL = "https://github.com/bisq-network/bisq-mobile/wiki/Help-improve-Bisq-Mobile:-opt%E2%80%90in-analytics"
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
@@ -81,6 +81,7 @@ open class SettingsPresenter(
         fetchSettings()
         observePushNotificationsEnabled()
         observeKeepConnectedInBackground()
+        observeAnalyticsEnabled()
     }
 
     private fun observePushNotificationsEnabled() {
@@ -110,6 +111,23 @@ open class SettingsPresenter(
             settingsRepository.data.collect { settings ->
                 _uiState.update {
                     it.copy(keepConnectedInBackground = settings.keepConnectedInBackground)
+                }
+            }
+        }
+    }
+
+    /**
+     * Reflect the persisted analytics opt-in state into the UI. Source of truth
+     * is `SettingsRepository.analyticsEnabled` — the DI module reads the same
+     * value via [SettingsRepository.analyticsEnabledIn] for the SDK's runtime
+     * gate, so a flip from here propagates to emission within the next track()
+     * call without any extra plumbing.
+     */
+    private fun observeAnalyticsEnabled() {
+        presenterScope.launch {
+            settingsRepository.data.collect { settings ->
+                _uiState.update {
+                    it.copy(analyticsEnabled = settings.analyticsEnabled)
                 }
             }
         }
@@ -148,6 +166,23 @@ open class SettingsPresenter(
 
             is SettingsUiAction.OnKeepConnectedInBackgroundToggle ->
                 onKeepConnectedInBackgroundToggle(action.enabled)
+
+            is SettingsUiAction.OnAnalyticsToggle -> onAnalyticsToggle(action.enabled)
+            SettingsUiAction.OnAnalyticsLearnMore ->
+                navigateToUrl(BisqLinks.BISQ_MOBILE_ANALYTICS_WIKI_URL)
+        }
+    }
+
+    private fun onAnalyticsToggle(enabled: Boolean) {
+        presenterScope.launch {
+            // Persist via the repo. The DI module's hot StateFlow view of
+            // analyticsEnabled picks this up on the next emission and the
+            // SDK's runtimeOptInProvider reflects the new value on the next
+            // track() call. Also mark the prompt as seen so the welcome
+            // carousel won't auto-prompt later if the user already engaged.
+            settingsRepository.update {
+                it.copy(analyticsEnabled = enabled, analyticsPromptSeen = true)
+            }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
@@ -211,7 +211,9 @@ fun SettingsContent(
                     )
 
                     BisqHDivider()
+                    AnalyticsSection(uiState, onAction)
 
+                    BisqHDivider()
                     BisqText.H4Light("settings.display.headline".i18n())
 
                     BisqGap.V1()
@@ -378,6 +380,74 @@ private fun PushNotificationsExtraGuidance(
             color = BisqTheme.colors.warning,
         )
     }
+}
+
+/**
+ * Crash & usage reporting (analytics) section. Two halves:
+ *  1. Title + toggle switch + subtitle (mirrors push notifications pattern).
+ *  2. Privacy bullets + "Learn more" link routing to the analytics wiki page.
+ *
+ * Visibility is unconditional — the privacy contract is opt-in everywhere, so
+ * every user gets to see this section and decide. The toggle persists through
+ * [SettingsPresenter.onAnalyticsToggle] → [SettingsRepository.setAnalyticsEnabled]
+ * → DI's `runtimeOptInProvider` StateFlow on the next emit.
+ *
+ * Excluded from coverage like the other declarative Compose helpers in this
+ * file — the underlying logic lives in the presenter and is unit-tested there.
+ */
+@ExcludeFromCoverage
+@Composable
+private fun AnalyticsSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsUiAction) -> Unit,
+) {
+    BisqText.H4Light("mobile.settings.analytics.title".i18n())
+
+    BisqGap.V1()
+
+    BisqSwitch(
+        label = "mobile.settings.analytics.toggleLabel".i18n(),
+        checked = uiState.analyticsEnabled,
+        onSwitch = { onAction(SettingsUiAction.OnAnalyticsToggle(it)) },
+    )
+
+    BisqGap.VQuarter()
+
+    BisqText.SmallLight(
+        text = "mobile.settings.analytics.subtitle".i18n(),
+        color = BisqTheme.colors.mid_grey20,
+    )
+
+    BisqGap.V1()
+
+    // Privacy bullets — four short lines summarising the wiki contract for
+    // users who won't tap "Learn more". Kept in i18n so translators can adapt
+    // wording per language.
+    AnalyticsBulletRow("mobile.settings.analytics.info.tor".i18n())
+    AnalyticsBulletRow("mobile.settings.analytics.info.noPii".i18n())
+    AnalyticsBulletRow("mobile.settings.analytics.info.noTrade".i18n())
+    AnalyticsBulletRow("mobile.settings.analytics.info.retention".i18n())
+
+    BisqGap.VHalf()
+
+    BisqText.SmallLight(
+        text = "mobile.settings.analytics.learnMore".i18n(),
+        color = BisqTheme.colors.primary,
+        modifier =
+            Modifier.clickable {
+                onAction(SettingsUiAction.OnAnalyticsLearnMore)
+            },
+    )
+}
+
+@ExcludeFromCoverage
+@Composable
+private fun AnalyticsBulletRow(text: String) {
+    BisqText.SmallLight(
+        text = "• $text",
+        color = BisqTheme.colors.mid_grey20,
+    )
+    BisqGap.VQuarter()
 }
 
 @ExcludeFromCoverage

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiAction.kt
@@ -80,4 +80,12 @@ sealed interface SettingsUiAction {
     data class OnKeepConnectedInBackgroundToggle(
         val enabled: Boolean,
     ) : SettingsUiAction
+
+    /** User toggled the opt-in analytics switch (issue #525). */
+    data class OnAnalyticsToggle(
+        val enabled: Boolean,
+    ) : SettingsUiAction
+
+    /** User tapped "Learn more" in the analytics section — opens the privacy wiki page. */
+    data object OnAnalyticsLearnMore : SettingsUiAction
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiState.kt
@@ -37,4 +37,12 @@ data class SettingsUiState(
      */
     val shouldShowKeepConnectedToggle: Boolean = false,
     val keepConnectedInBackground: Boolean = false,
+    /**
+     * Opt-in analytics toggle state (issue #525). Source of truth is
+     * `SettingsRepository.analyticsEnabled`. Default OFF — privacy contract is
+     * never opt-out. The DI module's `runtimeOptInProvider` reads the same
+     * backing settings value, so flipping this switch propagates to Sentry
+     * emission within the next track() call (no rebuild required).
+     */
+    val analyticsEnabled: Boolean = false,
 )

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/mocks/SettingsRepositoryMock.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/mocks/SettingsRepositoryMock.kt
@@ -81,4 +81,16 @@ class SettingsRepositoryMock :
             it.copy(cookiePermitOpeningBrowser = value)
         }
     }
+
+    override suspend fun setAnalyticsEnabled(value: Boolean) {
+        _data.update {
+            it.copy(analyticsEnabled = value)
+        }
+    }
+
+    override suspend fun setAnalyticsPromptSeen(value: Boolean) {
+        _data.update {
+            it.copy(analyticsPromptSeen = value)
+        }
+    }
 }


### PR DESCRIPTION

<img width="359" height="281" alt="Screenshot 2026-06-11 at 10 34 02" src="https://github.com/user-attachments/assets/29c99acf-fb87-4790-a9ab-778bf348dbbc" />

 - contribs to #525 
 - changed feature flag to only apply for debug builds (dev can change value in local.properties and will override)
 - made gating for this feature the dynamic, default off, new opt-in setting
 - implemented Settings UI
 - ensured sentry lib only loads when tor AND opt-in setting are both checked
 - implemented events flush after sentry init (for in session opt in) when opted in
 - improved logs to make clear for devs when a analytics log is skipped
 - improved docs and rewrite the ones not valid anymore
 - updated/added tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-controlled opt-in toggle for crash and usage reporting in Settings with privacy details (Tor routing, data retention, no personal/trade information).

* **Known Issues**
  * iOS builds may encounter "symbol multiply defined" errors for Sentry due to stale cache; resolve by cleaning the app and Xcode build folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->