### PR TITLE
GuardSuspendAction return Job?

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/main/ClientMainPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.main
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
@@ -67,6 +68,8 @@ open class ClientMainPresenter(
                 "mobile.connectivity.disconnected.client.message"
             }
 
+    private val _isConnectivityRecoveryEnabled = MutableStateFlow(true)
+
     override fun onConnectivityRecoveryAction() {
         if (isIOS()) {
             restartServicesAndNavigateToSplash()
@@ -76,10 +79,11 @@ open class ClientMainPresenter(
     }
 
     private fun restartServicesAndNavigateToSplash() {
-        presenterScope.launch {
-            showLoading()
+        guardedSuspendAction(
+            _isConnectivityRecoveryEnabled,
+            "restartServicesAndNavigateToSplash",
+        ) {
             val succeeded = applicationLifecycleService.restartAllServices()
-            hideLoading()
             if (succeeded) {
                 navigateTo(NavRoute.Splash()) {
                     it.popUpTo(NavRoute.TabContainer) { inclusive = true }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -10,6 +10,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -38,6 +39,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -226,7 +229,7 @@ class BasePresenterTest {
             val presenter = GuardTestPresenter(mainPresenter)
             presenter.onViewAttached()
 
-            assertTrue(presenter.runGuarded(guard))
+            assertNotNull(presenter.runGuarded(guard))
             advanceUntilIdle()
 
             assertTrue(guard.value)
@@ -240,12 +243,12 @@ class BasePresenterTest {
             val presenter = GuardTestPresenter(mainPresenter)
             presenter.onViewAttached()
 
-            assertTrue(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
+            assertNotNull(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
             advanceUntilIdle() // first block enters and suspends on delay
             assertEquals(1, presenter.blockStartCount)
             assertFalse(guard.value)
 
-            assertFalse(presenter.runGuarded(guard, blockForMs = 0))
+            assertNull(presenter.runGuarded(guard, blockForMs = 0))
             assertEquals(1, presenter.blockStartCount)
             assertEquals(0, presenter.completedActions)
         }
@@ -257,7 +260,7 @@ class BasePresenterTest {
             val presenter = GuardTestPresenter(mainPresenter)
             presenter.onViewAttached()
 
-            assertTrue(presenter.runGuarded(guard, reEnableGuardOnComplete = false))
+            assertNotNull(presenter.runGuarded(guard, reEnableGuardOnComplete = false))
             advanceUntilIdle()
 
             assertFalse(guard.value)
@@ -270,7 +273,7 @@ class BasePresenterTest {
             val presenter = GuardTestPresenter(mainPresenter)
             presenter.onViewAttached()
 
-            assertTrue(
+            assertNotNull(
                 presenter.runGuarded(reEnableGuardOnComplete = false) {
                     guard.value = true
                 },
@@ -278,6 +281,24 @@ class BasePresenterTest {
             advanceUntilIdle()
 
             assertTrue(guard.value)
+        }
+
+    @Test
+    fun `guardedSuspendAction returns cancellable Job that restores guard on cancel`() =
+        runTest(testDispatcher) {
+            val guard = MutableStateFlow(true)
+            val presenter = GuardTestPresenter(mainPresenter)
+            presenter.onViewAttached()
+
+            val job = assertNotNull(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
+            advanceUntilIdle()
+            assertFalse(guard.value)
+
+            job.cancel()
+            advanceUntilIdle()
+
+            assertTrue(guard.value)
+            verify(atLeast = 1) { globalUiManager.hideLoading() }
         }
 
     private class GuardTestPresenter(
@@ -292,7 +313,7 @@ class BasePresenterTest {
             showLoadingOverlay: Boolean = true,
             reEnableGuardOnComplete: Boolean = true,
             block: (suspend () -> Unit)? = null,
-        ): Boolean =
+        ): Job? =
             guardedSuspendAction(
                 guard,
                 "testAction",

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -243,14 +243,19 @@ class BasePresenterTest {
             val presenter = GuardTestPresenter(mainPresenter)
             presenter.onViewAttached()
 
-            assertNotNull(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
-            advanceUntilIdle() // first block enters and suspends on delay
-            assertEquals(1, presenter.blockStartCount)
-            assertFalse(guard.value)
+            val job = assertNotNull(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
+            try {
+                advanceUntilIdle() // first block enters and suspends on delay
+                assertEquals(1, presenter.blockStartCount)
+                assertFalse(guard.value)
 
-            assertNull(presenter.runGuarded(guard, blockForMs = 0))
-            assertEquals(1, presenter.blockStartCount)
-            assertEquals(0, presenter.completedActions)
+                assertNull(presenter.runGuarded(guard, blockForMs = 0))
+                assertEquals(1, presenter.blockStartCount)
+                assertEquals(0, presenter.completedActions)
+            } finally {
+                job.cancel()
+                advanceUntilIdle()
+            }
         }
 
     @Test
@@ -274,7 +279,7 @@ class BasePresenterTest {
             presenter.onViewAttached()
 
             assertNotNull(
-                presenter.runGuarded(reEnableGuardOnComplete = false) {
+                presenter.runGuarded(guard = guard, reEnableGuardOnComplete = false) {
                     guard.value = true
                 },
             )
@@ -297,6 +302,25 @@ class BasePresenterTest {
             job.cancel()
             advanceUntilIdle()
 
+            assertTrue(guard.value)
+            verify(atLeast = 1) { globalUiManager.hideLoading() }
+        }
+
+    @Test
+    fun `guardedSuspendAction restores guard and hides loading when cancelled before coroutine starts`() =
+        runTest(testDispatcher) {
+            val guard = MutableStateFlow(true)
+            val presenter = GuardTestPresenter(mainPresenter)
+            presenter.onViewAttached()
+
+            val job = assertNotNull(presenter.runGuarded(guard, blockForMs = Long.MAX_VALUE))
+            assertFalse(guard.value)
+            assertEquals(0, presenter.blockStartCount)
+
+            job.cancel()
+            advanceUntilIdle()
+
+            assertEquals(0, presenter.blockStartCount)
             assertTrue(guard.value)
             verify(atLeast = 1) { globalUiManager.hideLoading() }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.navigation.NavOptionsBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -481,7 +482,11 @@ abstract class BasePresenter(
      * Runs [block] on [presenterScope] behind [guard] using compareAndSet.
      * [guard] uses `true` = enabled; it is cleared for the duration of [block]
      * and restored in finally when [reEnableGuardOnComplete] is true.
-     * Returns whether the action was started.
+     *
+     * @return `null` when the guard rejects the call (action already in progress),
+     *   or the [Job] launched on [presenterScope] when the action was started.
+     *   The caller may call [Job.cancel] to abort in-flight work; the `finally`
+     *   block still runs on cancellation, restoring the guard and hiding loading.
      */
     protected fun guardedSuspendAction(
         guard: MutableStateFlow<Boolean>,
@@ -489,15 +494,15 @@ abstract class BasePresenter(
         showLoadingOverlay: Boolean = true,
         reEnableGuardOnComplete: Boolean = true,
         block: suspend () -> Unit,
-    ): Boolean {
+    ): Job? {
         if (!guard.compareAndSet(expect = true, update = false)) {
             log.w { "$actionName called while already in progress; ignoring" }
-            return false
+            return null
         }
         if (showLoadingOverlay) {
             showLoading()
         }
-        presenterScope.launch {
+        return presenterScope.launch {
             try {
                 block()
             } finally {
@@ -509,7 +514,6 @@ abstract class BasePresenter(
                 }
             }
         }
-        return true
     }
 
     protected fun registerChild(child: BasePresenter) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -481,12 +481,13 @@ abstract class BasePresenter(
     /**
      * Runs [block] on [presenterScope] behind [guard] using compareAndSet.
      * [guard] uses `true` = enabled; it is cleared for the duration of [block]
-     * and restored in finally when [reEnableGuardOnComplete] is true.
+     * and restored on job completion when [reEnableGuardOnComplete] is true.
      *
      * @return `null` when the guard rejects the call (action already in progress),
      *   or the [Job] launched on [presenterScope] when the action was started.
-     *   The caller may call [Job.cancel] to abort in-flight work; the `finally`
-     *   block still runs on cancellation, restoring the guard and hiding loading.
+     *   The caller may call [Job.cancel] to abort in-flight work; cleanup registered
+     *   via [Job.invokeOnCompletion] still runs on cancellation, restoring the guard
+     *   and hiding loading even when the coroutine body never started.
      */
     protected fun guardedSuspendAction(
         guard: MutableStateFlow<Boolean>,
@@ -502,18 +503,16 @@ abstract class BasePresenter(
         if (showLoadingOverlay) {
             showLoading()
         }
-        return presenterScope.launch {
-            try {
-                block()
-            } finally {
-                if (reEnableGuardOnComplete) {
-                    guard.value = true
-                }
-                if (showLoadingOverlay) {
-                    hideLoading()
-                }
+        val job = presenterScope.launch { block() }
+        job.invokeOnCompletion {
+            if (reEnableGuardOnComplete) {
+                guard.value = true
+            }
+            if (showLoadingOverlay) {
+                hideLoading()
             }
         }
+        return job
     }
 
     protected fun registerChild(child: BasePresenter) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1537

Also fixes this nit: https://github.com/bisq-network/bisq-mobile/pull/1536#discussion_r3465144887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of connectivity recovery by preventing duplicate recovery attempts and better handling loading/guard lifecycles.
  * Service restart flows now route back to the splash screen more consistently, with improved error snackbar behavior on failure.
* **Tests**
  * Updated guarded-action and cancellation coverage to reflect the new guarded execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->