### PR TITLE
Chore/upgrade kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ umbrel-image-version = "2.1.11.1"
 bisq-api-commit = "285cf42b5259c34f50a586620a75c6a8b1a158ab"
 
 # -------------------- Kotlin & JetBrains --------------------
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,13 +21,13 @@ umbrel-image-version = "2.1.11.1"
 bisq-api-commit = "285cf42b5259c34f50a586620a75c6a8b1a158ab"
 
 # -------------------- Kotlin & JetBrains --------------------
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 atomicfu = "0.31.0"
 compose-plugin = "1.10.3"
-ksp = "2.3.6"
+ksp = "2.3.9"
 kover = "0.9.7"
 
 # -------------------- Android --------------------


### PR DESCRIPTION
 - resolves #1497 
 - upgrade kotlin to latest stable major release 2.4.0
 - upgrade ksp to 2.3.9 as required by kotlin upgrade
 - compose stays same for now as the desirable 1.11.x bump causes tests to fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kotlin toolchain and related processing support to newer versions, improving compatibility and build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->