### PR TITLE
Release/connect 0.6.2 update

### DIFF
--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.6.2'
+    spec.version                  = '0.6.3'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,12 @@ object KoverExclusions {
         listOf(
             "*ComposableSingletons*",
             "bisqapps.*.generated.resources.*",
+            // Auto-generated i18n resource bundles (one giant `mapOf(...)` per language,
+            // produced by the generateResourceBundles task from mobile/*.properties). They are
+            // generated data tables, not logic — the same rationale as the Compose generated
+            // resources above. Beyond that, once a translation batch grows a bundle's initializer
+            // past the coverage engine's per-method instrumentation size limit so this is a key one
+            "network.bisq.mobile.i18n.GeneratedResourceBundles*",
             "network.bisq.mobile.presentation.design.*",
             // Thin wrapper around the Sentry-KMP `Sentry.init { ... }` lambda.
             // The whole point of the SentryClient interface (which DefaultSentryClient

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,14 +35,14 @@ node.name=Bisq Easy
 node.android.version=0.8.2
 
 client.name=Bisq Connect
-client.android.version=0.6.2
-client.ios.version=0.6.2
+client.android.version=0.6.3
+client.ios.version=0.6.3
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=45
-client.android.version.code=27
-node.android.version.code=45
+client.ios.version.code=46
+client.android.version.code=28
+node.android.version.code=44
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,8 +56,12 @@ kotlin.mpp.enableCInteropCommonization=true
 # kotlin.mpp.enableCInteropCommonization.nowarn=true
 
 # Code Coverage
-kover.coverage.minimum=75
-kover.diff.coverage.minimum=85
+# Overall minimum reflects real (non-generated) coverage. The generated i18n resource
+# bundles are excluded from Kover (see KoverExclusions in build.gradle.kts), so this bar
+# no longer includes ~36k lines of generated translation tables that used to inflate it.
+# Ratchet up as real domain/presentation test coverage grows.
+kover.coverage.minimum=55
+kover.diff.coverage.minimum=80
 
 # Feature (client app only)
 feature.muSigEnabled=false

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.6.2
-APP_VERSION_CODE=45
+APP_VERSION=0.6.3
+APP_VERSION_CODE=46

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.6.2):
+  - clientApp (0.6.3):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 4bedc1c62ac004efdeb6d791bc0e362723ec5734
+  clientApp: 020f8133d7fcae7bd33a150ae34fa823dcf6148e
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.6.2):
+  - clientApp (0.6.3):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 4bedc1c62ac004efdeb6d791bc0e362723ec5734
+  clientApp: 020f8133d7fcae7bd33a150ae34fa823dcf6148e
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: ec5b5b69704747770d600d7bd4f638a5cf9a33c8

--- a/iosClient/iosClient.xcodeproj/project.pbxproj
+++ b/iosClient/iosClient.xcodeproj/project.pbxproj
@@ -627,13 +627,14 @@
 /* Begin XCBuildConfiguration section */
 		745C4F812F96090B005424DB /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = BisqNotificationService/BisqNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(APP_VERSION_CODE)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = YRAZCRBR9J;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -649,7 +650,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(APP_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.BisqNotificationService";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -665,13 +666,14 @@
 		};
 		745C4F822F96090B005424DB /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = BisqNotificationService/BisqNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(APP_VERSION_CODE)";
 				DEVELOPMENT_TEAM = YRAZCRBR9J;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -686,7 +688,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(APP_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.BisqNotificationService";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = bisq.mobile.client.BisqConnect.BisqNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
 - contribs to #1514 
 - upgrades done in release/connect_0.6.2 off 0.6.1
 - fix warning on app version for NSE for next iOS releases
 - uncomfortable truth: our average koverage was measuring generating files inflating it. Last translation PR tanked the koverage, so had to exclude it and now current honest baseline is ~58%
 - update metadata and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android, iOS, and CocoaPods version numbers to `0.6.3`, along with the associated release/build codes.
  * Standardized iOS build settings to use shared app version values across configurations.

* **Tests**
  * Adjusted coverage settings to exclude generated localization resources from instrumentation, helping keep coverage reporting accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->