### PR TITLE
feat(more): section the more tab and adopt UiState/UiAction pattern

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/tabs/more/ClientMiscItemsPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/tabs/more/ClientMiscItemsPresenter.kt
@@ -5,9 +5,10 @@ import bisqapps.apps.clientapp.generated.resources.nav_trusted_node
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
-import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 class ClientMiscItemsPresenter(
@@ -16,15 +17,15 @@ class ClientMiscItemsPresenter(
 ) : MiscItemsPresenter(userProfileService, mainPresenter) {
     override fun getPaymentAccountNavRoute(): NavRoute = if (BuildConfig.MU_SIG_ENABLED) ClientNavRoute.PaymentAccountsMusig else NavRoute.PaymentAccounts
 
-    override fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
-        menuItems.add(
-            menuItems.size - 2,
-            MenuItem.Leaf(
-                "mobile.more.trustedNode".i18n(),
+    override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {
+        appItems.add(
+            appItems.size.coerceAtMost(1),
+            MenuItem(
+                label = UiString("mobile.more.trustedNode"),
                 icon = Res.drawable.nav_trusted_node,
-                ClientNavRoute.TrustedNodeSetupSettings,
+                route = ClientNavRoute.TrustedNodeSetupSettings,
             ),
         )
-        return menuItems.toList()
+        return appItems
     }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
@@ -3,9 +3,10 @@ package network.bisq.mobile.node.tabs.more
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.backup
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
-import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 class NodeMiscItemsPresenter(
@@ -14,14 +15,15 @@ class NodeMiscItemsPresenter(
 ) : MiscItemsPresenter(userProfileService, mainPresenter) {
     override fun getPaymentAccountNavRoute(): NavRoute = NavRoute.PaymentAccounts
 
-    override fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem> {
-        menuItems.add(
-            MenuItem.Leaf(
-                label = "mobile.more.backupAndRestore".i18n(),
+    override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {
+        appItems.add(
+            appItems.size.coerceAtMost(1),
+            MenuItem(
+                label = UiString("mobile.more.backupAndRestore"),
                 icon = Res.drawable.backup,
                 route = NavRoute.BackupAndRestore,
             ),
         )
-        return menuItems.toList()
+        return appItems
     }
 }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -311,6 +311,10 @@ mobile.more.settings=Settings
 mobile.more.trustedNode=Trusted node setup
 mobile.more.resources=Resources
 mobile.more.backupAndRestore=Backup & restore
+mobile.more.section.identity=Identity & trust
+mobile.more.section.tradingSetup=Trading setup
+mobile.more.section.help=Help
+mobile.more.section.app=App
 ################################################################################
 # Settings
 ################################################################################

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentTest.kt
@@ -1,0 +1,147 @@
+package network.bisq.mobile.presentation.tabs.more
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.nav_ignored_users
+import bisqapps.shared.presentation.generated.resources.nav_settings
+import bisqapps.shared.presentation.generated.resources.nav_user
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.UiString
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class MiscItemsContentTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setTestContent(
+        uiState: MiscItemsUiState,
+        onAction: (MiscItemsUiAction) -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    MiscItemsContent(uiState = uiState, onAction = onAction)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when rendered then shows section headers in uppercase`() {
+        setTestContent(uiState = sampleUiState())
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.more.section.identity".i18n().uppercase())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.more.section.app".i18n().uppercase())
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when rendered then shows item labels`() {
+        setTestContent(uiState = sampleUiState())
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.more.userProfile".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when enabled item clicked then dispatches OnMenuItemClick with its route`() {
+        var capturedAction: MiscItemsUiAction? = null
+        setTestContent(uiState = sampleUiState(), onAction = { capturedAction = it })
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.more.userProfile".i18n())
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(MiscItemsUiAction.OnMenuItemClick(NavRoute.UserProfile), capturedAction)
+    }
+
+    @Test
+    fun `when item is disabled then it is not enabled`() {
+        setTestContent(uiState = sampleUiState(ignoredEnabled = false))
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers".i18n())
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `when disabled item tapped then no action is dispatched`() {
+        var capturedAction: MiscItemsUiAction? = null
+        setTestContent(uiState = sampleUiState(ignoredEnabled = false), onAction = { capturedAction = it })
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers".i18n())
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        assertNull(capturedAction)
+    }
+
+    private fun sampleUiState(ignoredEnabled: Boolean = false) =
+        MiscItemsUiState(
+            sections =
+                listOf(
+                    MenuSection(
+                        title = UiString("mobile.more.section.identity"),
+                        items =
+                            listOf(
+                                MenuItem(
+                                    label = UiString("mobile.more.userProfile"),
+                                    icon = Res.drawable.nav_user,
+                                    route = NavRoute.UserProfile,
+                                ),
+                                MenuItem(
+                                    label = UiString("mobile.settings.ignoredUsers"),
+                                    icon = Res.drawable.nav_ignored_users,
+                                    route = NavRoute.IgnoredUsers,
+                                    isEnabled = ignoredEnabled,
+                                ),
+                            ),
+                    ),
+                    MenuSection(
+                        title = UiString("mobile.more.section.app"),
+                        items =
+                            listOf(
+                                MenuItem(
+                                    label = UiString("mobile.more.settings"),
+                                    icon = Res.drawable.nav_settings,
+                                    route = NavRoute.Settings,
+                                ),
+                            ),
+                    ),
+                ),
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
@@ -1,0 +1,196 @@
+package network.bisq.mobile.presentation.tabs.more
+
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.nav_settings
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import network.bisq.mobile.i18n.UiString
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.main.MainPresenter
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MiscItemsPresenterTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var userProfileService: UserProfileServiceFacade
+    private lateinit var mainPresenter: MainPresenter
+    private lateinit var globalUiManager: GlobalUiManager
+    private lateinit var navigationManager: NavigationManager
+
+    private lateinit var presenter: MiscItemsPresenter
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        userProfileService = mockk(relaxed = true)
+        mainPresenter = mockk(relaxed = true)
+        globalUiManager = mockk(relaxed = true)
+        navigationManager = mockk(relaxed = true)
+
+        startKoin {
+            modules(
+                module {
+                    single<NavigationManager> { navigationManager }
+                    single<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
+                    single<GlobalUiManager> { globalUiManager }
+                },
+            )
+        }
+
+        coEvery { userProfileService.getIgnoredUserProfileIds() } returns emptySet()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        try {
+            stopKoin()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun createPresenter(): MiscItemsPresenter = TestMiscItemsPresenter(userProfileService, mainPresenter)
+
+    private fun ignoredUsersItem(): MenuItem =
+        presenter.uiState.value.sections
+            .flatMap { it.items }
+            .first { it.route == NavRoute.IgnoredUsers }
+
+    @Test
+    fun `when attached then exposes the four sections in order`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter = createPresenter()
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            val titles =
+                presenter.uiState.value.sections
+                    .map { it.title.key }
+            assertEquals(
+                listOf(
+                    "mobile.more.section.identity",
+                    "mobile.more.section.tradingSetup",
+                    "mobile.more.section.help",
+                    "mobile.more.section.app",
+                ),
+                titles,
+            )
+        }
+
+    @Test
+    fun `when no ignored users then ignored users item is disabled`() =
+        runTest(testDispatcher) {
+            // Given
+            coEvery { userProfileService.getIgnoredUserProfileIds() } returns emptySet()
+            presenter = createPresenter()
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            assertFalse(ignoredUsersItem().isEnabled)
+        }
+
+    @Test
+    fun `when ignored users exist then ignored users item is enabled`() =
+        runTest(testDispatcher) {
+            // Given
+            coEvery { userProfileService.getIgnoredUserProfileIds() } returns setOf("ignored-user-id")
+            presenter = createPresenter()
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            assertTrue(ignoredUsersItem().isEnabled)
+        }
+
+    @Test
+    fun `when menu item clicked then navigates to its route`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // When
+            presenter.onAction(MiscItemsUiAction.OnMenuItemClick(NavRoute.Settings))
+            advanceUntilIdle()
+
+            // Then
+            verify { navigationManager.navigate(NavRoute.Settings, any(), any()) }
+        }
+
+    @Test
+    fun `when custom app items added then they appear in the app section`() =
+        runTest(testDispatcher) {
+            // Given
+            presenter = createPresenter()
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            val appSection =
+                presenter.uiState.value.sections
+                    .first { it.title.key == "mobile.more.section.app" }
+            val appLabels = appSection.items.map { it.label.key }
+            assertEquals(
+                listOf("mobile.more.settings", "mobile.more.custom", "mobile.more.resources"),
+                appLabels,
+            )
+        }
+
+    /**
+     * Minimal concrete subclass providing the two abstract hooks so the shared behaviour can be exercised
+     * without pulling in per-app resource/BuildConfig dependencies.
+     */
+    private class TestMiscItemsPresenter(
+        userProfileService: UserProfileServiceFacade,
+        mainPresenter: MainPresenter,
+    ) : MiscItemsPresenter(userProfileService, mainPresenter) {
+        override fun getPaymentAccountNavRoute(): NavRoute = NavRoute.PaymentAccounts
+
+        override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {
+            appItems.add(
+                1,
+                MenuItem(
+                    label = UiString("mobile.more.custom"),
+                    icon = Res.drawable.nav_settings,
+                    route = NavRoute.PaymentAccounts,
+                ),
+            )
+            return appItems
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -9,104 +9,92 @@ import bisqapps.shared.presentation.generated.resources.nav_resources
 import bisqapps.shared.presentation.generated.resources.nav_settings
 import bisqapps.shared.presentation.generated.resources.nav_support
 import bisqapps.shared.presentation.generated.resources.nav_user
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
-import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.jetbrains.compose.resources.DrawableResource
 
-/**
- * SettingsPresenter with default implementation
- */
 abstract class MiscItemsPresenter(
     private val userProfileService: UserProfileServiceFacade,
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    sealed class MenuItem(
-        val label: String,
-        val icon: DrawableResource? = null,
-    ) {
-        class Leaf(
-            label: String,
-            icon: DrawableResource,
-            val route: NavRoute,
-        ) : MenuItem(label, icon)
-
-        class Parent(
-            label: String,
-            val children: List<MenuItem>,
-        ) : MenuItem(label)
-    }
-
-    private val _menuItems = MutableStateFlow<MenuItem?>(null)
-    val menuItems: StateFlow<MenuItem?> = _menuItems.asStateFlow()
+    private val _uiState = MutableStateFlow(MiscItemsUiState())
+    val uiState: StateFlow<MiscItemsUiState> = _uiState.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
-
-        _menuItems.value = buildMenu(showIgnoredUser = false)
+        _uiState.update { it.copy(sections = buildSections()) }
         loadIgnoredUsers()
     }
 
     abstract fun getPaymentAccountNavRoute(): NavRoute
 
-    private fun buildMenu(showIgnoredUser: Boolean): MenuItem.Parent {
-        val defaultList: MutableList<MenuItem> =
-            mutableListOf(
-                MenuItem.Leaf(
-                    label = "mobile.more.support".i18n(),
-                    icon = Res.drawable.nav_support,
-                    route = NavRoute.Support,
-                ),
-                MenuItem.Leaf(
-                    label = "mobile.more.faqs".i18n(),
-                    icon = Res.drawable.icon_question_mark,
-                    route = NavRoute.Faqs,
-                ),
-                MenuItem.Leaf(
-                    label = "mobile.more.paymentAccounts".i18n(),
-                    icon = Res.drawable.nav_accounts,
-                    route = getPaymentAccountNavRoute(),
-                ),
-                MenuItem.Leaf(
-                    label = "mobile.more.reputation".i18n(),
-                    icon = Res.drawable.nav_reputation,
-                    route = NavRoute.Reputation,
-                ),
-                MenuItem.Leaf(
-                    label = "mobile.more.userProfile".i18n(),
+    private fun buildSections(showIgnoredUser: Boolean = false): List<MenuSection> {
+        val identityItems =
+            listOf(
+                MenuItem(
+                    label = UiString("mobile.more.userProfile"),
                     icon = Res.drawable.nav_user,
                     route = NavRoute.UserProfile,
                 ),
-                MenuItem.Leaf(
-                    label = "mobile.more.settings".i18n(),
+                MenuItem(
+                    label = UiString("mobile.settings.ignoredUsers"),
+                    icon = Res.drawable.nav_ignored_users,
+                    route = NavRoute.IgnoredUsers,
+                    isEnabled = showIgnoredUser,
+                ),
+                MenuItem(
+                    label = UiString("mobile.more.reputation"),
+                    icon = Res.drawable.nav_reputation,
+                    route = NavRoute.Reputation,
+                ),
+            )
+        val tradingSetupItems =
+            listOf(
+                MenuItem(
+                    label = UiString("mobile.more.paymentAccounts"),
+                    icon = Res.drawable.nav_accounts,
+                    route = getPaymentAccountNavRoute(),
+                ),
+            )
+        val helpItems =
+            listOf(
+                MenuItem(
+                    label = UiString("mobile.more.support"),
+                    icon = Res.drawable.nav_support,
+                    route = NavRoute.Support,
+                ),
+                MenuItem(
+                    label = UiString("mobile.more.faqs"),
+                    icon = Res.drawable.icon_question_mark,
+                    route = NavRoute.Faqs,
+                ),
+            )
+        val appItems: MutableList<MenuItem> =
+            mutableListOf(
+                MenuItem(
+                    label = UiString("mobile.more.settings"),
                     icon = Res.drawable.nav_settings,
                     route = NavRoute.Settings,
                 ),
-                MenuItem.Leaf(
-                    label = "mobile.more.resources".i18n(),
+                MenuItem(
+                    label = UiString("mobile.more.resources"),
                     icon = Res.drawable.nav_resources,
                     route = NavRoute.Resources,
                 ),
             )
-        if (showIgnoredUser) {
-            defaultList.add(
-                defaultList.size - 1,
-                MenuItem.Leaf(
-                    label = "mobile.settings.ignoredUsers".i18n(),
-                    icon = Res.drawable.nav_ignored_users,
-                    route = NavRoute.IgnoredUsers,
-                ),
-            )
-        }
-        return MenuItem.Parent(
-            label = "Bisq",
-            children = addCustomSettings(defaultList),
+        return listOf(
+            MenuSection(title = UiString("mobile.more.section.identity"), items = identityItems),
+            MenuSection(title = UiString("mobile.more.section.tradingSetup"), items = tradingSetupItems),
+            MenuSection(title = UiString("mobile.more.section.help"), items = helpItems),
+            MenuSection(title = UiString("mobile.more.section.app"), items = addCustomSettings(appItems)),
         )
     }
 
@@ -114,19 +102,22 @@ abstract class MiscItemsPresenter(
         presenterScope.launch {
             try {
                 val ignoredUserIds = userProfileService.getIgnoredUserProfileIds()
-
                 if (ignoredUserIds.isNotEmpty()) {
-                    _menuItems.value = buildMenu(showIgnoredUser = true)
+                    _uiState.update { it.copy(sections = buildSections(showIgnoredUser = true)) }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.e(e) { "Failed to load ignored users" }
             }
         }
     }
 
-    fun onNavigateTo(route: NavRoute) {
-        navigateTo(route)
+    fun onAction(action: MiscItemsUiAction) {
+        when (action) {
+            is MiscItemsUiAction.OnMenuItemClick -> navigateTo(action.route)
+        }
     }
 
-    abstract fun addCustomSettings(menuItems: MutableList<MenuItem>): List<MenuItem>
+    abstract fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem>
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsScreen.kt
@@ -1,25 +1,43 @@
 package network.bisq.mobile.presentation.tabs.more
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
-import bisqapps.shared.presentation.generated.resources.icon_web_link
+import bisqapps.shared.presentation.generated.resources.icon_question_mark
+import bisqapps.shared.presentation.generated.resources.nav_accounts
+import bisqapps.shared.presentation.generated.resources.nav_ignored_users
+import bisqapps.shared.presentation.generated.resources.nav_reputation
+import bisqapps.shared.presentation.generated.resources.nav_resources
+import bisqapps.shared.presentation.generated.resources.nav_settings
+import bisqapps.shared.presentation.generated.resources.nav_support
+import bisqapps.shared.presentation.generated.resources.nav_user
+import network.bisq.mobile.i18n.UiString
+import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowRightIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
-import network.bisq.mobile.presentation.common.ui.components.layout.BisqStaticLayout
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
@@ -28,16 +46,28 @@ fun MiscItemsScreen() {
     val presenter: MiscItemsPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val menuTree by presenter.menuItems.collectAsState()
+    val uiState by presenter.uiState.collectAsState()
 
-    BisqStaticLayout(
-        contentPadding = PaddingValues(all = BisqUIConstants.Zero),
-        verticalArrangement = Arrangement.Top,
-    ) {
-        menuTree?.let { root ->
-            Menu(menuItem = root) { selectedItem ->
-                if (selectedItem is MiscItemsPresenter.MenuItem.Leaf) {
-                    presenter.onNavigateTo(selectedItem.route)
+    MiscItemsContent(uiState = uiState, onAction = presenter::onAction)
+}
+
+@Composable
+internal fun MiscItemsContent(
+    uiState: MiscItemsUiState,
+    onAction: (MiscItemsUiAction) -> Unit,
+) {
+    BisqScaffold {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            uiState.sections.forEach { section ->
+                SectionHeader(title = section.title.i18n())
+                section.items.forEach { item ->
+                    ItemButton(item = item) { onAction(MiscItemsUiAction.OnMenuItemClick(item.route)) }
+                    BisqGap.VHalf()
                 }
             }
         }
@@ -45,43 +75,42 @@ fun MiscItemsScreen() {
 }
 
 @Composable
-private fun Menu(
-    menuItem: MiscItemsPresenter.MenuItem,
-    onNavigate: (MiscItemsPresenter.MenuItem) -> Unit,
-) {
-    when (menuItem) {
-        is MiscItemsPresenter.MenuItem.Parent ->
-            menuItem.children.forEach { child ->
-                ItemButton(label = child.label, icon = child.icon, onClick = { onNavigate(child) })
-                BisqGap.VHalf()
-            }
-
-        else -> {
-            ItemButton(label = menuItem.label, icon = menuItem.icon, onClick = { onNavigate(menuItem) })
-            BisqGap.VHalf()
-        }
-    }
+private fun SectionHeader(title: String) {
+    val modifier =
+        Modifier
+            .fillMaxWidth()
+            .padding(
+                start = BisqUIConstants.ScreenPadding,
+                top = BisqUIConstants.ScreenPadding,
+                bottom = BisqUIConstants.ScreenPaddingHalf,
+            )
+    BisqText.XSmallMedium(
+        text = title.uppercase(),
+        color = BisqTheme.colors.mid_grey20,
+        modifier = modifier,
+    )
 }
 
 @Composable
 private fun ItemButton(
-    label: String,
-    icon: DrawableResource? = null,
+    item: MenuItem,
     onClick: () -> Unit,
 ) {
+    val label = item.label.i18n()
+    val iconTint = if (item.isEnabled) null else ColorFilter.tint(BisqTheme.colors.mid_grey20)
     BisqButton(
         text = label,
         onClick = onClick,
         fullWidth = true,
         backgroundColor = BisqTheme.colors.dark_grey40,
+        disabled = !item.isEnabled,
         leftIcon = {
-            if (icon != null) {
-                Image(
-                    painter = painterResource(icon),
-                    contentDescription = label,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
+            Image(
+                painter = painterResource(item.icon),
+                contentDescription = label,
+                modifier = Modifier.size(20.dp),
+                colorFilter = iconTint,
+            )
         },
         rightIcon = { ArrowRightIcon() },
         textAlign = TextAlign.Start,
@@ -89,7 +118,63 @@ private fun ItemButton(
     )
 }
 
+private val miscItemsPreviewState =
+    MiscItemsUiState(
+        sections =
+            listOf(
+                MenuSection(
+                    title = UiString("mobile.more.section.identity"),
+                    items =
+                        listOf(
+                            MenuItem(UiString("mobile.more.userProfile"), Res.drawable.nav_user, NavRoute.UserProfile),
+                            MenuItem(
+                                label = UiString("mobile.settings.ignoredUsers"),
+                                icon = Res.drawable.nav_ignored_users,
+                                route = NavRoute.IgnoredUsers,
+                                isEnabled = false,
+                            ),
+                            MenuItem(
+                                UiString("mobile.more.reputation"),
+                                Res.drawable.nav_reputation,
+                                NavRoute.Reputation,
+                            ),
+                        ),
+                ),
+                MenuSection(
+                    title = UiString("mobile.more.section.tradingSetup"),
+                    items =
+                        listOf(
+                            MenuItem(
+                                UiString("mobile.more.paymentAccounts"),
+                                Res.drawable.nav_accounts,
+                                NavRoute.PaymentAccounts,
+                            ),
+                        ),
+                ),
+                MenuSection(
+                    title = UiString("mobile.more.section.help"),
+                    items =
+                        listOf(
+                            MenuItem(UiString("mobile.more.support"), Res.drawable.nav_support, NavRoute.Support),
+                            MenuItem(UiString("mobile.more.faqs"), Res.drawable.icon_question_mark, NavRoute.Faqs),
+                        ),
+                ),
+                MenuSection(
+                    title = UiString("mobile.more.section.app"),
+                    items =
+                        listOf(
+                            MenuItem(UiString("mobile.more.settings"), Res.drawable.nav_settings, NavRoute.Settings),
+                            MenuItem(UiString("mobile.more.resources"), Res.drawable.nav_resources, NavRoute.Resources),
+                        ),
+                ),
+            ),
+    )
+
+@ExcludeFromCoverage
+@Preview(name = "More — sections (Ignored users disabled)")
 @Composable
-fun WebLinkIcon(modifier: Modifier = Modifier.size(24.dp)) {
-    Image(painterResource(Res.drawable.icon_web_link), "Web link icon", modifier = modifier)
+private fun MiscItemsContentPreview() {
+    BisqTheme.Preview {
+        MiscItemsContent(uiState = miscItemsPreviewState, onAction = {})
+    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiAction.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.tabs.more
+
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+
+sealed interface MiscItemsUiAction {
+    data class OnMenuItemClick(
+        val route: NavRoute,
+    ) : MiscItemsUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiState.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.presentation.tabs.more
+
+import network.bisq.mobile.i18n.UiString
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import org.jetbrains.compose.resources.DrawableResource
+
+data class MiscItemsUiState(
+    val sections: List<MenuSection> = emptyList(),
+)
+
+data class MenuSection(
+    val title: UiString,
+    val items: List<MenuItem>,
+)
+
+data class MenuItem(
+    val label: UiString,
+    val icon: DrawableResource,
+    val route: NavRoute,
+    val isEnabled: Boolean = true,
+)


### PR DESCRIPTION
Resolves: https://github.com/bisq-network/bisq-mobile/issues/1520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesign “More” tab using grouped sections with section headers and item buttons.
  * Added localized section labels: Identity & trust, Trading setup, Help, and App.
* **Bug Fixes**
  * Improved menu entry handling so enabled/disabled states reflect ignored users correctly and clicks navigate appropriately.
  * Updated “trusted node” and “backup and restore” labels to use UI-ready localization.
* **Tests**
  * Added new UI and presenter tests covering section rendering, enabled states, and navigation/action dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->