### PR TITLE
bugfix/flaky_linux_ci_tests

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
@@ -28,7 +28,6 @@ import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import org.junit.Test
 import org.koin.core.module.Module
 import org.koin.dsl.module
-import kotlin.test.Ignore
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -107,6 +106,7 @@ class ClientPushNotificationServiceFacadeActivateTest : KoinIntegrationTestBase(
                 sensitiveSettingsRepository = sensitiveSettingsRepository,
                 pushNotificationTokenProvider = tokenProvider,
                 userProfileServiceFacade = userProfileServiceFacade,
+                backgroundDispatcher = testDispatcher,
             )
     }
 
@@ -202,7 +202,6 @@ class ClientPushNotificationServiceFacadeActivateTest : KoinIntegrationTestBase(
         }
 
     @Test
-    @Ignore("Flaky test")
     fun `onDeviceTokenReceived with re-registration failure updates state`() =
         runTest {
             sensitiveSettingsRepository.update { SensitiveSettings(bisqApiUrl = "http://localhost:8080") }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.push_notification
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,6 +33,10 @@ class ClientPushNotificationServiceFacade(
     private val sensitiveSettingsRepository: SensitiveSettingsRepository,
     private val pushNotificationTokenProvider: PushNotificationTokenProvider,
     private val userProfileServiceFacade: UserProfileServiceFacade,
+    // Background dispatcher for the (multi-second, blocking) symmetric-key init. Injectable so
+    // tests can pass the test dispatcher and keep it under the test scheduler — otherwise the
+    // Dispatchers.Default hop escapes runTest/advanceUntilIdle and makes registration tests flaky.
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ServiceFacade(),
     PushNotificationServiceFacade,
     Logging {
@@ -159,7 +164,7 @@ class ClientPushNotificationServiceFacade(
         // `commit()` to disk — both block whatever thread they run on, and
         // `presenterScope` runs on `Dispatchers.Main`. Using `Default` instead of `IO`
         // because `Dispatchers.IO` is JVM-only (internal on Kotlin/Native).
-        val symmetricKeyBase64 = withContext(Dispatchers.Default) { getOrCreatePushNotificationKeyBase64() }
+        val symmetricKeyBase64 = withContext(backgroundDispatcher) { getOrCreatePushNotificationKeyBase64() }
         validateSymmetricKey(platformInfo.type, symmetricKeyBase64)?.let { return it }
 
         log.i { "Registering device with deviceId: $deviceId, descriptor: $deviceDescriptor, platform: $platform" }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/open_trades/OpenTradeListPresenterTest.kt
@@ -104,6 +104,7 @@ class OpenTradeListPresenterTest {
                 settingsServiceFacade = settingsServiceFacade,
                 userProfileServiceFacade = userProfileServiceFacade,
                 filterOpenTradesUseCase = filterOpenTradesUseCase,
+                backgroundDispatcher = testDispatcher,
             )
         p.onViewAttached()
         return p

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4PresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4PresenterTest.kt
@@ -5,11 +5,13 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -32,7 +34,6 @@ import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -84,6 +85,7 @@ class State4PresenterTest {
             tradesServiceFacade,
             tradeReadStateRepository,
             shareFileService,
+            testDispatcher,
         )
     }
 
@@ -259,7 +261,6 @@ class State4PresenterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until timing issue is stabilized")
     fun onExportTradeClick_when_share_fails_shows_error() =
         runTest {
             val trade = tradeForTests("t-bad-share", "sx")
@@ -270,8 +271,9 @@ class State4PresenterTest {
                 Result.failure(RuntimeException("share denied"))
 
             presenter.onAction(State4UiAction.OnExportTradeClick)
+            advanceUntilIdle()
 
-            coVerify(timeout = 5000) { shareFileService.shareUtf8TextFile(any(), any()) }
+            coVerify(exactly = 1) { shareFileService.shareUtf8TextFile(any(), any()) }
             assertEquals("share denied", GenericErrorHandler.genericErrorMessage.value)
         }
 
@@ -323,7 +325,8 @@ class State4PresenterTest {
         tradesServiceFacade: TradesServiceFacade,
         tradeReadStateRepository: TradeReadStateRepository,
         shareFileService: ShareFileService,
-    ) : State4Presenter(mainPresenter, tradesServiceFacade, tradeReadStateRepository, shareFileService) {
+        backgroundDispatcher: CoroutineDispatcher,
+    ) : State4Presenter(mainPresenter, tradesServiceFacade, tradeReadStateRepository, shareFileService, backgroundDispatcher) {
         override fun resolveMyDirectionLabel(): String = DIRECTION
 
         override fun resolveMyOutcomeLabel(): String = OUTCOME

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.tabs.my_trades.open
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +35,11 @@ class OpenTradeListPresenter(
     private val settingsServiceFacade: SettingsServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val filterOpenTradesUseCase: FilterOpenTradesUseCase,
+    // Background dispatcher for the (CPU-bound) filter/sort pipeline. Injectable so tests can
+    // pass the test dispatcher and keep the pipeline under the test scheduler — otherwise the
+    // Dispatchers.Default hop escapes runTest and can resume on Main after resetMain(), which
+    // is the source of the flaky "Dispatchers.Main is used concurrently with setting it" failures.
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BasePresenter(mainPresenter) {
     private companion object {
         const val FILTER_DEBOUNCE_MS = 400L
@@ -77,7 +83,7 @@ class OpenTradeListPresenter(
                         sortBy = sort,
                         roleFilter = role,
                     )
-            }.flowOn(Dispatchers.Default)
+            }.flowOn(backgroundDispatcher)
                 .collect { (all, filtered) ->
                     _uiState.update {
                         it.copy(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4Presenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4Presenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.trade.trade_detail.states.common
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,10 @@ abstract class State4Presenter(
     private val tradesServiceFacade: TradesServiceFacade,
     private val tradeReadStateRepository: TradeReadStateRepository,
     private val shareFileService: ShareFileService,
+    // Background dispatcher for the (CPU-bound) CSV build. Injectable so tests can pass the test
+    // dispatcher and keep the export pipeline under the test scheduler — otherwise the
+    // Dispatchers.Default hop escapes runTest and forces real-time waits, which flake on CI.
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BasePresenter(mainPresenter) {
     private val _uiState = MutableStateFlow(State4UiState())
     val uiState: StateFlow<State4UiState> = _uiState.asStateFlow()
@@ -118,7 +123,7 @@ abstract class State4Presenter(
                 }
             val headers = TradeExportCsvHeaders.resolveForTrade(trade)
             val csv =
-                withContext(Dispatchers.Default) {
+                withContext(backgroundDispatcher) {
                     TradeCompletedCsv.buildCsv(trade, headers)
                 }
             val fileName = "BisqEasy-trade-${trade.shortTradeId}.csv"


### PR DESCRIPTION
 - allow to inject the dispatcher for for tests to able to control timings with coroutines. Test fer with Ignored OpenTradeListPresenter tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for the open trades list feature with improved test configuration and control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->