### PR TITLE
Schedule hide loading

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientServiceTest.kt
@@ -877,6 +877,33 @@ class WebSocketClientServiceTest {
         }
 
     @Test
+    fun `forceClientRecreation is no-op when no WebSocket client exists`() =
+        runTest(testDispatcher) {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            coEvery { kmpTorService.signalNewNym() } just Runs
+
+            val torWebSocketClientService =
+                WebSocketClientService(
+                    defaultHost = "abc.onion",
+                    defaultPort = 8090,
+                    httpClientService = httpClientService,
+                    webSocketClientFactory = webSocketClientFactory,
+                    sessionService = sessionService,
+                    sensitiveSettingsRepository = sensitiveSettingsRepository,
+                    kmpTorService = kmpTorService,
+                )
+
+            torWebSocketClientService.activate()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            torWebSocketClientService.forceClientRecreation()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) { kmpTorService.signalNewNym() }
+            coVerify(exactly = 0) { httpClientService.recreateClient() }
+        }
+
+    @Test
     fun `forceClientRecreation signals NEWNYM when using Tor proxy`() =
         runTest(testDispatcher) {
             val kmpTorService = mockk<KmpTorService>(relaxed = true)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewPresenterTest.kt
@@ -70,7 +70,7 @@ class PaymentAccountReviewPresenterTest {
         }
 
         every { globalUiManager.scheduleShowLoading() } returns Unit
-        every { globalUiManager.hideLoading() } returns Unit
+        every { globalUiManager.scheduleHideLoading() } returns Unit
     }
 
     @AfterTest
@@ -136,7 +136,7 @@ class PaymentAccountReviewPresenterTest {
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.addAccount(account) }
             verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             assertEquals(PaymentAccountReviewEffect.CloseCreateAccountFlow, effectDeferred.await())
         }
 
@@ -157,7 +157,7 @@ class PaymentAccountReviewPresenterTest {
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.addAccount(account) }
             verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             verify {
                 globalUiManager.showSnackbar(
                     "Account name already exists. Please choose a different one.",
@@ -186,7 +186,7 @@ class PaymentAccountReviewPresenterTest {
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.addAccount(account) }
             verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             verify {
                 globalUiManager.showSnackbar(
                     any(),

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewScreenTest.kt
@@ -97,7 +97,7 @@ class PaymentAccountReviewScreenTest {
             }
 
         every { globalUiManager.scheduleShowLoading() } returns Unit
-        every { globalUiManager.hideLoading() } returns Unit
+        every { globalUiManager.scheduleHideLoading() } returns Unit
         runCatching { stopKoin() }
         koinApplication =
             startKoin {
@@ -261,7 +261,7 @@ class PaymentAccountReviewScreenTest {
             composeTestRule.waitForIdle()
             coVerify(exactly = 1) { paymentAccountsServiceFacade.addAccount(account) }
             verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             assertTrue(closeCallbackInvoked)
         }
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
@@ -70,7 +70,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
         every { paymentAccountsServiceFacade.accountsByName } returns accountsByNameFlow
         every { globalUiManager.scheduleShowLoading() } returns Unit
-        every { globalUiManager.hideLoading() } returns Unit
+        every { globalUiManager.scheduleHideLoading() } returns Unit
         every { navigationManager.navigateBack(any()) } returns Unit
     }
 
@@ -169,7 +169,7 @@ class PaymentAccountMusigDetailPresenterTest {
             coVerify(exactly = 0) { paymentAccountsServiceFacade.deleteAccount(any()) }
             verify(exactly = 0) { navigationManager.navigateBack(any()) }
             verify(exactly = 0) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 0) { globalUiManager.hideLoading() }
+            verify(exactly = 0) { globalUiManager.scheduleHideLoading() }
         }
 
     @Test
@@ -191,7 +191,7 @@ class PaymentAccountMusigDetailPresenterTest {
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.deleteAccount(account.accountName) }
             verify(exactly = 2) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             verify(exactly = 1) { navigationManager.navigateBack(any()) }
             assertFalse(presenter.uiState.value.showDeleteConfirmationDialog)
         }
@@ -215,7 +215,7 @@ class PaymentAccountMusigDetailPresenterTest {
             // Then
             coVerify(exactly = 1) { paymentAccountsServiceFacade.deleteAccount(account.accountName) }
             verify(exactly = 1) { globalUiManager.scheduleShowLoading() }
-            verify(exactly = 1) { globalUiManager.hideLoading() }
+            verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
             verify(exactly = 0) { navigationManager.navigateBack(any()) }
             verify {
                 globalUiManager.showSnackbar(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -569,7 +569,10 @@ class WebSocketClientService(
      */
     internal suspend fun forceClientRecreation() {
         clientUpdateMutex.withLock {
-            val settings = currentClientSettings ?: return@withLock
+            if (currentClientSettings == null) {
+                log.i { "Skipping force client recreation — no active WebSocket client" }
+                return
+            }
             log.i { "Forcing full client recreation to recover stale HTTP client state / iOS NSURLSession" }
             // Dispose current client and clear settings so updateWebSocketClient
             // treats the next call as a fresh configuration

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -304,7 +304,7 @@ class BasePresenterTest {
             advanceUntilIdle()
 
             assertTrue(guard.value)
-            verify(atLeast = 1) { globalUiManager.hideLoading() }
+            verify(atLeast = 1) { globalUiManager.scheduleHideLoading() }
         }
 
     @Test
@@ -323,7 +323,7 @@ class BasePresenterTest {
 
             assertEquals(0, presenter.blockStartCount)
             assertTrue(guard.value)
-            verify(atLeast = 1) { globalUiManager.hideLoading() }
+            verify(atLeast = 1) { globalUiManager.scheduleHideLoading() }
         }
 
     private class GuardTestPresenter(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -207,6 +207,7 @@ class BasePresenterTest {
         val presenter = TestPresenter(mainPresenter)
 
         val result = runBlocking { presenter.navigateToUrlAwait("https://bisq.network") }
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(result)
         assertFalse(globalUiManager.isLoadingBlocking.value)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenterTest.kt
@@ -126,7 +126,7 @@ class BasePresenterTest {
         presenter.onViewHidden()
 
         // Loading should be hidden
-        verify(exactly = 1) { globalUiManager.hideLoading() }
+        verify(exactly = 1) { globalUiManager.scheduleHideLoading() }
         // Scope should NOT be disposed (no jobsManager.dispose call via unmanaged scope)
         // The presenter is still alive on the back stack
     }
@@ -233,7 +233,7 @@ class BasePresenterTest {
             advanceUntilIdle()
 
             assertTrue(guard.value)
-            verify(atLeast = 1) { globalUiManager.hideLoading() }
+            verify(atLeast = 1) { globalUiManager.scheduleHideLoading() }
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManagerTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManagerTest.kt
@@ -69,7 +69,7 @@ class GlobalUiManagerTest {
         }
 
     @Test
-    fun hideLoading_cancelsScheduledShow_beforeGraceDelayExpires() =
+    fun scheduleHideLoading_cancelsScheduledShow_beforeGraceDelayExpires() =
         runTest(testDispatcher) {
             // Given
             val globalUiManager = GlobalUiManager(testDispatcher)
@@ -80,27 +80,36 @@ class GlobalUiManagerTest {
             // Then: Not shown yet
             assertFalse(globalUiManager.showLoadingDialog.value)
 
-            // When: Hide before grace delay expires
+            // When: Hide before show grace delay expires
             testScheduler.advanceTimeBy(100) // Only 100ms of 150ms
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
 
-            // Then: Still false
+            // Then: Still blocked, dialog still false
+            assertTrue(globalUiManager.isLoadingBlocking.value)
             assertFalse(globalUiManager.showLoadingDialog.value)
 
-            // When: Wait past original grace delay
-            testScheduler.advanceTimeBy(100) // Total 200ms
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
 
-            // Then: Still false (job was cancelled)
+            // Then: Unblocked and dialog still false
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait past original show grace delay
+            testScheduler.advanceTimeBy(100)
+
+            // Then: Still false (show job was cancelled)
             assertFalse(globalUiManager.showLoadingDialog.value)
         }
 
     @Test
-    fun hideLoading_hidesDialog_afterGraceDelayExpires() =
+    fun scheduleHideLoading_hidesDialog_afterGraceDelayExpires() =
         runTest(testDispatcher) {
             // Given
             val globalUiManager = GlobalUiManager(testDispatcher)
 
-            // When: Schedule and wait for grace delay
+            // When: Schedule and wait for show grace delay
             globalUiManager.scheduleShowLoading()
             testScheduler.advanceTimeBy(150)
             testScheduler.runCurrent()
@@ -109,9 +118,18 @@ class GlobalUiManagerTest {
             assertTrue(globalUiManager.showLoadingDialog.value)
 
             // When: Hide
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
 
-            // Then: Dialog hidden immediately
+            // Then: Still visible and blocked during hide grace delay
+            assertTrue(globalUiManager.isLoadingBlocking.value)
+            assertTrue(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+
+            // Then: Dialog hidden and unblocked
+            assertFalse(globalUiManager.isLoadingBlocking.value)
             assertFalse(globalUiManager.showLoadingDialog.value)
         }
 
@@ -144,16 +162,25 @@ class GlobalUiManagerTest {
         }
 
     @Test
-    fun hideLoading_whenNotShowing_doesNothing() =
+    fun scheduleHideLoading_whenNotShowing_stillDelaysUnblock() =
         runTest(testDispatcher) {
             // Given
             val globalUiManager = GlobalUiManager(testDispatcher)
 
             // When: Hide without scheduling
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
 
             // Then: Still false (no error)
             assertFalse(globalUiManager.showLoadingDialog.value)
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+
+            // Then: Still false
+            assertFalse(globalUiManager.showLoadingDialog.value)
+            assertFalse(globalUiManager.isLoadingBlocking.value)
         }
 
     @Test
@@ -165,15 +192,24 @@ class GlobalUiManagerTest {
             // When: Simulate fast operation (completes in 50ms)
             globalUiManager.scheduleShowLoading()
             testScheduler.advanceTimeBy(50)
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
 
-            // Then: Dialog never shown (operation completed before grace delay)
+            // Then: Dialog never shown, still blocked during hide grace delay
+            assertFalse(globalUiManager.showLoadingDialog.value)
+            assertTrue(globalUiManager.isLoadingBlocking.value)
+
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+
+            // Then: Unblocked, dialog still not shown
+            assertFalse(globalUiManager.isLoadingBlocking.value)
             assertFalse(globalUiManager.showLoadingDialog.value)
 
-            // When: Wait past grace delay
+            // When: Wait past show grace delay
             testScheduler.advanceTimeBy(200)
 
-            // Then: Still not shown (job was cancelled)
+            // Then: Still not shown (show job was cancelled)
             assertFalse(globalUiManager.showLoadingDialog.value)
         }
 
@@ -185,7 +221,7 @@ class GlobalUiManagerTest {
 
             // When: Simulate slow operation (takes 300ms)
             globalUiManager.scheduleShowLoading()
-            testScheduler.advanceTimeBy(150) // Grace delay expires
+            testScheduler.advanceTimeBy(150) // Show grace delay expires
             testScheduler.runCurrent()
 
             // Then: Dialog shown
@@ -193,10 +229,15 @@ class GlobalUiManagerTest {
 
             // When: Operation completes
             testScheduler.advanceTimeBy(150) // Total 300ms
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
+
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
 
             // Then: Dialog hidden
             assertFalse(globalUiManager.showLoadingDialog.value)
+            assertFalse(globalUiManager.isLoadingBlocking.value)
         }
 
     @Test
@@ -224,7 +265,7 @@ class GlobalUiManagerTest {
         }
 
     @Test
-    fun hideLoading_setsIsLoadingBlockingToFalse() =
+    fun scheduleHideLoading_setsIsLoadingBlockingToFalseAfterGraceDelay() =
         runTest(testDispatcher) {
             // Given
             val globalUiManager = GlobalUiManager(testDispatcher)
@@ -234,7 +275,15 @@ class GlobalUiManagerTest {
             assertTrue(globalUiManager.isLoadingBlocking.value)
 
             // When: Hide loading
-            globalUiManager.hideLoading()
+            globalUiManager.scheduleHideLoading()
+
+            // Then: Still blocked during hide grace delay
+            assertTrue(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait for hide grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
 
             // Then: Both states are false
             assertFalse(globalUiManager.isLoadingBlocking.value)
@@ -261,5 +310,56 @@ class GlobalUiManagerTest {
             // Then: Both states are true
             assertTrue(globalUiManager.isLoadingBlocking.value)
             assertTrue(globalUiManager.showLoadingDialog.value)
+        }
+
+    @Test
+    fun scheduleShowLoading_cancelsPendingHide() =
+        runTest(testDispatcher) {
+            // Given
+            val globalUiManager = GlobalUiManager(testDispatcher)
+
+            globalUiManager.scheduleShowLoading()
+            testScheduler.advanceTimeBy(50)
+            globalUiManager.scheduleHideLoading()
+            testScheduler.advanceTimeBy(50)
+
+            // When: New operation starts before hide grace delay completes
+            globalUiManager.scheduleShowLoading()
+
+            // Then: Blocking stays active
+            assertTrue(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait for show grace delay
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+
+            // Then: Dialog shown again
+            assertTrue(globalUiManager.showLoadingDialog.value)
+        }
+
+    @Test
+    fun dispose_clearsLoadingStateImmediately() =
+        runTest(testDispatcher) {
+            // Given
+            val globalUiManager = GlobalUiManager(testDispatcher)
+
+            globalUiManager.scheduleShowLoading()
+            globalUiManager.scheduleHideLoading()
+
+            // When: Dispose during hide grace delay
+            globalUiManager.dispose()
+
+            // Then: Cleared immediately
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait past hide grace delay
+            testScheduler.advanceTimeBy(200)
+            testScheduler.runCurrent()
+
+            // Then: Still cleared
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
         }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/BasePresenter.kt
@@ -471,11 +471,11 @@ abstract class BasePresenter(
     }
 
     /**
-     * Hide the loading dialog and cancel any scheduled show.
+     * Schedule hiding the loading dialog after a grace delay.
      * Delegates to GlobalUiManager for app-level loading dialog management.
      */
     protected fun hideLoading() {
-        globalUiManager.hideLoading()
+        globalUiManager.scheduleHideLoading()
     }
 
     /**

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManager.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManager.kt
@@ -56,7 +56,8 @@ class GlobalUiManager(
     private val _showLoadingDialog = MutableStateFlow(false)
     val showLoadingDialog: StateFlow<Boolean> = _showLoadingDialog.asStateFlow()
 
-    private var loadingJob: Job? = null
+    private var showLoadingJob: Job? = null
+    private var hideLoadingJob: Job? = null
 
     // Snackbar actions as SharedFlow for one-time events (buffer holds 1, drops oldest on overflow)
     private val _snackbarActions =
@@ -70,12 +71,14 @@ class GlobalUiManager(
      * Schedule showing a loading dialog after a grace delay.
      * Immediately blocks screen interaction. If the operation completes before the delay expires,
      * the dialog never appears (avoiding flicker).
-     * Call hideLoading() when the operation completes to cancel the scheduled show and hide the dialog.
+     * Call [scheduleHideLoading] when the operation completes to cancel the scheduled show and hide the dialog.
      */
     fun scheduleShowLoading() {
+        hideLoadingJob?.cancel()
+        hideLoadingJob = null
         _isLoadingBlocking.value = true
-        loadingJob?.cancel()
-        loadingJob =
+        showLoadingJob?.cancel()
+        showLoadingJob =
             scope.launch {
                 delay(LOADING_DIALOG_GRACE_MS)
                 _showLoadingDialog.value = true
@@ -83,13 +86,20 @@ class GlobalUiManager(
     }
 
     /**
-     * Hide the loading dialog and cancel any scheduled show.
-     * Also removes the blocking overlay.
+     * Schedule hiding the loading dialog and blocking overlay after a grace delay.
+     * Cancels any scheduled show immediately, but keeps blocking interaction for the grace period
+     * so navigation can complete before the user can tap underlying UI.
      */
-    fun hideLoading() {
-        loadingJob?.cancel()
-        _isLoadingBlocking.value = false
-        _showLoadingDialog.value = false
+    fun scheduleHideLoading() {
+        showLoadingJob?.cancel()
+        showLoadingJob = null
+        hideLoadingJob?.cancel()
+        hideLoadingJob =
+            scope.launch {
+                delay(LOADING_DIALOG_GRACE_MS)
+                _isLoadingBlocking.value = false
+                _showLoadingDialog.value = false
+            }
     }
 
     /**
@@ -118,8 +128,17 @@ class GlobalUiManager(
      * Useful for testing scenarios where you want to cleanly tear down the manager.
      */
     fun dispose() {
-        hideLoading()
+        clearLoadingStateNow()
         scope.cancel()
+    }
+
+    private fun clearLoadingStateNow() {
+        showLoadingJob?.cancel()
+        showLoadingJob = null
+        hideLoadingJob?.cancel()
+        hideLoadingJob = null
+        _isLoadingBlocking.value = false
+        _showLoadingDialog.value = false
     }
 
     companion object {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -226,7 +226,7 @@ fun App(
                 )
             }
 
-            // Global loading overlay - blocks interaction immediately, shows dialog after grace delay
+            // Global loading overlay - blocks interaction immediately; show/hide dialog after grace delay
             LoadingOverlay(
                 isBlocking = isLoadingBlocking,
                 showDialog = showLoadingDialog,


### PR DESCRIPTION
Fix for the comment @ https://github.com/bisq-network/bisq-mobile/pull/1523#pullrequestreview-4540900916

Based on Matrix discussion,
Added a fix to avoid NEWNYM for pre-pairing case.
forceClientRecreation() is now skipped if `currentClientSettings is null`. which is the pre-pairing case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading indicators now use a short grace delay when showing and hiding, reducing flicker during quick actions.
* **Bug Fixes**
  * Fixed an edge case where forcing a WebSocket reconnect did nothing when no client was active.
  * Improved loading-state handling so account creation and delete flows hide the loader at the correct time.
* **Tests**
  * Expanded test coverage for loading timing, scheduled hide behavior, and the WebSocket no-client scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->