### PR TITLE
fix(main): reset GlobalUiManager on teardown to prevent frozen UI after restart

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManagerTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManagerTest.kt
@@ -362,4 +362,50 @@ class GlobalUiManagerTest {
             assertFalse(globalUiManager.isLoadingBlocking.value)
             assertFalse(globalUiManager.showLoadingDialog.value)
         }
+
+    @Test
+    fun reset_clearsLoadingStateImmediately() =
+        runTest(testDispatcher) {
+            // Given
+            val globalUiManager = GlobalUiManager(testDispatcher)
+
+            globalUiManager.scheduleShowLoading()
+            globalUiManager.scheduleHideLoading()
+
+            // When: Reset during hide grace delay
+            globalUiManager.reset()
+
+            // Then: Cleared immediately
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+
+            // When: Wait past hide grace delay
+            testScheduler.advanceTimeBy(200)
+            testScheduler.runCurrent()
+
+            // Then: Still cleared (pending jobs were cancelled)
+            assertFalse(globalUiManager.isLoadingBlocking.value)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+        }
+
+    @Test
+    fun reset_keepsScopeUsable_forSubsequentLoading() =
+        runTest(testDispatcher) {
+            // Given: a manager that was reset on a previous presenter teardown
+            val globalUiManager = GlobalUiManager(testDispatcher)
+            globalUiManager.scheduleShowLoading()
+            globalUiManager.reset()
+
+            // When: a new session schedules loading (regression guard for issue #1562)
+            globalUiManager.scheduleShowLoading()
+
+            // Then: blocking flips true immediately...
+            assertTrue(globalUiManager.isLoadingBlocking.value)
+
+            // ...and the dialog still appears after the grace delay (scope not cancelled)
+            assertFalse(globalUiManager.showLoadingDialog.value)
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+            assertTrue(globalUiManager.showLoadingDialog.value)
+        }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterCleanupTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterCleanupTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -38,12 +39,14 @@ import kotlin.test.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainPresenterCleanupTest {
     private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var globalUiManager: GlobalUiManager
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
         every { getScreenWidthDp() } returns 480
+        globalUiManager = mockk(relaxed = true)
         startKoin {
             modules(
                 module {
@@ -54,7 +57,7 @@ class MainPresenterCleanupTest {
                         }
                     }
                     single { NoopNavigationManager() as network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager }
-                    single { GlobalUiManager() }
+                    single { globalUiManager }
                 },
             )
         }
@@ -79,6 +82,18 @@ class MainPresenterCleanupTest {
             // Allow fire-and-forget coroutine to complete
             delay(100)
             coVerify { notificationService.stopNotificationService() }
+        }
+
+    @Test
+    fun `onDestroy resets GlobalUiManager without disposing its scope`() =
+        runBlocking {
+            // Regression guard for issue #1562: GlobalUiManager is an app-lifetime singleton, so
+            // teardown must reset() its transient loading state, never dispose() (cancel its scope).
+            val presenter = MainPresenterTestFactory.create()
+            presenter.onDestroy()
+            delay(100)
+            verify(exactly = 1) { globalUiManager.reset() }
+            verify(exactly = 0) { globalUiManager.dispose() }
         }
 
     @Test

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManager.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/base/GlobalUiManager.kt
@@ -124,8 +124,23 @@ class GlobalUiManager(
     }
 
     /**
-     * Dispose of the manager and cancel all pending operations.
-     * Useful for testing scenarios where you want to cleanly tear down the manager.
+     * Reset transient loading state without tearing down the scope.
+     * Cancels any pending show/hide jobs and clears both the blocking overlay and the dialog.
+     *
+     * Use this on presenter teardown: [GlobalUiManager] is an app-lifetime singleton that outlives
+     * any individual presenter, so its [scope] must stay usable for the next session. Cancelling the
+     * scope here (via [dispose]) would permanently break [scheduleShowLoading]/[scheduleHideLoading]
+     * and leave [isLoadingBlocking] stuck `true` after an Activity is recreated over a surviving
+     * process (e.g. foreground-service kill + immediate restart), freezing the UI.
+     */
+    fun reset() {
+        clearLoadingStateNow()
+    }
+
+    /**
+     * Dispose of the manager and cancel all pending operations, including the underlying [scope].
+     * Only for teardown/testing where the instance is discarded — the scope is not recreated, so a
+     * disposed instance can no longer schedule loading. For production presenter teardown use [reset].
      */
     fun dispose() {
         clearLoadingStateNow()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -223,7 +223,10 @@ open class MainPresenter(
 
     @CallSuper
     override fun onDestroying() {
-        globalUiManager.dispose()
+        // reset (not dispose) — GlobalUiManager is an app-lifetime singleton that outlives this
+        // presenter. Cancelling its scope here would leave the loading overlay stuck after an
+        // Activity is recreated over a surviving process, freezing the UI (issue #1562).
+        globalUiManager.reset()
         cleanupNotificationService()
         super.onDestroying()
     }


### PR DESCRIPTION
Resolves: https://github.com/bisq-network/bisq-mobile/issues/1562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the loading overlay could remain stuck after leaving a screen.
  * Loading state now clears properly during lifecycle changes, and loading indicators can appear normally again afterward.
* **Tests**
  * Added regression coverage for loading-state cleanup and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->