### PR TITLE
Fix slow network banner dismiss on Tor startup

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -1,0 +1,162 @@
+package network.bisq.mobile.client.common.domain.service.offers
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.ConnectionState
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
+import network.bisq.mobile.client.common.test_utils.KoinIntegrationTestBase
+import network.bisq.mobile.data.model.offerbook.MarketListItem
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
+    private val marketPriceServiceFacade =
+        object : MarketPriceServiceFacade(mockk(relaxed = true)) {
+            override fun findMarketPriceItem(marketVO: MarketVO) = null
+
+            override fun findUSDMarketPriceItem() = null
+
+            override fun refreshSelectedFormattedMarketPrice() {}
+
+            override fun selectMarket(marketListItem: MarketListItem) = Result.success(Unit)
+        }
+    private val apiGateway: OfferbookApiGateway = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+    private lateinit var facade: ClientOffersServiceFacade
+
+    private val usdMarket = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
+
+    override fun onSetup() {
+        every { webSocketClientService.connectionState } returns connectionState
+        facade =
+            ClientOffersServiceFacade(
+                marketPriceServiceFacade = marketPriceServiceFacade,
+                apiGateway = apiGateway,
+                json = json,
+                webSocketClientService = webSocketClientService,
+            )
+    }
+
+    @Test
+    fun `activate subscribes to num offers`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+
+            coVerify { apiGateway.subscribeNumOffers() }
+        }
+
+    @Test
+    fun `activate tolerates num offers subscription failure`() =
+        runTest {
+            coEvery { apiGateway.subscribeNumOffers() } throws RuntimeException("subscribe failed")
+
+            facade.activate()
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `num offers websocket event updates market list`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.getMarkets() } returns Result.success(listOf(usdMarket))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Connected
+            waitUntil { facade.offerbookMarketItems.value.isNotEmpty() }
+
+            numOffersObserver.setEvent(numOffersEvent("""{"USD": 5}"""))
+            advanceUntilIdle()
+
+            assertEquals(
+                5,
+                facade.offerbookMarketItems.value
+                    .single()
+                    .numOffers,
+            )
+        }
+
+    @Test
+    fun `cached num offers replayed when markets load after websocket snapshot`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.getMarkets() } returns Result.success(listOf(usdMarket))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            numOffersObserver.setEvent(numOffersEvent("""{"USD": 7}"""))
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Connected
+            waitUntil { facade.offerbookMarketItems.value.isNotEmpty() }
+
+            assertEquals(
+                7,
+                facade.offerbookMarketItems.value
+                    .single()
+                    .numOffers,
+            )
+        }
+
+    @Test
+    fun `deactivate clears offerbook markets`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+            numOffersObserver.setEvent(numOffersEvent("""{"USD": 3}"""))
+            advanceUntilIdle()
+
+            facade.deactivate()
+            advanceUntilIdle()
+
+            assertTrue(facade.offerbookMarketItems.value.isEmpty())
+        }
+
+    private fun numOffersEvent(payload: String) =
+        WebSocketEvent(
+            topic = Topic.NUM_OFFERS,
+            subscriberId = "num-offers-test",
+            deferredPayload = payload,
+            modificationType = ModificationType.REPLACE,
+            sequenceNumber = 1,
+        )
+
+    private fun waitUntil(
+        timeoutMs: Long = 2_000L,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "Timed out waiting for condition" }
+            Thread.sleep(5)
+        }
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -686,6 +687,65 @@ class WebSocketClientServiceTest {
 
             assertEquals(setOf(Topic.MARKET_PRICE), webSocketClientService.failedSubscriptionTopics.first())
             assertFalse(webSocketClientService.isSubscriptionsPending.first())
+        }
+
+    @Test
+    fun `applySubscriptions subscribes banner-critical topics before other topics`() =
+        runTest(testDispatcher) {
+            val connectedStateFlow = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+            val mockWsClient = mockk<WebSocketClient>(relaxed = true)
+            every { mockWsClient.webSocketClientStatus } returns connectedStateFlow
+            every { mockWsClient.apiUrl } returns
+                mockk {
+                    every { host } returns "localhost"
+                }
+            val subscribeOrder = mutableListOf<Topic>()
+            coEvery { mockWsClient.subscribe(any(), any(), any()) } coAnswers {
+                subscribeOrder.add(firstArg())
+                thirdArg()
+            }
+            every { webSocketClientFactory.createNewClient(any(), any(), any(), any()) } returns mockWsClient
+
+            webSocketClientService.activate()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            httpClientChangedFlow.emit(
+                HttpClientSettings(
+                    bisqApiUrl = "http://localhost:8080",
+                    tlsFingerprint = null,
+                    clientId = "client-id",
+                    sessionId = "session-id",
+                    sessionExpiresAt = Long.MAX_VALUE,
+                ),
+            )
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            webSocketClientService.subscribe(Topic.CLOSED_TRADES)
+            webSocketClientService.subscribe(Topic.TRADES)
+            webSocketClientService.subscribe(Topic.NUM_OFFERS)
+            webSocketClientService.subscribe(Topic.NUM_USER_PROFILES)
+            webSocketClientService.subscribe(Topic.MARKET_PRICE)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            connectedStateFlow.value = ConnectionState.Connected
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                listOf(
+                    Topic.MARKET_PRICE,
+                    Topic.NUM_USER_PROFILES,
+                    Topic.NUM_OFFERS,
+                    Topic.CLOSED_TRADES,
+                    Topic.TRADES,
+                ),
+                subscribeOrder,
+            )
+            val bannerEndIndex = subscribeOrder.indexOf(Topic.NUM_OFFERS)
+            val slowTopicStartIndex = subscribeOrder.indexOf(Topic.CLOSED_TRADES)
+            assertTrue(
+                bannerEndIndex in 0 until slowTopicStartIndex,
+                "Banner topics must be subscribed before CLOSED_TRADES, got order=$subscribeOrder",
+            )
         }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -14,6 +14,7 @@ import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.model.offerbook.OfferbookMarket
@@ -25,6 +26,7 @@ import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPrese
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OfferFormattingUtil
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
+import kotlin.concurrent.Volatile
 
 class ClientOffersServiceFacade(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
@@ -47,16 +49,22 @@ class ClientOffersServiceFacade(
 
     private var getMarketsJob: Job? = null
 
+    /** Latest NUM_OFFERS payload; replayed when [fillMarketListItems] runs after an early WS snapshot. */
+    @Volatile
+    private var cachedNumOffersByMarketCode: Map<String, Int>? = null
+
     // Life cycle
     override suspend fun activate() {
         super<OffersServiceFacade>.activate()
 
         observeMarketPrice()
         observeAvailableMarkets()
+        observeNumOffers()
     }
 
     override suspend fun deactivate() {
         _offerbookMarketItems.value = emptyList()
+        cachedNumOffersByMarketCode = null
         hasSubscribedToOffers.value = false
         super<OffersServiceFacade>.deactivate()
     }
@@ -149,7 +157,6 @@ class ClientOffersServiceFacade(
                                 } else {
                                     val markets = result.getOrThrow()
                                     fillMarketListItems(markets)
-                                    subscribeNumOffers()
                                     getMarketsJob?.cancel() // we only need this once
                                 }
                             }
@@ -175,8 +182,17 @@ class ClientOffersServiceFacade(
         }
     }
 
-    private suspend fun subscribeNumOffers() {
-        val observer = apiGateway.subscribeNumOffers()
+    private fun observeNumOffers() {
+        serviceScope.launch {
+            try {
+                collectNumOffers(apiGateway.subscribeNumOffers())
+            } catch (e: Exception) {
+                log.e(e) { "Failed to subscribe to numOffers" }
+            }
+        }
+    }
+
+    private suspend fun collectNumOffers(observer: WebSocketEventObserver) {
         observer.webSocketEvent.collect { webSocketEvent ->
             if (webSocketEvent?.deferredPayload == null) {
                 return@collect
@@ -189,13 +205,9 @@ class ClientOffersServiceFacade(
                         webSocketEvent,
                     )
                 val numOffersByMarketCode = webSocketEventPayload.payload
-
+                cachedNumOffersByMarketCode = numOffersByMarketCode
                 _offerbookMarketItems.update { list ->
-                    list.map { marketListItem ->
-                        numOffersByMarketCode[marketListItem.market.quoteCurrencyCode]
-                            ?.let { marketListItem.copy(numOffers = it) }
-                            ?: marketListItem
-                    }
+                    applyNumOffersToMarketList(list, numOffersByMarketCode)
                 }
             } catch (e: Exception) {
                 log.e(e) { "Error processing numOffers WebSocket event" }
@@ -345,11 +357,23 @@ class ClientOffersServiceFacade(
     }
 
     private fun fillMarketListItems(markets: List<network.bisq.mobile.data.replicated.common.currency.MarketVO>) {
+        val numOffersByMarketCode = cachedNumOffersByMarketCode
         val marketListItems =
             markets.map { marketVO ->
-                MarketListItem.from(marketVO)
+                val numOffers = numOffersByMarketCode?.get(marketVO.quoteCurrencyCode) ?: 0
+                MarketListItem.from(marketVO, numOffers)
             }
 
         _offerbookMarketItems.value = marketListItems
     }
+
+    private fun applyNumOffersToMarketList(
+        list: List<MarketListItem>,
+        numOffersByMarketCode: Map<String, Int>,
+    ): List<MarketListItem> =
+        list.map { marketListItem ->
+            numOffersByMarketCode[marketListItem.market.quoteCurrencyCode]
+                ?.let { marketListItem.copy(numOffers = it) }
+                ?: marketListItem
+        }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -73,13 +73,16 @@ class WebSocketClientService(
     companion object {
         private const val SESSION_RENEWAL_COOLDOWN_MS = 30_000L
 
-        // Initial subscriptions tracked for network banner:
-        private val initialSubscriptionTypes =
-            setOf(
+        // Banner-critical subscriptions — applied first so the network banner can dismiss early.
+        private val bannerSubscriptionPriorityOrder =
+            listOf(
                 SubscriptionType(Topic.MARKET_PRICE, null),
                 SubscriptionType(Topic.NUM_USER_PROFILES, null),
                 SubscriptionType(Topic.NUM_OFFERS, null),
             )
+
+        // Initial subscriptions tracked for network banner:
+        private val initialSubscriptionTypes = bannerSubscriptionPriorityOrder.toSet()
     }
 
     @Volatile
@@ -491,7 +494,7 @@ class WebSocketClientService(
             }
             val subs = requestedSubscriptions.value
             log.d { "applying subscriptions on WS client, entry count: ${subs.size}" }
-            subs.forEach { entry ->
+            subscriptionEntriesInApplyOrder(subs).forEach { entry ->
                 try {
                     entry.value.resetSequence()
                     client.subscribe(
@@ -510,6 +513,20 @@ class WebSocketClientService(
             }
             subscriptionsAreApplied = true
         }
+    }
+
+    private fun subscriptionEntriesInApplyOrder(
+        subs: Map<SubscriptionType, WebSocketEventObserver>,
+    ): List<Map.Entry<SubscriptionType, WebSocketEventObserver>> {
+        val prioritized =
+            bannerSubscriptionPriorityOrder.mapNotNull { type ->
+                subs.entries.find { it.key == type }
+            }
+        val rest =
+            subs.entries.filter { entry ->
+                entry.key !in initialSubscriptionTypes
+            }
+        return prioritized + rest
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1466

 - Prioritize banner-critical WebSocket subscriptions
 - subscribe NUM_OFFERS at activate with cached replay into the market list

With these changes, the banner is not even appearing as MARKET_PRICE, NUM_USER_PROFILES and NUM_OFFERS, are fetched before Dashboard is shown.

Note:
This should be merged after https://github.com/bisq-network/bisq-mobile/pull/1482, since that PR resolves reconnect issues (especially with android)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market list now shows per-market offer counts immediately after initial snapshot via a cached num-offers map; lifecycle starts/stops observation on activate/deactivate.

* **Bug Fixes**
  * Banner-critical notification subscriptions are applied before other subscriptions to ensure high-priority alerts arrive first.

* **Tests**
  * Added tests verifying subscription ordering, num-offers handling, replay of cached events, and lifecycle clearing of market data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->