### PR TITLE
fix: Show reconnecting overlay in client app during reconnection

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -204,6 +204,24 @@ class ClientMainPresenterTest {
         }
 
     @Test
+    fun `when disconnected without prior reconnecting then hides connection lost dialog`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+
+            statusFlow.value = ConnectivityService.ConnectivityStatus.DISCONNECTED
+            advanceUntilIdle()
+
+            assertFalse(presenter.showReconnectOverlay.value)
+            assertFalse(presenter.showAllConnectionsLostDialogue.value)
+        }
+
+    @Test
     fun `when disconnected after prolonged reconnecting then shows connection lost dialog`() =
         runTest(testDispatcher) {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.data.model.TradeReadStateMap
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
+import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
@@ -35,6 +36,9 @@ import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ClientMainPresenterTest {
@@ -61,6 +65,7 @@ class ClientMainPresenterTest {
         connectivityService = mockk(relaxed = true)
         networkServiceFacade = mockk(relaxed = true)
         every { connectivityService.clientRevoked } returns MutableStateFlow(false)
+        every { connectivityService.status } returns MutableStateFlow(ConnectivityService.ConnectivityStatus.BOOTSTRAPPING)
         settingsServiceFacade = mockk(relaxed = true)
         tradesServiceFacade = mockk(relaxed = true)
         userProfileServiceFacade = mockk(relaxed = true)
@@ -147,4 +152,82 @@ class ClientMainPresenterTest {
 
             verify(exactly = 1) { connectivityService.stopMonitoring() }
         }
+
+    @Test
+    fun `when reconnecting and main content visible then shows reconnect overlay`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+
+            statusFlow.value = ConnectivityService.ConnectivityStatus.RECONNECTING
+            advanceUntilIdle()
+
+            assertTrue(presenter.showReconnectOverlay.value)
+            assertFalse(presenter.showAllConnectionsLostDialogue.value)
+        }
+
+    @Test
+    fun `when reconnecting before main content visible then hides reconnect overlay`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            assertFalse(presenter.showReconnectOverlay.value)
+        }
+
+    @Test
+    fun `when reconnection succeeds then hides reconnect overlay`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+
+            assertTrue(presenter.showReconnectOverlay.value)
+
+            statusFlow.value = ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED
+            advanceUntilIdle()
+
+            assertFalse(presenter.showReconnectOverlay.value)
+        }
+
+    @Test
+    fun `when disconnected after prolonged reconnecting then shows connection lost dialog`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+
+            statusFlow.value = ConnectivityService.ConnectivityStatus.DISCONNECTED
+            advanceUntilIdle()
+
+            assertFalse(presenter.showReconnectOverlay.value)
+            assertTrue(presenter.showAllConnectionsLostDialogue.value)
+        }
+
+    @Test
+    fun `uses client specific reconnect overlay copy keys`() {
+        val presenter = createPresenter()
+
+        assertEquals("mobile.connectivity.reconnecting.client.info", presenter.reconnectOverlayInfoKey)
+        assertEquals("mobile.connectivity.reconnecting.client.details", presenter.reconnectOverlayDetailsKey)
+        assertEquals("mobile.connectivity.disconnected.client.title", presenter.connectionsLostDialogTitleKey)
+        assertEquals("mobile.connectivity.disconnected.client.message", presenter.connectionsLostDialogMessageKey)
+    }
 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -239,6 +239,72 @@ class ClientMainPresenterTest {
             assertTrue(presenter.showAllConnectionsLostDialogue.value)
         }
 
+    /**
+     * Guards against a regression where a brief intermediate CONNECTED state (e.g.
+     * RECONNECTING → CONNECTED_AND_DATA_RECEIVED → DISCONNECTED) would incorrectly
+     * trigger the "connection lost" dialog. The previous-status tracking must reset
+     * once we hit a connected state, so a subsequent DISCONNECTED is treated as a
+     * fresh disconnect — NOT a post-reconnect-timeout transition.
+     */
+    @Test
+    fun `disconnected after intermediate connected state does not show lost dialog`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+            assertTrue(presenter.showReconnectOverlay.value)
+
+            // Reconnect briefly succeeds — the prior RECONNECTING cycle is now over.
+            statusFlow.value = ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED
+            advanceUntilIdle()
+            assertFalse(presenter.showReconnectOverlay.value)
+
+            // A new, distinct disconnect — NOT a timeout from the prior cycle.
+            statusFlow.value = ConnectivityService.ConnectivityStatus.DISCONNECTED
+            advanceUntilIdle()
+
+            assertFalse(presenter.showReconnectOverlay.value)
+            assertFalse(
+                presenter.showAllConnectionsLostDialogue.value,
+                "dialog must NOT show for a disconnect that did not directly follow RECONNECTING",
+            )
+        }
+
+    /**
+     * Backgrounding the app during a reconnect should hide the overlay (no foreground
+     * UI to show it on), and foregrounding again while still RECONNECTING should bring
+     * the overlay back. The previous-status tracking resets when main goes hidden,
+     * so the re-emerged RECONNECTING is treated as a fresh transition (not a stale one).
+     */
+    @Test
+    fun `mainVisible toggling during reconnecting keeps overlay in sync with status`() =
+        runTest(testDispatcher) {
+            val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
+            every { connectivityService.status } returns statusFlow
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+            assertTrue(presenter.showReconnectOverlay.value)
+
+            // App backgrounded — overlay hidden.
+            presenter.setIsMainContentVisible(false)
+            advanceUntilIdle()
+            assertFalse(presenter.showReconnectOverlay.value)
+            assertFalse(presenter.showAllConnectionsLostDialogue.value)
+
+            // App foregrounded again while reconnect is still in progress — overlay returns.
+            presenter.setIsMainContentVisible(true)
+            advanceUntilIdle()
+            assertTrue(presenter.showReconnectOverlay.value)
+            assertFalse(presenter.showAllConnectionsLostDialogue.value)
+        }
+
     @Test
     fun `uses client specific reconnect overlay copy keys`() {
         val presenter = createPresenter()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
@@ -1,11 +1,13 @@
 package network.bisq.mobile.client.main
 
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
+import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
@@ -41,14 +43,33 @@ open class ClientMainPresenter(
         urlLauncher,
         applicationLifecycleService,
     ) {
+    override val reconnectOverlayInfoKey: String = "mobile.connectivity.reconnecting.client.info"
+    override val reconnectOverlayDetailsKey: String = "mobile.connectivity.reconnecting.client.details"
+    override val connectionsLostDialogTitleKey: String = "mobile.connectivity.disconnected.client.title"
+    override val connectionsLostDialogMessageKey: String = "mobile.connectivity.disconnected.client.message"
+
     override fun onViewAttached() {
         super.onViewAttached()
         listenForConnectivity()
+        observeConnectivity()
         observeClientRevocation()
     }
 
     private fun listenForConnectivity() {
         connectivityService.startMonitoring()
+    }
+
+    private fun observeConnectivity() {
+        presenterScope.launch {
+            combine(connectivityService.status, isMainContentVisible) { status, mainVisible ->
+                status to mainVisible
+            }.collect { (status, mainVisible) ->
+                _showAllConnectionsLostDialogue.value =
+                    status == ConnectivityService.ConnectivityStatus.DISCONNECTED && mainVisible
+                _showReconnectOverlay.value =
+                    status == ConnectivityService.ConnectivityStatus.RECONNECTING && mainVisible
+            }
+        }
     }
 
     @ExcludeFromCoverage

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
@@ -59,15 +59,27 @@ open class ClientMainPresenter(
         connectivityService.startMonitoring()
     }
 
+    private var previousConnectivityStatus: ConnectivityService.ConnectivityStatus? = null
+
     private fun observeConnectivity() {
         presenterScope.launch {
             combine(connectivityService.status, isMainContentVisible) { status, mainVisible ->
                 status to mainVisible
             }.collect { (status, mainVisible) ->
-                _showAllConnectionsLostDialogue.value =
-                    status == ConnectivityService.ConnectivityStatus.DISCONNECTED && mainVisible
+                if (!mainVisible) {
+                    _showReconnectOverlay.value = false
+                    _showAllConnectionsLostDialogue.value = false
+                    previousConnectivityStatus = null
+                    return@collect
+                }
+
                 _showReconnectOverlay.value =
-                    status == ConnectivityService.ConnectivityStatus.RECONNECTING && mainVisible
+                    status == ConnectivityService.ConnectivityStatus.RECONNECTING
+                _showAllConnectionsLostDialogue.value =
+                    previousConnectivityStatus == ConnectivityService.ConnectivityStatus.RECONNECTING &&
+                    status == ConnectivityService.ConnectivityStatus.DISCONNECTED
+
+                previousConnectivityStatus = status
             }
         }
     }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -38,11 +38,17 @@ mobile.connectivity.disconnected.title=All connections lost
 mobile.connectivity.disconnected.message=You have lost all network connections.\n\n\
   Please check your internet connection and restart Bisq.
 mobile.connectivity.disconnected.restart=Restart
+mobile.connectivity.disconnected.client.title=Unable to connect
+mobile.connectivity.disconnected.client.message=Connection to your trusted node could not be restored.\n\n\
+  Please check your internet connection, verify the trusted node is up and running, and restart the app.
 mobile.connectivity.reconnecting.title=Reconnecting
 mobile.connectivity.reconnecting.info=All connections to the Bisq P2P network have been lost.
 mobile.connectivity.reconnecting.details=This may occur if Bisq was in the background or lost internet connection.\n\n\
   Please wait while connections are reestablished. If reconnection fails, restart Bisq.
 mobile.connectivity.reconnecting.restart=Restart
+mobile.connectivity.reconnecting.client.info=Connection to your trusted node was lost.
+mobile.connectivity.reconnecting.client.details=This may occur if the app was in the background, lost internet connection, or the trusted node is down.\n\n\
+  If the trusted node is up and running, please wait while the connection is reestablished. If reconnection fails, restart the app.
 mobile.connectivity.enum.bootstrapping=Bootstrapping
 mobile.connectivity.enum.disconnected=Disconnected
 mobile.connectivity.enum.reconnecting=Reconnecting

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -211,14 +211,18 @@ fun App(
 
             if (showAllConnectionsLostDialogue) {
                 WarningConfirmationDialog(
-                    headline = "mobile.connectivity.disconnected.title".i18n(),
-                    message = "mobile.connectivity.disconnected.message".i18n(),
-                    confirmButtonText = "mobile.connectivity.disconnected.restart".i18n(),
+                    headline = mainPresenter.connectionsLostDialogTitleKey.i18n(),
+                    message = mainPresenter.connectionsLostDialogMessageKey.i18n(),
+                    confirmButtonText = mainPresenter.connectionsLostDialogRestartKey.i18n(),
                     onConfirm = { presenter.onRestartApp() },
                     onDismiss = { presenter.onCloseConnectionLostDialogue() },
                 )
             } else if (showReconnectOverlay) {
-                ReconnectingOverlay(onClick = { presenter.onRestartApp() })
+                ReconnectingOverlay(
+                    onClick = { presenter.onRestartApp() },
+                    infoKey = mainPresenter.reconnectOverlayInfoKey,
+                    detailsKey = mainPresenter.reconnectOverlayDetailsKey,
+                )
             }
 
             // Global loading overlay - blocks interaction immediately, shows dialog after grace delay
@@ -245,7 +249,11 @@ fun App(
 }
 
 @Composable
-fun ReconnectingOverlay(onClick: (() -> Unit)? = null) {
+fun ReconnectingOverlay(
+    onClick: (() -> Unit)? = null,
+    infoKey: String = "mobile.connectivity.reconnecting.info",
+    detailsKey: String = "mobile.connectivity.reconnecting.details",
+) {
     Box(
         modifier =
             Modifier
@@ -291,13 +299,13 @@ fun ReconnectingOverlay(onClick: (() -> Unit)? = null) {
                 BisqGap.VQuarter()
 
                 BisqText.LargeLight(
-                    text = "mobile.connectivity.reconnecting.info".i18n(),
+                    text = infoKey.i18n(),
                     color = BisqTheme.colors.light_grey50,
                     textAlign = TextAlign.Center,
                 )
 
                 BisqText.BaseLight(
-                    text = "mobile.connectivity.reconnecting.details".i18n(),
+                    text = detailsKey.i18n(),
                     color = BisqTheme.colors.light_grey50,
                     textAlign = TextAlign.Center,
                 )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -70,6 +70,13 @@ open class MainPresenter(
     protected val _showReconnectOverlay = MutableStateFlow(false)
     override val showReconnectOverlay: StateFlow<Boolean> = _showReconnectOverlay.asStateFlow()
 
+    open val reconnectOverlayInfoKey: String = "mobile.connectivity.reconnecting.info"
+    open val reconnectOverlayDetailsKey: String = "mobile.connectivity.reconnecting.details"
+
+    open val connectionsLostDialogTitleKey: String = "mobile.connectivity.disconnected.title"
+    open val connectionsLostDialogMessageKey: String = "mobile.connectivity.disconnected.message"
+    open val connectionsLostDialogRestartKey: String = "mobile.connectivity.disconnected.restart"
+
     final override val languageCode: StateFlow<String> get() = settingsService.languageCode
 
     var view: Any? = null


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1492

- Show the shared `ReconnectingOverlay` (with client specific text) in the client app when `ClientConnectivityService` enters `RECONNECTING` (after main content is visible)
- Show the connection-lost dialog when reconnecting times out and status becomes `DISCONNECTED`

 
<img width="395" height="767" alt="Reconnecting" src="https://github.com/user-attachments/assets/b2056b0a-3aa1-4df4-8335-7a49f856337e" />

<img width="389" height="714" alt="Unable to connect" src="https://github.com/user-attachments/assets/c272a179-c823-46bf-9926-695ab9f41c45" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connectivity-aware UI updates with a reconnect overlay and a “connections lost” dialog that reflect current connection status.
  * Reconnecting overlay and connection-loss dialog text are now driven by new client-specific localization keys.
* **Bug Fixes**
  * Improved overlay/dialog visibility behavior across reconnecting, connected, and disconnected transitions, including correct handling when main content is hidden/shown.
* **Tests**
  * Extended unit tests to cover connectivity-driven UI state transitions and verify the localized copy keys used in the overlay and dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->