### PR TITLE
feat(coroutines): add injectable DispatcherProvider abstraction

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ object KoverExclusions {
             // gate isn't the right tool to cover.
             "network.bisq.mobile.client.common.di.*",
             "network.bisq.mobile.node.common.di.*",
+            "network.bisq.mobile.data.di.*",
         )
 }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/coroutines/AppDispatcherProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/coroutines/AppDispatcherProvider.kt
@@ -1,0 +1,13 @@
+package network.bisq.mobile.data.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
+
+class AppDispatcherProvider : DispatcherProvider {
+    override val main: CoroutineDispatcher get() = Dispatchers.Main
+    override val io: CoroutineDispatcher get() = Dispatchers.IO
+    override val default: CoroutineDispatcher get() = Dispatchers.Default
+    override val unconfined: CoroutineDispatcher get() = Dispatchers.Unconfined
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/di/DataModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/di/DataModule.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.data.di
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import network.bisq.mobile.data.coroutines.AppDispatcherProvider
 import network.bisq.mobile.data.datastore.createDataStore
 import network.bisq.mobile.data.datastore.serializer.OfferbookFilterConfigsSerializer
 import network.bisq.mobile.data.datastore.serializer.SettingsSerializer
@@ -17,6 +18,7 @@ import network.bisq.mobile.data.repository.TradeReadStateRepositoryImpl
 import network.bisq.mobile.data.repository.UserRepositoryImpl
 import network.bisq.mobile.data.utils.EnvironmentController
 import network.bisq.mobile.data.utils.getStorageDir
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
@@ -94,4 +96,6 @@ val dataModule =
                 get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
             }
         }
+
+        single<DispatcherProvider> { AppDispatcherProvider() }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/coroutines/DispatcherProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/coroutines/DispatcherProvider.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.domain.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+    val unconfined: CoroutineDispatcher
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/coroutines/AppDispatcherProviderTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/coroutines/AppDispatcherProviderTest.kt
@@ -1,0 +1,30 @@
+package network.bisq.mobile.data.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class AppDispatcherProviderTest {
+    private val provider = AppDispatcherProvider()
+
+    @Test
+    fun `main maps to Dispatchers Main`() {
+        assertSame(Dispatchers.Main, provider.main)
+    }
+
+    @Test
+    fun `io maps to Dispatchers IO`() {
+        assertSame(Dispatchers.IO, provider.io)
+    }
+
+    @Test
+    fun `default maps to Dispatchers Default`() {
+        assertSame(Dispatchers.Default, provider.default)
+    }
+
+    @Test
+    fun `unconfined maps to Dispatchers Unconfined`() {
+        assertSame(Dispatchers.Unconfined, provider.unconfined)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
@@ -35,6 +35,7 @@ import network.bisq.mobile.presentation.startup.user_agreement.UserAgreementPres
 import network.bisq.mobile.presentation.tabs.dashboard.DashboardPresenter
 import network.bisq.mobile.presentation.tabs.my_trades.MyTradesPresenter
 import network.bisq.mobile.presentation.tabs.offers.OfferbookMarketPresenter
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -78,7 +79,8 @@ import kotlin.test.assertTrue
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScreenAnalyticsCoverageTest {
-    private val testDispatcher = StandardTestDispatcher()
+    private val dispatcherProvider = StandardTestDispatcherProvider()
+    private val testDispatcher = dispatcherProvider.default
     private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private val analyticsService: AnalyticsService = mockk(relaxed = true)
 
@@ -238,6 +240,7 @@ class ScreenAnalyticsCoverageTest {
                 userProfileServiceFacade = mockk(relaxed = true),
                 settingsRepository = mockk(relaxed = true),
                 computeOfferbookMarketListUseCase = mockk(relaxed = true),
+                dispatcherProvider = dispatcherProvider,
             )
         assertEquals(AnalyticsEvent.ScreenOpened.OfferbookMarket, presenter.analyticsScreenEvent())
     }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/OfferbookMarketPresenterTestFactory.kt
@@ -2,17 +2,17 @@ package network.bisq.mobile.presentation.common.test_utils
 
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.presentation.tabs.offers.OfferbookMarketPresenter
 import network.bisq.mobile.presentation.tabs.offers.usecase.ComputeOfferbookMarketListUseCase
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
 
 object OfferbookMarketPresenterTestFactory {
     fun create(
@@ -32,7 +32,7 @@ object OfferbookMarketPresenterTestFactory {
 
                 override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
             },
-        computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
+        dispatcherProvider: DispatcherProvider,
     ): OfferbookMarketPresenter {
         val mainPresenter =
             MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
@@ -47,7 +47,7 @@ object OfferbookMarketPresenterTestFactory {
             userProfileServiceFacade = userProfileServiceFacade,
             settingsRepository = settingsRepository,
             computeOfferbookMarketListUseCase = ComputeOfferbookMarketListUseCase(marketPriceServiceFacade),
-            computationDispatcher = computationDispatcher,
+            dispatcherProvider = dispatcherProvider,
         )
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterLifecycleTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -30,6 +29,7 @@ import network.bisq.mobile.presentation.common.test_utils.OfferbookMarketPresent
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -66,7 +66,8 @@ private class LifecycleAwareTestJobsManager(
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class OfferbookMarketPresenterLifecycleTest {
-    private val testDispatcher = StandardTestDispatcher()
+    private val dispatcherProvider = StandardTestDispatcherProvider()
+    private val testDispatcher = dispatcherProvider.default
 
     @BeforeTest
     fun setUp() {
@@ -100,7 +101,7 @@ class OfferbookMarketPresenterLifecycleTest {
     fun `filter survives tab switch lifecycle`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             // Simulate first tab enter
             presenter.onViewAttached()
@@ -137,7 +138,7 @@ class OfferbookMarketPresenterLifecycleTest {
     fun `sortBy survives tab switch lifecycle`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             // Simulate first tab enter
             presenter.onViewAttached()
@@ -176,7 +177,7 @@ class OfferbookMarketPresenterLifecycleTest {
             // Pre-set a non-default filter in DataStore
             settingsRepository.setMarketFilter(MarketFilter.WithOffers)
 
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             // Simulate tab enter — should sync from DataStore
             presenter.onViewAttached()
@@ -211,7 +212,7 @@ class OfferbookMarketPresenterLifecycleTest {
                     settingsRepository = settingsRepository,
                     offersServiceFacade = offersServiceFacade,
                     marketPriceServiceFacade = marketPriceServiceFacade,
-                    computationDispatcher = testDispatcher,
+                    dispatcherProvider = dispatcherProvider,
                 )
 
             presenter.onViewAttached()
@@ -237,7 +238,7 @@ class OfferbookMarketPresenterLifecycleTest {
     fun `filter and sortBy work through multiple tab switches`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             // First cycle
             presenter.onViewAttached()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterSettingsPersistenceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenterSettingsPersistenceTest.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.OfferbookMarketPresenterTestFactory
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import org.koin.core.context.startKoin
@@ -29,7 +30,8 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OfferbookMarketPresenterSettingsPersistenceTest {
-    private val testDispatcher = StandardTestDispatcher()
+    private val dispatcherProvider = StandardTestDispatcherProvider()
+    private val testDispatcher = dispatcherProvider.default
 
     @BeforeTest
     fun setUp() {
@@ -63,7 +65,7 @@ class OfferbookMarketPresenterSettingsPersistenceTest {
     fun `changing market sort by from UI persists to SettingsRepository`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             presenter.setSortBy(MarketSortBy.NameAZ)
             advanceUntilIdle()
@@ -75,7 +77,7 @@ class OfferbookMarketPresenterSettingsPersistenceTest {
     fun `changing market filter from UI persists to SettingsRepository`() =
         runTest(testDispatcher) {
             val settingsRepository = SettingsRepositoryMock()
-            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository)
+            val presenter = OfferbookMarketPresenterTestFactory.create(settingsRepository, dispatcherProvider = dispatcherProvider)
 
             presenter.setFilter(MarketFilter.WithOffers)
             advanceUntilIdle()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -145,7 +145,7 @@ val presentationModule =
         factory { ComputeOfferbookMarketListUseCase(get()) }
 
         // Offerbook
-        single<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get(), get(), get(), get()) }
+        single<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get(), get(), get(), get(), get()) }
 
         // Take offer
         single { TakeOfferCoordinator(get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketPresenter.kt
@@ -1,7 +1,5 @@
 package network.bisq.mobile.presentation.tabs.offers
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +14,7 @@ import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.combine
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
@@ -31,9 +30,7 @@ class OfferbookMarketPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
     private val computeOfferbookMarketListUseCase: ComputeOfferbookMarketListUseCase,
-    // Background dispatcher for the (CPU-bound) market-list computation. Injectable so tests can
-    // pass the test dispatcher and keep the pipeline under the test scheduler.
-    private val computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val dispatcherProvider: DispatcherProvider,
 ) : BasePresenter(mainPresenter) {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.OfferbookMarket
 
@@ -121,7 +118,7 @@ class OfferbookMarketPresenter(
                 offersServiceFacade.offerbookMarketItems,
             ) { filter, searchText, sortBy, _, languageCode, items ->
                 computeOfferbookMarketListUseCase(filter, searchText, sortBy, languageCode, items)
-            }.flowOn(computationDispatcher)
+            }.flowOn(dispatcherProvider.default)
                 .collect { result ->
                     _marketListItemWithNumOffers.value = result
                 }

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/coroutines/StandardTestDispatcherProvider.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/coroutines/StandardTestDispatcherProvider.kt
@@ -1,0 +1,14 @@
+package network.bisq.mobile.test.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
+
+class StandardTestDispatcherProvider : DispatcherProvider {
+    private val testDispatcher = StandardTestDispatcher()
+
+    override val main: CoroutineDispatcher get() = testDispatcher
+    override val io: CoroutineDispatcher get() = testDispatcher
+    override val default: CoroutineDispatcher get() = testDispatcher
+    override val unconfined: CoroutineDispatcher get() = testDispatcher
+}

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/coroutines/UnconfinedTestDispatcherProvider.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/coroutines/UnconfinedTestDispatcherProvider.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.test.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
+
+// TODO: Not consumed yet. Kept intentionally as part of the shared test toolkit for the
+//  upcoming DispatcherProvider migration, where some presenter tests will need an unconfined
+//  (eager) dispatcher instead of the standard (queued) StandardTestDispatcherProvider — e.g.
+//  flows whose emissions must run immediately without advanceUntilIdle(). Wire up with its
+//  first consumer, or remove and re-add then if it is still unused.
+@OptIn(ExperimentalCoroutinesApi::class)
+class UnconfinedTestDispatcherProvider : DispatcherProvider {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    override val main: CoroutineDispatcher get() = testDispatcher
+    override val io: CoroutineDispatcher get() = testDispatcher
+    override val default: CoroutineDispatcher get() = testDispatcher
+    override val unconfined: CoroutineDispatcher get() = testDispatcher
+}


### PR DESCRIPTION
## Introduce `DispatcherProvider` for injectable coroutine dispatchers

  ### Motivation

  - **One dependency for all dispatchers.** Instead of threading a separate `CoroutineDispatcher` param for each dispatcher a class might touch, injecting one `DispatcherProvider` exposes the whole set
  (`main`/`io`/`default`/`unconfined`). When a presenter/service later needs a *different* dispatcher, it just reads `dispatcherProvider.io` — **no new constructor param and no DI wiring change**. That keeps
  constructor signatures and Koin modules stable as usage evolves.
  - **Deterministic tests, no silent traps.** The previous approach hardcoded `Dispatchers.Default`/`IO`/`Main`, or took a per-call dispatcher param *with a default*. That default is the trap: tests still
  compile and pass without setting it, so a developer can easily **forget to override the dispatcher in tests**, silently running work on a real background thread instead of the test scheduler — making flows
  non-deterministic (`advanceUntilIdle()` can't drive them). The new provider has **no default**, so the dependency is explicit at every call site.
  - **Single source of truth.** The real-`Dispatchers.*` mapping lives in one place (`AppDispatcherProvider`), so a future change (e.g. a custom IO pool, or a special dispatcher for a platform) is a one-line
  edit rather than a hunt across constructors.

  ### Change

  - `DispatcherProvider` (interface) + `AppDispatcherProvider` (production impl, registered as a Koin `single`) mapping `main`/`io`/`default`/`unconfined` to the real `Dispatchers.*`.
  - `StandardTestDispatcherProvider` / `UnconfinedTestDispatcherProvider` in `test-utils`, routing every dispatcher to one `TestDispatcher` for deterministic scheduling.

  Production behavior is unchanged (`default` still resolves to `Dispatchers.Default`). As a **pilot**, only `OfferbookMarketPresenter` is migrated; other presenters follow the same recipe later.

  ### Notes for reviewers

  - **`UnconfinedTestDispatcherProvider`:** added alongside the standard one as part of the shared test toolkit but not yet referenced by any test. It's test-only (not shipped, not in Kover), so no runtime
  cost — can drop it and reintroduce when a consumer needs it if reviewers prefer.
  - **Coverage:** the diff-coverage check is failing only because it counts the new Koin binding line in `DataModule` (`single<DispatcherProvider> { AppDispatcherProvider() }`) — declarative DI wiring that
  isn't unit-tested in isolation. `data.di` isn't in the Kover exclusion list (unlike `client.common.di` / `node.common.di`); the actual logic (`AppDispatcherProvider`) is covered by
  `AppDispatcherProviderTest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a shared dispatcher-provider abstraction for consistent coroutine context selection across app and tests.
  * Updated the offerbook presenter to use the injected dispatcher provider for its work scheduling.

* **Bug Fixes**
  * Improved coroutine execution consistency between runtime behavior and unit tests for offer-related screens.

* **Tests**
  * Added coverage to verify dispatcher mappings.
  * Updated existing unit tests to use standard (and unconfined) test dispatcher providers.

* **Chores**
  * Adjusted code coverage reporting exclusions for dispatcher bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->