### PR TITLE
Feature/relayed notifications deep linking

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -270,7 +270,8 @@ class BisqFirebaseMessagingService :
      * (older trusted nodes), we fall back to the trade list — the same
      * behaviour as before.
      */
-    private fun pendingIntentFor(
+    @VisibleForTesting
+    internal fun pendingIntentFor(
         notificationId: String,
         category: NotificationCategory,
         tradeId: String?,
@@ -299,7 +300,8 @@ class BisqFirebaseMessagingService :
         return PendingIntent.getActivity(this, requestCode, launchIntent, flags)
     }
 
-    private fun deepLinkRouteFor(
+    @VisibleForTesting
+    internal fun deepLinkRouteFor(
         category: NotificationCategory,
         tradeId: String?,
     ): DeepLinkableRoute? = Companion.deepLinkRouteFor(category, tradeId)

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.util.Base64
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -90,6 +91,43 @@ class BisqFirebaseMessagingService :
             val plaintextBytes = cipher.doFinal(ciphertextWithTag)
             return String(plaintextBytes, Charsets.UTF_8)
         }
+
+        /**
+         * Resolves the navigation destination from `(category, tradeId?)`. Kept as
+         * a pure function in the companion object so it's directly unit-testable
+         * without instantiating the [FirebaseMessagingService] (which requires
+         * Android lifecycle scaffolding).
+         *
+         * - Trade-scoped categories ([NotificationCategory.TRADE_UPDATE],
+         *   [NotificationCategory.CHAT_MESSAGE]) with a non-null `tradeId`
+         *   deep-link to the specific trade ([NavRoute.OpenTrade]).
+         * - Trade-scoped categories without `tradeId` (older trusted nodes that
+         *   predate the wire-format change for bisq-network/bisq-mobile#1395)
+         *   fall back to the open-trade list.
+         * - Non-trade categories ([NotificationCategory.OFFER_UPDATE],
+         *   [NotificationCategory.GENERAL]) have no deep link; the launcher
+         *   intent in `pendingIntentFor` takes over.
+         */
+        @VisibleForTesting
+        internal fun deepLinkRouteFor(
+            category: NotificationCategory,
+            tradeId: String?,
+        ): DeepLinkableRoute? =
+            when (category) {
+                NotificationCategory.TRADE_UPDATE,
+                NotificationCategory.CHAT_MESSAGE,
+                ->
+                    if (tradeId.isNullOrBlank()) {
+                        NavRoute.TabMyTrades(NavRoute.TabMyTrades.TAB_OPEN)
+                    } else {
+                        NavRoute.OpenTrade(tradeId)
+                    }
+                // No deep link for offerbook market or general — fall back to
+                // launcher intent in `pendingIntentFor`.
+                NotificationCategory.OFFER_UPDATE,
+                NotificationCategory.GENERAL,
+                -> null
+            }
     }
 
     override fun onNewToken(token: String) {
@@ -162,7 +200,7 @@ class BisqFirebaseMessagingService :
             }
 
         val category = NotificationCategory.fromPayload(payload)
-        showNotification(payload.id, category)
+        showNotification(payload.id, category, payload.tradeId)
     }
 
     /**
@@ -183,13 +221,14 @@ class BisqFirebaseMessagingService :
     private fun showNotification(
         notificationId: String,
         category: NotificationCategory,
+        tradeId: String?,
     ) {
         if (!hasPostNotificationsPermission()) {
             log.w { "POST_NOTIFICATIONS not granted — dropping decrypted push" }
             return
         }
 
-        val pending = pendingIntentFor(notificationId, category)
+        val pending = pendingIntentFor(notificationId, category, tradeId)
 
         val builder =
             NotificationCompat
@@ -224,18 +263,22 @@ class BisqFirebaseMessagingService :
      * For categories without a matching deep link we fall back to the plain
      * launcher intent so tapping still opens the app.
      *
-     * The encrypted FCM payload only carries `id`, `title`, `message`, and
-     * `category` — no trade id — so the deepest we can route is the trade list
-     * (open trades / chats) and the offerbook list.
+     * When the FCM payload carries a `tradeId` (bisq-network/bisq-mobile#1395
+     * — present from trusted nodes built against bisq2 with the corresponding
+     * change), trade-scoped categories deep-link straight to the specific
+     * trade screen (`bisq://OpenTrade/<tradeId>`). When `tradeId` is absent
+     * (older trusted nodes), we fall back to the trade list — the same
+     * behaviour as before.
      */
     private fun pendingIntentFor(
         notificationId: String,
         category: NotificationCategory,
+        tradeId: String?,
     ): PendingIntent? {
         val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         val requestCode = notificationId.hashCode()
 
-        val deepLinkRoute = deepLinkRouteFor(category)
+        val deepLinkRoute = deepLinkRouteFor(category, tradeId)
         if (deepLinkRoute != null) {
             val intent =
                 Intent(
@@ -256,17 +299,10 @@ class BisqFirebaseMessagingService :
         return PendingIntent.getActivity(this, requestCode, launchIntent, flags)
     }
 
-    private fun deepLinkRouteFor(category: NotificationCategory): DeepLinkableRoute? =
-        when (category) {
-            NotificationCategory.TRADE_UPDATE,
-            NotificationCategory.CHAT_MESSAGE,
-            -> NavRoute.TabMyTrades(NavRoute.TabMyTrades.TAB_OPEN)
-            // No deep link for offerbook market or general — fall back to
-            // launcher intent in `pendingIntentFor`.
-            NotificationCategory.OFFER_UPDATE,
-            NotificationCategory.GENERAL,
-            -> null
-        }
+    private fun deepLinkRouteFor(
+        category: NotificationCategory,
+        tradeId: String?,
+    ): DeepLinkableRoute? = Companion.deepLinkRouteFor(category, tradeId)
 
     @Serializable
     internal data class NotificationPayload(
@@ -277,6 +313,12 @@ class BisqFirebaseMessagingService :
         // the brittle title-keyword mapping. Default null for backwards
         // compatibility with bisq2 versions that don't populate it yet.
         val category: String? = null,
+        // Optional bisq2 trade id from the trusted node. When present, taps on
+        // trade-scoped notifications deep-link straight to the specific trade
+        // screen instead of the open-trade list. Default null for backwards
+        // compatibility with trusted nodes that predate
+        // bisq-network/bisq-mobile#1395.
+        val tradeId: String? = null,
     )
 
     /**

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client.common.domain.service.push_notification
 
 import android.util.Base64
 import network.bisq.mobile.client.common.test_utils.TestApplication
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -12,6 +13,7 @@ import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -244,6 +246,111 @@ class BisqFirebaseMessagingServiceTest {
                 "unexpected category for title: $title",
             )
         }
+    }
+
+    // ----- deepLinkRouteFor (tradeId-aware deep linking, #1395) -----
+
+    @Test
+    fun `deepLinkRouteFor TRADE_UPDATE with tradeId routes to specific OpenTrade`() {
+        val route =
+            BisqFirebaseMessagingService.deepLinkRouteFor(
+                BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = "trade-abcd-1234",
+            )
+
+        assertEquals(NavRoute.OpenTrade("trade-abcd-1234"), route)
+    }
+
+    @Test
+    fun `deepLinkRouteFor CHAT_MESSAGE with tradeId routes to specific OpenTrade`() {
+        val route =
+            BisqFirebaseMessagingService.deepLinkRouteFor(
+                BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE,
+                tradeId = "trade-abcd-1234",
+            )
+
+        assertEquals(NavRoute.OpenTrade("trade-abcd-1234"), route)
+    }
+
+    @Test
+    fun `deepLinkRouteFor TRADE_UPDATE without tradeId falls back to open-trade list (older trusted nodes)`() {
+        // Older trusted nodes (pre-#1395) don't populate tradeId. The mobile
+        // client must keep working — fall back to the trade list, same as the
+        // pre-#1395 behaviour. If we ever change this to "no deep link" we'd
+        // surprise users with the launcher landing instead of trades.
+        val route =
+            BisqFirebaseMessagingService.deepLinkRouteFor(
+                BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = null,
+            )
+
+        assertEquals(
+            NavRoute.TabMyTrades(NavRoute.TabMyTrades.TAB_OPEN),
+            route,
+        )
+    }
+
+    @Test
+    fun `deepLinkRouteFor treats blank tradeId same as null`() {
+        // Defensive: an empty string from a buggy trusted node MUST NOT produce
+        // `bisq://OpenTrade/` (which would route to a non-existent trade). Treat
+        // blank as absent and fall back to the open-trade list.
+        val route =
+            BisqFirebaseMessagingService.deepLinkRouteFor(
+                BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE,
+                tradeId = "   ",
+            )
+
+        assertEquals(
+            NavRoute.TabMyTrades(NavRoute.TabMyTrades.TAB_OPEN),
+            route,
+        )
+    }
+
+    @Test
+    fun `deepLinkRouteFor OFFER_UPDATE returns null regardless of tradeId`() {
+        // Offer notifications aren't trade-scoped — even a spurious tradeId
+        // from the backend must not produce a trade deep link.
+        listOf(null, "spurious-trade-id").forEach { tradeId ->
+            val route =
+                BisqFirebaseMessagingService.deepLinkRouteFor(
+                    BisqFirebaseMessagingService.NotificationCategory.OFFER_UPDATE,
+                    tradeId = tradeId,
+                )
+            assertNull(route, "OFFER_UPDATE must have no deep link route (tradeId=$tradeId)")
+        }
+    }
+
+    @Test
+    fun `deepLinkRouteFor GENERAL returns null regardless of tradeId`() {
+        listOf(null, "spurious-trade-id").forEach { tradeId ->
+            val route =
+                BisqFirebaseMessagingService.deepLinkRouteFor(
+                    BisqFirebaseMessagingService.NotificationCategory.GENERAL,
+                    tradeId = tradeId,
+                )
+            assertNull(route, "GENERAL must have no deep link route (tradeId=$tradeId)")
+        }
+    }
+
+    // ----- NotificationPayload tradeId field (wire-format compat) -----
+
+    @Test
+    fun `NotificationPayload tradeId defaults to null for backwards compatibility`() {
+        // Older trusted nodes that don't emit `tradeId` must deserialize cleanly
+        // — the default-null on the data class makes the field optional on the
+        // wire. Mirrors the older-node compatibility approach used for the
+        // `category` field.
+        val payload =
+            BisqFirebaseMessagingService.NotificationPayload(
+                id = "1",
+                title = "Trade update",
+                message = "msg",
+                category = "trade_update",
+                // tradeId omitted → default null
+            )
+
+        assertNull(payload.tradeId)
     }
 
     private fun aesGcmEncrypt(

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
@@ -1,11 +1,14 @@
 package network.bisq.mobile.client.common.domain.service.push_notification
 
+import android.content.Intent
 import android.util.Base64
 import network.bisq.mobile.client.common.test_utils.TestApplication
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import java.security.SecureRandom
 import javax.crypto.Cipher
@@ -13,6 +16,7 @@ import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -351,6 +355,107 @@ class BisqFirebaseMessagingServiceTest {
             )
 
         assertNull(payload.tradeId)
+    }
+
+    // ----- pendingIntentFor (deep-link Intent wiring, #1395) -----
+    //
+    // These tests exercise the full chain: pendingIntentFor → instance
+    // deepLinkRouteFor → Companion.deepLinkRouteFor → URI on the Intent.
+    // They cover the new `tradeId` plumbing through pendingIntentFor and the
+    // instance-level delegator that pure companion-function tests can't reach.
+
+    @Test
+    fun `pendingIntentFor TRADE_UPDATE with tradeId builds an ACTION_VIEW intent to bisq OpenTrade`() {
+        val service = Robolectric.buildService(BisqFirebaseMessagingService::class.java).get()
+
+        val pending =
+            service.pendingIntentFor(
+                notificationId = "notif-1",
+                category = BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = "trade-abcd-1234",
+            )
+
+        assertNotNull(pending, "pendingIntentFor must build a deep-link intent when tradeId is present")
+        val intent = Shadows.shadowOf(pending).savedIntent
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("bisq://OpenTrade/trade-abcd-1234", intent.data?.toString())
+    }
+
+    @Test
+    fun `pendingIntentFor CHAT_MESSAGE with tradeId builds an ACTION_VIEW intent to bisq OpenTrade`() {
+        // Chat messages in a trade context deep-link directly to the trade
+        // (rather than just the chat tab) because chats live inside the trade
+        // screen, and the trade screen already opens the conversation panel.
+        val service = Robolectric.buildService(BisqFirebaseMessagingService::class.java).get()
+
+        val pending =
+            service.pendingIntentFor(
+                notificationId = "notif-chat",
+                category = BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE,
+                tradeId = "trade-abcd-1234",
+            )
+
+        assertNotNull(pending)
+        val intent = Shadows.shadowOf(pending).savedIntent
+        assertEquals("bisq://OpenTrade/trade-abcd-1234", intent.data?.toString())
+    }
+
+    @Test
+    fun `pendingIntentFor TRADE_UPDATE without tradeId falls back to trade list deep link`() {
+        // Older trusted nodes (pre-#1395) don't emit tradeId. The intent must
+        // still be a deep link so tap goes to the trade list, not the launcher.
+        val service = Robolectric.buildService(BisqFirebaseMessagingService::class.java).get()
+
+        val pending =
+            service.pendingIntentFor(
+                notificationId = "notif-1",
+                category = BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = null,
+            )
+
+        assertNotNull(pending)
+        val intent = Shadows.shadowOf(pending).savedIntent
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        // Mirrors NavRoute.TabMyTrades(TAB_OPEN).toUriString().
+        assertEquals("bisq://TabMyTrades?initialTab=0", intent.data?.toString())
+    }
+
+    @Test
+    fun `pendingIntentFor treats blank tradeId same as null for TRADE_UPDATE`() {
+        // A malformed payload with whitespace-only tradeId must NOT produce
+        // `bisq://OpenTrade/   ` — same defensive contract as the companion
+        // `deepLinkRouteFor` and the iOS NSE.
+        val service = Robolectric.buildService(BisqFirebaseMessagingService::class.java).get()
+
+        val pending =
+            service.pendingIntentFor(
+                notificationId = "notif-1",
+                category = BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = "   ",
+            )
+
+        assertNotNull(pending)
+        val intent = Shadows.shadowOf(pending).savedIntent
+        assertEquals("bisq://TabMyTrades?initialTab=0", intent.data?.toString())
+    }
+
+    @Test
+    fun `instance deepLinkRouteFor delegates to the companion implementation`() {
+        // The instance-level `deepLinkRouteFor` is a thin pass-through to the
+        // companion function (kept so non-static contexts inside the service
+        // don't need to qualify with `Companion.`). This test exists so the
+        // delegator participates in PR diff coverage — the substance of the
+        // routing logic is already covered by the `deepLinkRouteFor ...`
+        // tests above against the companion.
+        val service = Robolectric.buildService(BisqFirebaseMessagingService::class.java).get()
+
+        val route =
+            service.deepLinkRouteFor(
+                BisqFirebaseMessagingService.NotificationCategory.TRADE_UPDATE,
+                tradeId = "trade-1",
+            )
+
+        assertEquals(NavRoute.OpenTrade("trade-1"), route)
     }
 
     private fun aesGcmEncrypt(

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -76,16 +76,40 @@ class NotificationService: UNNotificationServiceExtension {
             let payload = try JSONDecoder().decode(NotificationPayload.self, from: decryptedData)
 
             // Privacy: show only a category-based summary on the lock screen.
-            let summary = NotificationCategory.from(title: payload.title)
+            // Prefer the explicit `payload.category` from the trusted node — only
+            // fall back to the title-keyword heuristic for older bisq2 versions
+            // that don't yet populate `category`. Mirrors the Android-side fix in
+            // bisq-network/bisq-mobile#1450.
+            let summary = NotificationCategory.from(payload: payload)
             bestAttemptContent.title = "Bisq"
             bestAttemptContent.body = summary.displayText
 
-            // Pass opaque identifiers only — no human-readable trade details in userInfo
-            bestAttemptContent.userInfo = bestAttemptContent.userInfo.merging([
+            // Pass opaque identifiers only — no human-readable trade details in userInfo.
+            // notification_trade_id is forwarded ONLY when the trusted node
+            // emitted it (bisq-network/bisq-mobile#1395), letting the main app's
+            // notification tap handler deep-link straight to the specific trade.
+            // Older trusted nodes omit the field; the main app falls back to the
+            // category-only routing in that case.
+            var userInfo: [AnyHashable: Any] = [
                 "nse_decrypted": true,
                 "notification_id": payload.id,
                 "notification_category": summary.rawValue,
-            ]) { _, new in new }
+            ]
+            if let tradeId = payload.tradeId, !tradeId.isEmpty {
+                userInfo["notification_trade_id"] = tradeId
+            }
+            // Synthesize a `default`-action deep-link URI so the existing main-app
+            // AppDelegate.userNotificationCenter(_:didReceive:) handler — already
+            // wired for local notifications — routes a tap on a relayed push
+            // through the same `ExternalUriHandler.onNewUri(...)` codepath. The
+            // URI scheme matches NavRoute.toUriString() on the Kotlin side
+            // (bisq://OpenTrade/<id> | bisq://TabMyTrades?initialTab=0), keeping
+            // Android and iOS routing identical. Mirrors the Android
+            // deepLinkRouteFor(category, tradeId) logic.
+            if let deepLink = summary.deepLinkUri(tradeId: payload.tradeId) {
+                userInfo["default"] = deepLink
+            }
+            bestAttemptContent.userInfo = bestAttemptContent.userInfo.merging(userInfo) { _, new in new }
 
             os_log("NSE: decryption success, category=%{public}@", log: log, type: .info, summary.rawValue)
             writeBreadcrumb(stage: "decrypt_success:\(summary.rawValue)")
@@ -124,13 +148,65 @@ class NotificationService: UNNotificationServiceExtension {
             }
         }
 
+        /// Deep-link URI to use for a notification tap. Matches the Android
+        /// `deepLinkRouteFor(category, tradeId)` mapping exactly:
+        /// - Trade-scoped categories with a `tradeId` → `bisq://OpenTrade/<id>`.
+        /// - Trade-scoped categories without `tradeId` (older trusted nodes that
+        ///   predate bisq-network/bisq-mobile#1395) → trade list fallback.
+        /// - Offer/general → nil (no deep link; tap just opens the app).
+        ///
+        /// The URI is consumed by `AppDelegate.userNotificationCenter(_:didReceive:)`
+        /// via `userInfo["default"]`, then routed through `ExternalUriHandler`.
+        func deepLinkUri(tradeId: String?) -> String? {
+            switch self {
+            case .tradeUpdate, .chatMessage:
+                if let tradeId = tradeId, !tradeId.isEmpty {
+                    return "bisq://OpenTrade/\(tradeId)"
+                }
+                // Trade list. Matches NavRoute.TabMyTrades.toUriString() with
+                // initialTab=0 (TAB_OPEN). Hard-coded mirror of the Kotlin
+                // route because the NSE can't link the Kotlin shared module
+                // (its binary footprint would explode the NSE memory limit).
+                return "bisq://TabMyTrades?initialTab=0"
+            case .offerUpdate, .general:
+                return nil
+            }
+        }
+
+        /// Resolves the category from the decrypted payload, preferring the
+        /// explicit `category` id over the brittle title-keyword heuristic.
+        ///
+        /// - When `payload.category` is present and recognized, use it. This is
+        ///   the stable wire signal from the trusted node.
+        /// - When `payload.category` is present but unknown to this client
+        ///   (e.g. a newer bisq2 introduced a new id like `dispute_alert`),
+        ///   return `.general` rather than running the title heuristic — the
+        ///   node already told us it's a specific category, so a generic banner
+        ///   is more honest than guessing.
+        /// - When `payload.category` is absent (older bisq2 that predates
+        ///   bisq-network/bisq-mobile#1450), fall back to title-keyword
+        ///   scanning. This matches the Android-side `fromPayload` contract.
+        static func from(payload: NotificationPayload) -> NotificationCategory {
+            if let categoryId = payload.category {
+                return NotificationCategory(rawValue: categoryId) ?? .general
+            }
+            return from(title: payload.title)
+        }
+
         static func from(title: String) -> NotificationCategory {
             let lower = title.lowercased()
-            if lower.contains("trade") || lower.contains("payment") || lower.contains("btc") {
-                return .tradeUpdate
-            }
+            // Chat keyword check is intentionally ordered BEFORE the trade/payment/btc
+            // check: trade-private chat titles built by bisq2 (e.g.
+            // "Alice (Bisq Easy → Open Trades → Bob)") contain "trade" but no chat
+            // keyword, so they'll still mislabel as trade-update on older nodes —
+            // the explicit `category` path above is the real fix. For titles that
+            // contain BOTH (e.g. "Trade chat update"), chat wins. Mirrors the
+            // Android ordering tested by `fromTitle prefers chat over trade keywords`.
             if lower.contains("message") || lower.contains("chat") {
                 return .chatMessage
+            }
+            if lower.contains("trade") || lower.contains("payment") || lower.contains("btc") {
+                return .tradeUpdate
             }
             if lower.contains("offer") {
                 return .offerUpdate
@@ -215,4 +291,14 @@ private struct NotificationPayload: Decodable {
     let id: String
     let title: String
     let message: String
+    /// Stable category id emitted by the trusted node (bisq2 #1450). Mirrors
+    /// `Notification.Category#getId` on the bisq2 side and
+    /// `BisqFirebaseMessagingService.NotificationCategory#id` on Android. Optional
+    /// for backward compatibility with trusted nodes that don't yet populate it.
+    let category: String?
+    /// Bisq2 trade id surfaced by the trusted node (bisq-network/bisq-mobile#1395).
+    /// When present, the main app deep-links a notification tap straight to the
+    /// trade screen instead of the open-trade list. Optional for backward
+    /// compatibility with older trusted nodes that don't emit it.
+    let tradeId: String?
 }

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -95,7 +95,7 @@ class NotificationService: UNNotificationServiceExtension {
                 "notification_id": payload.id,
                 "notification_category": summary.rawValue,
             ]
-            if let tradeId = payload.tradeId, !tradeId.isEmpty {
+            if let tradeId = payload.tradeId, !tradeId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 userInfo["notification_trade_id"] = tradeId
             }
             // Synthesize a `default`-action deep-link URI so the existing main-app
@@ -160,7 +160,7 @@ class NotificationService: UNNotificationServiceExtension {
         func deepLinkUri(tradeId: String?) -> String? {
             switch self {
             case .tradeUpdate, .chatMessage:
-                if let tradeId = tradeId, !tradeId.isEmpty {
+                if let tradeId = tradeId, !tradeId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     return "bisq://OpenTrade/\(tradeId)"
                 }
                 // Trade list. Matches NavRoute.TabMyTrades.toUriString() with


### PR DESCRIPTION
 - resolves #1395 
 - depends on https://github.com/bisq-network/bisq2/pull/4839
 - implement deep linking based on tradeId and categoryId in both platforms
 - added AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now support direct routing to specific trades when trade identifiers are available in the notification payload.
  * Fallback navigation directs to the trades list when specific trade context is unavailable.

* **Tests**
  * Comprehensive unit tests added for notification routing behavior and backward compatibility with notifications lacking trade identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->