### PR TITLE
Add FAQs sreen implementation to More tab

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -4,6 +4,7 @@ import network.bisq.mobile.client.common.presentation.support.ClientSupportPrese
 import network.bisq.mobile.client.common.presentation.top_bar.ClientTopBarPresenter
 import network.bisq.mobile.client.main.ClientMainPresenter
 import network.bisq.mobile.client.offerbook.ClientOfferbookPresenter
+import network.bisq.mobile.client.settings.faqs.FaqClientPresenter
 import network.bisq.mobile.client.splash.ClientSplashPresenter
 import network.bisq.mobile.client.tabs.more.ClientMiscItemsPresenter
 import network.bisq.mobile.client.trusted_node_setup.TrustedNodeSetupPresenter
@@ -12,6 +13,7 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPre
 import network.bisq.mobile.presentation.main.AppPresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offerbook.OfferbookPresenter
+import network.bisq.mobile.presentation.settings.faqs.FaqPresenter
 import network.bisq.mobile.presentation.startup.splash.SplashPresenter
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 import org.koin.dsl.bind
@@ -83,6 +85,8 @@ val clientPresentationModule =
         } bind ITopBarPresenter::class
 
         factory<MiscItemsPresenter> { ClientMiscItemsPresenter(get(), get()) }
+
+        factory<FaqPresenter> { FaqClientPresenter(get()) }
 
         factory<ClientSupportPresenter> {
             ClientSupportPresenter(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/settings/faqs/FaqClientPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/settings/faqs/FaqClientPresenter.kt
@@ -1,0 +1,12 @@
+package network.bisq.mobile.client.settings.faqs
+
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.presentation.settings.faqs.FaqPresenter
+
+class FaqClientPresenter(
+    mainPresenter: MainPresenter,
+) : FaqPresenter(
+        mainPresenter = mainPresenter,
+        q2AnswerKey = "mobile.faqs.q2.answer.connect",
+        q3AnswerKey = "mobile.faqs.q3.answer.connect",
+    )

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -6,7 +6,6 @@ import network.bisq.mobile.client.common.domain.service.push_notification.Client
 import network.bisq.mobile.client.common.domain.service.push_notification.IosPushNotificationTokenProvider
 import network.bisq.mobile.client.common.domain.service.push_notification.PushNotificationApiGateway
 import network.bisq.mobile.client.common.domain.service.push_notification.PushNotificationTokenProvider
-import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.data.service.AppForegroundController
 import network.bisq.mobile.data.service.ForegroundDetector
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.node.common.di
 
 import network.bisq.mobile.node.main.NodeMainPresenter
 import network.bisq.mobile.node.settings.backup.presentation.BackupPresenter
+import network.bisq.mobile.node.settings.faqs.FaqNodePresenter
 import network.bisq.mobile.node.settings.settings.NodeSettingsPresenter
 import network.bisq.mobile.node.startup.onboarding.NodeOnboardingPresenter
 import network.bisq.mobile.node.startup.splash.NodeSplashPresenter
@@ -16,6 +17,7 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPre
 import network.bisq.mobile.presentation.main.AppPresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offerbook.OfferbookPresenter
+import network.bisq.mobile.presentation.settings.faqs.FaqPresenter
 import network.bisq.mobile.presentation.settings.settings.SettingsPresenter
 import network.bisq.mobile.presentation.startup.onboarding.OnboardingPresenter
 import network.bisq.mobile.presentation.startup.splash.SplashPresenter
@@ -56,6 +58,8 @@ val androidNodePresentationModule =
         factory<TopBarPresenter> { TopBarPresenter(get(), get(), get(), get()) } bind ITopBarPresenter::class
 
         factory<MiscItemsPresenter> { NodeMiscItemsPresenter(get(), get()) }
+
+        factory<FaqPresenter> { FaqNodePresenter(get()) }
 
         factory<BackupPresenter> { BackupPresenter(get(), get()) }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/settings/faqs/FaqNodePresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/settings/faqs/FaqNodePresenter.kt
@@ -1,0 +1,12 @@
+package network.bisq.mobile.node.settings.faqs
+
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.presentation.settings.faqs.FaqPresenter
+
+class FaqNodePresenter(
+    mainPresenter: MainPresenter,
+) : FaqPresenter(
+        mainPresenter = mainPresenter,
+        q2AnswerKey = "mobile.faqs.q2.answer.node",
+        q3AnswerKey = "mobile.faqs.q3.answer.node",
+    )

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -274,6 +274,7 @@ mobile.user.paymentAccounts.unsupported=This account is not supported
 # More
 ################################################################################
 mobile.more.support=Support
+mobile.more.faqs=FAQs
 mobile.more.reputation=Reputation
 mobile.more.userProfile=User profile
 mobile.more.paymentAccounts=Payment accounts
@@ -350,6 +351,30 @@ mobile.resources.restore.error.decryptionFailed=Decryption with the provided pas
 mobile.resources.restore.error.unzipFailed=Extracting zip file failed.
 mobile.resources.restore.error.missingBackupDir=Could not restore because backup directory is not present.
 mobile.resources.restore.error.invalidBackupStructure=The backup directory does not have the expected subdirectories.
+
+################################################################################
+# FAQs
+################################################################################
+mobile.faqs.screenTitle=Frequently asked questions
+mobile.faqs.header.title=Bisq Easy
+mobile.faqs.header.subtitle=Common questions answered
+mobile.faqs.footer.stillHaveQuestions=Still have questions?
+mobile.faqs.wantToKnowMore=Want to know more?
+mobile.faqs.q1.question=What is Bisq?
+mobile.faqs.q1.answer=Bisq is an open-source, decentralised bitcoin exchange. There is no company, no account, and no KYC. Trades happen directly between peers over Tor. This app uses Bisq Easy — a reputation-based trade protocol where there is no escrow and no security deposit. Instead, sellers build verifiable trust through bonded BSQ, account age, signed witness records, and proof-of-burn, all aggregated into a reputation score. If a dispute arises, mediation is available. Payment is made directly between traders using local payment methods.
+mobile.faqs.q2.question=How do I buy bitcoin?
+mobile.faqs.q2.answer.connect=Open the Offerbook tab and browse offers from sellers. Tap an offer that matches your payment method and amount. Check the seller's reputation score — it is your main safety signal in Bisq Easy. Tap "Take offer", then follow the on-screen steps: send fiat payment to the seller's account and confirm once sent. The seller will verify receipt and send bitcoin to your wallet. Note: you are trading through the Bisq2 node you paired with — make sure you trust that node operator.
+mobile.faqs.q2.answer.node=Open the Offerbook tab and browse offers from sellers. Tap an offer that matches your payment method and amount. Check the seller's reputation score — it is your main safety signal in Bisq Easy. Tap "Take offer", then follow the on-screen steps: send fiat payment to the seller's account and confirm once sent. The seller will verify receipt and send bitcoin directly to your wallet. Your app runs its own Bisq2 node — you are trading peer-to-peer without any intermediary.
+mobile.faqs.q3.question=How do I sell bitcoin?
+mobile.faqs.q3.answer.connect=Go to the Offerbook tab and tap "+" to create a sell offer, or browse existing buy offers and take one. Set your price (market rate or custom), amount range, and accepted payment methods. As a seller you need reputation — buyers rely on it since they send fiat first. Once a buyer takes your offer, share your payment account details via the trade chat. After the buyer confirms payment, send bitcoin to their wallet address. Note: transactions are broadcast through your paired Bisq2 node.
+mobile.faqs.q3.answer.node=Go to the Offerbook tab and tap "+" to create a sell offer, or browse existing buy offers and take one. Set your price (market rate or custom), amount range, and accepted payment methods. As a seller you need reputation — buyers rely on it since they send fiat first. Once a buyer takes your offer, share your payment account details via the trade chat. After the buyer confirms payment, send bitcoin directly to their wallet. Your embedded node signs and broadcasts the transaction — no third party is involved.
+mobile.faqs.q4.question=How do I increase my profile reputation?
+mobile.faqs.q4.answer=Reputation in Bisq Easy is built through several verifiable actions: ageing your Bisq profile, having your account signed by trusted peers, burning BSQ, or bonding BSQ. Each source contributes to an aggregated reputation score shown as a 5-star rating. A higher score makes your sell offers more attractive, since buyers rely on reputation as their primary safety signal. Tap "Reputation" in the More tab to see your current score and learn which actions carry the most weight.
+mobile.faqs.q5.question=Does Bisq hold my bitcoin or personal data?
+mobile.faqs.q5.answer=No. Bisq Easy is non-custodial — bitcoin moves directly from the seller's wallet to the buyer's wallet. There are no user accounts, no email address, no identity verification of any kind. Your pseudonymous profile exists only on the Bisq P2P network. All connections are routed through Tor to protect your IP address.
+mobile.faqs.q6.question=What fees does Bisq Easy charge?
+mobile.faqs.q6.answer=Bisq Easy charges no platform or trading fee for either side. The seller pays the Bitcoin network mining fee when sending bitcoin to the buyer — buyers pay no mining fee. As a trade-off for the zero platform fee, Bisq Easy is designed for smaller trade amounts based on the seller's reputation level. Desktop Bisq 2 supports additional protocols — including MuSig with 2-of-2 multisig escrow — for larger trades; these are not yet available in the mobile app.
+
 
 ################################################################################
 # Reputation

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenterTest.kt
@@ -1,0 +1,116 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FaqPresenterTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var globalUiManager: GlobalUiManager
+    private lateinit var mainPresenter: MainPresenter
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        I18nSupport.initialize("en")
+
+        mainPresenter = mockk(relaxed = true)
+        globalUiManager = mockk(relaxed = true)
+
+        startKoin {
+            modules(
+                module {
+                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
+                    single<NavigationManager> { mockk(relaxed = true) }
+                    single { globalUiManager }
+                },
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `when presenter is created then ui state contains localized FAQ items`() =
+        runTest(testDispatcher) {
+            // Given / When
+            val presenter =
+                createPresenter(
+                    q2AnswerKey = "mobile.faqs.q2.answer.connect",
+                    q3AnswerKey = "mobile.faqs.q3.answer.node",
+                )
+
+            // Then
+            val faqs = presenter.uiState.value.faqs
+            assertEquals(6, faqs.size)
+            assertEquals("mobile.faqs.q1.question".i18n(), faqs[0].question)
+            assertEquals("mobile.faqs.q1.answer".i18n(), faqs[0].answer)
+            assertEquals("mobile.faqs.q2.question".i18n(), faqs[1].question)
+            assertEquals("mobile.faqs.q2.answer.connect".i18n(), faqs[1].answer)
+            assertEquals("mobile.faqs.q3.question".i18n(), faqs[2].question)
+            assertEquals("mobile.faqs.q3.answer.node".i18n(), faqs[2].answer)
+        }
+
+    @Test
+    fun `when want to know more clicked then opens FAQ url`() =
+        runTest(testDispatcher) {
+            // Given
+            val presenter = createPresenter()
+
+            // When
+            presenter.onAction(FaqUiAction.OnWantToKnowMoreClick)
+            advanceUntilIdle()
+
+            // Then
+            coVerify(exactly = 1) { mainPresenter.navigateToUrlWithLauncher(BisqLinks.FREQUENTLY_ASKED_QUESTIONS_URL) }
+            verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
+        }
+
+    private fun createPresenter(
+        q2AnswerKey: String = "mobile.faqs.q2.answer.connect",
+        q3AnswerKey: String = "mobile.faqs.q3.answer.connect",
+    ): FaqPresenter =
+        TestFaqPresenter(
+            mainPresenter = mainPresenter,
+            q2AnswerKey = q2AnswerKey,
+            q3AnswerKey = q3AnswerKey,
+        )
+
+    private class TestFaqPresenter(
+        mainPresenter: MainPresenter,
+        q2AnswerKey: String,
+        q3AnswerKey: String,
+    ) : FaqPresenter(
+            mainPresenter = mainPresenter,
+            q2AnswerKey = q2AnswerKey,
+            q3AnswerKey = q3AnswerKey,
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreenContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreenContentUiTest.kt
@@ -1,0 +1,171 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FaqScreenContentUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockOnAction: (FaqUiAction) -> Unit
+    private lateinit var faqUiState: FaqUiState
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+        mockOnAction = mockk(relaxed = true)
+        faqUiState = sampleFaqUiState()
+    }
+
+    private fun sampleFaqUiState(): FaqUiState =
+        FaqUiState(
+            faqs =
+                listOf(
+                    FaqItemUiState(
+                        question = "mobile.faqs.q1.question".i18n(),
+                        answer = "mobile.faqs.q1.answer".i18n(),
+                    ),
+                    FaqItemUiState(
+                        question = "mobile.faqs.q2.question".i18n(),
+                        answer = "mobile.faqs.q2.answer.connect".i18n(),
+                    ),
+                    FaqItemUiState(
+                        question = "mobile.faqs.q3.question".i18n(),
+                        answer = "mobile.faqs.q3.answer.connect".i18n(),
+                    ),
+                ),
+        )
+
+    private fun setTestContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    content()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when faq content renders then shows header questions and footer link`() {
+        setTestContent {
+            FaqScreenContent(
+                uiState = faqUiState,
+                onAction = mockOnAction,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.faqs.header.title".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.faqs.header.subtitle".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.faqs.q1.question".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.faqs.q2.question".i18n()).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.faqs.wantToKnowMore".i18n())
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when faq question clicked then answer expands`() {
+        setTestContent {
+            FaqScreenContent(
+                uiState = faqUiState,
+                onAction = mockOnAction,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.faqs.q1.answer".i18n()).assertDoesNotExist()
+
+        composeTestRule
+            .onNodeWithText("mobile.faqs.q1.question".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.faqs.q1.answer".i18n()).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when expanded faq question clicked again then answer collapses`() {
+        setTestContent {
+            FaqScreenContent(
+                uiState = faqUiState,
+                onAction = mockOnAction,
+                initialExpandedIndex = 0,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("mobile.faqs.q1.answer".i18n()).assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mobile.faqs.q1.question".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.faqs.q1.answer".i18n()).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when second faq question clicked then only second answer is shown`() {
+        setTestContent {
+            FaqScreenContent(
+                uiState = faqUiState,
+                onAction = mockOnAction,
+                initialExpandedIndex = 0,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.faqs.q2.question".i18n())
+            .performClick()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.faqs.q1.answer".i18n()).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.faqs.q2.answer.connect".i18n()).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when want to know more clicked then triggers action`() {
+        setTestContent {
+            FaqScreenContent(
+                uiState = faqUiState,
+                onAction = mockOnAction,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.faqs.wantToKnowMore".i18n())
+            .performScrollTo()
+            .performClick()
+
+        verify { mockOnAction(FaqUiAction.OnWantToKnowMoreClick) }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
@@ -128,6 +128,9 @@ interface NavRoute {
     data object Support : NavRoute
 
     @Serializable
+    data object Faqs : NavRoute
+
+    @Serializable
     data object Reputation : NavRoute
 
     @Serializable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
@@ -35,6 +35,7 @@ import network.bisq.mobile.presentation.offer.take_offer.payment_method.TakeOffe
 import network.bisq.mobile.presentation.offer.take_offer.review.TakeOfferReviewTradeScreen
 import network.bisq.mobile.presentation.offer.take_offer.settlement.TakeOfferSettlementMethodScreen
 import network.bisq.mobile.presentation.offerbook.OfferbookScreen
+import network.bisq.mobile.presentation.settings.faqs.FaqScreen
 import network.bisq.mobile.presentation.settings.ignored_users.IgnoredUsersScreen
 import network.bisq.mobile.presentation.settings.payment_accounts.PaymentAccountsScreen
 import network.bisq.mobile.presentation.settings.reputation.ReputationScreen
@@ -107,6 +108,7 @@ fun NavGraphBuilder.addCommonAppRoutes() {
     addScreen<NavRoute.ChatRules> { ChatRulesScreen() }
     addScreen<NavRoute.Settings> { SettingsScreen() }
     addScreen<NavRoute.Support> { SupportScreen() }
+    addScreen<NavRoute.Faqs> { FaqScreen() }
     addScreen<NavRoute.Reputation> { ReputationScreen() }
     addScreen<NavRoute.UserProfile> { UserProfileScreen() }
     addScreen<NavRoute.PaymentAccounts> { PaymentAccountsScreen() }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.common.ui.utils
 
 object BisqLinks {
     const val BISQ_EASY_WIKI_URL = "https://bisq.wiki/Bisq_Easy"
+    const val FREQUENTLY_ASKED_QUESTIONS_URL = "https://bisq.wiki/Frequently_asked_questions"
     const val REPUTATION_WIKI_URL = "https://bisq.wiki/Reputation"
     const val BUILD_REPUTATION_WIKI_URL = "https://bisq.wiki/Reputation#How_to_Build_Reputation"
     const val BLUE_WALLET_TUTORIAL_1_URL = "https://www.youtube.com/watch?v=NqY3wBhloH4"

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenter.kt
@@ -1,0 +1,51 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.base.BasePresenter
+import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.main.MainPresenter
+
+abstract class FaqPresenter(
+    mainPresenter: MainPresenter,
+    private val q2AnswerKey: String,
+    private val q3AnswerKey: String,
+) : BasePresenter(mainPresenter) {
+    private val _uiState = MutableStateFlow(FaqUiState(faqs = buildFaqList()))
+    val uiState = _uiState.asStateFlow()
+
+    fun onAction(action: FaqUiAction) {
+        when (action) {
+            FaqUiAction.OnWantToKnowMoreClick -> navigateToUrl(BisqLinks.FREQUENTLY_ASKED_QUESTIONS_URL)
+        }
+    }
+
+    private fun buildFaqList(): List<FaqItemUiState> =
+        listOf(
+            FaqItemUiState(
+                question = "mobile.faqs.q1.question".i18n(),
+                answer = "mobile.faqs.q1.answer".i18n(),
+            ),
+            FaqItemUiState(
+                question = "mobile.faqs.q2.question".i18n(),
+                answer = q2AnswerKey.i18n(),
+            ),
+            FaqItemUiState(
+                question = "mobile.faqs.q3.question".i18n(),
+                answer = q3AnswerKey.i18n(),
+            ),
+            FaqItemUiState(
+                question = "mobile.faqs.q4.question".i18n(),
+                answer = "mobile.faqs.q4.answer".i18n(),
+            ),
+            FaqItemUiState(
+                question = "mobile.faqs.q5.question".i18n(),
+                answer = "mobile.faqs.q5.answer".i18n(),
+            ),
+            FaqItemUiState(
+                question = "mobile.faqs.q6.question".i18n(),
+                answer = "mobile.faqs.q6.answer".i18n(),
+            ),
+        )
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreen.kt
@@ -1,0 +1,256 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowDownIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowRightIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.BisqLogoGreen
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
+import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
+
+@Composable
+fun FaqScreen() {
+    val presenter = RememberPresenterLifecycleBackStackAware<FaqPresenter>()
+
+    val uiState by presenter.uiState.collectAsState()
+
+    FaqScreenContent(
+        uiState = uiState,
+        onAction = presenter::onAction,
+        topBar = { TopBar("mobile.faqs.screenTitle".i18n(), showUserAvatar = false) },
+    )
+}
+
+@Composable
+fun FaqScreenContent(
+    uiState: FaqUiState,
+    onAction: (FaqUiAction) -> Unit,
+    initialExpandedIndex: Int = -1,
+    topBar: @Composable () -> Unit = {},
+) {
+    var expandedIndex by rememberSaveable { mutableIntStateOf(initialExpandedIndex) }
+
+    BisqScaffold(
+        topBar = topBar,
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            FaqLogoHeader()
+
+            BisqGap.V2()
+
+            uiState.faqs.forEachIndexed { index, faq ->
+                FaqItem(
+                    faq = faq,
+                    isExpanded = expandedIndex == index,
+                    onToggle = {
+                        expandedIndex = if (expandedIndex == index) -1 else index
+                    },
+                )
+
+                BisqHDivider(verticalPadding = BisqUIConstants.ScreenPaddingHalf)
+            }
+
+            BisqGap.V2()
+
+            FaqFooterLink(onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun FaqLogoHeader() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        BisqLogoGreen(modifier = Modifier.size(72.dp))
+        BisqGap.V1()
+        BisqText.H3Light(
+            text = "mobile.faqs.header.title".i18n(),
+            textAlign = TextAlign.Center,
+        )
+        BisqGap.VHalf()
+        BisqText.SmallLight(
+            text = "mobile.faqs.header.subtitle".i18n(),
+            color = BisqTheme.colors.mid_grey20,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun FaqItem(
+    faq: FaqItemUiState,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
+                .clickable(onClick = onToggle)
+                .animateContentSize(animationSpec = tween(durationMillis = 200)),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = BisqUIConstants.ScreenPaddingHalf),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            BisqText.BaseLight(
+                text = faq.question,
+                modifier = Modifier.weight(1f),
+            )
+            BisqGap.H1()
+            if (isExpanded) {
+                ArrowDownIcon(modifier = Modifier.size(12.dp))
+            } else {
+                ArrowRightIcon(modifier = Modifier.size(12.dp))
+            }
+        }
+
+        if (isExpanded) {
+            BisqText.BaseLight(
+                text = faq.answer,
+                color = BisqTheme.colors.light_grey50,
+                modifier = Modifier.padding(bottom = BisqUIConstants.ScreenPaddingHalf),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FaqFooterLink(onAction: (FaqUiAction) -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        BisqGap.V1()
+        BisqText.SmallLight(
+            text = "mobile.faqs.footer.stillHaveQuestions".i18n(),
+            color = BisqTheme.colors.mid_grey20,
+            textAlign = TextAlign.Center,
+        )
+        BisqGap.VHalf()
+        BisqButton(
+            text = "mobile.faqs.wantToKnowMore".i18n(),
+            onClick = { onAction(FaqUiAction.OnWantToKnowMoreClick) },
+            color = BisqTheme.colors.primary,
+            type = BisqButtonType.Underline,
+            padding = PaddingValues(all = BisqUIConstants.Zero),
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(name = "FAQ Screen — All Collapsed")
+@Composable
+private fun FaqScreenAllCollapsedPreview() {
+    BisqTheme.Preview {
+        FaqScreenContent(
+            uiState = faqPreviewUiState,
+            onAction = {},
+            topBar = { FaqPreviewTopBar() },
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(name = "FAQ Screen — First Expanded")
+@Composable
+private fun FaqScreenFirstExpandedPreview() {
+    BisqTheme.Preview {
+        FaqScreenContent(
+            uiState = faqPreviewUiState,
+            initialExpandedIndex = 0,
+            onAction = {},
+            topBar = { FaqPreviewTopBar() },
+        )
+    }
+}
+
+@Composable
+private fun FaqPreviewTopBar() {
+    TopBarContent(
+        title = "Frequently Asked Questions",
+        showBackButton = true,
+        showUserAvatar = false,
+    )
+}
+
+private val faqPreviewUiState =
+    FaqUiState(
+        faqs =
+            listOf(
+                FaqItemUiState(
+                    question = "What is Bisq?",
+                    answer =
+                        "Bisq is an open-source, decentralised bitcoin exchange. " +
+                            "Trades happen directly between peers over Tor, without accounts or KYC.",
+                ),
+                FaqItemUiState(
+                    question = "How do I buy bitcoin?",
+                    answer =
+                        "Open the Offerbook tab, choose an offer that matches your payment method, " +
+                            "and follow the trade steps shown in the app.",
+                ),
+                FaqItemUiState(
+                    question = "How do I sell bitcoin?",
+                    answer =
+                        "Create a sell offer or take an existing buy offer, then coordinate payment " +
+                            "and bitcoin transfer with the buyer through the trade chat.",
+                ),
+                FaqItemUiState(
+                    question = "How do I increase my profile reputation?",
+                    answer =
+                        "Build reputation through profile age, account signing, burning BSQ, or bonding BSQ.",
+                ),
+            ),
+    )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqUiAction.kt
@@ -1,0 +1,5 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+sealed interface FaqUiAction {
+    data object OnWantToKnowMoreClick : FaqUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqUiState.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.presentation.settings.faqs
+
+data class FaqUiState(
+    val faqs: List<FaqItemUiState> = emptyList(),
+)
+
+data class FaqItemUiState(
+    val question: String,
+    val answer: String,
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.tabs.more
 
 import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.icon_question_mark
 import bisqapps.shared.presentation.generated.resources.nav_accounts
 import bisqapps.shared.presentation.generated.resources.nav_ignored_users
 import bisqapps.shared.presentation.generated.resources.nav_reputation
@@ -61,6 +62,11 @@ abstract class MiscItemsPresenter(
                     label = "mobile.more.support".i18n(),
                     icon = Res.drawable.nav_support,
                     route = NavRoute.Support,
+                ),
+                MenuItem.Leaf(
+                    label = "mobile.more.faqs".i18n(),
+                    icon = Res.drawable.icon_question_mark,
+                    route = NavRoute.Faqs,
                 ),
                 MenuItem.Leaf(
                     label = "mobile.more.paymentAccounts".i18n(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new FAQs screen with expandable questions and a “want to know more” link that opens the frequently asked questions page.
  * Included FAQs in the More menu and added dedicated navigation/route to the FAQs screen.
  * Added FAQ localization content and wired separate FAQ presenters for the mobile client and node views.
* **Tests**
  * Added unit and Compose UI tests covering FAQ rendering, expand/collapse behavior, and the “want to know more” action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->