### PR TITLE
Fixes splash getting stuck at "Starting Tor… 0%" when kmp-tor dies early with CtrlConnection Stream Ended

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -365,6 +365,7 @@ val clientDomainModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
@@ -9,6 +9,7 @@ import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
 import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
 
@@ -17,7 +18,8 @@ class ClientNetworkServiceFacade(
     private val httpClientService: HttpClientService,
     private val webSocketClientService: WebSocketClientService,
     kmpTorService: KmpTorService,
-) : NetworkServiceFacade(kmpTorService) {
+    applicationBootstrapFacade: ApplicationBootstrapFacade,
+) : NetworkServiceFacade(kmpTorService, applicationBootstrapFacade) {
     override val numConnections: StateFlow<Int> =
         webSocketClientService.connectionState
             .map { if (it is ConnectionState.Connected) 1 else -1 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -112,7 +112,7 @@ val androidNodeDomainModule =
 
         single<MessageDeliveryServiceFacade> { NodeMessageDeliveryServiceFacade(get()) }
 
-        single { NodeNetworkServiceFacade(get(), get()) } bind NetworkServiceFacade::class
+        single { NodeNetworkServiceFacade(get(), get(), get()) } bind NetworkServiceFacade::class
 
         single<KmpTorService> {
             val applicationService = get<AndroidApplicationService>()

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -201,11 +201,6 @@ class NodeApplicationLifecycleService(
             } catch (e: Exception) {
                 log.e("Error at applicationService.shutdown", e)
             }
-        } else {
-            log.i {
-                "Skipping applicationService shutdown — bisq2 never left INITIALIZE_APP; " +
-                    "preserving NetworkService transport nodes for in-process Tor retry"
-            }
         }
 
         applicationBootstrapFacade.deactivate()

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.node.common.domain.service
 
 import android.app.Activity
+import bisq.application.State
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
@@ -192,15 +193,29 @@ class NodeApplicationLifecycleService(
         connectivityService.deactivate()
         settingsServiceFacade.deactivate()
 
-        try {
-            log.i { "Stopping applicationService" }
-            provider.applicationService.shutdown().await()
-            log.i { "ApplicationService stopped" }
-        } catch (e: Exception) {
-            log.e("Error at applicationService.shutdown", e)
+        if (shouldShutdownApplicationService()) {
+            try {
+                log.i { "Stopping applicationService" }
+                provider.applicationService.shutdown().await()
+                log.i { "ApplicationService stopped" }
+            } catch (e: Exception) {
+                log.e("Error at applicationService.shutdown", e)
+            }
+        } else {
+            log.i {
+                "Skipping applicationService shutdown — bisq2 never left INITIALIZE_APP; " +
+                    "preserving NetworkService transport nodes for in-process Tor retry"
+            }
         }
 
         applicationBootstrapFacade.deactivate()
         networkServiceFacade.deactivate()
     }
+
+    /**
+     * bisq2 [NetworkService.shutdown] clears transport nodes; they are only recreated in the
+     * [NetworkService] constructor. Avoid shutdown before the first [initialize] so splash
+     * Tor retry can run in-process.
+     */
+    private fun shouldShutdownApplicationService(): Boolean = provider.state.get().get() != State.INITIALIZE_APP
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
@@ -12,6 +12,7 @@ import bisq.network.p2p.services.peer_group.PeerGroupService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -20,7 +21,8 @@ import kotlin.streams.toList
 class NodeNetworkServiceFacade(
     private val provider: AndroidApplicationService.Provider,
     kmpTorService: KmpTorService,
-) : NetworkServiceFacade(kmpTorService),
+    applicationBootstrapFacade: ApplicationBootstrapFacade,
+) : NetworkServiceFacade(kmpTorService, applicationBootstrapFacade),
     Node.Listener {
     // While tor starts up we use -1 to flag as network not available yet
     private val _numConnections = MutableStateFlow(-1)

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -235,29 +236,65 @@ class ApplicationBootstrapFacadeTest : KoinTest {
         }
 
     @Test
-    fun `tor failure within grace period retries and does not show failure dialog`() =
+    fun `handleTorBootstrapError suppresses transient failure until grace elapses`() =
         runTest(testDispatcher) {
-            val kmpTorService = mockk<KmpTorService>(relaxed = true)
-            val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
-            val progressFlow = MutableStateFlow(0)
-            every { kmpTorService.state } returns stateFlow
-            every { kmpTorService.bootstrapProgress } returns progressFlow
-            coEvery { kmpTorService.startTor(any(), any()) } returns false
-            val facade = TestFacade(kmpTorService)
-
+            val facade = TestFacade(mockk(relaxed = true), testScheduler)
             try {
-                facade.fakeTimeMillis = 1_000_000L
-                facade.observeTorStatePublic()
+                testScheduler.advanceTimeBy(1_000_000)
+                facade.markTorBootstrapStartingForTest(testScheduler.currentTime)
+                testScheduler.advanceTimeBy(10_000)
+                facade.handleTorBootstrapErrorForTest(RuntimeException("network flake"))
+                assertFalse(facade.torBootstrapFailed.value)
 
-                stateFlow.emit(KmpTorService.TorState.Starting)
+                testScheduler.advanceTimeBy(50_000)
                 advanceUntilIdle()
+                assertTrue(facade.torBootstrapFailed.value)
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
 
-                facade.fakeTimeMillis = 1_010_000L
-                stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Circuit build timeout")))
-                advanceUntilIdle()
+    @Test
+    fun `handleTorBootstrapError arms terminal failure immediately`() =
+        runTest(testDispatcher) {
+            val facade = TestFacade(mockk(relaxed = true), testScheduler)
+            try {
+                testScheduler.advanceTimeBy(1_000_000)
+                facade.markTorBootstrapStartingForTest(testScheduler.currentTime)
+                testScheduler.advanceTimeBy(10_000)
+                facade.handleTorBootstrapErrorForTest(
+                    InterruptedException("CtrlConnection Stream Ended"),
+                )
+                assertTrue(facade.torBootstrapFailed.value)
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
 
-                assertFalse(facade.torBootstrapFailed.value, "Single transient failure should retry, not show dialog")
-                coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
+    @Test
+    fun `handleTorBootstrapError arms transient failure after grace period elapsed`() =
+        runTest(testDispatcher) {
+            val facade = TestFacade(mockk(relaxed = true), testScheduler)
+            try {
+                testScheduler.advanceTimeBy(1_000_000)
+                facade.markTorBootstrapStartingForTest(testScheduler.currentTime)
+                testScheduler.advanceTimeBy(65_000)
+                facade.handleTorBootstrapErrorForTest(RuntimeException("Tor failed permanently"))
+                assertTrue(facade.torBootstrapFailed.value)
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
+
+    @Test
+    fun `handleTorBootstrapError ignores stale errors before starting is observed`() =
+        runTest(testDispatcher) {
+            val facade = TestFacade(mockk(relaxed = true), testScheduler)
+            try {
+                facade.handleTorBootstrapErrorForTest(
+                    InterruptedException("CtrlConnection Stream Ended"),
+                )
+                assertFalse(facade.torBootstrapFailed.value)
             } finally {
                 facade.releaseTestResources()
             }
@@ -271,16 +308,16 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             val progressFlow = MutableStateFlow(0)
             every { kmpTorService.state } returns stateFlow
             every { kmpTorService.bootstrapProgress } returns progressFlow
-            val facade = TestFacade(kmpTorService)
+            val facade = TestFacade(kmpTorService, testScheduler)
 
             try {
-                facade.fakeTimeMillis = 1_000_000L
+                testScheduler.advanceTimeBy(1_000_000)
                 facade.observeTorStatePublic()
 
                 stateFlow.emit(KmpTorService.TorState.Starting)
                 advanceUntilIdle()
 
-                facade.fakeTimeMillis = 1_010_000L
+                testScheduler.advanceTimeBy(10_000)
                 stateFlow.emit(KmpTorService.TorState.Stopped(InterruptedException("CtrlConnection Stream Ended")))
                 advanceUntilIdle()
 
@@ -314,63 +351,6 @@ class ApplicationBootstrapFacadeTest : KoinTest {
                     facade.torBootstrapFailed.value,
                     "Stale Stopped(error) before first Starting should not arm failure dialog",
                 )
-            } finally {
-                facade.releaseTestResources()
-            }
-        }
-
-    @Test
-    fun `three transient failures within grace period show failure dialog`() =
-        runTest(testDispatcher) {
-            val kmpTorService = mockk<KmpTorService>(relaxed = true)
-            val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
-            val progressFlow = MutableStateFlow(0)
-            every { kmpTorService.state } returns stateFlow
-            every { kmpTorService.bootstrapProgress } returns progressFlow
-            coEvery { kmpTorService.startTor(any(), any()) } returns false
-            val facade = TestFacade(kmpTorService)
-
-            try {
-                facade.fakeTimeMillis = 1_000_000L
-                facade.observeTorStatePublic()
-
-                repeat(3) { attempt ->
-                    stateFlow.emit(KmpTorService.TorState.Starting)
-                    advanceUntilIdle()
-                    facade.fakeTimeMillis = 1_010_000L + (attempt * 1_000L)
-                    stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Circuit build timeout")))
-                    advanceUntilIdle()
-                }
-
-                assertTrue(facade.torBootstrapFailed.value, "Third transient failure should show dialog")
-                coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
-            } finally {
-                facade.releaseTestResources()
-            }
-        }
-
-    @Test
-    fun `tor failure after grace period shows failure dialog`() =
-        runTest(testDispatcher) {
-            val kmpTorService = mockk<KmpTorService>(relaxed = true)
-            val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
-            val progressFlow = MutableStateFlow(0)
-            every { kmpTorService.state } returns stateFlow
-            every { kmpTorService.bootstrapProgress } returns progressFlow
-            val facade = TestFacade(kmpTorService)
-
-            try {
-                facade.fakeTimeMillis = 1_000_000L
-                facade.observeTorStatePublic()
-
-                stateFlow.emit(KmpTorService.TorState.Starting)
-                advanceUntilIdle()
-
-                facade.fakeTimeMillis = 1_065_000L
-                stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Tor failed permanently")))
-                advanceUntilIdle()
-
-                assertTrue(facade.torBootstrapFailed.value, "Tor failure after grace period should show dialog")
             } finally {
                 facade.releaseTestResources()
             }
@@ -446,10 +426,11 @@ class ApplicationBootstrapFacadeTest : KoinTest {
 // Test subclass to expose protected functionality for unit testing only
 private class TestFacade(
     kmpTorService: KmpTorService,
+    private val scheduler: TestCoroutineScheduler? = null,
 ) : ApplicationBootstrapFacade(kmpTorService) {
     var fakeTimeMillis: Long = 0L
 
-    override fun currentTimeMillis(): Long = fakeTimeMillis
+    override fun currentTimeMillis(): Long = scheduler?.currentTime ?: fakeTimeMillis
 
     fun startTimeoutForStagePublic(
         stageName: String = state.value,

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.domain.service.bootstrap
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +67,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
 
             assertEquals("loading", facade.state.value)
             assertEquals(0.42f, facade.progress.value)
+            facade.releaseTestResources()
         }
 
     @Test
@@ -80,6 +83,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             advanceUntilIdle()
 
             assertTrue(facade.isTimeoutDialogVisible.value)
+            facade.releaseTestResources()
         }
 
     @Test
@@ -98,6 +102,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             // advance the remaining time -> dialog should now be visible
             testScheduler.advanceTimeBy(100_000)
             assertTrue(facade.isTimeoutDialogVisible.value)
+            facade.releaseTestResources()
         }
 
     @Test
@@ -114,6 +119,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             advanceUntilIdle()
 
             assertFalse(facade.isTimeoutDialogVisible.value)
+            facade.releaseTestResources()
         }
 
     @Test
@@ -154,7 +160,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
                 assertEquals("", facade.currentBootstrapStage.value, "currentBootstrapStage should be reset")
             } finally {
                 // Stop the elapsed ticker so runTest's end-of-test idle drain doesn't hang on it.
-                facade.deactivate()
+                facade.releaseTestResources()
             }
         }
 
@@ -185,8 +191,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             runCurrent()
             assertTrue(facade.isTimeoutDialogVisible.value, "Timeout should fire after reactivation")
 
-            // Stop the elapsed ticker so runTest's end-of-test idle drain doesn't hang on it.
-            facade.deactivate()
+            facade.releaseTestResources()
         }
 
     @Test
@@ -199,36 +204,64 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             every { kmpTorService.bootstrapProgress } returns progressFlow
             val facade = TestFacade(kmpTorService)
 
-            // Start observing
-            facade.observeTorStatePublic()
+            try {
+                facade.observeTorStatePublic()
 
-            // Emit Starting state via flow
-            stateFlow.emit(KmpTorService.TorState.Starting)
-            advanceUntilIdle()
+                stateFlow.emit(KmpTorService.TorState.Starting)
+                advanceUntilIdle()
 
-            // Starting should set a small progress value
-            assertEquals(0.1f, facade.progress.value)
+                assertEquals(0.1f, facade.progress.value)
 
-            val before = facade.state.value
+                val before = facade.state.value
 
-            // Emit bootstrap progress update and verify facade state changed
-            progressFlow.emit(42)
-            advanceUntilIdle()
-            assertTrue(facade.state.value != before && facade.state.value.contains("42"))
+                progressFlow.emit(42)
+                advanceUntilIdle()
+                assertTrue(facade.state.value != before && facade.state.value.contains("42"))
 
-            // Emit Started state -> progress should update to 0.25f and further progress updates ignored
-            stateFlow.emit(KmpTorService.TorState.Started)
-            advanceUntilIdle()
-            assertEquals(0.25f, facade.progress.value)
+                stateFlow.emit(KmpTorService.TorState.Started)
+                advanceUntilIdle()
+                assertEquals(0.25f, facade.progress.value)
 
-            val afterStarted = facade.state.value
-            progressFlow.emit(99)
-            advanceUntilIdle()
-            assertEquals(afterStarted, facade.state.value)
+                val afterStarted = facade.state.value
+                progressFlow.emit(99)
+                advanceUntilIdle()
+                assertEquals(afterStarted, facade.state.value)
+            } finally {
+                facade.releaseTestResources()
+            }
         }
 
     @Test
-    fun `tor failure within grace period does not show failure dialog`() =
+    fun `tor failure within grace period retries and does not show failure dialog`() =
+        runTest(testDispatcher) {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
+            val progressFlow = MutableStateFlow(0)
+            every { kmpTorService.state } returns stateFlow
+            every { kmpTorService.bootstrapProgress } returns progressFlow
+            coEvery { kmpTorService.startTor(any(), any()) } returns false
+            val facade = TestFacade(kmpTorService)
+
+            try {
+                facade.fakeTimeMillis = 1_000_000L
+                facade.observeTorStatePublic()
+
+                stateFlow.emit(KmpTorService.TorState.Starting)
+                advanceUntilIdle()
+
+                facade.fakeTimeMillis = 1_010_000L
+                stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Circuit build timeout")))
+                advanceUntilIdle()
+
+                assertFalse(facade.torBootstrapFailed.value, "Single transient failure should retry, not show dialog")
+                coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
+
+    @Test
+    fun `tor terminal failure within grace period shows failure dialog immediately`() =
         runTest(testDispatcher) {
             val kmpTorService = mockk<KmpTorService>(relaxed = true)
             val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
@@ -237,19 +270,80 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             every { kmpTorService.bootstrapProgress } returns progressFlow
             val facade = TestFacade(kmpTorService)
 
-            facade.fakeTimeMillis = 1_000_000L
-            facade.observeTorStatePublic()
+            try {
+                facade.fakeTimeMillis = 1_000_000L
+                facade.observeTorStatePublic()
 
-            // Tor starts
-            stateFlow.emit(KmpTorService.TorState.Starting)
-            advanceUntilIdle()
+                stateFlow.emit(KmpTorService.TorState.Starting)
+                advanceUntilIdle()
 
-            // Tor fails after 10 seconds (within 60s grace period)
-            facade.fakeTimeMillis = 1_010_000L
-            stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Circuit build timeout")))
-            advanceUntilIdle()
+                facade.fakeTimeMillis = 1_010_000L
+                stateFlow.emit(KmpTorService.TorState.Stopped(InterruptedException("CtrlConnection Stream Ended")))
+                advanceUntilIdle()
 
-            assertFalse(facade.torBootstrapFailed.value, "Tor failure within grace period should not show dialog")
+                assertTrue(facade.torBootstrapFailed.value, "Terminal Tor failure should show dialog immediately")
+                coVerify(exactly = 0) { kmpTorService.startTor(any(), any()) }
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
+
+    @Test
+    fun `stale tor stopped error before starting is ignored on reactivation`() =
+        runTest(testDispatcher) {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            val stateFlow =
+                MutableStateFlow<KmpTorService.TorState>(
+                    KmpTorService.TorState.Stopped(InterruptedException("CtrlConnection Stream Ended")),
+                )
+            val progressFlow = MutableStateFlow(0)
+            every { kmpTorService.state } returns stateFlow
+            every { kmpTorService.bootstrapProgress } returns progressFlow
+            val facade = TestFacade(kmpTorService)
+
+            try {
+                facade.activate()
+                runCurrent()
+                facade.observeTorStatePublic()
+                runCurrent()
+
+                assertFalse(
+                    facade.torBootstrapFailed.value,
+                    "Stale Stopped(error) before first Starting should not arm failure dialog",
+                )
+            } finally {
+                facade.releaseTestResources()
+            }
+        }
+
+    @Test
+    fun `three transient failures within grace period show failure dialog`() =
+        runTest(testDispatcher) {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            val stateFlow = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
+            val progressFlow = MutableStateFlow(0)
+            every { kmpTorService.state } returns stateFlow
+            every { kmpTorService.bootstrapProgress } returns progressFlow
+            coEvery { kmpTorService.startTor(any(), any()) } returns false
+            val facade = TestFacade(kmpTorService)
+
+            try {
+                facade.fakeTimeMillis = 1_000_000L
+                facade.observeTorStatePublic()
+
+                repeat(3) { attempt ->
+                    stateFlow.emit(KmpTorService.TorState.Starting)
+                    advanceUntilIdle()
+                    facade.fakeTimeMillis = 1_010_000L + (attempt * 1_000L)
+                    stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Circuit build timeout")))
+                    advanceUntilIdle()
+                }
+
+                assertTrue(facade.torBootstrapFailed.value, "Third transient failure should show dialog")
+                coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
+            } finally {
+                facade.releaseTestResources()
+            }
         }
 
     @Test
@@ -262,19 +356,21 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             every { kmpTorService.bootstrapProgress } returns progressFlow
             val facade = TestFacade(kmpTorService)
 
-            facade.fakeTimeMillis = 1_000_000L
-            facade.observeTorStatePublic()
+            try {
+                facade.fakeTimeMillis = 1_000_000L
+                facade.observeTorStatePublic()
 
-            // Tor starts
-            stateFlow.emit(KmpTorService.TorState.Starting)
-            advanceUntilIdle()
+                stateFlow.emit(KmpTorService.TorState.Starting)
+                advanceUntilIdle()
 
-            // Tor fails after 65 seconds (past 60s grace period)
-            facade.fakeTimeMillis = 1_065_000L
-            stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Tor failed permanently")))
-            advanceUntilIdle()
+                facade.fakeTimeMillis = 1_065_000L
+                stateFlow.emit(KmpTorService.TorState.Stopped(RuntimeException("Tor failed permanently")))
+                advanceUntilIdle()
 
-            assertTrue(facade.torBootstrapFailed.value, "Tor failure after grace period should show dialog")
+                assertTrue(facade.torBootstrapFailed.value, "Tor failure after grace period should show dialog")
+            } finally {
+                facade.releaseTestResources()
+            }
         }
 
     @Test
@@ -306,7 +402,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             assertEquals(10L, facade.bootstrapElapsedSeconds.value, "elapsed should count from the restart baseline")
 
             // Stop the elapsed ticker so runTest's end-of-test idle drain doesn't hang on it.
-            facade.deactivate()
+            facade.releaseTestResources()
         }
 
     @Test
@@ -334,8 +430,7 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             testScheduler.advanceTimeBy(5_000)
             runCurrent()
             assertEquals(frozen, facade.bootstrapElapsedSeconds.value, "elapsed ticker should be stopped after failure")
-            // No deactivate() needed: handleBootstrapFailure already cancelled the ticker, so the
-            // end-of-test idle drain won't hang.
+            facade.releaseTestResources()
         }
 }
 
@@ -360,5 +455,10 @@ private class TestFacade(
 
     fun observeTorStatePublic() {
         observeTorState()
+    }
+
+    /** Ensures [CoroutineJobsManager] is disposed even when tests use serviceScope without [activate]. */
+    suspend fun releaseTestResources() {
+        releaseServiceResources()
     }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/ApplicationBootstrapFacadeTest.kt
@@ -182,16 +182,19 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             // Deactivate and reactivate
             facade.deactivate()
             facade.activate()
-            // activate() starts a perpetual 1s elapsed-time ticker; advanceUntilIdle() would hang.
-            runCurrent()
 
-            // Now timeouts should work again (bootstrapSuccessful was reset)
-            facade.startTimeoutForStagePublic("stage-after-reactivate")
-            testScheduler.advanceTimeBy(90_001)
-            runCurrent()
-            assertTrue(facade.isTimeoutDialogVisible.value, "Timeout should fire after reactivation")
+            try {
+                // activate() starts a perpetual 1s elapsed-time ticker; advanceUntilIdle() would hang.
+                runCurrent()
 
-            facade.releaseTestResources()
+                // Now timeouts should work again (bootstrapSuccessful was reset)
+                facade.startTimeoutForStagePublic("stage-after-reactivate")
+                testScheduler.advanceTimeBy(90_001)
+                runCurrent()
+                assertTrue(facade.isTimeoutDialogVisible.value, "Timeout should fire after reactivation")
+            } finally {
+                facade.releaseTestResources()
+            }
         }
 
     @Test
@@ -382,27 +385,33 @@ class ApplicationBootstrapFacadeTest : KoinTest {
             // Start bootstrap; the elapsed ticker counts from this baseline.
             facade.fakeTimeMillis = 1_000_000L
             facade.activate()
-            runCurrent()
+            try {
+                runCurrent()
 
-            // Let ~100s accumulate (simulating a slow attempt that then fails).
-            facade.fakeTimeMillis = 1_100_000L
-            testScheduler.advanceTimeBy(1_000)
-            runCurrent()
-            assertTrue(facade.bootstrapElapsedSeconds.value >= 100L, "elapsed should accumulate before restart")
+                // Let ~100s accumulate (simulating a slow attempt that then fails).
+                facade.fakeTimeMillis = 1_100_000L
+                testScheduler.advanceTimeBy(1_000)
+                runCurrent()
+                assertTrue(facade.bootstrapElapsedSeconds.value >= 100L, "elapsed should accumulate before restart")
 
-            // Restart Tor -> the clock resets immediately to 0.
-            facade.startTor(purgeTorDir = false)
-            runCurrent()
-            assertEquals(0L, facade.bootstrapElapsedSeconds.value, "startTor should reset elapsed to 0")
+                // Restart Tor -> the clock resets immediately to 0.
+                facade.startTor(purgeTorDir = false)
+                runCurrent()
+                assertEquals(0L, facade.bootstrapElapsedSeconds.value, "startTor should reset elapsed to 0")
 
-            // Subsequent ticks count from the restart baseline, not the original activate baseline.
-            facade.fakeTimeMillis = 1_110_000L
-            testScheduler.advanceTimeBy(1_000)
-            runCurrent()
-            assertEquals(10L, facade.bootstrapElapsedSeconds.value, "elapsed should count from the restart baseline")
-
-            // Stop the elapsed ticker so runTest's end-of-test idle drain doesn't hang on it.
-            facade.releaseTestResources()
+                // Subsequent ticks count from the restart baseline, not the original activate baseline.
+                facade.fakeTimeMillis = 1_110_000L
+                testScheduler.advanceTimeBy(1_000)
+                runCurrent()
+                assertEquals(
+                    10L,
+                    facade.bootstrapElapsedSeconds.value,
+                    "elapsed should count from the restart baseline",
+                )
+            } finally {
+                // Stop the elapsed ticker so runTest's end-of-test idle drain doesn't hang on it.
+                facade.releaseTestResources()
+            }
         }
 
     @Test

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/TorBootstrapErrorClassificationTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/TorBootstrapErrorClassificationTest.kt
@@ -25,11 +25,51 @@ class TorBootstrapErrorClassificationTest {
     }
 
     @Test
+    fun `daemon stopped is terminal`() {
+        assertTrue(
+            TorBootstrapErrorClassification.isTerminal(
+                RuntimeException("daemon stopped"),
+            ),
+        )
+    }
+
+    @Test
+    fun `tor process exited is terminal`() {
+        assertTrue(
+            TorBootstrapErrorClassification.isTerminal(
+                RuntimeException("tor process exited"),
+            ),
+        )
+    }
+
+    @Test
+    fun `control connection is terminal`() {
+        assertTrue(
+            TorBootstrapErrorClassification.isTerminal(
+                RuntimeException("control connection closed"),
+            ),
+        )
+    }
+
+    @Test
+    fun `terminal marker in nested cause is detected`() {
+        val inner = RuntimeException("CtrlConnection Stream Ended")
+        val outer = RuntimeException("Bootstrap failed", inner)
+        assertTrue(TorBootstrapErrorClassification.isTerminal(outer))
+    }
+
+    @Test
     fun `cancellation is not terminal`() {
         assertFalse(
             TorBootstrapErrorClassification.isTerminal(
                 kotlinx.coroutines.CancellationException("cancelled"),
             ),
         )
+    }
+
+    @Test
+    fun `null message with non-terminal cause is transient`() {
+        val outer = RuntimeException(null as String?, RuntimeException("circuit build timeout"))
+        assertFalse(TorBootstrapErrorClassification.isTerminal(outer))
     }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/TorBootstrapErrorClassificationTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/bootstrap/TorBootstrapErrorClassificationTest.kt
@@ -1,0 +1,35 @@
+package network.bisq.mobile.domain.service.bootstrap
+
+import network.bisq.mobile.data.service.bootstrap.TorBootstrapErrorClassification
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TorBootstrapErrorClassificationTest {
+    @Test
+    fun `CtrlConnection Stream Ended is terminal`() {
+        assertTrue(
+            TorBootstrapErrorClassification.isTerminal(
+                InterruptedException("CtrlConnection Stream Ended"),
+            ),
+        )
+    }
+
+    @Test
+    fun `circuit build timeout is transient`() {
+        assertFalse(
+            TorBootstrapErrorClassification.isTerminal(
+                RuntimeException("Circuit build timeout"),
+            ),
+        )
+    }
+
+    @Test
+    fun `cancellation is not terminal`() {
+        assertFalse(
+            TorBootstrapErrorClassification.isTerminal(
+                kotlinx.coroutines.CancellationException("cancelled"),
+            ),
+        )
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -6,9 +6,9 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -57,8 +57,7 @@ class NetworkServiceFacadeTest : KoinTest {
         Dispatchers.resetMain()
     }
 
-    private fun createFacade(torEnabled: Boolean): TestNetworkServiceFacade =
-        TestNetworkServiceFacade(kmpTorService, applicationBootstrapFacade, torEnabled)
+    private fun createFacade(torEnabled: Boolean): TestNetworkServiceFacade = TestNetworkServiceFacade(kmpTorService, applicationBootstrapFacade, torEnabled)
 
     @Test
     fun `ensureTorRunning starts tor when enabled and stopped`() =

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -6,31 +6,48 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.di.testModule
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
+import network.bisq.mobile.data.service.network.TorBootstrapNotReadyException
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.test.KoinTest
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NetworkServiceFacadeTest : KoinTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var kmpTorService: KmpTorService
+    private lateinit var applicationBootstrapFacade: ApplicationBootstrapFacade
+    private lateinit var torStateFlow: MutableStateFlow<KmpTorService.TorState>
+    private lateinit var torBootstrapFailedFlow: MutableStateFlow<Boolean>
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         kmpTorService = mockk(relaxed = true)
+        applicationBootstrapFacade = mockk(relaxed = true)
+        torStateFlow = MutableStateFlow(KmpTorService.TorState.Stopped())
+        torBootstrapFailedFlow = MutableStateFlow(false)
+        every { kmpTorService.state } returns torStateFlow
+        every { kmpTorService.bootstrapProgress } returns MutableStateFlow(0)
+        every { applicationBootstrapFacade.torBootstrapFailed } returns torBootstrapFailedFlow
+        coEvery { kmpTorService.startTor(any(), any()) } returns false
+        coEvery { kmpTorService.stopTor(any()) } returns Unit
         startKoin { modules(testModule) }
     }
 
@@ -40,15 +57,12 @@ class NetworkServiceFacadeTest : KoinTest {
         Dispatchers.resetMain()
     }
 
-    private fun createFacade(torEnabled: Boolean): TestNetworkServiceFacade {
-        every { kmpTorService.state } returns MutableStateFlow(KmpTorService.TorState.Stopped())
-        every { kmpTorService.bootstrapProgress } returns MutableStateFlow(0)
-        return TestNetworkServiceFacade(kmpTorService, torEnabled)
-    }
+    private fun createFacade(torEnabled: Boolean): TestNetworkServiceFacade =
+        TestNetworkServiceFacade(kmpTorService, applicationBootstrapFacade, torEnabled)
 
     @Test
     fun `ensureTorRunning starts tor when enabled and stopped`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
             facade.ensureTorRunning()
             coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
@@ -56,7 +70,7 @@ class NetworkServiceFacadeTest : KoinTest {
 
     @Test
     fun `ensureTorRunning does nothing when tor disabled`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = false)
             facade.ensureTorRunning()
             coVerify(exactly = 0) { kmpTorService.startTor(any(), any()) }
@@ -64,27 +78,24 @@ class NetworkServiceFacadeTest : KoinTest {
 
     @Test
     fun `ensureTorRunning does nothing when tor already started`() =
-        runTest {
-            every { kmpTorService.state } returns
-                MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Started)
-            every { kmpTorService.bootstrapProgress } returns MutableStateFlow(100)
-            val facade = TestNetworkServiceFacade(kmpTorService, torEnabled = true)
+        runTest(testDispatcher) {
+            torStateFlow.value = KmpTorService.TorState.Started
+            val facade = createFacade(torEnabled = true)
             facade.ensureTorRunning()
             coVerify(exactly = 0) { kmpTorService.startTor(any(), any()) }
         }
 
     @Test
     fun `ensureTorRunning catches non-cancellation exception and returns`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
             coEvery { kmpTorService.startTor(any(), any()) } throws RuntimeException("tor error")
-            // Should not throw - exception is caught and logged
             facade.ensureTorRunning()
         }
 
     @Test
     fun `activate does not start tor when disabled`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = false)
             facade.activate()
             coVerify(exactly = 0) { kmpTorService.startTor(any(), any()) }
@@ -92,50 +103,108 @@ class NetworkServiceFacadeTest : KoinTest {
 
     @Test
     fun `activate starts tor once when it succeeds first attempt`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
-            coEvery { kmpTorService.startTor(any(), any()) } returns true
+            coEvery { kmpTorService.startTor(any(), any()) } coAnswers {
+                torStateFlow.value = KmpTorService.TorState.Started
+                true
+            }
             facade.activate()
             coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
         }
 
     @Test
     fun `activate retries after a failed start and stops once tor is up`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
-            // First attempt fails (e.g. stale cookie AUTHENTICATE), second succeeds after cleanup.
-            coEvery { kmpTorService.startTor(any(), any()) } returnsMany listOf(false, true)
+            var attempt = 0
+            coEvery { kmpTorService.startTor(any(), any()) } coAnswers {
+                attempt++
+                if (attempt == 1) {
+                    false
+                } else {
+                    torStateFlow.value = KmpTorService.TorState.Started
+                    true
+                }
+            }
             facade.activate()
             coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
         }
 
     @Test
-    fun `activate gives up after max attempts and returns without hanging`() =
-        runTest {
+    fun `activate throws TorBootstrapNotReadyException after max start attempts and bootstrap failure`() =
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
-            // Always fails: activate must return (not suspend forever waiting for Started).
             coEvery { kmpTorService.startTor(any(), any()) } returns false
-            facade.activate()
-            // MAX_TOR_START_ATTEMPTS = 3 (private const in NetworkServiceFacade).
+            val activateJob =
+                launch {
+                    assertFailsWith<TorBootstrapNotReadyException> {
+                        facade.activate()
+                    }
+                }
+            runCurrent()
+            torBootstrapFailedFlow.value = true
+            runCurrent()
+            activateJob.join()
             coVerify(exactly = 3) { kmpTorService.startTor(any(), any()) }
+            coVerify(exactly = 1) { kmpTorService.stopTor(any()) }
         }
 
     @Test
     fun `activate keeps retrying when a start attempt throws`() =
-        runTest {
+        runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
-            // Non-cancellation throw on first attempt is caught and treated as a failed attempt,
-            // then the second attempt succeeds.
-            coEvery { kmpTorService.startTor(any(), any()) } throws RuntimeException("tor error") andThen true
+            var attempt = 0
+            coEvery { kmpTorService.startTor(any(), any()) } coAnswers {
+                attempt++
+                if (attempt == 1) {
+                    throw RuntimeException("tor error")
+                } else {
+                    torStateFlow.value = KmpTorService.TorState.Started
+                    true
+                }
+            }
             facade.activate()
             coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate completes when tor reaches started`() =
+        runTest(testDispatcher) {
+            val facade = createFacade(torEnabled = true)
+            val activateJob =
+                launch {
+                    facade.activate()
+                }
+            runCurrent()
+            torStateFlow.value = KmpTorService.TorState.Started
+            activateJob.join()
+            coVerify(atLeast = 1) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate throws TorBootstrapNotReadyException when bootstrap fails`() =
+        runTest(testDispatcher) {
+            val facade = createFacade(torEnabled = true)
+            val activateJob =
+                launch {
+                    assertFailsWith<TorBootstrapNotReadyException> {
+                        facade.activate()
+                    }
+                }
+            runCurrent()
+            torBootstrapFailedFlow.value = true
+            runCurrent()
+            activateJob.join()
+            coVerify(exactly = 1) { kmpTorService.stopTor(any()) }
         }
 }
 
 private class TestNetworkServiceFacade(
     kmpTorService: KmpTorService,
+    applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val torEnabled: Boolean,
-) : NetworkServiceFacade(kmpTorService) {
+) : NetworkServiceFacade(kmpTorService, applicationBootstrapFacade) {
     override val numConnections: StateFlow<Int> = MutableStateFlow(0)
     override val allDataReceived: StateFlow<Boolean> = MutableStateFlow(false)
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -197,6 +197,24 @@ class NetworkServiceFacadeTest : KoinTest {
             activateJob.join()
             coVerify(exactly = 1) { kmpTorService.stopTor(any()) }
         }
+
+    @Test
+    fun `activate throws TorBootstrapNotReadyException when bootstrap fails even if stopTor fails`() =
+        runTest(testDispatcher) {
+            coEvery { kmpTorService.stopTor(any()) } throws RuntimeException("stop failed")
+            val facade = createFacade(torEnabled = true)
+            val activateJob =
+                launch {
+                    assertFailsWith<TorBootstrapNotReadyException> {
+                        facade.activate()
+                    }
+                }
+            runCurrent()
+            torBootstrapFailedFlow.value = true
+            runCurrent()
+            activateJob.join()
+            coVerify(exactly = 1) { kmpTorService.stopTor(any()) }
+        }
 }
 
 private class TestNetworkServiceFacade(

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -220,6 +220,26 @@ class NetworkServiceFacadeTest : KoinTest {
         }
 
     @Test
+    fun `activate throws TorBootstrapNotReadyException when await times out without started or failure signal`() =
+        runTest(testDispatcher) {
+            val facade = createFacade(torEnabled = true)
+            val activateJob =
+                launch {
+                    assertFailsWith<TorBootstrapNotReadyException> {
+                        facade.activate()
+                    }
+                }
+            runCurrent()
+            advanceTimeBy(2_000L)
+            runCurrent()
+            advanceTimeBy(KmpTorService.DEFAULT_DAEMON_START_TIMEOUT_MS + KmpTorService.DEFAULT_BOOTSTRAP_TIMEOUT_MS)
+            runCurrent()
+            activateJob.join()
+            coVerify(exactly = 3) { kmpTorService.startTor(any(), any()) }
+            coVerify(exactly = 1) { kmpTorService.stopTor(any()) }
+        }
+
+    @Test
     fun `activate throws TorBootstrapNotReadyException when bootstrap fails even if stopTor fails`() =
         runTest(testDispatcher) {
             coEvery { kmpTorService.stopTor(any()) } throws RuntimeException("stop failed")

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -131,6 +131,25 @@ class NetworkServiceFacadeTest : KoinTest {
         }
 
     @Test
+    fun `startTorWithRetries stops when terminal bootstrap failure is flagged`() =
+        runTest(testDispatcher) {
+            val facade = createFacade(torEnabled = true)
+            coEvery { kmpTorService.startTor(any(), any()) } coAnswers {
+                torBootstrapFailedFlow.value = true
+                false
+            }
+            val activateJob =
+                launch {
+                    assertFailsWith<TorBootstrapNotReadyException> {
+                        facade.activate()
+                    }
+                }
+            runCurrent()
+            activateJob.join()
+            coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
     fun `activate throws TorBootstrapNotReadyException after max start attempts and bootstrap failure`() =
         runTest(testDispatcher) {
             val facade = createFacade(torEnabled = true)
@@ -141,6 +160,8 @@ class NetworkServiceFacadeTest : KoinTest {
                         facade.activate()
                     }
                 }
+            runCurrent()
+            advanceTimeBy(2_000L)
             runCurrent()
             torBootstrapFailedFlow.value = true
             runCurrent()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/ServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/ServiceFacade.kt
@@ -39,4 +39,13 @@ abstract class ServiceFacade :
             jobsManager.dispose()
         }
     }
+
+    /**
+     * Test-only helper: cancel all managed coroutines regardless of [isActivated].
+     * Used when tests start jobs via [serviceScope] without calling [activate].
+     */
+    protected suspend fun releaseServiceResources() {
+        isActivated.value = false
+        jobsManager.dispose()
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -293,14 +293,10 @@ abstract class ApplicationBootstrapFacade(
 
         // Possibly stale error - Ignore
         if (torStartingTimestamp == 0L) {
-            log.w {
-                "Bootstrap: Ignoring stale Tor Stopped(error) before first Starting this cycle: $errorMessage"
-            }
             return
         }
 
         if (TorBootstrapErrorClassification.isTerminal(error)) {
-            log.w { "Bootstrap: Terminal Tor error — arming failure dialog: $errorMessage" }
             armTorBootstrapFailed(errorMessage)
             return
         }
@@ -308,10 +304,6 @@ abstract class ApplicationBootstrapFacade(
         val elapsed = currentTimeMillis() - torStartingTimestamp
         if (elapsed < TOR_FAILURE_GRACE_PERIOD_MS) {
             torGracePeriodFailureCount++
-            log.w {
-                "Bootstrap: Tor transient error within grace period (${elapsed / 1000}s), " +
-                    "attempt $torGracePeriodFailureCount/$TOR_MAX_GRACE_RETRIES: $errorMessage — retrying"
-            }
             setState("mobile.bootstrap.tor.starting".i18n(0))
             if (torGracePeriodFailureCount >= TOR_MAX_GRACE_RETRIES) {
                 armTorBootstrapFailed(errorMessage)
@@ -334,12 +326,9 @@ abstract class ApplicationBootstrapFacade(
         serviceScope.launch {
             try {
                 kmpTorService.startTor()
-            } catch (e: Exception) {
-                if (e is CancellationException) {
-                    log.d(e) { "Bootstrap: Grace-period Tor retry cancelled" }
-                } else {
-                    log.e(e) { "Bootstrap: Grace-period Tor retry failed to invoke startTor" }
-                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
             }
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -24,11 +24,12 @@ abstract class ApplicationBootstrapFacade(
             90_000L // 90 seconds per stage
         private const val BOOTSTRAP_ELAPSED_TICK_MS = 1_000L
 
-        // Grace period before showing the Tor bootstrap failed dialog.
+        // Grace period for transient Tor bootstrap errors before arming the failure dialog.
         // On iOS, kmp-tor can emit transient Stopped(error) events during initial
         // circuit establishment (especially over slow networks or onion addresses).
-        // We suppress the failure dialog during this window and let Tor retry.
+        // Within this window we retry startTor() up to [TOR_MAX_GRACE_RETRIES] times.
         internal const val TOR_FAILURE_GRACE_PERIOD_MS = 60_000L
+        internal const val TOR_MAX_GRACE_RETRIES = 3
     }
 
     @Volatile
@@ -42,6 +43,9 @@ abstract class ApplicationBootstrapFacade(
 
     @Volatile
     private var torStartingTimestamp: Long = 0L
+
+    @Volatile
+    private var torGracePeriodFailureCount: Int = 0
 
     @Volatile
     private var elapsedTimerJob: Job? = null
@@ -131,6 +135,7 @@ abstract class ApplicationBootstrapFacade(
         elapsedTimerJob?.cancel()
         elapsedTimerJob = null
         torStartingTimestamp = 0L
+        torGracePeriodFailureCount = 0
         bootstrapStartedTimestamp = currentTimeMillis()
 
         super.activate()
@@ -184,28 +189,8 @@ abstract class ApplicationBootstrapFacade(
 
                     is TorState.Stopped -> {
                         torProgressCollectJob?.cancel()
-                        if (newState.error != null) {
-                            val errorMessage =
-                                listOfNotNull(
-                                    newState.error.message,
-                                    newState.error.cause?.message,
-                                ).firstOrNull()
-                                    ?: "Unknown Tor error"
-
-                            val elapsed = currentTimeMillis() - torStartingTimestamp
-                            if (torStartingTimestamp > 0 && elapsed < TOR_FAILURE_GRACE_PERIOD_MS) {
-                                // Within grace period — Tor may still recover. Log but don't
-                                // show the failure dialog yet. The general stage timeout
-                                // (90s) will catch genuinely stuck connections.
-                                log.w { "Bootstrap: Tor error within grace period (${elapsed / 1000}s): $errorMessage — suppressing failure dialog" }
-                                setState("mobile.bootstrap.tor.starting".i18n(0))
-                            } else {
-                                setState("mobile.bootstrap.tor.failed".i18n() + ": $errorMessage")
-                                cancelTimeout(showProgressToast = false)
-                                setTorBootstrapFailed(true)
-                                log.e { "Bootstrap: Tor initialization failed - $errorMessage" }
-                            }
-                        }
+                        val error = newState.error ?: return@collect
+                        handleTorBootstrapError(error)
                     }
                 }
             }
@@ -298,9 +283,71 @@ abstract class ApplicationBootstrapFacade(
 
     protected open fun onTorStarted() {}
 
+    private fun handleTorBootstrapError(error: Throwable) {
+        val errorMessage =
+            listOfNotNull(
+                error.message,
+                error.cause?.message,
+            ).firstOrNull()
+                ?: "Unknown Tor error"
+
+        // Possibly stale error - Ignore
+        if (torStartingTimestamp == 0L) {
+            log.w {
+                "Bootstrap: Ignoring stale Tor Stopped(error) before first Starting this cycle: $errorMessage"
+            }
+            return
+        }
+
+        if (TorBootstrapErrorClassification.isTerminal(error)) {
+            log.w { "Bootstrap: Terminal Tor error — arming failure dialog: $errorMessage" }
+            armTorBootstrapFailed(errorMessage)
+            return
+        }
+
+        val elapsed = currentTimeMillis() - torStartingTimestamp
+        if (elapsed < TOR_FAILURE_GRACE_PERIOD_MS) {
+            torGracePeriodFailureCount++
+            log.w {
+                "Bootstrap: Tor transient error within grace period (${elapsed / 1000}s), " +
+                    "attempt $torGracePeriodFailureCount/$TOR_MAX_GRACE_RETRIES: $errorMessage — retrying"
+            }
+            setState("mobile.bootstrap.tor.starting".i18n(0))
+            if (torGracePeriodFailureCount >= TOR_MAX_GRACE_RETRIES) {
+                armTorBootstrapFailed(errorMessage)
+            } else {
+                scheduleGracePeriodTorRetry()
+            }
+        } else {
+            armTorBootstrapFailed(errorMessage)
+        }
+    }
+
+    private fun armTorBootstrapFailed(errorMessage: String) {
+        setState("mobile.bootstrap.tor.failed".i18n() + ": $errorMessage")
+        cancelTimeout(showProgressToast = false)
+        setTorBootstrapFailed(true)
+        log.e { "Bootstrap: Tor initialization failed - $errorMessage" }
+    }
+
+    private fun scheduleGracePeriodTorRetry() {
+        serviceScope.launch {
+            try {
+                kmpTorService.startTor()
+            } catch (e: Exception) {
+                if (e is CancellationException) {
+                    log.d(e) { "Bootstrap: Grace-period Tor retry cancelled" }
+                } else {
+                    log.e(e) { "Bootstrap: Grace-period Tor retry failed to invoke startTor" }
+                }
+            }
+        }
+    }
+
     fun startTor(purgeTorDir: Boolean) {
         serviceScope.launch {
             setTorBootstrapFailed(false)
+            torGracePeriodFailureCount = 0
             // Restarting Tor is a fresh connection attempt, so reset the slow-path clock:
             // otherwise the "still connecting, this is normal" banner would reappear immediately
             // showing the elapsed time of the failed attempt. The elapsed ticker keeps running

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.data.service.bootstrap
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -12,7 +13,6 @@ import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.KmpTorService.TorState
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.i18n.i18n
-import androidx.annotation.VisibleForTesting
 import kotlin.concurrent.Volatile
 
 abstract class ApplicationBootstrapFacade(

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.KmpTorService.TorState
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.i18n.i18n
+import androidx.annotation.VisibleForTesting
 import kotlin.concurrent.Volatile
 
 abstract class ApplicationBootstrapFacade(
@@ -24,12 +25,11 @@ abstract class ApplicationBootstrapFacade(
             90_000L // 90 seconds per stage
         private const val BOOTSTRAP_ELAPSED_TICK_MS = 1_000L
 
-        // Grace period for transient Tor bootstrap errors before arming the failure dialog.
-        // On iOS, kmp-tor can emit transient Stopped(error) events during initial
-        // circuit establishment (especially over slow networks or onion addresses).
-        // Within this window we retry startTor() up to [TOR_MAX_GRACE_RETRIES] times.
+        // Grace period before arming the failure dialog for transient Tor bootstrap errors.
+        // On iOS, kmp-tor can emit transient Stopped(error) events during initial circuit
+        // establishment (especially over slow networks or onion addresses). Start retries
+        // are owned by [network.bisq.mobile.data.service.network.NetworkServiceFacade].
         internal const val TOR_FAILURE_GRACE_PERIOD_MS = 60_000L
-        internal const val TOR_MAX_GRACE_RETRIES = 3
     }
 
     @Volatile
@@ -45,7 +45,13 @@ abstract class ApplicationBootstrapFacade(
     private var torStartingTimestamp: Long = 0L
 
     @Volatile
-    private var torGracePeriodFailureCount: Int = 0
+    private var torBootstrapStartObserved: Boolean = false
+
+    @Volatile
+    private var torGracePeriodArmJob: Job? = null
+
+    @Volatile
+    private var pendingGracePeriodErrorMessage: String? = null
 
     @Volatile
     private var elapsedTimerJob: Job? = null
@@ -135,7 +141,9 @@ abstract class ApplicationBootstrapFacade(
         elapsedTimerJob?.cancel()
         elapsedTimerJob = null
         torStartingTimestamp = 0L
-        torGracePeriodFailureCount = 0
+        torBootstrapStartObserved = false
+        cancelGracePeriodArmJob()
+        pendingGracePeriodErrorMessage = null
         bootstrapStartedTimestamp = currentTimeMillis()
 
         super.activate()
@@ -143,6 +151,8 @@ abstract class ApplicationBootstrapFacade(
     }
 
     override suspend fun deactivate() {
+        cancelGracePeriodArmJob()
+        pendingGracePeriodErrorMessage = null
         cancelTimeout()
         cancelElapsedTimer()
         super.deactivate()
@@ -163,6 +173,9 @@ abstract class ApplicationBootstrapFacade(
             kmpTorService.state.collect { newState ->
                 when (newState) {
                     is TorState.Starting -> {
+                        cancelGracePeriodArmJob()
+                        pendingGracePeriodErrorMessage = null
+                        torBootstrapStartObserved = true
                         torStartingTimestamp = currentTimeMillis()
                         setState("mobile.bootstrap.tor.starting".i18n(0))
                         setProgress(0.1f)
@@ -178,6 +191,8 @@ abstract class ApplicationBootstrapFacade(
                     }
 
                     is TorState.Started -> {
+                        cancelGracePeriodArmJob()
+                        pendingGracePeriodErrorMessage = null
                         torProgressCollectJob?.cancel()
                         setTorBootstrapProgress(100)
                         setState("mobile.bootstrap.tor.started".i18n())
@@ -283,6 +298,17 @@ abstract class ApplicationBootstrapFacade(
 
     protected open fun onTorStarted() {}
 
+    @VisibleForTesting
+    internal fun markTorBootstrapStartingForTest(startTimestamp: Long) {
+        torBootstrapStartObserved = true
+        torStartingTimestamp = startTimestamp
+    }
+
+    @VisibleForTesting
+    internal fun handleTorBootstrapErrorForTest(error: Throwable) {
+        handleTorBootstrapError(error)
+    }
+
     private fun handleTorBootstrapError(error: Throwable) {
         val errorMessage =
             generateSequence(error) { it.cause }
@@ -290,54 +316,80 @@ abstract class ApplicationBootstrapFacade(
                 .firstOrNull()
                 ?: "Unknown Tor error"
 
-        // Possibly stale error - Ignore
-        if (torStartingTimestamp == 0L) {
+        // Ignore stale Stopped(error) emissions from before the current bootstrap attempt.
+        if (!torBootstrapStartObserved) {
             return
         }
 
         if (TorBootstrapErrorClassification.isTerminal(error)) {
+            cancelGracePeriodArmJob()
+            pendingGracePeriodErrorMessage = null
             armTorBootstrapFailed(errorMessage)
             return
         }
 
         val elapsed = currentTimeMillis() - torStartingTimestamp
-        if (elapsed < TOR_FAILURE_GRACE_PERIOD_MS) {
-            torGracePeriodFailureCount++
-            setState("mobile.bootstrap.tor.starting".i18n(0))
-            if (torGracePeriodFailureCount >= TOR_MAX_GRACE_RETRIES) {
-                armTorBootstrapFailed(errorMessage)
-            } else {
-                scheduleGracePeriodTorRetry()
-            }
-        } else {
+        if (elapsed >= TOR_FAILURE_GRACE_PERIOD_MS) {
+            cancelGracePeriodArmJob()
+            pendingGracePeriodErrorMessage = null
             armTorBootstrapFailed(errorMessage)
+            return
         }
+
+        log.w { "Transient Tor bootstrap error within grace period (${elapsed}ms): $errorMessage" }
+        pendingGracePeriodErrorMessage = errorMessage
+        setState("mobile.bootstrap.tor.starting".i18n(0))
+        scheduleGracePeriodArm()
     }
 
     private fun armTorBootstrapFailed(errorMessage: String) {
+        cancelGracePeriodArmJob()
+        pendingGracePeriodErrorMessage = null
         setState("mobile.bootstrap.tor.failed".i18n() + ": $errorMessage")
         cancelTimeout(showProgressToast = false)
         setTorBootstrapFailed(true)
+        torBootstrapStartObserved = false
         torStartingTimestamp = 0L
         log.e { "Bootstrap: Tor initialization failed - $errorMessage" }
     }
 
-    private fun scheduleGracePeriodTorRetry() {
-        serviceScope.launch {
-            try {
-                kmpTorService.startTor()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log.w(e) { "Bootstrap: grace-period Tor retry failed" }
-            }
+    private fun scheduleGracePeriodArm() {
+        if (torGracePeriodArmJob?.isActive == true) {
+            return
         }
+        val delayMs =
+            (torStartingTimestamp + TOR_FAILURE_GRACE_PERIOD_MS - currentTimeMillis())
+                .coerceAtLeast(0L)
+        torGracePeriodArmJob =
+            serviceScope.launch {
+                try {
+                    delay(delayMs)
+                    if (torBootstrapStartObserved && !_torBootstrapFailed.value) {
+                        armTorBootstrapFailed(
+                            pendingGracePeriodErrorMessage ?: "Unknown Tor error",
+                        )
+                    }
+                } catch (e: Exception) {
+                    if (e is CancellationException) {
+                        log.d { "Bootstrap: Grace-period arm job cancelled" }
+                    } else {
+                        log.e(e) { "Bootstrap: Error in grace-period arm job" }
+                    }
+                }
+            }
+    }
+
+    private fun cancelGracePeriodArmJob() {
+        torGracePeriodArmJob?.cancel()
+        torGracePeriodArmJob = null
     }
 
     fun startTor(purgeTorDir: Boolean) {
         serviceScope.launch {
             setTorBootstrapFailed(false)
-            torGracePeriodFailureCount = 0
+            cancelGracePeriodArmJob()
+            pendingGracePeriodErrorMessage = null
+            torBootstrapStartObserved = false
             torStartingTimestamp = 0L
             // Restarting Tor is a fresh connection attempt, so reset the slow-path clock:
             // otherwise the "still connecting, this is normal" banner would reappear immediately

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationBootstrapFacade.kt
@@ -285,10 +285,9 @@ abstract class ApplicationBootstrapFacade(
 
     private fun handleTorBootstrapError(error: Throwable) {
         val errorMessage =
-            listOfNotNull(
-                error.message,
-                error.cause?.message,
-            ).firstOrNull()
+            generateSequence(error) { it.cause }
+                .mapNotNull { it.message }
+                .firstOrNull()
                 ?: "Unknown Tor error"
 
         // Possibly stale error - Ignore
@@ -319,6 +318,7 @@ abstract class ApplicationBootstrapFacade(
         setState("mobile.bootstrap.tor.failed".i18n() + ": $errorMessage")
         cancelTimeout(showProgressToast = false)
         setTorBootstrapFailed(true)
+        torStartingTimestamp = 0L
         log.e { "Bootstrap: Tor initialization failed - $errorMessage" }
     }
 
@@ -328,7 +328,8 @@ abstract class ApplicationBootstrapFacade(
                 kmpTorService.startTor()
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                log.w(e) { "Bootstrap: grace-period Tor retry failed" }
             }
         }
     }
@@ -337,6 +338,7 @@ abstract class ApplicationBootstrapFacade(
         serviceScope.launch {
             setTorBootstrapFailed(false)
             torGracePeriodFailureCount = 0
+            torStartingTimestamp = 0L
             // Restarting Tor is a fresh connection attempt, so reset the slow-path clock:
             // otherwise the "still connecting, this is normal" banner would reappear immediately
             // showing the elapsed time of the failed attempt. The elapsed ticker keeps running

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -254,6 +254,34 @@ abstract class ApplicationLifecycleService(
         }
     }
 
+    /**
+     * Full in-process recovery after a Tor bootstrap failure on splash.
+     *
+     * Restarting kmp-tor alone is not enough on Node: bisq2 [activateServiceFacades]
+     * may have aborted before [androidApplicationService.initialize] ran.
+     */
+    suspend fun restartTorBootstrap(purgeTorDir: Boolean = false): Boolean {
+        if (isTerminating.value) {
+            log.w { "Cannot restart Tor bootstrap: app is terminating" }
+            return false
+        }
+        return try {
+            if (purgeTorDir) {
+                kmpTorService.stopAndPurgeWorkingDir()
+            }
+            deactivateServiceFacades()
+            activateServiceFacades()
+            true
+        } catch (_: TorBootstrapNotReadyException) {
+            false
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.e(e) { "Tor bootstrap restart failed" }
+            false
+        }
+    }
+
     protected open fun onUnrecoverableError(e: Throwable) {
         log.e(e) { "Unrecoverable error detected. Application must be restarted. Stopping services." }
         serviceScope.launch {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.service.BaseService
 import network.bisq.mobile.data.service.network.KmpTorService
+import network.bisq.mobile.data.service.network.TorBootstrapNotReadyException
 import network.bisq.mobile.data.utils.getPlatformInfo
 import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.AnalyticsService
@@ -71,6 +72,7 @@ abstract class ApplicationLifecycleService(
         serviceScope.launch {
             try {
                 activateServiceFacades()
+            } catch (_: TorBootstrapNotReadyException) {
             } catch (e: Exception) {
                 onUnrecoverableError(e)
             }
@@ -242,6 +244,8 @@ abstract class ApplicationLifecycleService(
             deactivateServiceFacades()
             activateServiceFacades()
             true
+        } catch (_: TorBootstrapNotReadyException) {
+            false
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -275,7 +275,8 @@ abstract class ApplicationLifecycleService(
             false
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            log.e(e) { "restartTorBootstrap failed" }
             false
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -262,7 +262,6 @@ abstract class ApplicationLifecycleService(
      */
     suspend fun restartTorBootstrap(purgeTorDir: Boolean = false): Boolean {
         if (isTerminating.value) {
-            log.w { "Cannot restart Tor bootstrap: app is terminating" }
             return false
         }
         return try {
@@ -276,8 +275,7 @@ abstract class ApplicationLifecycleService(
             false
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
-        } catch (e: Exception) {
-            log.e(e) { "Tor bootstrap restart failed" }
+        } catch (_: Exception) {
             false
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.CancellationException
  * Classifies Tor bootstrap [Throwable]s for grace-period handling in [ApplicationBootstrapFacade].
  *
  * Terminal failures must surface [ApplicationBootstrapFacade.torBootstrapFailed] immediately.
- * Transient circuit-establishment errors may be retried during the grace window (P1).
+ * Transient circuit-establishment errors are suppressed until the grace window elapses.
  */
 object TorBootstrapErrorClassification {
     fun isTerminal(error: Throwable): Boolean {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
@@ -1,0 +1,41 @@
+package network.bisq.mobile.data.service.bootstrap
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Classifies Tor bootstrap [Throwable]s for grace-period handling in [ApplicationBootstrapFacade].
+ *
+ * Terminal failures must surface [ApplicationBootstrapFacade.torBootstrapFailed] immediately.
+ * Transient circuit-establishment errors may be retried during the grace window (P1).
+ */
+object TorBootstrapErrorClassification {
+    fun isTerminal(error: Throwable): Boolean {
+        if (error is CancellationException) {
+            return false
+        }
+        return collectMessages(error).any(::isTerminalMessage)
+    }
+
+    internal fun isTerminalMessage(message: String): Boolean {
+        val normalized = message.lowercase()
+        return TERMINAL_MESSAGE_MARKERS.any { marker -> normalized.contains(marker) }
+    }
+
+    private fun collectMessages(error: Throwable): List<String> {
+        val messages = mutableListOf<String>()
+        var current: Throwable? = error
+        while (current != null) {
+            current.message?.let { messages.add(it) }
+            current = current.cause
+        }
+        return messages
+    }
+
+    private val TERMINAL_MESSAGE_MARKERS =
+        listOf(
+            "ctrlconnection stream ended",
+            "daemon stopped",
+            "control connection",
+            "tor process exited",
+        )
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
@@ -7,6 +7,10 @@ import kotlinx.coroutines.CancellationException
  *
  * Terminal failures must surface [ApplicationBootstrapFacade.torBootstrapFailed] immediately.
  * Transient circuit-establishment errors are suppressed until the grace window elapses.
+ *
+ * String matching notes (kmp-tor has no structured failure kinds today):
+ * - Markers validated against kmp-tor **2.6.0** and kmp-tor-resource **409.5.0** (`gradle/libs.versions.toml`).
+ * - Re-check [TERMINAL_MESSAGE_MARKERS] after any kmp-tor upgrade — wording can change between releases.
  */
 object TorBootstrapErrorClassification {
     fun isTerminal(error: Throwable): Boolean {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/TorBootstrapErrorClassification.kt
@@ -23,8 +23,9 @@ object TorBootstrapErrorClassification {
 
     private fun collectMessages(error: Throwable): List<String> {
         val messages = mutableListOf<String>()
+        val seen = mutableSetOf<Throwable>()
         var current: Throwable? = error
-        while (current != null) {
+        while (current != null && seen.add(current)) {
             current.message?.let { messages.add(it) }
             current = current.cause
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -58,8 +58,8 @@ class KmpTorService(
 ) : BaseService(),
     Logging {
     companion object {
-        private const val DEFAULT_DAEMON_START_TIMEOUT_MS = 60_000L
-        private const val DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000L // 2 minutes for bootstrap
+        internal const val DEFAULT_DAEMON_START_TIMEOUT_MS = 60_000L
+        internal const val DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000L // 2 minutes for bootstrap
     }
 
     sealed class TorState {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -3,7 +3,6 @@ package network.bisq.mobile.data.service.network
 import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.aSocket
 import io.matthewnelson.kmp.file.File
-import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.tor.runtime.Action.Companion.startDaemonAsync
 import io.matthewnelson.kmp.tor.runtime.Action.Companion.stopDaemonAsync
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
@@ -37,7 +36,6 @@ import network.bisq.mobile.i18n.i18n
 import okio.FileSystem
 import okio.Path
 import okio.SYSTEM
-import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 
 /**
@@ -62,19 +60,6 @@ class KmpTorService(
     companion object {
         private const val DEFAULT_DAEMON_START_TIMEOUT_MS = 60_000L
         private const val DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000L // 2 minutes for bootstrap
-
-        /**
-         * DEBUG test hook to reproduce "CtrlConnection Stream Ended" failures.
-         *
-         * When > 0, [configTor] throws after the SOCKS port is known — immediately before
-         * control-port setup. Each injected failure decrements the counter, so the first N
-         * start attempts fail and subsequent attempts proceed normally.
-         *
-         * Set to 1 to reproduce the initial failure while still allowing recovery on retry.
-         * Defaults to 0 (disabled).
-         */
-        @Volatile
-        var simulateCtrlConnectionFailures: Int = 1
     }
 
     sealed class TorState {
@@ -333,22 +318,12 @@ class KmpTorService(
         }
     }
 
-    private fun throwSimulatedCtrlConnectionFailure() {
-        if (simulateCtrlConnectionFailures <= 0) {
-            return
-        }
-        simulateCtrlConnectionFailures--
-        log.w { "DEBUG: Simulating Tor bootstrap failure: CtrlConnection Stream Ended (remaining=$simulateCtrlConnectionFailures)" }
-        throw InterruptedException("CtrlConnection Stream Ended")
-    }
-
     private suspend fun configTor() {
         try {
             // Note: protected by outer withTimeout in startTor()
             val socksPort =
                 awaitSocksPort()
                     ?: throw KmpTorException("Service stopped before SOCKS port available")
-            throwSimulatedCtrlConnectionFailure()
             val controlPort = readControlPort()
 
             writeExternalTorConfig(socksPort, controlPort)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.data.service.network
 import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.aSocket
 import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.tor.runtime.Action.Companion.startDaemonAsync
 import io.matthewnelson.kmp.tor.runtime.Action.Companion.stopDaemonAsync
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
@@ -36,6 +37,7 @@ import network.bisq.mobile.i18n.i18n
 import okio.FileSystem
 import okio.Path
 import okio.SYSTEM
+import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 
 /**
@@ -60,6 +62,19 @@ class KmpTorService(
     companion object {
         private const val DEFAULT_DAEMON_START_TIMEOUT_MS = 60_000L
         private const val DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000L // 2 minutes for bootstrap
+
+        /**
+         * DEBUG test hook to reproduce "CtrlConnection Stream Ended" failures.
+         *
+         * When > 0, [configTor] throws after the SOCKS port is known — immediately before
+         * control-port setup. Each injected failure decrements the counter, so the first N
+         * start attempts fail and subsequent attempts proceed normally.
+         *
+         * Set to 1 to reproduce the initial failure while still allowing recovery on retry.
+         * Defaults to 0 (disabled).
+         */
+        @Volatile
+        var simulateCtrlConnectionFailures: Int = 1
     }
 
     sealed class TorState {
@@ -318,12 +333,22 @@ class KmpTorService(
         }
     }
 
+    private fun throwSimulatedCtrlConnectionFailure() {
+        if (simulateCtrlConnectionFailures <= 0) {
+            return
+        }
+        simulateCtrlConnectionFailures--
+        log.w { "DEBUG: Simulating Tor bootstrap failure: CtrlConnection Stream Ended (remaining=$simulateCtrlConnectionFailures)" }
+        throw InterruptedException("CtrlConnection Stream Ended")
+    }
+
     private suspend fun configTor() {
         try {
             // Note: protected by outer withTimeout in startTor()
             val socksPort =
                 awaitSocksPort()
                     ?: throw KmpTorException("Service stopped before SOCKS port available")
+            throwSimulatedCtrlConnectionFailure()
             val controlPort = readControlPort()
 
             writeExternalTorConfig(socksPort, controlPort)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
@@ -4,12 +4,18 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import network.bisq.mobile.data.service.LifeCycleAware
 import network.bisq.mobile.data.service.ServiceFacade
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.utils.Logging
 
 abstract class NetworkServiceFacade(
     private val kmpTorService: KmpTorService,
+    private val applicationBootstrapFacade: ApplicationBootstrapFacade,
 ) : ServiceFacade(),
     LifeCycleAware,
     Logging {
@@ -31,6 +37,7 @@ abstract class NetworkServiceFacade(
 
         if (isTorEnabled()) {
             startTorWithRetries()
+            awaitTorStartedOrBootstrapFailed()
         }
     }
 
@@ -89,5 +96,36 @@ abstract class NetworkServiceFacade(
                 currentCoroutineContext().ensureActive()
             }
         }
+    }
+
+    private suspend fun awaitTorStartedOrBootstrapFailed() {
+        if (kmpTorService.state.value is KmpTorService.TorState.Started) {
+            return
+        }
+
+        val torStarted =
+            kmpTorService.state
+                .filter { it is KmpTorService.TorState.Started }
+                .map { TorActivationOutcome.Started }
+
+        val torFailed =
+            applicationBootstrapFacade.torBootstrapFailed
+                .filter { it }
+                .map { TorActivationOutcome.BootstrapFailed }
+
+        when (merge(torStarted, torFailed).first()) {
+            TorActivationOutcome.Started -> Unit
+
+            TorActivationOutcome.BootstrapFailed -> {
+                deactivate()
+                throw TorBootstrapNotReadyException()
+            }
+        }
+    }
+
+    private sealed interface TorActivationOutcome {
+        data object Started : TorActivationOutcome
+
+        data object BootstrapFailed : TorActivationOutcome
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.data.service.LifeCycleAware
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.domain.utils.Logging
+import kotlin.coroutines.cancellation.CancellationException
 
 abstract class NetworkServiceFacade(
     private val kmpTorService: KmpTorService,
@@ -117,7 +118,13 @@ abstract class NetworkServiceFacade(
             TorActivationOutcome.Started -> Unit
 
             TorActivationOutcome.BootstrapFailed -> {
-                deactivate()
+                try {
+                    deactivate()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.e(e) { "Failed to deactivate after Tor bootstrap failure" }
+                }
                 throw TorBootstrapNotReadyException()
             }
         }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.data.service.network
 
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -8,6 +9,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.withTimeout
 import network.bisq.mobile.data.service.LifeCycleAware
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
@@ -26,6 +28,11 @@ abstract class NetworkServiceFacade(
         // subsequent attempt succeeds. Kept small — genuine failures should surface, not loop.
         private const val MAX_TOR_START_ATTEMPTS = 3
         private const val TOR_START_RETRY_DELAY_MS = 1_000L
+
+        // Upper bound for awaiting Started / torBootstrapFailed after [startTorWithRetries].
+        // Aligns with kmp-tor per-attempt daemon + bootstrap caps in [KmpTorService.startTor].
+        private const val TOR_ACTIVATION_AWAIT_TIMEOUT_MS =
+            KmpTorService.DEFAULT_DAEMON_START_TIMEOUT_MS + KmpTorService.DEFAULT_BOOTSTRAP_TIMEOUT_MS
     }
 
     abstract val numConnections: StateFlow<Int>
@@ -129,20 +136,34 @@ abstract class NetworkServiceFacade(
                 .filter { it }
                 .map { TorActivationOutcome.BootstrapFailed }
 
-        when (merge(torStarted, torFailed).first()) {
-            TorActivationOutcome.Started -> Unit
-
-            TorActivationOutcome.BootstrapFailed -> {
-                try {
-                    deactivate()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log.e(e) { "Failed to deactivate after Tor bootstrap failure" }
+        try {
+            when (
+                withTimeout(TOR_ACTIVATION_AWAIT_TIMEOUT_MS) {
+                    merge(torStarted, torFailed).first()
                 }
-                throw TorBootstrapNotReadyException()
+            ) {
+                TorActivationOutcome.Started -> Unit
+
+                TorActivationOutcome.BootstrapFailed -> handleTorBootstrapNotReady()
             }
+        } catch (_: TimeoutCancellationException) {
+            log.w {
+                "Timed out after ${TOR_ACTIVATION_AWAIT_TIMEOUT_MS}ms waiting for Tor started " +
+                    "or bootstrap failure; treating as not ready"
+            }
+            handleTorBootstrapNotReady()
         }
+    }
+
+    private suspend fun handleTorBootstrapNotReady() {
+        try {
+            deactivate()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.e(e) { "Failed to deactivate after Tor bootstrap failure" }
+        }
+        throw TorBootstrapNotReadyException()
     }
 
     private sealed interface TorActivationOutcome {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
@@ -57,6 +57,12 @@ abstract class NetworkServiceFacade(
      */
     private suspend fun startTorWithRetries() {
         repeat(MAX_TOR_START_ATTEMPTS) { attempt ->
+            if (applicationBootstrapFacade.torBootstrapFailed.value) {
+                log.i { "Tor bootstrap failed (terminal); skipping remaining start attempts" }
+                return
+            }
+            currentCoroutineContext().ensureActive()
+
             val started =
                 try {
                     kmpTorService.startTor()
@@ -66,6 +72,15 @@ abstract class NetworkServiceFacade(
                     false
                 }
             if (started) return
+
+            if (applicationBootstrapFacade.torBootstrapFailed.value) {
+                log.i {
+                    "Tor bootstrap failed (terminal) after attempt ${attempt + 1}/$MAX_TOR_START_ATTEMPTS; " +
+                        "skipping remaining retries"
+                }
+                return
+            }
+
             if (attempt < MAX_TOR_START_ATTEMPTS - 1) {
                 log.w { "Tor did not start (attempt ${attempt + 1}/$MAX_TOR_START_ATTEMPTS); retrying in ${TOR_START_RETRY_DELAY_MS}ms" }
                 delay(TOR_START_RETRY_DELAY_MS)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/TorBootstrapNotReadyException.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/TorBootstrapNotReadyException.kt
@@ -1,0 +1,11 @@
+package network.bisq.mobile.data.service.network
+
+/**
+ * Tor bootstrap failed before [NetworkServiceFacade] could finish activation.
+ *
+ * Expected on the user-recovery path (retry / purge Tor data). Must not trigger
+ * [network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService.onUnrecoverableError].
+ */
+class TorBootstrapNotReadyException(
+    message: String = "Tor bootstrap failed before network services could start",
+) : Exception(message)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
@@ -1,10 +1,13 @@
 package network.bisq.mobile.presentation.common.service
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.data.service.network.KmpTorService
+import network.bisq.mobile.data.service.network.TorBootstrapNotReadyException
 import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
 import kotlin.test.Test
@@ -26,6 +29,7 @@ class ApplicationLifecycleServiceRestartTest {
         var activateCalls = 0
         var failOnDeactivate = false
         var failOnActivate = false
+        var throwTorBootstrapNotReadyOnActivate = false
 
         override suspend fun deactivateServiceFacades() {
             deactivateCalls++
@@ -36,6 +40,9 @@ class ApplicationLifecycleServiceRestartTest {
 
         override suspend fun activateServiceFacades() {
             activateCalls++
+            if (throwTorBootstrapNotReadyOnActivate) {
+                throw TorBootstrapNotReadyException()
+            }
             if (failOnActivate) {
                 throw RuntimeException("activate failed")
             }
@@ -107,6 +114,83 @@ class ApplicationLifecycleServiceRestartTest {
             val result = service.restartTorBootstrap()
 
             assertTrue(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
+
+    @Test
+    fun `restartTorBootstrap returns false when deactivation fails`() =
+        runTest {
+            val service =
+                TrackingLifecycleService().apply {
+                    failOnDeactivate = true
+                }
+
+            val result = service.restartTorBootstrap()
+
+            assertFalse(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(0, service.activateCalls)
+        }
+
+    @Test
+    fun `restartTorBootstrap returns false when activation fails`() =
+        runTest {
+            val service =
+                TrackingLifecycleService().apply {
+                    failOnActivate = true
+                }
+
+            val result = service.restartTorBootstrap()
+
+            assertFalse(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
+
+    @Test
+    fun `restartTorBootstrap returns false when app is terminating`() =
+        runTest {
+            val service =
+                object : TrackingLifecycleService() {
+                    init {
+                        compareAndSetIsTerminating(expect = false, update = true)
+                    }
+                }
+
+            val result = service.restartTorBootstrap()
+
+            assertFalse(result)
+            assertEquals(0, service.deactivateCalls)
+            assertEquals(0, service.activateCalls)
+        }
+
+    @Test
+    fun `restartTorBootstrap purges tor dir when purgeTorDir is true`() =
+        runTest {
+            val kmpTorService = mockk<KmpTorService>(relaxed = true)
+            coEvery { kmpTorService.stopAndPurgeWorkingDir() } returns Unit
+            val service = TrackingLifecycleService(kmpTorService = kmpTorService)
+
+            val result = service.restartTorBootstrap(purgeTorDir = true)
+
+            assertTrue(result)
+            coVerify(exactly = 1) { kmpTorService.stopAndPurgeWorkingDir() }
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
+
+    @Test
+    fun `restartTorBootstrap returns false when Tor bootstrap is not ready`() =
+        runTest {
+            val service =
+                TrackingLifecycleService().apply {
+                    throwTorBootstrapNotReadyOnActivate = true
+                }
+
+            val result = service.restartTorBootstrap()
+
+            assertFalse(result)
             assertEquals(1, service.deactivateCalls)
             assertEquals(1, service.activateCalls)
         }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceRestartTest.kt
@@ -98,4 +98,16 @@ class ApplicationLifecycleServiceRestartTest {
 
             assertFalse(result)
         }
+
+    @Test
+    fun `restartTorBootstrap deactivates then activates service facades`() =
+        runTest {
+            val service = TrackingLifecycleService()
+
+            val result = service.restartTorBootstrap()
+
+            assertTrue(result)
+            assertEquals(1, service.deactivateCalls)
+            assertEquals(1, service.activateCalls)
+        }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -290,8 +290,7 @@ open class MainPresenter(
         applicationLifecycleService.restartApp(view)
     }
 
-    suspend fun restartTorBootstrap(purgeTorDir: Boolean = false): Boolean =
-        applicationLifecycleService.restartTorBootstrap(purgeTorDir)
+    suspend fun restartTorBootstrap(purgeTorDir: Boolean = false): Boolean = applicationLifecycleService.restartTorBootstrap(purgeTorDir)
 
     open fun onConnectivityRecoveryAction() {
         onRestartApp()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/MainPresenter.kt
@@ -290,6 +290,9 @@ open class MainPresenter(
         applicationLifecycleService.restartApp(view)
     }
 
+    suspend fun restartTorBootstrap(purgeTorDir: Boolean = false): Boolean =
+        applicationLifecycleService.restartTorBootstrap(purgeTorDir)
+
     open fun onConnectivityRecoveryAction() {
         onRestartApp()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
@@ -216,9 +216,7 @@ abstract class SplashPresenter(
 
     protected open fun restartTorAfterFailure(purgeTorDir: Boolean) {
         presenterScope.launch {
-            if (!mainPresenter.restartTorBootstrap(purgeTorDir)) {
-                log.w { "Tor bootstrap lifecycle restart failed" }
-            }
+            mainPresenter.restartTorBootstrap(purgeTorDir)
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/splash/SplashPresenter.kt
@@ -24,7 +24,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 
 abstract class SplashPresenter(
-    mainPresenter: MainPresenter,
+    private val mainPresenter: MainPresenter,
     private val applicationBootstrapFacade: ApplicationBootstrapFacade,
     private val userProfileService: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
@@ -207,11 +207,19 @@ abstract class SplashPresenter(
     }
 
     private fun onRestartTor() {
-        applicationBootstrapFacade.startTor(false)
+        restartTorAfterFailure(purgeTorDir = false)
     }
 
     private fun onPurgeRestartTor() {
-        applicationBootstrapFacade.startTor(true)
+        restartTorAfterFailure(purgeTorDir = true)
+    }
+
+    protected open fun restartTorAfterFailure(purgeTorDir: Boolean) {
+        presenterScope.launch {
+            if (!mainPresenter.restartTorBootstrap(purgeTorDir)) {
+                log.w { "Tor bootstrap lifecycle restart failed" }
+            }
+        }
     }
 
     private fun onTerminateApp() {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1572

After multiple attempts, I couldn't get the "CtrlConnection Stream Ended" error. So I added the error simulation code in kmpTorService, observed the issues and fixed them.

 - Classifies terminal Tor errors (CtrlConnection Stream Ended, daemon stopped, etc.) and throws torBootstrapFailed immediately, bypassing the grace period. With `TorBootstrapErrorClassification`, we can now define which errors are terminal and which are transient that can be retried.
 - Transient errors within 60s trigger bounded startTor() retries (up to 3) before escalating to the failure dialog.
 - Unblocks NetworkServiceFacade.activate() — waits for either Tor started or bootstrap failed, then throws TorBootstrapNotReadyException (swallowed as expected failure, not unrecoverable).

androidNode specific:
 - Wires splash recovery - "Restart Tor" / "Purge & restart" run a full in-process lifecycle restart via restartTorBootstrap(), required after activation aborts (especially on Node, where bisq2 may never have left INITIALIZE_APP) - Without this, after retry Tor reached 100% connectivity and connection to p2p network is not initialized.

To quickly simulate the error and test the fixes, you can undo the cleanup logic in 5cee534c9f0e45a8998096d08c917aca295d4f69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Tor bootstrap restart flow with automatic recovery, including an option to retry after purging Tor data.
  * Exposed Tor restart control via the main presenter and updated the splash recovery flow to use it.
* **Bug Fixes**
  * Improved handling of Tor bootstrap readiness failures as expected recovery events, with better terminal vs non-terminal detection.
  * Enhanced lifecycle activation/shutdown behavior during startup to avoid interrupting early recovery attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->