### PR TITLE
bugfix/connect_first_market_fetch_after_cold_start_fails_freq_over_tor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,11 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         env:
           CI: true
-        run: ./gradlew clean test --no-configuration-cache -x :apps:nodeApp:test --info
+        # --no-build-cache forces test tasks to actually execute rather than being restored as
+        # build-cache hits. Kover's per-test coverage (.ic) binary is only produced when the test
+        # JVM runs with the Kover agent; a cache-hit test task produces no coverage, which then
+        # makes the separate koverVerify step see near-zero coverage intermittently (flaky failures).
+        run: ./gradlew clean test --no-configuration-cache --no-build-cache -x :apps:nodeApp:test --info
 
       - name: Run Kover Verification (Ubuntu only, excluding nodeApp)
         if: startsWith(matrix.os, 'ubuntu')

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
@@ -20,6 +21,19 @@ import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocket
 import network.bisq.mobile.client.common.test_utils.KoinIntegrationTestBase
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory.fromPrice
+import network.bisq.mobile.data.replicated.common.network.AddressByTransportTypeMapVO
+import network.bisq.mobile.data.replicated.network.identity.NetworkIdVO
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationDto
+import network.bisq.mobile.data.replicated.security.keys.PubKeyVO
+import network.bisq.mobile.data.replicated.security.keys.PublicKeyVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -166,8 +180,8 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
             advanceUntilIdle()
             coVerify(exactly = 1) { apiGateway.subscribeOffers() }
 
-            // Loading timeout (12s) fires — guard must be released
-            advanceTimeBy(13_000L)
+            // Loading timeout (30s) fires — guard must be released
+            advanceTimeBy(31_000L)
             advanceUntilIdle()
 
             // Second market selection — must re-subscribe instead of being permanently stuck
@@ -236,14 +250,160 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
             coVerify(exactly = 2) { apiGateway.subscribeOffers() }
         }
 
-    private fun offersEvent(payload: String) =
-        WebSocketEvent(
-            topic = Topic.OFFERS,
-            subscriberId = "offers-test",
-            deferredPayload = payload,
-            modificationType = ModificationType.REPLACE,
-            sequenceNumber = 1,
+    /**
+     * Core regression for the "empty offers after cold start over Tor" bug: the initial OFFERS
+     * snapshot can arrive AFTER the loading timeout on a slow Tor connection. The timeout must
+     * only stop the spinner — it must NOT tear down the subscription — so a late snapshot still
+     * populates the list reactively without the user having to re-enter the market.
+     */
+    @Test
+    fun `offers delivered after loading timeout still populate because subscription stays alive`() =
+        runTest {
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            // advanceUntilIdle drives past the loading timeout, which must fire and stop the spinner
+            advanceUntilIdle()
+            assertEquals(false, facade.isOfferbookLoading.value)
+
+            // Late snapshot arrives well after the timeout — the still-alive collector must consume it
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "late-offer")))
+            advanceUntilIdle()
+
+            assertEquals(1, facade.offerbookListItems.value.size)
+            assertEquals(
+                "late-offer",
+                facade.offerbookListItems.value
+                    .single()
+                    .offerId,
+            )
+        }
+
+    /**
+     * Count-aware loading: when the OFFERS snapshot slice for the selected market is empty but
+     * NUM_OFFERS says the market has offers, we keep the spinner instead of flashing a false
+     * "no offers" — then clear it once the real offers land.
+     */
+    @Test
+    fun `empty offers snapshot keeps loading while numOffers indicates offers exist`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+            coEvery { apiGateway.getMarkets() } returns Result.success(listOf(brlMarket))
+
+            facade.activate()
+            advanceUntilIdle()
+            numOffersObserver.setEvent(numOffersEvent("""{"BRL": 15}"""))
+            connectionState.value = ConnectionState.Connected
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            // runCurrent processes the subscribe launch without advancing the virtual clock
+            // past the loading timeout, so the timeout does not pre-empt the count-aware check.
+            runCurrent()
+
+            // Empty snapshot slice for BRL, but NUM_OFFERS says 15 → keep the spinner
+            offersObserver.setEvent(offersEvent("[]", sequenceNumber = 1))
+            runCurrent()
+            assertTrue(facade.isOfferbookLoading.value)
+
+            // Real offers arrive → loading clears and the list populates
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "o1"), sequenceNumber = 2))
+            runCurrent()
+            assertEquals(false, facade.isOfferbookLoading.value)
+            assertEquals(1, facade.offerbookListItems.value.size)
+        }
+
+    /**
+     * Control for the count-aware guard: when NUM_OFFERS says the market has no offers, an empty
+     * snapshot is authoritative — loading must clear so the "no offers" state can render.
+     */
+    @Test
+    fun `empty offers snapshot clears loading when numOffers indicates no offers`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+            coEvery { apiGateway.getMarkets() } returns Result.success(listOf(brlMarket))
+
+            facade.activate()
+            advanceUntilIdle()
+            numOffersObserver.setEvent(numOffersEvent("""{"BRL": 0}"""))
+            connectionState.value = ConnectionState.Connected
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 0))
+            runCurrent()
+
+            offersObserver.setEvent(offersEvent("[]", sequenceNumber = 1))
+            runCurrent()
+
+            assertEquals(false, facade.isOfferbookLoading.value)
+        }
+
+    private fun offersEvent(
+        payload: String,
+        sequenceNumber: Int = 1,
+        modificationType: ModificationType = ModificationType.REPLACE,
+    ) = WebSocketEvent(
+        topic = Topic.OFFERS,
+        subscriberId = "offers-test",
+        deferredPayload = payload,
+        modificationType = modificationType,
+        sequenceNumber = sequenceNumber,
+    )
+
+    private fun offersPayload(
+        market: MarketVO,
+        vararg offerIds: String,
+    ): String = json.encodeToString(offerIds.map { buildOfferDto(it, market) })
+
+    private fun buildOfferDto(
+        id: String,
+        market: MarketVO,
+    ): OfferItemPresentationDto {
+        val makerNetworkId =
+            NetworkIdVO(
+                AddressByTransportTypeMapVO(mapOf()),
+                PubKeyVO(PublicKeyVO("pub"), keyId = "key", hash = "hash", id = "id"),
+            )
+        val offer =
+            BisqEasyOfferVO(
+                id = id,
+                date = 0L,
+                makerNetworkId = makerNetworkId,
+                direction = DirectionEnum.BUY,
+                market = market,
+                amountSpec = QuoteSideFixedAmountSpecVO(100_00L),
+                priceSpec = FixPriceSpecVO(PriceQuoteVOFactory.fromPrice(100_00L, market)),
+                protocolTypes = emptyList(),
+                baseSidePaymentMethodSpecs = emptyList(),
+                quoteSidePaymentMethodSpecs = emptyList(),
+                offerOptions = emptyList(),
+                supportedLanguageCodes = emptyList(),
+            )
+        return OfferItemPresentationDto(
+            bisqEasyOffer = offer,
+            isMyOffer = false,
+            userProfile = createMockUserProfile("Alice"),
+            formattedDate = "",
+            formattedQuoteAmount = "",
+            formattedBaseAmount = "",
+            formattedPrice = "",
+            formattedPriceSpec = "",
+            quoteSidePaymentMethods = emptyList(),
+            baseSidePaymentMethods = emptyList(),
+            reputationScore = ReputationScoreVO(0, 0.0, 0),
         )
+    }
 
     private fun numOffersEvent(payload: String) =
         WebSocketEvent(

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -62,6 +62,9 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
 
     override fun onSetup() {
         every { webSocketClientService.connectionState } returns connectionState
+        // Neutral default for the REST fast-path so existing tests are unaffected; an empty result
+        // is a no-op (the subscription remains the source of truth for empty markets).
+        coEvery { apiGateway.getOffers(any()) } returns Result.success(emptyList())
         facade =
             ClientOffersServiceFacade(
                 marketPriceServiceFacade = marketPriceServiceFacade,
@@ -379,6 +382,102 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
             runCurrent()
 
             assertEquals(false, facade.isOfferbookLoading.value)
+        }
+
+    /**
+     * REST fast-path: on market selection we fetch the market's offers directly, which returns
+     * without waiting for the (serially-applied, cold-start-delayed) OFFERS subscription snapshot.
+     */
+    @Test
+    fun `rest prefetch populates offers before the subscription snapshot arrives`() =
+        runTest {
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns WebSocketEventObserver() // never delivers
+            coEvery { apiGateway.getOffers("BRL") } returns Result.success(listOf(buildOfferDto("rest-offer", brlMarket)))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+
+            assertEquals(1, facade.offerbookListItems.value.size)
+            assertEquals(
+                "rest-offer",
+                facade.offerbookListItems.value
+                    .single()
+                    .offerId,
+            )
+            assertEquals(false, facade.isOfferbookLoading.value)
+        }
+
+    /**
+     * The REST fast-path is best-effort: if the endpoint fails (e.g. not supported by the node),
+     * we fall back to the OFFERS subscription exactly as before.
+     */
+    @Test
+    fun `rest prefetch failure is tolerated and the subscription still populates`() =
+        runTest {
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+            coEvery { apiGateway.getOffers("BRL") } throws RuntimeException("endpoint not available")
+
+            facade.activate()
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "sub-offer")))
+            advanceUntilIdle()
+
+            assertEquals(1, facade.offerbookListItems.value.size)
+            assertEquals(
+                "sub-offer",
+                facade.offerbookListItems.value
+                    .single()
+                    .offerId,
+            )
+        }
+
+    /**
+     * The OFFERS subscription remains the source of truth: when its snapshot arrives it replaces the
+     * REST-prefetched head-start data for that market.
+     */
+    @Test
+    fun `subscription snapshot overrides the rest prefetched offers`() =
+        runTest {
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+            coEvery { apiGateway.getOffers("BRL") } returns Result.success(listOf(buildOfferDto("rest-offer", brlMarket)))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+
+            // REST head-start populated first
+            assertEquals(
+                "rest-offer",
+                facade.offerbookListItems.value
+                    .single()
+                    .offerId,
+            )
+
+            // Authoritative subscription snapshot (REPLACE) supersedes the REST data
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "sub-offer")))
+            advanceUntilIdle()
+
+            assertEquals(1, facade.offerbookListItems.value.size)
+            assertEquals(
+                "sub-offer",
+                facade.offerbookListItems.value
+                    .single()
+                    .offerId,
+            )
         }
 
     private fun offersEvent(

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -158,44 +158,13 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
         }
 
     /**
-     * Regression test for the "stuck subscription guard" bug: if the initial OFFERS
-     * subscription request never produces a payload (e.g. trusted node misbehaving),
-     * the loading timeout fires — and historically `hasSubscribedToOffers` stayed
-     * `true`, leaving every subsequent `selectOfferbookMarket` call stuck showing
-     * zero offers forever (until app restart).
+     * After the loading timeout fires, the OFFERS subscription must stay alive and the guard must
+     * stay set: re-selecting a market must NOT re-subscribe. Re-subscribing would cancel the
+     * in-flight subscription that is about to deliver its snapshot — which is exactly why, before
+     * this fix, offers only appeared after navigating back and forth on a slow Tor cold start.
      */
     @Test
-    fun `loading timeout releases the guard so next selectOfferbookMarket re-subscribes`() =
-        runTest {
-            val firstObserver = WebSocketEventObserver()
-            val secondObserver = WebSocketEventObserver()
-            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
-            coEvery { apiGateway.subscribeOffers() } returnsMany listOf(firstObserver, secondObserver)
-
-            facade.activate()
-            advanceUntilIdle()
-
-            // First market selection — subscribes (and server never delivers an OFFERS payload)
-            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
-            advanceUntilIdle()
-            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
-
-            // Loading timeout (30s) fires — guard must be released
-            advanceTimeBy(31_000L)
-            advanceUntilIdle()
-
-            // Second market selection — must re-subscribe instead of being permanently stuck
-            facade.selectOfferbookMarket(MarketListItem.from(usdMarket, numOffers = 82))
-            advanceUntilIdle()
-            coVerify(exactly = 2) { apiGateway.subscribeOffers() }
-        }
-
-    /**
-     * Happy path control: when the subscription is alive and serving data, switching
-     * markets must NOT re-subscribe (filters are applied in-process against the cache).
-     */
-    @Test
-    fun `subsequent selectOfferbookMarket does not re-subscribe while subscription is alive`() =
+    fun `loading timeout keeps the subscription alive and re-selection does not re-subscribe`() =
         runTest {
             val offersObserver = WebSocketEventObserver()
             coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
@@ -205,9 +174,72 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
             advanceUntilIdle()
 
             facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
+
+            // Loading timeout (30s) fires — spinner stops but the subscription stays alive
+            advanceTimeBy(31_000L)
+            advanceUntilIdle()
+            assertEquals(false, facade.isOfferbookLoading.value)
+
+            // Re-selecting the same market must not trigger a second subscription
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeOffers() }
+
+            // The late snapshot still lands on the original (alive) subscription and populates
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "late-offer")))
+            advanceUntilIdle()
+            assertEquals(1, facade.offerbookListItems.value.size)
+        }
+
+    /**
+     * Distinguishes "NUM_OFFERS not received yet" (unknown) from "confirmed zero": an empty OFFERS
+     * snapshot for a market whose count we don't know yet must keep the spinner, not flash a false
+     * "no offers".
+     */
+    @Test
+    fun `empty offers snapshot keeps loading while numOffers is unknown`() =
+        runTest {
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns WebSocketEventObserver()
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+
+            // No NUM_OFFERS event delivered → count for BRL is unknown
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 15))
+            runCurrent()
+
+            offersObserver.setEvent(offersEvent("[]", sequenceNumber = 1))
+            runCurrent()
+
+            assertTrue(facade.isOfferbookLoading.value)
+        }
+
+    /**
+     * Happy path control: when the subscription is alive and serving data, switching
+     * markets must NOT re-subscribe (filters are applied in-process against the cache).
+     */
+    @Test
+    fun `subsequent selectOfferbookMarket does not re-subscribe while subscription is alive`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+            // NUM_OFFERS explicitly reports zero for BRL, so an empty snapshot is authoritative.
+            numOffersObserver.setEvent(numOffersEvent("""{"BRL": 0}"""))
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 0))
             // runCurrent() processes the launches without advancing the virtual clock past
-            // the 12s loading timeout — otherwise the timeout would fire first and reset
-            // the guard, defeating the point of this happy-path test.
+            // the loading timeout — otherwise the timeout would fire first, muddying this
+            // happy-path test.
             runCurrent()
 
             // Delivering an event causes applyOffersToSelectedMarket to set isLoading=false

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -480,6 +480,48 @@ class ClientOffersServiceFacadeTest : KoinIntegrationTestBase() {
             )
         }
 
+    /**
+     * Regression for "created offer not visible until re-entering the market": NUM_OFFERS bumps the
+     * count promptly, but the OFFERS ADDED push can lag on a slow connection. On reselect, a count
+     * mismatch (cached offers != NUM_OFFERS) reconciles the cache via REST so the new offer shows.
+     */
+    @Test
+    fun `reselecting a market with a stale cache count reconciles via rest`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+
+            facade.activate()
+            advanceUntilIdle()
+
+            // First cold select: the subscription delivers a single offer for BRL
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 1))
+            advanceUntilIdle()
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "o1"), sequenceNumber = 1))
+            advanceUntilIdle()
+            assertEquals(1, facade.offerbookListItems.value.size)
+
+            // NUM_OFFERS now reports 2 (an offer was just created) but the OFFERS ADDED hasn't arrived
+            numOffersObserver.setEvent(numOffersEvent("""{"BRL": 2}"""))
+            advanceUntilIdle()
+
+            // Reselect → count mismatch (cached 1 vs numOffers 2) → REST reconcile returns the real 2
+            coEvery { apiGateway.getOffers("BRL") } returns
+                Result.success(listOf(buildOfferDto("o1", brlMarket), buildOfferDto("o2", brlMarket)))
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 2))
+            advanceUntilIdle()
+
+            assertEquals(2, facade.offerbookListItems.value.size)
+            assertEquals(
+                setOf("o1", "o2"),
+                facade.offerbookListItems.value
+                    .map { it.offerId }
+                    .toSet(),
+            )
+        }
+
     private fun offersEvent(
         payload: String,
         sequenceNumber: Int = 1,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -52,11 +52,12 @@ class ClientOffersServiceFacade(
     private var offerbookListItemsByMarket: MutableMap<String, MutableMap<String, OfferItemPresentationModel>> = mutableMapOf()
 
     /**
-     * Guards single OFFERS WebSocket subscription across market selections. Reset to false
-     * on loading timeout or collect error so the next [selectOfferbookMarket] re-attempts
-     * the subscription. Without this reset, a single failed initial subscription leaves the
-     * app unable to ever show offers again until process restart (CRITICAL bug — manifested
-     * when the trusted node does not respond to the OFFERS subscription request).
+     * Guards the single OFFERS WebSocket subscription across market selections. Kept set for the
+     * lifetime of the subscription so that switching markets only re-applies filters against the
+     * cache instead of re-subscribing. It is released only on a genuine collect error (see
+     * [resetOffersSubscriptionState]) or on [deactivate]. Notably it is NOT released on the loading
+     * timeout: the subscription is kept alive so a late snapshot still populates, and re-selecting a
+     * market must not trigger a re-subscribe (which would cancel the in-flight subscription).
      */
     private var hasSubscribedToOffers = atomic(false)
 
@@ -355,17 +356,20 @@ class ClientOffersServiceFacade(
         _offerbookListItems.value = list ?: emptyList()
 
         // Count-aware loading: NUM_OFFERS (from a separate, eagerly-subscribed topic) is the source
-        // of truth for how many offers a market has. If it says this market has offers but the
-        // OFFERS snapshot slice for it is still empty, the snapshot simply hasn't caught up yet — so
-        // we keep the spinner instead of flashing a false "no offers" state, and leave the loading
-        // timeout armed as a safety net. Once the real offers arrive (or NUM_OFFERS reports zero)
-        // the result is authoritative and we clear the loading state.
-        val expectedNumOffers = cachedNumOffersByMarketCode?.get(selectedCurrency) ?: 0
-        if (list.isNullOrEmpty() && expectedNumOffers > 0) {
-            log.d { "Awaiting $expectedNumOffers known offers for $selectedCurrency; keeping loading state" }
-        } else {
+        // of truth for how many offers a market has. We only clear the spinner once the result is
+        // authoritative: either the market has offers, or NUM_OFFERS explicitly reports zero for it.
+        // A missing NUM_OFFERS entry means "not received yet" (unknown) — NOT zero — so in that case
+        // we keep the spinner rather than flashing a false "no offers", and likewise while the count
+        // says there are offers but the OFFERS snapshot slice hasn't caught up. The loading timeout
+        // stays armed as a safety net for both.
+        val knownNumOffers: Int? = cachedNumOffersByMarketCode?.get(selectedCurrency)
+        val hasOffers = !list.isNullOrEmpty()
+        val confirmedEmpty = knownNumOffers == 0
+        if (hasOffers || confirmedEmpty) {
             _isOfferbookLoading.value = false
             loadingTimeoutJob?.cancel()
+        } else {
+            log.d { "Keeping loading state for $selectedCurrency (knownNumOffers=$knownNumOffers, offers=${list?.size ?: 0})" }
         }
     }
 
@@ -401,16 +405,20 @@ class ClientOffersServiceFacade(
                     // job cancelled
                 }
                 if (_isOfferbookLoading.value) {
-                    log.w { "Offerbook loading timed out for market ${selectedOfferbookMarket.value.market.quoteCurrencyCode}" }
-                    // Stop the blocking spinner, but KEEP the OFFERS subscription collector alive:
-                    // on a slow Tor cold start the initial snapshot can arrive after this timeout and
-                    // it must still populate the list reactively. (The old behaviour cancelled the
-                    // in-flight subscription here, throwing away the snapshot that was about to land —
-                    // that was the "offers empty after cold start until you re-enter the market" bug.)
-                    // We only release the guard so a manual re-selection can also re-attempt in the
-                    // rare case the node never responds to the subscription at all.
+                    log.w { "Offerbook loading timed out for market ${selectedOfferbookMarket.value.market.quoteCurrencyCode}; keeping subscription alive for a late snapshot" }
+                    // Only stop the blocking spinner. We deliberately KEEP the OFFERS subscription
+                    // collector alive AND keep the subscription guard set:
+                    //  - On a slow Tor cold start the OFFERS snapshot is queued behind the other
+                    //    topics and can arrive well after this timeout; the alive collector then
+                    //    populates the list reactively with no user action.
+                    //  - We must NOT release the guard here: doing so lets a re-selection call
+                    //    subscribeOffers() again, whose first act is to cancel the in-flight
+                    //    subscription — throwing away the snapshot that is about to land. That churn
+                    //    was exactly why offers only appeared after going back and forth.
+                    // Recovery when the node genuinely never answers happens at the connection layer:
+                    // a reconnect re-applies all registered subscriptions (incl. OFFERS) to the same
+                    // observer, so the alive collector still receives the snapshot.
                     _isOfferbookLoading.value = false
-                    hasSubscribedToOffers.value = false
                 }
             }
     }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -108,6 +108,7 @@ class ClientOffersServiceFacade(
             if (!hasCache) {
                 _isOfferbookLoading.value = true
                 startLoadingTimeout()
+                prefetchOffersViaRest(code)
             }
 
             if (hasSubscribedToOffers.compareAndSet(expect = false, update = true)) {
@@ -237,6 +238,51 @@ class ClientOffersServiceFacade(
             } catch (e: Exception) {
                 log.e(e) { "Error processing numOffers WebSocket event" }
             }
+        }
+    }
+
+    /**
+     * Best-effort REST fast-path for the selected market. On a cold Tor start the OFFERS
+     * subscription snapshot can be delayed many seconds because [WebSocketClientService] applies
+     * subscriptions serially and one slow topic blocks the rest. A direct REST request does not sit
+     * behind that applier, so it typically returns in a few seconds and lets us populate the offers
+     * immediately. This is purely additive: on failure we simply keep waiting for the subscription
+     * (unchanged behaviour), and we never overwrite data the subscription has already delivered.
+     */
+    private fun prefetchOffersViaRest(code: String) {
+        serviceScope.launch {
+            runCatching { apiGateway.getOffers(code).getOrThrow() }
+                .onSuccess { offers -> applyRestPrefetchedOffers(code, offers) }
+                .onFailure { e -> log.w(e) { "REST offers prefetch failed for $code; relying on the OFFERS subscription" } }
+        }
+    }
+
+    private suspend fun applyRestPrefetchedOffers(
+        code: String,
+        offers: List<OfferItemPresentationDto>,
+    ) {
+        // Let the OFFERS subscription be the source of truth for genuinely-empty markets; only the
+        // subscription snapshot can authoritatively confirm "no offers".
+        if (offers.isEmpty()) return
+
+        val models =
+            offers.associate { dto ->
+                val model = OfferItemPresentationModel(dto)
+                model.offerId to model
+            }
+
+        var applied = false
+        offersMutex.withLock {
+            // Don't clobber data the OFFERS subscription may already have delivered for this market.
+            if (offerbookListItemsByMarket[code].isNullOrEmpty()) {
+                offerbookListItemsByMarket.getOrPut(code) { mutableMapOf() }.putAll(models)
+                applied = true
+            }
+        }
+
+        if (applied) {
+            log.d { "REST prefetch populated ${models.size} offers for $code" }
+            applyOffersToSelectedMarket()
         }
     }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -109,6 +109,17 @@ class ClientOffersServiceFacade(
                 _isOfferbookLoading.value = true
                 startLoadingTimeout()
                 prefetchOffersViaRest(code)
+            } else {
+                // We have cached offers, but if NUM_OFFERS reports a different count our cached
+                // offers are stale — e.g. an offer the user just created (count already bumped)
+                // whose OFFERS ADDED push hasn't arrived yet on a slow/Tor connection. Reconcile
+                // via REST in the background (no spinner); the corrected list updates in place.
+                val cachedCount = offerbookListItemsByMarket[code]?.size ?: 0
+                val knownCount = cachedNumOffersByMarketCode?.get(code)
+                if (knownCount != null && knownCount != cachedCount) {
+                    log.d { "Cached offers for $code look stale (cached=$cachedCount, numOffers=$knownCount); reconciling via REST" }
+                    prefetchOffersViaRest(code, replaceExisting = true)
+                }
             }
 
             if (hasSubscribedToOffers.compareAndSet(expect = false, update = true)) {
@@ -249,10 +260,13 @@ class ClientOffersServiceFacade(
      * immediately. This is purely additive: on failure we simply keep waiting for the subscription
      * (unchanged behaviour), and we never overwrite data the subscription has already delivered.
      */
-    private fun prefetchOffersViaRest(code: String) {
+    private fun prefetchOffersViaRest(
+        code: String,
+        replaceExisting: Boolean = false,
+    ) {
         serviceScope.launch {
             runCatching { apiGateway.getOffers(code).getOrThrow() }
-                .onSuccess { offers -> applyRestPrefetchedOffers(code, offers) }
+                .onSuccess { offers -> applyRestPrefetchedOffers(code, offers, replaceExisting) }
                 .onFailure { e -> log.w(e) { "REST offers prefetch failed for $code; relying on the OFFERS subscription" } }
         }
     }
@@ -260,9 +274,10 @@ class ClientOffersServiceFacade(
     private suspend fun applyRestPrefetchedOffers(
         code: String,
         offers: List<OfferItemPresentationDto>,
+        replaceExisting: Boolean,
     ) {
         // Let the OFFERS subscription be the source of truth for genuinely-empty markets; only the
-        // subscription snapshot can authoritatively confirm "no offers".
+        // subscription snapshot (or its REMOVED events) can authoritatively confirm "no offers".
         if (offers.isEmpty()) return
 
         val models =
@@ -273,15 +288,25 @@ class ClientOffersServiceFacade(
 
         var applied = false
         offersMutex.withLock {
-            // Don't clobber data the OFFERS subscription may already have delivered for this market.
-            if (offerbookListItemsByMarket[code].isNullOrEmpty()) {
-                offerbookListItemsByMarket.getOrPut(code) { mutableMapOf() }.putAll(models)
-                applied = true
+            val marketMap = offerbookListItemsByMarket.getOrPut(code) { mutableMapOf() }
+            when {
+                // Reconcile: authoritative REST result replaces a stale cache (count mismatch).
+                replaceExisting -> {
+                    marketMap.clear()
+                    marketMap.putAll(models)
+                    applied = true
+                }
+                // Cold prefetch: only populate if the subscription hasn't delivered anything yet,
+                // so we never clobber fresher subscription data.
+                marketMap.isEmpty() -> {
+                    marketMap.putAll(models)
+                    applied = true
+                }
             }
         }
 
         if (applied) {
-            log.d { "REST prefetch populated ${models.size} offers for $code" }
+            log.d { "REST prefetch (${if (replaceExisting) "reconcile" else "cold"}) populated ${models.size} offers for $code" }
             applyOffersToSelectedMarket()
         }
     }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -35,7 +35,12 @@ class ClientOffersServiceFacade(
     private val webSocketClientService: WebSocketClientService,
 ) : OffersServiceFacade() {
     private companion object {
-        private const val LOADING_TIMEOUT_MS = 12000L
+        // Upper bound for how long we show the blocking spinner while waiting for the initial
+        // OFFERS snapshot. Aligned with the WebSocket request round-trip timeout (30s): on a cold
+        // Tor connection the OFFERS subscription is queued behind the banner subscriptions and its
+        // snapshot can take well over 10s to arrive. This is only a spinner cap — the subscription
+        // is kept alive past it (see [startLoadingTimeout]), so a late snapshot still populates.
+        private const val LOADING_TIMEOUT_MS = 30000L
     }
 
     private var marketPriceUpdateJob: Job? = null
@@ -348,8 +353,20 @@ class ClientOffersServiceFacade(
         }
 
         _offerbookListItems.value = list ?: emptyList()
-        _isOfferbookLoading.value = false
-        loadingTimeoutJob?.cancel()
+
+        // Count-aware loading: NUM_OFFERS (from a separate, eagerly-subscribed topic) is the source
+        // of truth for how many offers a market has. If it says this market has offers but the
+        // OFFERS snapshot slice for it is still empty, the snapshot simply hasn't caught up yet — so
+        // we keep the spinner instead of flashing a false "no offers" state, and leave the loading
+        // timeout armed as a safety net. Once the real offers arrive (or NUM_OFFERS reports zero)
+        // the result is authoritative and we clear the loading state.
+        val expectedNumOffers = cachedNumOffersByMarketCode?.get(selectedCurrency) ?: 0
+        if (list.isNullOrEmpty() && expectedNumOffers > 0) {
+            log.d { "Awaiting $expectedNumOffers known offers for $selectedCurrency; keeping loading state" }
+        } else {
+            _isOfferbookLoading.value = false
+            loadingTimeoutJob?.cancel()
+        }
     }
 
     private fun scheduleOffersPriceRefresh() {
@@ -385,10 +402,15 @@ class ClientOffersServiceFacade(
                 }
                 if (_isOfferbookLoading.value) {
                     log.w { "Offerbook loading timed out for market ${selectedOfferbookMarket.value.market.quoteCurrencyCode}" }
-                    // Release the subscription guard so the next selectOfferbookMarket
-                    // can re-attempt subscription. Without this, the app would be stuck
-                    // showing 0 offers for every market until process restart.
-                    resetOffersSubscriptionState()
+                    // Stop the blocking spinner, but KEEP the OFFERS subscription collector alive:
+                    // on a slow Tor cold start the initial snapshot can arrive after this timeout and
+                    // it must still populate the list reactively. (The old behaviour cancelled the
+                    // in-flight subscription here, throwing away the snapshot that was about to land —
+                    // that was the "offers empty after cold start until you re-enter the market" bug.)
+                    // We only release the guard so a manual re-selection can also re-attempt in the
+                    // rare case the node never responds to the subscription at all.
+                    _isOfferbookLoading.value = false
+                    hasSubscribedToOffers.value = false
                 }
             }
     }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -261,6 +261,7 @@ mobile.offerbook.filters.selectAll=Select all
 mobile.offerbook.filters.selectNone=Select none
 mobile.offerbook.filters.noPaymentMatches=No payment methods match your search
 mobile.offerbook.filters.noSettlementMatches=No settlement methods match your search
+mobile.offerbook.slowLoadingHint=Offers loading — Tor connections take a bit longer
 
 mobile.settlement.bitcoin=Bitcoin
 mobile.settlement.lightning=Lightning

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
@@ -135,6 +135,7 @@ class OfferbookPresenterFilterPersistenceTest {
         val offersService = mockk<OffersServiceFacade>()
         every { offersService.offerbookListItems } returns offersFlow
         every { offersService.selectedOfferbookMarket } returns marketFlow
+        every { offersService.isOfferbookLoading } returns MutableStateFlow(false)
         coEvery { offersService.deleteOffer(any()) } returns Result.success(true)
 
         val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -178,6 +178,7 @@ class OfferbookPresenterFilterTest {
         val offersService = mockk<OffersServiceFacade>()
         every { offersService.offerbookListItems } returns offersFlow
         every { offersService.selectedOfferbookMarket } returns marketFlow
+        every { offersService.isOfferbookLoading } returns MutableStateFlow(false)
         coEvery { offersService.deleteOffer(any()) } returns Result.success(true)
         // User profile facade for OfferbookPresenter
         val offerUserProfileService = mockk<UserProfileServiceFacade>(relaxed = true)
@@ -516,6 +517,7 @@ class OfferbookPresenterFilterTest {
             val offersService = mockk<OffersServiceFacade>()
             every { offersService.offerbookListItems } returns offersFlow
             every { offersService.selectedOfferbookMarket } returns marketFlow
+            every { offersService.isOfferbookLoading } returns MutableStateFlow(false)
             coEvery { offersService.deleteOffer(any()) } returns Result.success(true)
             val offerUserProfileService = mockk<UserProfileServiceFacade>(relaxed = true)
             every { offerUserProfileService.selectedUserProfile } returns MutableStateFlow(createMockUserProfile("me"))
@@ -601,6 +603,7 @@ class OfferbookPresenterFilterTest {
             val offersService = mockk<OffersServiceFacade>()
             every { offersService.offerbookListItems } returns offersFlow
             every { offersService.selectedOfferbookMarket } returns marketFlow
+            every { offersService.isOfferbookLoading } returns MutableStateFlow(false)
             coEvery { offersService.deleteOffer(any()) } returns Result.success(true)
 
             val offerUserProfileService = mockk<UserProfileServiceFacade>(relaxed = true)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
@@ -1,0 +1,179 @@
+package network.bisq.mobile.presentation.offerbook
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.data.model.market.MarketPriceItem
+import network.bisq.mobile.data.model.offerbook.MarketListItem
+import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
+import network.bisq.mobile.data.model.offerbook.OfferbookMarket
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
+import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.data.service.offers.OffersServiceFacade
+import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
+import network.bisq.mobile.domain.repository.SettingsRepository
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
+import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
+import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
+import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * The offerbook shows a "still loading" snackbar when the offers stay loading for more than 5s
+ * (common on slow/Tor cold starts). Verifies the hint fires after the threshold, and is suppressed
+ * if loading finishes first (the collectLatest cancels the pending delay).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OfferbookPresenterSlowLoadingHintTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var globalUiManager: GlobalUiManager
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+        every { getScreenWidthDp() } returns 480
+        globalUiManager = mockk(relaxed = true)
+        startKoin {
+            modules(
+                module {
+                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
+                    single<NavigationManager> { NoopNavigationManager() }
+                    single<GlobalUiManager> { globalUiManager }
+                },
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+    @Test
+    fun `shows slow-loading hint when offers stay loading past the threshold`() =
+        runTest(testDispatcher) {
+            val loading = MutableStateFlow(true)
+            val presenter = buildPresenter(loading)
+
+            presenter.onViewAttached()
+            advanceTimeBy(5_100L)
+            advanceUntilIdle()
+
+            coVerify {
+                globalUiManager.showSnackbar(
+                    "mobile.offerbook.slowLoadingHint".i18n(),
+                    SnackbarType.WARNING,
+                    any(),
+                    any(),
+                )
+            }
+        }
+
+    @Test
+    fun `does not show slow-loading hint when offers finish loading before the threshold`() =
+        runTest(testDispatcher) {
+            val loading = MutableStateFlow(true)
+            val presenter = buildPresenter(loading)
+
+            presenter.onViewAttached()
+            advanceTimeBy(2_000L)
+            loading.value = false
+            advanceTimeBy(5_000L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                globalUiManager.showSnackbar(
+                    "mobile.offerbook.slowLoadingHint".i18n(),
+                    SnackbarType.WARNING,
+                    any(),
+                    any(),
+                )
+            }
+        }
+
+    private fun buildPresenter(loadingFlow: MutableStateFlow<Boolean>): OfferbookPresenter {
+        val mainPresenter =
+            MainPresenterTestFactory.create(
+                applicationLifecycleService = TestApplicationLifecycleService(),
+            )
+
+        val offersService = mockk<OffersServiceFacade>(relaxed = true)
+        val market = OfferbookMarket(MarketVO("BTC", "USD", "Bitcoin", "US Dollar"))
+        every { offersService.offerbookListItems } returns MutableStateFlow(emptyList<OfferItemPresentationModel>())
+        every { offersService.selectedOfferbookMarket } returns MutableStateFlow(market)
+        every { offersService.isOfferbookLoading } returns loadingFlow
+
+        val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
+        every { userProfileServiceFacade.selectedUserProfile } returns MutableStateFlow(createMockUserProfile("me"))
+        coEvery { userProfileServiceFacade.isUserIgnored(any()) } returns false
+
+        val settingsRepository = mockk<SettingsRepository>(relaxed = true)
+        val marketPriceServiceFacade =
+            object : MarketPriceServiceFacade(settingsRepository) {
+                override fun findMarketPriceItem(marketVO: MarketVO): MarketPriceItem? = null
+
+                override fun findUSDMarketPriceItem(): MarketPriceItem? = null
+
+                override fun refreshSelectedFormattedMarketPrice() {}
+
+                override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
+            }
+
+        val reputationService = mockk<ReputationServiceFacade>(relaxed = true)
+        coEvery { reputationService.getReputation(any()) } returns
+            Result.success(ReputationScoreVO(totalScore = 999_999L, fiveSystemScore = 5.0, ranking = 1))
+
+        val tradeRestrictingAlertServiceFacade = mockk<TradeRestrictingAlertServiceFacade>(relaxed = true)
+        every { tradeRestrictingAlertServiceFacade.alert } returns MutableStateFlow(null)
+
+        val offerbookFilterConfigRepository = mockk<OfferbookFilterConfigRepository>(relaxed = true)
+        coEvery { offerbookFilterConfigRepository.getConfig(any()) } returns OfferbookFilterConfig()
+        coEvery { offerbookFilterConfigRepository.setConfig(any(), any()) } returns Unit
+
+        return OfferbookPresenter(
+            mainPresenter,
+            offersService,
+            mockk<TakeOfferCoordinator>(relaxed = true),
+            mockk<CreateOfferCoordinator>(relaxed = true),
+            marketPriceServiceFacade,
+            userProfileServiceFacade,
+            reputationService,
+            tradeRestrictingAlertServiceFacade,
+            offerbookFilterConfigRepository,
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.offerbook
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -137,6 +138,24 @@ open class OfferbookPresenter(
         launchMarketFilterRestore()
         launchOfferFiltering()
         launchFilterUiStateDerivation()
+        launchSlowLoadingHint()
+    }
+
+    /**
+     * If the offerbook stays in the loading state for more than [SLOW_LOADING_HINT_DELAY_MS], nudge
+     * the user with a snackbar — the OFFERS snapshot can lag on slow/Tor connections (it is queued
+     * behind other subscriptions on a cold start). collectLatest cancels the pending delay whenever
+     * the loading flag changes, so the hint only fires once per sustained loading episode.
+     */
+    private fun launchSlowLoadingHint() {
+        presenterScope.launch {
+            offersServiceFacade.isOfferbookLoading.collectLatest { isLoading ->
+                if (isLoading) {
+                    delay(SLOW_LOADING_HINT_DELAY_MS)
+                    showSnackbar("mobile.offerbook.slowLoadingHint".i18n(), type = SnackbarType.WARNING)
+                }
+            }
+        }
     }
 
     private fun launchMarketFilterRestore() {
@@ -829,5 +848,9 @@ open class OfferbookPresenter(
         _isCreateOfferEnabled.value = true
         _isDeleteOfferEnabled.value = true
         _isTakeOfferEnabled.value = true
+    }
+
+    private companion object {
+        private const val SLOW_LOADING_HINT_DELAY_MS = 5000L
     }
 }


### PR DESCRIPTION
 - fixes #1563 
 - contribs to #1514 
 - fixed using TDD to avoid regressions int he future, increased timeout for loading market offers, improved logging and docs. Do not cancel the offers job early (~12 secs at the moment when roundtrip timeout is 30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offerbook loading logic to be NUM_OFFERS-aware, keeping the spinner on for “unknown” or delayed OFFERS and clearing it only when counts indicate no offers.
  * Increased offer loading timeout and changed it to stop only the spinner while keeping live offers updates active for late snapshots.
  * Added REST prefetch as a best-effort path, with cache reconciliation and subscription data taking priority.

* **New Features**
  * Added a slow-loading hint snackbar for prolonged offer loading.

* **Tests**
  * Expanded coverage for OFFERS/NUM_OFFERS edge cases, REST prefetch and failure handling, and added slow-loading hint tests.

* **Chores**
  * Updated CI Gradle invocation to disable build cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->