### PR TITLE
bugfix/flaky_offers_or_timeout_can_cause_app_to_stop_selecting_market

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -6,7 +6,9 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.ConnectionState
@@ -42,6 +44,7 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
     private lateinit var facade: ClientOffersServiceFacade
 
     private val usdMarket = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
+    private val brlMarket = MarketVO("BTC", "BRL", "Bitcoin", "Brazilian Real")
 
     override fun onSetup() {
         every { webSocketClientService.connectionState } returns connectionState
@@ -139,6 +142,108 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
 
             assertTrue(facade.offerbookMarketItems.value.isEmpty())
         }
+
+    /**
+     * Regression test for the "stuck subscription guard" bug: if the initial OFFERS
+     * subscription request never produces a payload (e.g. trusted node misbehaving),
+     * the loading timeout fires — and historically `hasSubscribedToOffers` stayed
+     * `true`, leaving every subsequent `selectOfferbookMarket` call stuck showing
+     * zero offers forever (until app restart).
+     */
+    @Test
+    fun `loading timeout releases the guard so next selectOfferbookMarket re-subscribes`() =
+        runTest {
+            val firstObserver = WebSocketEventObserver()
+            val secondObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returnsMany listOf(firstObserver, secondObserver)
+
+            facade.activate()
+            advanceUntilIdle()
+
+            // First market selection — subscribes (and server never delivers an OFFERS payload)
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
+
+            // Loading timeout (12s) fires — guard must be released
+            advanceTimeBy(13_000L)
+            advanceUntilIdle()
+
+            // Second market selection — must re-subscribe instead of being permanently stuck
+            facade.selectOfferbookMarket(MarketListItem.from(usdMarket, numOffers = 82))
+            advanceUntilIdle()
+            coVerify(exactly = 2) { apiGateway.subscribeOffers() }
+        }
+
+    /**
+     * Happy path control: when the subscription is alive and serving data, switching
+     * markets must NOT re-subscribe (filters are applied in-process against the cache).
+     */
+    @Test
+    fun `subsequent selectOfferbookMarket does not re-subscribe while subscription is alive`() =
+        runTest {
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            // runCurrent() processes the launches without advancing the virtual clock past
+            // the 12s loading timeout — otherwise the timeout would fire first and reset
+            // the guard, defeating the point of this happy-path test.
+            runCurrent()
+
+            // Delivering an event causes applyOffersToSelectedMarket to set isLoading=false
+            // and cancel the timeout, so the timeout will not fire even after advanceUntilIdle.
+            offersObserver.setEvent(offersEvent("[]"))
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(usdMarket, numOffers = 82))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
+        }
+
+    /**
+     * The subscription collector job and loading timeout job must be cancelled on
+     * `deactivate()` so they don't linger past the facade's lifecycle.
+     */
+    @Test
+    fun `deactivate cancels active subscription so re-activate cleanly re-subscribes`() =
+        runTest {
+            val firstObserver = WebSocketEventObserver()
+            val secondObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returnsMany listOf(firstObserver, secondObserver)
+
+            facade.activate()
+            advanceUntilIdle()
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
+
+            facade.deactivate()
+            advanceUntilIdle()
+
+            facade.activate()
+            advanceUntilIdle()
+            facade.selectOfferbookMarket(MarketListItem.from(usdMarket, numOffers = 82))
+            advanceUntilIdle()
+
+            coVerify(exactly = 2) { apiGateway.subscribeOffers() }
+        }
+
+    private fun offersEvent(payload: String) =
+        WebSocketEvent(
+            topic = Topic.OFFERS,
+            subscriberId = "offers-test",
+            deferredPayload = payload,
+            modificationType = ModificationType.REPLACE,
+            sequenceNumber = 1,
+        )
 
     private fun numOffersEvent(payload: String) =
         WebSocketEvent(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -45,7 +45,22 @@ class ClientOffersServiceFacade(
     // Misc
     private val offersMutex = Mutex()
     private var offerbookListItemsByMarket: MutableMap<String, MutableMap<String, OfferItemPresentationModel>> = mutableMapOf()
+
+    /**
+     * Guards single OFFERS WebSocket subscription across market selections. Reset to false
+     * on loading timeout or collect error so the next [selectOfferbookMarket] re-attempts
+     * the subscription. Without this reset, a single failed initial subscription leaves the
+     * app unable to ever show offers again until process restart (CRITICAL bug — manifested
+     * when the trusted node does not respond to the OFFERS subscription request).
+     */
     private var hasSubscribedToOffers = atomic(false)
+
+    /**
+     * Coroutine handle for the active OFFERS subscription collector. Captured so it can be
+     * cancelled cleanly on reset / deactivate without leaving orphan collectors attached
+     * to stale observers.
+     */
+    private var offersSubscriptionJob: Job? = null
 
     private var getMarketsJob: Job? = null
 
@@ -65,6 +80,10 @@ class ClientOffersServiceFacade(
     override suspend fun deactivate() {
         _offerbookMarketItems.value = emptyList()
         cachedNumOffersByMarketCode = null
+        offersSubscriptionJob?.cancel()
+        offersSubscriptionJob = null
+        loadingTimeoutJob?.cancel()
+        loadingTimeoutJob = null
         hasSubscribedToOffers.value = false
         super<OffersServiceFacade>.deactivate()
     }
@@ -216,31 +235,46 @@ class ClientOffersServiceFacade(
     }
 
     private fun subscribeOffers() {
-        serviceScope.launch {
-            // We subscribe for all markets
-            val observer = apiGateway.subscribeOffers()
-            observer.webSocketEvent.collect { webSocketEvent ->
-                if (webSocketEvent?.deferredPayload == null) {
-                    return@collect
-                }
+        offersSubscriptionJob?.cancel()
+        offersSubscriptionJob =
+            serviceScope.launch {
+                // We subscribe for all markets
+                val observer = apiGateway.subscribeOffers()
+                observer.webSocketEvent.collect { webSocketEvent ->
+                    if (webSocketEvent?.deferredPayload == null) {
+                        return@collect
+                    }
 
-                runCatching {
-                    val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
-                        WebSocketEventPayload.from(
-                            json,
-                            webSocketEvent,
-                        )
-                    val payload: List<OfferItemPresentationDto> = webSocketEventPayload.payload
-                    log.d { "WebSocket offer update - Type: ${webSocketEvent.modificationType}, Count: ${payload.size}" }
-                    updateOffersByMarket(webSocketEvent, payload)
-                    applyOffersToSelectedMarket()
-                }.onFailure { e ->
-                    log.e(e) { "Error processing offers WebSocket event (seq=${webSocketEvent.sequenceNumber})" }
-                    _isOfferbookLoading.value = false
-                    loadingTimeoutJob?.cancel()
+                    runCatching {
+                        val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
+                            WebSocketEventPayload.from(
+                                json,
+                                webSocketEvent,
+                            )
+                        val payload: List<OfferItemPresentationDto> = webSocketEventPayload.payload
+                        log.d { "WebSocket offer update - Type: ${webSocketEvent.modificationType}, Count: ${payload.size}" }
+                        updateOffersByMarket(webSocketEvent, payload)
+                        applyOffersToSelectedMarket()
+                    }.onFailure { e ->
+                        log.e(e) { "Error processing offers WebSocket event (seq=${webSocketEvent.sequenceNumber})" }
+                        // Release the guard so the next selectOfferbookMarket re-subscribes
+                        // (otherwise switching markets just re-applies filters on empty cache).
+                        resetOffersSubscriptionState()
+                    }
                 }
             }
-        }
+    }
+
+    /**
+     * Releases the offers subscription guard and cancels the collector. The next
+     * [selectOfferbookMarket] call will trigger a fresh subscribe attempt.
+     */
+    private fun resetOffersSubscriptionState() {
+        _isOfferbookLoading.value = false
+        loadingTimeoutJob?.cancel()
+        offersSubscriptionJob?.cancel()
+        offersSubscriptionJob = null
+        hasSubscribedToOffers.value = false
     }
 
     private suspend fun updateOffersByMarket(
@@ -351,7 +385,10 @@ class ClientOffersServiceFacade(
                 }
                 if (_isOfferbookLoading.value) {
                     log.w { "Offerbook loading timed out for market ${selectedOfferbookMarket.value.market.quoteCurrencyCode}" }
-                    _isOfferbookLoading.value = false
+                    // Release the subscription guard so the next selectOfferbookMarket
+                    // can re-attempt subscription. Without this, the app would be stuck
+                    // showing 0 offers for every market until process restart.
+                    resetOffersSubscriptionState()
                 }
             }
     }


### PR DESCRIPTION
 - get handle of the offers subscription job to cleanup properly so that it relaunches properly when needed
 - found whilst working on #1432 , couldn't repro in prod and we haven't got any reports but issue is technically there and could potentially happen to anyone until we get this to prod