### PR TITLE
fix: Android force client recreation and Tor NEWNYM on reconnect recovery

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
@@ -59,12 +59,6 @@ class ClientConnectivityServiceTest {
             override val type = PlatformType.ANDROID
         }
 
-    private val iosPlatformInfo =
-        object : PlatformInfo {
-            override val name = "iOS Test"
-            override val type = PlatformType.IOS
-        }
-
     private class TestClientConnectivityService(
         webSocket: WebSocketClientService,
         platform: PlatformInfo,
@@ -72,8 +66,6 @@ class ClientConnectivityServiceTest {
         override val maxReconnectingDurationMs: Long
             get() = 400L
     }
-
-    private fun createIosService(): ClientConnectivityService = ClientConnectivityService(webSocketClientService, iosPlatformInfo)
 
     @After
     fun tearDown() {
@@ -550,29 +542,26 @@ class ClientConnectivityServiceTest {
         }
 
     // ///////////////////////////////////////////////////////////////////////////
-    // iOS-specific reconnection recovery tests
+    // Force client recreation recovery tests
     // ///////////////////////////////////////////////////////////////////////////
 
     @Test
-    fun `iOS calls forceClientRecreation after threshold disconnected cycles`() =
+    fun `calls forceClientRecreation after threshold disconnected cycles`() =
         runBlocking {
-            val iosService = createIosService()
             every { webSocketClientService.isConnected() } returns false
             coEvery { webSocketClientService.triggerReconnect() } just Runs
             coEvery { webSocketClientService.forceClientRecreation() } just Runs
 
-            iosService.activate()
-            // Use period shorter than threshold to hit it quickly
-            // Threshold is IOS_FORCE_RECREATE_CYCLES (12), so we need 12+ cycles
-            iosService.startMonitoring(period = 50, startDelay = 0)
-            delay(50 * 15) // enough for >12 cycles
+            clientConnectivityService.activate()
+            // Threshold is 12 cycles on both platforms; use a short period to hit it quickly.
+            clientConnectivityService.startMonitoring(period = 50, startDelay = 0)
+            delay(50 * 15)
 
             coVerify(atLeast = 1) { webSocketClientService.forceClientRecreation() }
-            iosService.stopMonitoring()
         }
 
     @Test
-    fun `Android never calls forceClientRecreation even after many disconnected cycles`() =
+    fun `uses triggerReconnect before reaching forceClientRecreation threshold`() =
         runBlocking {
             every { webSocketClientService.isConnected() } returns false
             coEvery { webSocketClientService.triggerReconnect() } just Runs
@@ -580,59 +569,36 @@ class ClientConnectivityServiceTest {
 
             clientConnectivityService.activate()
             clientConnectivityService.startMonitoring(period = 50, startDelay = 0)
-            delay(50 * 20) // well past the iOS threshold
+            delay(50 * 5)
 
+            coVerify(atLeast = 1) { webSocketClientService.triggerReconnect() }
             coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
         }
 
     @Test
-    fun `iOS resets reconnecting counter when connection recovers`() =
+    fun `resets reconnecting counter when connection recovers`() =
         runBlocking {
-            val iosService = createIosService()
             var connected = false
             every { webSocketClientService.isConnected() } answers { connected }
             coEvery { webSocketClientService.triggerReconnect() } just Runs
             coEvery { webSocketClientService.forceClientRecreation() } just Runs
 
-            iosService.activate()
-            iosService.startMonitoring(period = 50, startDelay = 0)
-            // Accumulate some disconnected cycles (but below threshold)
+            clientConnectivityService.activate()
+            clientConnectivityService.startMonitoring(period = 50, startDelay = 0)
             delay(50 * 5)
 
-            // Connection recovers
             connected = true
             delay(50 * 3)
 
             assertEquals(
                 ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED,
-                iosService.status.value,
+                clientConnectivityService.status.value,
             )
 
-            // Disconnect again — counter should have reset, so forceClientRecreation
-            // should not be called yet (we haven't hit the threshold again)
             connected = false
-            delay(50 * 5) // only 5 cycles, below threshold of 12
-
-            coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
-            iosService.stopMonitoring()
-        }
-
-    @Test
-    fun `iOS uses triggerReconnect before reaching threshold`() =
-        runBlocking {
-            val iosService = createIosService()
-            every { webSocketClientService.isConnected() } returns false
-            coEvery { webSocketClientService.triggerReconnect() } just Runs
-            coEvery { webSocketClientService.forceClientRecreation() } just Runs
-
-            iosService.activate()
-            iosService.startMonitoring(period = 50, startDelay = 0)
-            // Only run a few cycles, below threshold
             delay(50 * 5)
 
-            coVerify(atLeast = 1) { webSocketClientService.triggerReconnect() }
             coVerify(exactly = 0) { webSocketClientService.forceClientRecreation() }
-            iosService.stopMonitoring()
         }
 
     @Test

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.client.common.domain.service.network
 
 import io.mockk.Runs
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -57,6 +58,12 @@ class ClientConnectivityServiceTest {
         object : PlatformInfo {
             override val name = "Android Test"
             override val type = PlatformType.ANDROID
+        }
+
+    private val iosPlatformInfo =
+        object : PlatformInfo {
+            override val name = "iOS Test"
+            override val type = PlatformType.IOS
         }
 
     private class TestClientConnectivityService(
@@ -548,12 +555,37 @@ class ClientConnectivityServiceTest {
     @Test
     fun `calls forceClientRecreation after threshold disconnected cycles`() =
         runBlocking {
-            every { webSocketClientService.isConnected() } returns false
-            coEvery { webSocketClientService.triggerReconnect() } just Runs
+            // Both platforms share the same threshold today; exercise each when-branch.
+            for (platform in listOf(androidPlatformInfo, iosPlatformInfo)) {
+                clearMocks(webSocketClientService)
+                every { webSocketClientService.isConnected() } returns false
+                every { webSocketClientService.failedSubscriptionTopics } returns MutableStateFlow(emptySet())
+                coEvery { webSocketClientService.triggerReconnect() } just Runs
+                coEvery { webSocketClientService.forceClientRecreation() } just Runs
+
+                val service = ClientConnectivityService(webSocketClientService, platform)
+                try {
+                    service.activate()
+                    // Threshold is 12 cycles on both platforms; use a short period to hit it quickly.
+                    service.startMonitoring(period = 50, startDelay = 0)
+                    delay(50 * 15)
+
+                    coVerify(atLeast = 1) { webSocketClientService.forceClientRecreation() }
+                } finally {
+                    service.stopMonitoring()
+                }
+            }
+        }
+
+    @Test
+    fun `calls forceClientRecreation after threshold untrusted health check failures`() =
+        runBlocking {
+            every { webSocketClientService.isConnected() } returns true
+            coEvery { webSocketClientService.sendHealthCheck() } returns false
+            coEvery { webSocketClientService.forceReconnect() } just Runs
             coEvery { webSocketClientService.forceClientRecreation() } just Runs
 
             clientConnectivityService.activate()
-            // Threshold is 12 cycles on both platforms; use a short period to hit it quickly.
             clientConnectivityService.startMonitoring(period = 50, startDelay = 0)
             delay(50 * 15)
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
@@ -28,6 +28,7 @@ import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSett
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
 import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.domain.utils.DateUtils
 import org.junit.After
 import org.junit.Before
@@ -813,6 +814,54 @@ class WebSocketClientServiceTest {
 
             coVerify { httpClientService.disposeClient() }
             assertEquals(emptySet(), webSocketClientService.failedSubscriptionTopics.first())
+        }
+
+    @Test
+    fun `forceClientRecreation signals NEWNYM when using Tor proxy`() =
+        runTest(testDispatcher) {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            coEvery { kmpTorService.signalNewNym() } just Runs
+
+            val torWebSocketClientService =
+                WebSocketClientService(
+                    defaultHost = "abc.onion",
+                    defaultPort = 8090,
+                    httpClientService = httpClientService,
+                    webSocketClientFactory = webSocketClientFactory,
+                    sessionService = sessionService,
+                    sensitiveSettingsRepository = sensitiveSettingsRepository,
+                    kmpTorService = kmpTorService,
+                )
+
+            val connectedStateFlow = MutableStateFlow<ConnectionState>(ConnectionState.Connected)
+            val mockWsClient = mockk<WebSocketClient>(relaxed = true)
+            every { mockWsClient.webSocketClientStatus } returns connectedStateFlow
+            every { mockWsClient.apiUrl } returns
+                mockk {
+                    every { host } returns "abc.onion"
+                }
+            every { webSocketClientFactory.createNewClient(any(), any(), any(), any()) } returns mockWsClient
+
+            torWebSocketClientService.activate()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            httpClientChangedFlow.emit(
+                HttpClientSettings(
+                    bisqApiUrl = "http://abc.onion:8090",
+                    tlsFingerprint = null,
+                    clientId = "client-id",
+                    sessionId = "session-id",
+                    sessionExpiresAt = Long.MAX_VALUE,
+                    externalProxyUrl = "127.0.0.1:9050",
+                    isTorProxy = true,
+                ),
+            )
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            torWebSocketClientService.forceClientRecreation()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify { kmpTorService.signalNewNym() }
         }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -318,6 +318,7 @@ val clientDomainModule =
                 get(),
                 get(),
                 get(),
+                kmpTorService = get(),
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
@@ -264,10 +264,11 @@ open class ClientConnectivityService(
     }
 
     private fun shouldForceClientRecreation(): Boolean =
-        consecutiveReconnectingCycles >= when (platformInfo.type) {
-            PlatformType.IOS -> IOS_FORCE_RECREATE_CYCLES
-            PlatformType.ANDROID -> ANDROID_FORCE_RECREATE_CYCLES
-        }
+        consecutiveReconnectingCycles >=
+            when (platformInfo.type) {
+                PlatformType.IOS -> IOS_FORCE_RECREATE_CYCLES
+                PlatformType.ANDROID -> ANDROID_FORCE_RECREATE_CYCLES
+            }
 
     /**
      * Sends a lightweight health check request to verify the server is responsive.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
@@ -39,6 +39,7 @@ open class ClientConnectivityService(
         // permanently keep status at REQUESTING_INVENTORY on Tor connections.
         const val ROUND_TRIP_SLOW_THRESHOLD_TOR = 3000L
         internal const val IOS_FORCE_RECREATE_CYCLES = 12 // ~60s at default 5s period
+        internal const val ANDROID_FORCE_RECREATE_CYCLES = 12 // ~60s at default 5s period
 
         private const val DEFAULT_AVERAGE_TRIP_TIME = -1L // invalid
         const val MIN_REQUESTS_TO_ASSESS_SPEED = 3 // invalid
@@ -169,7 +170,7 @@ open class ClientConnectivityService(
                             consecutiveReconnectingCycles++
                             log.d { "Not connected, consecutiveReconnectingCycles=$consecutiveReconnectingCycles" }
                             if (shouldForceClientRecreation()) {
-                                log.i { "iOS: forcing client recreation after $consecutiveReconnectingCycles failed cycles" }
+                                log.i { "Forcing client recreation after $consecutiveReconnectingCycles failed cycles (platform=${platformInfo.type})" }
                                 webSocketClientService.forceClientRecreation()
                                 consecutiveReconnectingCycles = 0
                             } else {
@@ -197,7 +198,7 @@ open class ClientConnectivityService(
                                 consecutiveReconnectingCycles++
                                 log.d { "Untrusted connection health check failed, consecutiveReconnectingCycles=$consecutiveReconnectingCycles" }
                                 if (shouldForceClientRecreation()) {
-                                    log.i { "iOS: forcing client recreation after $consecutiveReconnectingCycles failed untrusted cycles" }
+                                    log.i { "Forcing client recreation after $consecutiveReconnectingCycles failed untrusted cycles (platform=${platformInfo.type})" }
                                     webSocketClientService.forceClientRecreation()
                                     consecutiveReconnectingCycles = 0
                                 } else {
@@ -263,8 +264,10 @@ open class ClientConnectivityService(
     }
 
     private fun shouldForceClientRecreation(): Boolean =
-        platformInfo.type == PlatformType.IOS &&
-            consecutiveReconnectingCycles >= IOS_FORCE_RECREATE_CYCLES
+        consecutiveReconnectingCycles >= when (platformInfo.type) {
+            PlatformType.IOS -> IOS_FORCE_RECREATE_CYCLES
+            PlatformType.ANDROID -> ANDROID_FORCE_RECREATE_CYCLES
+        }
 
     /**
      * Sends a lightweight health check request to verify the server is responsive.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
@@ -16,6 +16,7 @@ Source of truth is the code. Update this file whenever connectivity behaviour ch
 | `websocket/WebSocketClientImpl.kt` | Connect, listen, request/response, reconnect backoff |
 | `websocket/WebSocketClient.kt` | Connect timeouts: 15s clearnet / 60s `.onion` |
 | `service/network/ClientConnectivityService.kt` | Health polling, derives raw status, calls `setConnectivityStatus()` |
+| `data/.../KmpTorService.kt` | Tor runtime; `signalNewNym()` on force recreation (Tor proxy only) |
 | `data/.../ConnectivityService.kt` | Shared `ConnectivityStatus` enum, `setConnectivityStatus()`, RECONNECTING timeout |
 
 ```text
@@ -94,11 +95,11 @@ checkConnectivity() loop
         ├─ !isConnected() OR connectionUntrusted
         │       ├─ !isConnected()
         │       │       ├─ triggerReconnect() if not already connected at WCS layer
-        │       │       └─ iOS: 12 consecutive cycles ──► forceClientRecreation()
+        │       │       └─ 12 consecutive cycles ──► forceClientRecreation()
         │       │
         │       └─ isConnected() but untrusted (prior health check failed)
         │               ├─ health check pass ──► restore trust, derive status
-        │               └─ health check fail ──► forceReconnect(); iOS may forceClientRecreation()
+        │               └─ health check fail ──► forceReconnect(); may forceClientRecreation()
         │
         └─ connected and trusted
                 ├─ health check pass ──► derive status
@@ -152,7 +153,7 @@ After timeout, health polls may still compute `rawStatus = RECONNECTING`, but `s
 
 ---
 
-## Flow 3 — Reconnect & iOS force recreation
+## Flow 3 — Reconnect & force recreation
 
 ```text
 reconnect()  [CCS triggerReconnect/forceReconnect | WCS on abnormal disconnect]
@@ -173,9 +174,10 @@ connect(min(determineTimeout(host), 30s))   // 30s cap even for 60s Tor hosts
 
 WCS triggerReconnect(): only calls reconnect() when WCS reports not connected.
 
-iOS forceClientRecreation() (CCS after 12 failed cycles):
+forceClientRecreation() (CCS after 12 failed cycles, iOS + Android):
         dispose WS ──► cancel state collector ──► HttpClientService.recreateClient()
-        ──► httpClientChangedFlow ──► updateWebSocketClient() ──► new client + connect()
+        ├─ Tor proxy ──► KmpTorService.signalNewNym() (fresh circuits)
+        └─► httpClientChangedFlow ──► updateWebSocketClient() ──► new client + connect()
 ```
 
 Constants (`WebSocketClientImpl`): `STALE_RECONNECT_THRESHOLD_MS` = 30s; `MAX_RECONNECT_ATTEMPTS` = 5; `RECONNECT_CONNECT_TIMEOUT` = 30s.
@@ -222,6 +224,6 @@ Bootstrap session POST also persists `sessionExpiresAt` (same as renewal).
 | | Android (OkHttp) | iOS (Darwin) |
 |--|------------------|--------------|
 | Dead TCP detection | More reliable | Often needs health checks |
-| Stuck reconnect recovery | `triggerReconnect` / backoff | + `forceClientRecreation()` after 12×5s failures |
+| Stuck reconnect recovery | `triggerReconnect` / backoff + `forceClientRecreation()` after 12×5s | same |
 | Tor SOCKS in settings | `127.0.0.1:port` as configured | `127.0.0.1` normalized to `localhost` in `HttpClientSettings` |
 | HTTP client hard reset | `disposeClient()` / settings-driven recreate | `recreateClient()` closes and re-emits settings |

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.sync.withLock
 import network.bisq.mobile.client.common.domain.access.session.SessionService
 import network.bisq.mobile.client.common.domain.access.session.SessionValidity
 import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
-import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.client.common.domain.httpclient.HttpClientSettings
 import network.bisq.mobile.client.common.domain.httpclient.exception.UnauthorizedApiAccessException
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
@@ -41,6 +40,7 @@ import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.utils.getPlatformInfo
 import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.utils.DateUtils

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -571,10 +571,10 @@ class WebSocketClientService(
             // Must release clientUpdateMutex first since updateWebSocketClient acquires it
         }
         // Call outside the lock since updateWebSocketClient acquires clientUpdateMutex
-        httpClientService.recreateClient()
         if (isTorProxy) {
             kmpTorService?.signalNewNym()
         }
+        httpClientService.recreateClient()
     }
 
     /**

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.sync.withLock
 import network.bisq.mobile.client.common.domain.access.session.SessionService
 import network.bisq.mobile.client.common.domain.access.session.SessionValidity
 import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
+import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.client.common.domain.httpclient.HttpClientSettings
 import network.bisq.mobile.client.common.domain.httpclient.exception.UnauthorizedApiAccessException
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
@@ -66,6 +67,7 @@ class WebSocketClientService(
     private val webSocketClientFactory: WebSocketClientFactory,
     private val sessionService: SessionService? = null,
     private val sensitiveSettingsRepository: SensitiveSettingsRepository? = null,
+    private val kmpTorService: KmpTorService? = null,
 ) : ServiceFacade(),
     Logging {
     companion object {
@@ -570,6 +572,9 @@ class WebSocketClientService(
         }
         // Call outside the lock since updateWebSocketClient acquires clientUpdateMutex
         httpClientService.recreateClient()
+        if (isTorProxy) {
+            kmpTorService?.signalNewNym()
+        }
     }
 
     /**

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -551,7 +551,7 @@ class WebSocketClientService(
     internal suspend fun forceClientRecreation() {
         clientUpdateMutex.withLock {
             val settings = currentClientSettings ?: return@withLock
-            log.i { "Forcing full client recreation to recover stale iOS NSURLSession" }
+            log.i { "Forcing full client recreation to recover stale HTTP client state / iOS NSURLSession" }
             // Dispose current client and clear settings so updateWebSocketClient
             // treats the next call as a fresh configuration
             currentClient.value?.dispose()

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceSignalNewNymTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceSignalNewNymTest.kt
@@ -1,0 +1,73 @@
+package network.bisq.mobile.data.service.network
+
+import io.matthewnelson.kmp.tor.runtime.TorRuntime
+import io.matthewnelson.kmp.tor.runtime.core.ctrl.Reply
+import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
+import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.After
+import org.junit.Test
+import java.nio.file.Files
+
+class KmpTorServiceSignalNewNymTest {
+    @After
+    fun tearDown() {
+        unmockkStatic(TOR_CMD_UTIL_JVM)
+    }
+
+    private fun createService(): KmpTorService {
+        val root = Files.createTempDirectory("kmpTorSignalNewNym").toFile().apply { deleteOnExit() }
+        return KmpTorService(root.absolutePath.toPath())
+    }
+
+    private fun setTorRuntime(
+        service: KmpTorService,
+        runtime: TorRuntime?,
+    ) {
+        val field =
+            KmpTorService::class.java.getDeclaredField("torRuntime").apply {
+                isAccessible = true
+            }
+        field.set(service, runtime)
+    }
+
+    @Test
+    fun `signalNewNym is no-op when tor runtime is not started`() =
+        runTest {
+            createService().signalNewNym()
+        }
+
+    @Test
+    fun `signalNewNym sends NEWNYM when tor runtime is available`() =
+        runTest {
+            mockkStatic(TOR_CMD_UTIL_JVM)
+            val mockRuntime = mockk<TorRuntime>()
+            coEvery { mockRuntime.executeAsync(TorCmd.Signal.NewNym) } returns Reply.Success.OK
+
+            val service = createService()
+            setTorRuntime(service, mockRuntime)
+            service.signalNewNym()
+        }
+
+    @Test
+    fun `signalNewNym swallows exceptions from tor runtime`() =
+        runTest {
+            mockkStatic(TOR_CMD_UTIL_JVM)
+            val mockRuntime = mockk<TorRuntime>()
+            coEvery { mockRuntime.executeAsync(TorCmd.Signal.NewNym) } throws RuntimeException("rate limited")
+
+            val service = createService()
+            setTorRuntime(service, mockRuntime)
+            service.signalNewNym()
+        }
+
+    private companion object {
+        // @file:JvmName("TorCmdUtil") on kmp-tor's executeAsync extensions
+        const val TOR_CMD_UTIL_JVM = "io.matthewnelson.kmp.tor.runtime.core.util.TorCmdUtil"
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceSignalNewNymTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceSignalNewNymTest.kt
@@ -5,6 +5,7 @@ import io.matthewnelson.kmp.tor.runtime.core.ctrl.Reply
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
@@ -52,6 +53,7 @@ class KmpTorServiceSignalNewNymTest {
             val service = createService()
             setTorRuntime(service, mockRuntime)
             service.signalNewNym()
+            coVerify(exactly = 1) { mockRuntime.executeAsync(TorCmd.Signal.NewNym) }
         }
 
     @Test
@@ -64,6 +66,7 @@ class KmpTorServiceSignalNewNymTest {
             val service = createService()
             setTorRuntime(service, mockRuntime)
             service.signalNewNym()
+            coVerify(exactly = 1) { mockRuntime.executeAsync(TorCmd.Signal.NewNym) }
         }
 
     private companion object {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -9,6 +9,8 @@ import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
 import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
+import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
+import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -185,6 +187,23 @@ class KmpTorService(
             _socksPort.filterNotNull(),
             _state.filter { it is TorState.Stopped },
         )
+
+    /**
+     * Sends a NEWNYM signal to Tor, requesting fresh circuits for all subsequent
+     * connections. This is a no-op if Tor is not running or the signal fails.
+     *
+     * Tor enforces a 10-second rate limit on NEWNYM; if called more often it
+     * silently returns RATE_LIMITED, which is harmless.
+     */
+    suspend fun signalNewNym() {
+        val runtime = torRuntime ?: return
+        try {
+            runtime.executeAsync(TorCmd.Signal.NewNym)
+            log.i { "NEWNYM signal sent — Tor will use fresh circuits" }
+        } catch (e: Exception) {
+            log.w(e) { "NEWNYM signal failed" }
+        }
+    }
 
     suspend fun stopTor(reason: Throwable? = null) {
         startDefer?.cancel()


### PR DESCRIPTION
PR4 of breaking down of https://github.com/bisq-network/bisq-mobile/pull/1445 into small chunks.

1. Android OkHttp doesn't have a zombie connections/session as with iOS's NSURLSession. Verified the same by adding logs to OkHttp, as well. But still I guess, it got some stale states which disturb later connects. Force recreating the HttpClient in android, reduces many failed re-connect attempts. So now made forceClientRecreation for both android and ios.
OkHttp logging code @ https://github.com/nostrbuddha/bisq-mobile/tree/okhttp_logging. But didn't add this code as part of PR, as it bloats the code

2. Immediately on force recreation with Tor active, send Tor `NEWNYM` via new `KmpTorService.signalNewNym()` so subsequent connections use fresh circuits. This almost eliminates all re-connect attempts that take like ~200s. Most connect now happen <60. In some rounds, it goes upto 100s max.

This holds for ~15 rounds of bisq2 node disconnect / reconnect, after which the failure to connect happens.

Sample run of 12 disconnect / reconnect rounds:

round | t1_bisq_initialized | t2_android_ws | t2_ios_ws | android_duration_seconds | ios_duration_seconds | status
-- | -- | -- | -- | -- | -- | --
1 | 2026-06-11 13:02:45 | 2026-06-11 13:03:31 | 2026-06-11 13:03:36 | 46 | 51 | success
2 | 2026-06-11 13:06:19 | 2026-06-11 13:07:16 | 2026-06-11 13:07:10 | 57 | 51 | success
3 | 2026-06-11 13:09:20 | 2026-06-11 13:10:42 | 2026-06-11 13:10:28 | 82 | 68 | success
4 | 2026-06-11 13:13:13 | 2026-06-11 13:13:26 | 2026-06-11 13:13:45 | 13 | 32 | success
5 | 2026-06-11 13:15:49 | 2026-06-11 13:16:22 | 2026-06-11 13:16:24 | 33 | 35 | success
6 | 2026-06-11 13:18:34 | 2026-06-11 13:19:27 | 2026-06-11 13:19:50 | 53 | 76 | success
7 | 2026-06-11 13:21:46 | 2026-06-11 13:23:03 | 2026-06-11 13:22:50 | 77 | 64 | success
8 | 2026-06-11 13:25:24 | 2026-06-11 13:26:30 | 2026-06-11 13:26:28 | 66 | 64 | success
9 | 2026-06-11 13:28:32 | 2026-06-11 13:29:31 | 2026-06-11 13:29:18 | 59 | 46 | success
10 | 2026-06-11 13:31:42 | 2026-06-11 13:32:37 | 2026-06-11 13:32:26 | 55 | 44 | success
11 | 2026-06-11 13:34:51 | 2026-06-11 13:35:23 | 2026-06-11 13:35:41 | 32 | 50 | success
12 | 2026-06-11 13:37:59 | 2026-06-11 13:38:25 | 2026-06-11 13:38:30 | 26 | 31 | success

This can be compared with re-connect times before @ 
https://github.com/bisq-network/bisq-mobile/pull/1459#issue-4580410917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cross-platform connectivity recovery with unified force-recreation behavior
  * Enhanced Tor proxy integration with new signal handling for connection recovery

* **Tests**
  * Added comprehensive connectivity recovery test coverage across platforms
  * Added Tor proxy signal behavior validation

* **Documentation**
  * Updated connectivity documentation to reflect recovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->