### PR TITLE
fix: iOS reconnect overlay -> 'Restart services' button

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -325,62 +325,66 @@ class ClientMainPresenterTest {
     @Test
     fun `uses client specific iOS reconnect overlay copy keys`() {
         mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
-        every { getPlatformInfo() } returns
-            object : PlatformInfo {
-                override val name = "iOS"
-                override val type = PlatformType.IOS
-            }
-
-        val presenter = createPresenter()
-
-        assertEquals("mobile.connectivity.reconnecting.client.details.ios", presenter.reconnectOverlayDetailsKey)
-        assertEquals("mobile.connectivity.reconnecting.restartServices", presenter.reconnectOverlayButtonKey)
-        assertEquals("mobile.connectivity.disconnected.client.message.ios", presenter.connectionsLostDialogMessageKey)
-
-        unmockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
-    }
-
-    @Test
-    fun `onConnectivityRecoveryAction on iOS restarts services and navigates to splash`() =
-        runTest(testDispatcher) {
-            mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+        try {
             every { getPlatformInfo() } returns
                 object : PlatformInfo {
                     override val name = "iOS"
                     override val type = PlatformType.IOS
                 }
 
-            val navigationManager = mockk<NavigationManager>(relaxed = true)
-            coEvery { applicationLifecycleService.restartAllServices() } returns true
-
-            stopKoin()
-            startKoin {
-                modules(
-                    clientTestModule,
-                    module {
-                        single<ClientConnectivityService> { connectivityService }
-                        single<NetworkServiceFacade> { networkServiceFacade }
-                        single<SettingsServiceFacade> { settingsServiceFacade }
-                        single<TradesServiceFacade> { tradesServiceFacade }
-                        single<UserProfileServiceFacade> { userProfileServiceFacade }
-                        single<OpenTradesNotificationService> { openTradesNotificationService }
-                        single<TradeReadStateRepository> { tradeReadStateRepository }
-                        single<ApplicationLifecycleService> { applicationLifecycleService }
-                        single<UrlLauncher> { urlLauncher }
-                        single<NavigationManager> { navigationManager }
-                    },
-                )
-            }
-
             val presenter = createPresenter()
-            presenter.onViewAttached()
-            presenter.onConnectivityRecoveryAction()
-            advanceUntilIdle()
 
-            coVerify { applicationLifecycleService.restartAllServices() }
-            verify { navigationManager.navigate(NavRoute.Splash(), any(), any()) }
-
+            assertEquals("mobile.connectivity.reconnecting.client.details.ios", presenter.reconnectOverlayDetailsKey)
+            assertEquals("mobile.connectivity.reconnecting.restartServices", presenter.reconnectOverlayButtonKey)
+            assertEquals("mobile.connectivity.disconnected.client.message.ios", presenter.connectionsLostDialogMessageKey)
+        } finally {
             unmockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+        }
+    }
+
+    @Test
+    fun `onConnectivityRecoveryAction on iOS restarts services and navigates to splash`() =
+        runTest(testDispatcher) {
+            mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+            try {
+                every { getPlatformInfo() } returns
+                    object : PlatformInfo {
+                        override val name = "iOS"
+                        override val type = PlatformType.IOS
+                    }
+
+                val navigationManager = mockk<NavigationManager>(relaxed = true)
+                coEvery { applicationLifecycleService.restartAllServices() } returns true
+
+                stopKoin()
+                startKoin {
+                    modules(
+                        clientTestModule,
+                        module {
+                            single<ClientConnectivityService> { connectivityService }
+                            single<NetworkServiceFacade> { networkServiceFacade }
+                            single<SettingsServiceFacade> { settingsServiceFacade }
+                            single<TradesServiceFacade> { tradesServiceFacade }
+                            single<UserProfileServiceFacade> { userProfileServiceFacade }
+                            single<OpenTradesNotificationService> { openTradesNotificationService }
+                            single<TradeReadStateRepository> { tradeReadStateRepository }
+                            single<ApplicationLifecycleService> { applicationLifecycleService }
+                            single<UrlLauncher> { urlLauncher }
+                            single<NavigationManager> { navigationManager }
+                        },
+                    )
+                }
+
+                val presenter = createPresenter()
+                presenter.onViewAttached()
+                presenter.onConnectivityRecoveryAction()
+                advanceUntilIdle()
+
+                coVerify { applicationLifecycleService.restartAllServices() }
+                verify { navigationManager.navigate(NavRoute.Splash(), any(), any()) }
+            } finally {
+                unmockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+            }
         }
 
     @Test

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,8 +28,13 @@ import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.UrlLauncher
+import network.bisq.mobile.data.utils.getPlatformInfo
+import network.bisq.mobile.domain.model.PlatformInfo
+import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import org.junit.After
 import org.junit.Before
@@ -306,12 +312,84 @@ class ClientMainPresenterTest {
         }
 
     @Test
-    fun `uses client specific reconnect overlay copy keys`() {
+    fun `uses client specific reconnect overlay copy keys on Android`() {
         val presenter = createPresenter()
 
         assertEquals("mobile.connectivity.reconnecting.client.info", presenter.reconnectOverlayInfoKey)
         assertEquals("mobile.connectivity.reconnecting.client.details", presenter.reconnectOverlayDetailsKey)
+        assertEquals("mobile.connectivity.reconnecting.restart", presenter.reconnectOverlayButtonKey)
         assertEquals("mobile.connectivity.disconnected.client.title", presenter.connectionsLostDialogTitleKey)
         assertEquals("mobile.connectivity.disconnected.client.message", presenter.connectionsLostDialogMessageKey)
+    }
+
+    @Test
+    fun `uses client specific iOS reconnect overlay copy keys`() {
+        mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+        every { getPlatformInfo() } returns
+            object : PlatformInfo {
+                override val name = "iOS"
+                override val type = PlatformType.IOS
+            }
+
+        val presenter = createPresenter()
+
+        assertEquals("mobile.connectivity.reconnecting.client.details.ios", presenter.reconnectOverlayDetailsKey)
+        assertEquals("mobile.connectivity.reconnecting.restartServices", presenter.reconnectOverlayButtonKey)
+        assertEquals("mobile.connectivity.disconnected.client.message.ios", presenter.connectionsLostDialogMessageKey)
+
+        unmockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+    }
+
+    @Test
+    fun `onConnectivityRecoveryAction on iOS restarts services and navigates to splash`() =
+        runTest(testDispatcher) {
+            mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+            every { getPlatformInfo() } returns
+                object : PlatformInfo {
+                    override val name = "iOS"
+                    override val type = PlatformType.IOS
+                }
+
+            val navigationManager = mockk<NavigationManager>(relaxed = true)
+            coEvery { applicationLifecycleService.restartAllServices() } returns true
+
+            stopKoin()
+            startKoin {
+                modules(
+                    clientTestModule,
+                    module {
+                        single<ClientConnectivityService> { connectivityService }
+                        single<NetworkServiceFacade> { networkServiceFacade }
+                        single<SettingsServiceFacade> { settingsServiceFacade }
+                        single<TradesServiceFacade> { tradesServiceFacade }
+                        single<UserProfileServiceFacade> { userProfileServiceFacade }
+                        single<OpenTradesNotificationService> { openTradesNotificationService }
+                        single<TradeReadStateRepository> { tradeReadStateRepository }
+                        single<ApplicationLifecycleService> { applicationLifecycleService }
+                        single<UrlLauncher> { urlLauncher }
+                        single<NavigationManager> { navigationManager }
+                    },
+                )
+            }
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            presenter.onConnectivityRecoveryAction()
+            advanceUntilIdle()
+
+            coVerify { applicationLifecycleService.restartAllServices() }
+            verify { navigationManager.navigate(NavRoute.Splash(), any(), any()) }
+
+            unmockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
+        }
+
+    @Test
+    fun `onConnectivityRecoveryAction on Android calls restartApp`() {
+        val presenter = createPresenter()
+        presenter.attachView(mockk(relaxed = true))
+
+        presenter.onConnectivityRecoveryAction()
+
+        verify { applicationLifecycleService.restartApp(any()) }
     }
 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
@@ -913,8 +913,7 @@ class TrustedNodeSetupPresenterTest {
     fun `hides connection failed warning on retry press`() =
         runTest(testDispatcher) {
             // Given
-            coEvery { applicationLifecycleService.deactivate() } returns Unit
-            coEvery { applicationLifecycleService.activate() } returns Unit
+            coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
             presenter.initialize(isWorkflow = true, showConnectionFailed = true)
             advanceUntilIdle()
@@ -925,8 +924,7 @@ class TrustedNodeSetupPresenterTest {
 
             // Then
             assertFalse(presenter.uiState.value.showConnectionFailedWarning)
-            coVerify { applicationLifecycleService.deactivate() }
-            coVerify { applicationLifecycleService.activate() }
+            coVerify { applicationLifecycleService.restartAllServices() }
             verify { navigationManager.navigate(NavRoute.Splash(), any(), any()) }
         }
 
@@ -1016,8 +1014,7 @@ class TrustedNodeSetupPresenterTest {
     @Test
     fun `re-enables retry guard when connection failed warning is shown again after successful retry`() =
         runTest(testDispatcher) {
-            coEvery { applicationLifecycleService.deactivate() } returns Unit
-            coEvery { applicationLifecycleService.activate() } returns Unit
+            coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
             presenter.initialize(isWorkflow = true, showConnectionFailed = true)
             advanceUntilIdle()
@@ -1037,8 +1034,7 @@ class TrustedNodeSetupPresenterTest {
     @Test
     fun `re-enables retry guard when subscriptions failed warning is shown again after successful retry`() =
         runTest(testDispatcher) {
-            coEvery { applicationLifecycleService.deactivate() } returns Unit
-            coEvery { applicationLifecycleService.activate() } returns Unit
+            coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
             presenter.initialize(isWorkflow = true, showSubscriptionsFailed = true)
             advanceUntilIdle()
@@ -1063,7 +1059,7 @@ class TrustedNodeSetupPresenterTest {
     fun `re-shows connection failed warning when lifecycle restart fails`() =
         runTest(testDispatcher) {
             // Given
-            coEvery { applicationLifecycleService.deactivate() } throws RuntimeException("deactivate failed")
+            coEvery { applicationLifecycleService.restartAllServices() } returns false
             setupPresenter()
             presenter.initialize(isWorkflow = true, showConnectionFailed = true)
             advanceUntilIdle()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
@@ -44,9 +44,51 @@ open class ClientMainPresenter(
         applicationLifecycleService,
     ) {
     override val reconnectOverlayInfoKey: String = "mobile.connectivity.reconnecting.client.info"
-    override val reconnectOverlayDetailsKey: String = "mobile.connectivity.reconnecting.client.details"
+    override val reconnectOverlayDetailsKey: String
+        get() =
+            if (isIOS()) {
+                "mobile.connectivity.reconnecting.client.details.ios"
+            } else {
+                "mobile.connectivity.reconnecting.client.details"
+            }
+    override val reconnectOverlayButtonKey: String
+        get() =
+            if (isIOS()) {
+                "mobile.connectivity.reconnecting.restartServices"
+            } else {
+                "mobile.connectivity.reconnecting.restart"
+            }
     override val connectionsLostDialogTitleKey: String = "mobile.connectivity.disconnected.client.title"
-    override val connectionsLostDialogMessageKey: String = "mobile.connectivity.disconnected.client.message"
+    override val connectionsLostDialogMessageKey: String
+        get() =
+            if (isIOS()) {
+                "mobile.connectivity.disconnected.client.message.ios"
+            } else {
+                "mobile.connectivity.disconnected.client.message"
+            }
+
+    override fun onConnectivityRecoveryAction() {
+        if (isIOS()) {
+            restartServicesAndNavigateToSplash()
+        } else {
+            super.onConnectivityRecoveryAction()
+        }
+    }
+
+    private fun restartServicesAndNavigateToSplash() {
+        presenterScope.launch {
+            showLoading()
+            val succeeded = applicationLifecycleService.restartAllServices()
+            hideLoading()
+            if (succeeded) {
+                navigateTo(NavRoute.Splash()) {
+                    it.popUpTo(NavRoute.TabContainer) { inclusive = true }
+                }
+            } else {
+                showSnackbar("mobile.connectivity.restartFailed".i18n(), SnackbarType.ERROR)
+            }
+        }
+    }
 
     override fun onViewAttached() {
         super.onViewAttached()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenter.kt
@@ -341,19 +341,7 @@ class TrustedNodeSetupPresenter(
         ) {
             _uiState.update { it.copy(showConnectionFailedWarning = false, showSubscriptionsFailedWarning = false) }
 
-            // TODO this client networking reset is a good candidate for the new UseCase component if we were to
-            //      reuse this
-            val restartSucceeded =
-                try {
-                    // Full lifecycle restart: deactivate then reactivate all services
-                    // This ensures fresh coroutine scopes for the retry attempt
-                    applicationLifecycleService.deactivate()
-                    applicationLifecycleService.activate()
-                    true
-                } catch (e: Exception) {
-                    log.e(e) { "Lifecycle restart failed during retry" }
-                    false
-                }
+            val restartSucceeded = applicationLifecycleService.restartAllServices()
 
             if (restartSucceeded) {
                 // Navigate to Splash to trigger fresh bootstrap attempt

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -242,6 +242,8 @@ abstract class ApplicationLifecycleService(
             deactivateServiceFacades()
             activateServiceFacades()
             true
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             log.e(e) { "Service restart failed" }
             false

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -224,6 +224,30 @@ abstract class ApplicationLifecycleService(
         }
     }
 
+    /**
+     * In-process restart of all service facades. Used on iOS where [restartApp]
+     * is unavailable, and shared with connection-retry flows that need a clean
+     * lifecycle cycle without killing the process.
+     *
+     * Calls [deactivateServiceFacades] / [activateServiceFacades] directly so
+     * failures propagate to the caller (unlike [deactivate]/[activate], which
+     * swallow errors for background lifecycle management).
+     */
+    suspend fun restartAllServices(): Boolean {
+        if (isTerminating.value) {
+            log.w { "Cannot restart services: app is terminating" }
+            return false
+        }
+        return try {
+            deactivateServiceFacades()
+            activateServiceFacades()
+            true
+        } catch (e: Exception) {
+            log.e(e) { "Service restart failed" }
+            false
+        }
+    }
+
     protected open fun onUnrecoverableError(e: Throwable) {
         log.e(e) { "Unrecoverable error detected. Application must be restarted. Stopping services." }
         serviceScope.launch {

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -46,6 +46,12 @@ mobile.connectivity.reconnecting.info=All connections to the Bisq P2P network ha
 mobile.connectivity.reconnecting.details=This may occur if Bisq was in the background or lost internet connection.\n\n\
   Please wait while connections are reestablished. If reconnection fails, restart Bisq.
 mobile.connectivity.reconnecting.restart=Restart
+mobile.connectivity.reconnecting.restartServices=Restart services
+mobile.connectivity.reconnecting.client.details.ios=This may occur if the app was in the background, lost internet connection, or the trusted node is down.\n\n\
+  If the trusted node is up and running, please wait while the connection is reestablished. If reconnection fails, tap Restart services to restart all services and return to the home screen.
+mobile.connectivity.disconnected.client.message.ios=Connection to your trusted node could not be restored.\n\n\
+  Please check your internet connection, verify the trusted node is up and running, and tap Restart services to restart all services.
+mobile.connectivity.restartFailed=Could not restart services. Please try again.
 mobile.connectivity.reconnecting.client.info=Connection to your trusted node was lost.
 mobile.connectivity.reconnecting.client.details=This may occur if the app was in the background, lost internet connection, or the trusted node is down.\n\n\
   If the trusted node is up and running, please wait while the connection is reestablished. If reconnection fails, restart the app.

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
@@ -1,0 +1,101 @@
+package network.bisq.mobile.presentation.common.service
+
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
+import network.bisq.mobile.data.service.network.KmpTorService
+import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
+import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ApplicationLifecycleServiceRestartTest {
+    private open class TrackingLifecycleService(
+        applicationBootstrapFacade: ApplicationBootstrapFacade = mockk(relaxed = true),
+        kmpTorService: KmpTorService = mockk(relaxed = true),
+    ) : ApplicationLifecycleService(
+            applicationBootstrapFacade,
+            kmpTorService,
+            NoOpAnalyticsService,
+            AnalyticsBootstrapConfig(dsn = "", environment = "test", release = "test", isDebug = false),
+        ) {
+        var deactivateCalls = 0
+        var activateCalls = 0
+        var failOnDeactivate = false
+        var failOnActivate = false
+
+        override suspend fun deactivateServiceFacades() {
+            deactivateCalls++
+            if (failOnDeactivate) {
+                throw RuntimeException("deactivate failed")
+            }
+        }
+
+        override suspend fun activateServiceFacades() {
+            activateCalls++
+            if (failOnActivate) {
+                throw RuntimeException("activate failed")
+            }
+        }
+    }
+
+    @Test
+    fun `restartAllServices deactivates then activates service facades`() =
+        runTest {
+            val service = TrackingLifecycleService()
+
+            val result = service.restartAllServices()
+
+            assertTrue(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
+
+    @Test
+    fun `restartAllServices returns false when deactivation fails`() =
+        runTest {
+            val service =
+                TrackingLifecycleService().apply {
+                    failOnDeactivate = true
+                }
+
+            val result = service.restartAllServices()
+
+            assertFalse(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(0, service.activateCalls)
+        }
+
+    @Test
+    fun `restartAllServices returns false when activation fails`() =
+        runTest {
+            val service =
+                TrackingLifecycleService().apply {
+                    failOnActivate = true
+                }
+
+            val result = service.restartAllServices()
+
+            assertFalse(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
+
+    @Test
+    fun `restartAllServices returns false when app is terminating`() =
+        runTest {
+            val service =
+                object : TrackingLifecycleService() {
+                    init {
+                        compareAndSetIsTerminating(expect = false, update = true)
+                    }
+                }
+
+            val result = service.restartAllServices()
+
+            assertFalse(result)
+        }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -213,15 +213,16 @@ fun App(
                 WarningConfirmationDialog(
                     headline = mainPresenter.connectionsLostDialogTitleKey.i18n(),
                     message = mainPresenter.connectionsLostDialogMessageKey.i18n(),
-                    confirmButtonText = mainPresenter.connectionsLostDialogRestartKey.i18n(),
-                    onConfirm = { presenter.onRestartApp() },
+                    confirmButtonText = mainPresenter.reconnectOverlayButtonKey.i18n(),
+                    onConfirm = { mainPresenter.onConnectivityRecoveryAction() },
                     onDismiss = { presenter.onCloseConnectionLostDialogue() },
                 )
             } else if (showReconnectOverlay) {
                 ReconnectingOverlay(
-                    onClick = { presenter.onRestartApp() },
+                    onClick = { mainPresenter.onConnectivityRecoveryAction() },
                     infoKey = mainPresenter.reconnectOverlayInfoKey,
                     detailsKey = mainPresenter.reconnectOverlayDetailsKey,
+                    buttonTextKey = mainPresenter.reconnectOverlayButtonKey,
                 )
             }
 
@@ -253,6 +254,7 @@ fun ReconnectingOverlay(
     onClick: (() -> Unit)? = null,
     infoKey: String = "mobile.connectivity.reconnecting.info",
     detailsKey: String = "mobile.connectivity.reconnecting.details",
+    buttonTextKey: String = "mobile.connectivity.reconnecting.restart",
 ) {
     Box(
         modifier =
@@ -311,7 +313,7 @@ fun ReconnectingOverlay(
                 )
                 BisqGap.VHalf()
                 BisqButton(
-                    text = "mobile.connectivity.reconnecting.restart".i18n(),
+                    text = buttonTextKey.i18n(),
                     type = BisqButtonType.Outline,
                     onClick = onClick,
                 )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -54,7 +54,7 @@ open class MainPresenter(
     private val settingsService: SettingsServiceFacade,
     private val tradeReadStateRepository: TradeReadStateRepository,
     private val urlLauncher: UrlLauncher,
-    private val applicationLifecycleService: ApplicationLifecycleService,
+    protected val applicationLifecycleService: ApplicationLifecycleService,
 ) : BasePresenter(null),
     AppPresenter {
     // Observable state
@@ -73,9 +73,10 @@ open class MainPresenter(
     open val reconnectOverlayInfoKey: String = "mobile.connectivity.reconnecting.info"
     open val reconnectOverlayDetailsKey: String = "mobile.connectivity.reconnecting.details"
 
+    open val reconnectOverlayButtonKey: String = "mobile.connectivity.reconnecting.restart"
+
     open val connectionsLostDialogTitleKey: String = "mobile.connectivity.disconnected.title"
     open val connectionsLostDialogMessageKey: String = "mobile.connectivity.disconnected.message"
-    open val connectionsLostDialogRestartKey: String = "mobile.connectivity.disconnected.restart"
 
     final override val languageCode: StateFlow<String> get() = settingsService.languageCode
 
@@ -284,6 +285,10 @@ open class MainPresenter(
 
     override fun onRestartApp() {
         applicationLifecycleService.restartApp(view)
+    }
+
+    open fun onConnectivityRecoveryAction() {
+        onRestartApp()
     }
 
     override fun onTerminateApp() {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1534

On iOS client, the button label is now: Restart services. Tapping it runs an in-process `restartAllServices()` (deactivate/activate all service facades, including Tor), then navigates to Splash for a fresh bootstrap.

<img width="393" height="792" alt="iosClient - Reconnecting" src="https://github.com/user-attachments/assets/02501411-6d60-4fb0-a8e8-2b7c868ff238" />

<img width="391" height="768" alt="iosClient - Lost" src="https://github.com/user-attachments/assets/2f20004a-3d72-40fb-9849-ad54b8500b4c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced connectivity recovery with platform-specific restart behaviors for improved reliability
  * New error feedback display when automatic service restart fails
  * Improved reconnection overlay with customizable action button labels

* **Tests**
  * Comprehensive test coverage for service restart functionality
  * Expanded connectivity recovery testing across platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->