### PR TITLE
Fix bug on search bard in offers tab

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
@@ -19,14 +19,7 @@ object OfferbookMarketPresenterTestFactory {
             mockk<OffersServiceFacade>(relaxed = true).also {
                 every { it.offerbookMarketItems } returns MutableStateFlow(emptyList())
             },
-    ): OfferbookMarketPresenter {
-        val mainPresenter =
-            MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
-
-        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
-        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
-
-        val marketPriceServiceFacade =
+        marketPriceServiceFacade: MarketPriceServiceFacade =
             object : MarketPriceServiceFacade(settingsRepository) {
                 override fun findMarketPriceItem(marketVO: MarketVO) = null
 
@@ -36,7 +29,13 @@ object OfferbookMarketPresenterTestFactory {
                 }
 
                 override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
-            }
+            },
+    ): OfferbookMarketPresenter {
+        val mainPresenter =
+            MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
+
+        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
 
         return OfferbookMarketPresenter(
             mainPresenter = mainPresenter,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.presentation.common.test_utils
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
@@ -30,6 +32,7 @@ object OfferbookMarketPresenterTestFactory {
 
                 override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
             },
+        computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
     ): OfferbookMarketPresenter {
         val mainPresenter =
             MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
@@ -44,6 +47,7 @@ object OfferbookMarketPresenterTestFactory {
             userProfileServiceFacade = userProfileServiceFacade,
             settingsRepository = settingsRepository,
             computeOfferbookMarketListUseCase = ComputeOfferbookMarketListUseCase(marketPriceServiceFacade),
+            computationDispatcher = computationDispatcher,
         )
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -57,7 +57,6 @@ import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -213,6 +212,7 @@ class OfferbookPresenterFilterTest {
                 reputationService,
                 tradeRestrictingAlertServiceFacade,
                 FakeOfferbookFilterConfigRepository(),
+                computationDispatcher = testDispatcher,
             )
         offersFlow.value = allOffers
         presenter.onViewAttached()
@@ -242,7 +242,6 @@ class OfferbookPresenterFilterTest {
     }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_onlyMyOffers_filters_to_user_offers() =
         runTest(testDispatcher) {
             val allOffers =
@@ -274,7 +273,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_empty_selection_shows_no_offers() =
         runTest(testDispatcher) {
             val allOffers =
@@ -311,7 +309,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_baseline_availability_remains_stable() =
         runTest(testDispatcher) {
             val allOffers =
@@ -344,7 +341,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_selection_restoration_shows_all_offers() =
         runTest(testDispatcher) {
             val allOffers =
@@ -377,7 +373,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_onlyMyOffers_with_no_own_offers_marks_filters_active() =
         runTest(testDispatcher) {
             val allOffers =
@@ -410,7 +405,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_method_filters_mark_filters_active_when_list_empty() =
         runTest(testDispatcher) {
             val allOffers =
@@ -443,7 +437,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_onlyMyOffers_respects_method_filters() =
         runTest(testDispatcher) {
             val allOffers =
@@ -550,6 +543,7 @@ class OfferbookPresenterFilterTest {
                     mockk(relaxed = true),
                     mockk(relaxed = true),
                     repository,
+                    computationDispatcher = testDispatcher,
                 )
 
             presenter.onViewAttached()
@@ -572,7 +566,6 @@ class OfferbookPresenterFilterTest {
         }
 
     @Test
-    @Ignore("Flaky on CI/Linux; temporarily disabled until Offerbook filter timing is stabilized")
     fun test_cross_market_payment_filter_persistence() =
         runTest(testDispatcher) {
             // Scenario: User filters to only WISE and REVOLUT,
@@ -643,6 +636,7 @@ class OfferbookPresenterFilterTest {
                     reputationService,
                     tradeRestrictingAlertServiceFacade,
                     FakeOfferbookFilterConfigRepository(),
+                    computationDispatcher = testDispatcher,
                 )
             presenter.onViewAttached()
             runCurrent()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.tabs.offers
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.CoroutineScope
@@ -8,13 +9,22 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.model.market.MarketFilter
+import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.model.market.MarketSortBy
+import network.bisq.mobile.data.model.offerbook.MarketListItem
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.data.service.offers.OffersServiceFacade
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.OfferbookMarketPresenterTestFactory
@@ -177,6 +187,57 @@ class OfferbookMarketPresenterLifecycleTest {
         }
 
     @Test
+    fun `search filtering continues after back stack hide and reveal`() =
+        runTest(testDispatcher) {
+            val settingsRepository = SettingsRepositoryMock()
+            val marketItems =
+                MutableStateFlow(
+                    listOf(
+                        marketItem("USD", "US Dollar", numOffers = 3),
+                        marketItem("EUR", "Euro", numOffers = 2),
+                        marketItem("BRL", "Brazilian Real", numOffers = 1),
+                    ),
+                )
+            val offersServiceFacade =
+                mockk<OffersServiceFacade>(relaxed = true).also {
+                    every { it.offerbookMarketItems } returns marketItems
+                }
+            val marketPriceServiceFacade =
+                FakeMarketPriceServiceFacade(
+                    settingsRepository,
+                    marketsWithPrice = setOf("USD", "EUR", "BRL"),
+                )
+            val presenter =
+                OfferbookMarketPresenterTestFactory.create(
+                    settingsRepository = settingsRepository,
+                    offersServiceFacade = offersServiceFacade,
+                    marketPriceServiceFacade = marketPriceServiceFacade,
+                )
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+            waitUntil { presenter.marketCodes() == listOf("USD", "EUR", "BRL") }
+            assertEquals(listOf("USD", "EUR", "BRL"), presenter.marketCodes())
+
+            presenter.setSearchText("eu")
+            advanceUntilIdle()
+            waitUntil { presenter.marketCodes() == listOf("EUR") }
+            assertEquals(listOf("EUR"), presenter.marketCodes())
+
+            // Back-stack-aware lifecycle hides and reveals without disposing presenterScope.
+            presenter.onViewHidden()
+            advanceUntilIdle()
+            presenter.onViewRevealed()
+            advanceUntilIdle()
+
+            presenter.setSearchText("br")
+            advanceUntilIdle()
+            waitUntil { presenter.marketCodes() == listOf("BRL") }
+
+            assertEquals(listOf("BRL"), presenter.marketCodes())
+        }
+
+    @Test
     fun `filter and sortBy work through multiple tab switches`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
@@ -210,4 +271,50 @@ class OfferbookMarketPresenterLifecycleTest {
             advanceUntilIdle()
             assertEquals(MarketFilter.All, presenter.filter.value)
         }
+
+    private fun OfferbookMarketPresenter.marketCodes(): List<String> = marketListItemWithNumOffers.value.map { it.market.quoteCurrencyCode }
+
+    private suspend fun waitUntil(
+        timeoutMs: Long = 1000,
+        condition: () -> Boolean,
+    ) {
+        val start = System.currentTimeMillis()
+        while (!condition()) {
+            if (System.currentTimeMillis() - start > timeoutMs) break
+            delay(10)
+        }
+    }
+
+    private fun marketItem(
+        quoteCode: String,
+        quoteName: String,
+        numOffers: Int,
+    ): MarketListItem {
+        val market =
+            MarketVO(
+                baseCurrencyCode = "BTC",
+                quoteCurrencyCode = quoteCode,
+                baseCurrencyName = "Bitcoin",
+                quoteCurrencyName = quoteName,
+            )
+        return MarketListItem.from(market = market, numOffers = numOffers)
+    }
+
+    private class FakeMarketPriceServiceFacade(
+        settingsRepository: SettingsRepository,
+        private val marketsWithPrice: Set<String>,
+    ) : MarketPriceServiceFacade(settingsRepository) {
+        override fun findMarketPriceItem(marketVO: MarketVO): MarketPriceItem? {
+            if (!marketsWithPrice.contains(marketVO.quoteCurrencyCode)) return null
+            val quote = PriceQuoteVOFactory.run { fromPrice(priceValue = 100_00L, market = marketVO) }
+            return MarketPriceItem(marketVO, quote, formattedPrice = "100")
+        }
+
+        override fun findUSDMarketPriceItem(): MarketPriceItem? = findMarketPriceItem(MarketVO("BTC", "USD"))
+
+        override fun refreshSelectedFormattedMarketPrice() {
+        }
+
+        override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
+    }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -212,16 +211,15 @@ class OfferbookMarketPresenterLifecycleTest {
                     settingsRepository = settingsRepository,
                     offersServiceFacade = offersServiceFacade,
                     marketPriceServiceFacade = marketPriceServiceFacade,
+                    computationDispatcher = testDispatcher,
                 )
 
             presenter.onViewAttached()
             advanceUntilIdle()
-            waitUntil { presenter.marketCodes() == listOf("USD", "EUR", "BRL") }
             assertEquals(listOf("USD", "EUR", "BRL"), presenter.marketCodes())
 
             presenter.setSearchText("eu")
             advanceUntilIdle()
-            waitUntil { presenter.marketCodes() == listOf("EUR") }
             assertEquals(listOf("EUR"), presenter.marketCodes())
 
             // Back-stack-aware lifecycle hides and reveals without disposing presenterScope.
@@ -232,8 +230,6 @@ class OfferbookMarketPresenterLifecycleTest {
 
             presenter.setSearchText("br")
             advanceUntilIdle()
-            waitUntil { presenter.marketCodes() == listOf("BRL") }
-
             assertEquals(listOf("BRL"), presenter.marketCodes())
         }
 
@@ -273,17 +269,6 @@ class OfferbookMarketPresenterLifecycleTest {
         }
 
     private fun OfferbookMarketPresenter.marketCodes(): List<String> = marketListItemWithNumOffers.value.map { it.market.quoteCurrencyCode }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 1000,
-        condition: () -> Boolean,
-    ) {
-        val start = System.currentTimeMillis()
-        while (!condition()) {
-            if (System.currentTimeMillis() - start > timeoutMs) break
-            delay(10)
-        }
-    }
 
     private fun marketItem(
         quoteCode: String,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.tabs.offers
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,6 +31,9 @@ class OfferbookMarketPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
     private val computeOfferbookMarketListUseCase: ComputeOfferbookMarketListUseCase,
+    // Background dispatcher for the (CPU-bound) market-list computation. Injectable so tests can
+    // pass the test dispatcher and keep the pipeline under the test scheduler.
+    private val computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BasePresenter(mainPresenter) {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.OfferbookMarket
 
@@ -117,7 +121,7 @@ class OfferbookMarketPresenter(
                 offersServiceFacade.offerbookMarketItems,
             ) { filter, searchText, sortBy, _, languageCode, items ->
                 computeOfferbookMarketListUseCase(filter, searchText, sortBy, languageCode, items)
-            }.flowOn(Dispatchers.Default)
+            }.flowOn(computationDispatcher)
                 .collect { result ->
                     _marketListItemWithNumOffers.value = result
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
@@ -31,13 +31,11 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.inputfiel
 import network.bisq.mobile.presentation.common.ui.components.organisms.market.MarketFilters
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
-import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.koin.compose.koinInject
+import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
 
 @Composable
 fun OfferbookMarketScreen() {
-    val presenter: OfferbookMarketPresenter = koinInject()
-    RememberPresenterLifecycle(presenter)
+    val presenter = RememberPresenterLifecycleBackStackAware<OfferbookMarketPresenter>()
 
     var showFilterDialog by remember { mutableStateOf(false) }
     val searchText by presenter.searchText.collectAsState()


### PR DESCRIPTION
Fixes: https://github.com/bisq-network/bisq-mobile/issues/1516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where the offers market search filter could reset or fail to stay in sync when hiding and then returning to the screen.
  * Search results now remain correctly filtered after navigation/backstack visibility changes, providing consistent behavior when you revisit the offers market.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->