### PR TITLE
Release/anode 0.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.0
 
 node.name=Bisq Easy
-node.android.version=0.8.0
+node.android.version=0.8.1
 
 client.name=Bisq Connect
 client.android.version=0.6.1
@@ -42,7 +42,7 @@ client.ios.version=0.6.1
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=44
 client.android.version.code=26
-node.android.version.code=43
+node.android.version.code=44
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.0
 
 node.name=Bisq Easy
-node.android.version=0.7.1
+node.android.version=0.8.0
 
 client.name=Bisq Connect
 client.android.version=0.6.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.11"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "88977fe698979c9300f360ebb8f3d69ee9672a66"
+bisq-core-commit = "2173c42b8ea2474199823e17942cf6dbacedafa6"
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing
 bisq-desktop-pairing = "2.1.11"
 # API version is usually same as bisq-core but for more control we keep it separated


### PR DESCRIPTION
 - contribs to #1513 
 - bump up versions and update refs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android node artifact version to 0.8.1
  * Updated Bisq2 core dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->