### PR TITLE
chore/revert_removal_of_dead_code_post_refactors_causing_bootstrapping_issues

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -127,11 +127,12 @@ val androidNodeDomainModule =
         // pattern. Node app sends to the bisq-easy-node-android GlitchTip
         // project (DSN from gradle.properties / local.properties).
         single<NativeSentryInitializer> { SentryJavaNativeSentryInitializer() }
-        // SOCKS port source: bisq2's embedded NetworkService. The node app's
-        // KmpTorService binding is NEVER started (its startTor() is only
-        // called from the Connect-side TrustedNodeSetupUseCase) — so we must
-        // NOT wire KmpTorSocksPortProvider here or analytics would suspend
-        // forever waiting on a Tor instance nobody ever starts.
+        // SOCKS port source: bisq2's embedded NetworkService. This provider polls the SOCKS proxy
+        // that bisq2 core is actually routing through (its Node.getSocksProxy()), which resolves once
+        // bisq2 core's node is up. NOTE: kmp-tor IS started on the node (NetworkServiceFacade.activate()
+        // -> kmpTorService.startTor(); bisq2 core then uses it as external Tor). So its own SOCKS port
+        // is available earlier — switching to KmpTorSocksPortProvider would resolve sooner and is a
+        // valid future optimization; the current provider is kept for coherence with bisq2's routing.
         single<AnalyticsSocksPortProvider> { Bisq2SocksPortProvider(get()) }
         single {
             // See ClientDomainModule for the matching pattern + rationale.

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/analytics/Bisq2SocksPortProvider.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/analytics/Bisq2SocksPortProvider.kt
@@ -7,12 +7,17 @@ import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
 
 /**
- * [AnalyticsSocksPortProvider] for the bisq-easy Node app. The embedded bisq2
- * stack runs its own Tor instance via `bisq.network.tor.TorService` — kmp-tor
- * is bound in the node app's DI but is NEVER started there (kmp-tor's
- * `startTor()` is only called from the Connect-side `TrustedNodeSetupUseCase`).
- * Polling kmp-tor's flow would suspend forever on the node app — which is
- * exactly what the user hit when they first tested Phase 1 analytics.
+ * [AnalyticsSocksPortProvider] for the bisq-easy Node app. On the node, kmp-tor
+ * runs the Tor daemon (NetworkServiceFacade.activate() -> kmpTorService.startTor())
+ * and bisq2 core is configured to use it as external Tor (UseExternalTor). This
+ * provider reports the SOCKS proxy that bisq2 core is routing through, read from
+ * its own NetworkService rather than from kmp-tor directly.
+ *
+ * (Historical note: an earlier version of this comment claimed kmp-tor is never
+ * started on the node — that is FALSE; it is started. kmp-tor's own SOCKS port
+ * is in fact available earlier than bisq2 core's, so a KmpTorSocksPortProvider
+ * would resolve sooner — a possible future optimization. This provider is kept
+ * for coherence with bisq2's routing.)
  *
  * bisq2's `NetworkService` does not expose an observable SOCKS-port flow; it
  * makes the SOCKS proxy available synchronously via

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/bootstrap/NodeApplicationBootstrapFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/bootstrap/NodeApplicationBootstrapFacade.kt
@@ -32,14 +32,18 @@ class NodeApplicationBootstrapFacade(
         super.activate()
         log.i { "Bootstrap: super.activate() completed, calling onInitializeAppState()" }
 
-        // Set initial state before observing; bisq2 core's application State drives progress from here.
+        // Set initial state before observing - Tor progress will update this
         _bootstrapPhase.value = BootstrapPhase.INITIALIZE_APP
         setState("splash.applicationServiceState.INITIALIZE_APP".i18n())
         setProgress(0f)
 
-        // The node embeds bisq2 core's own Tor via NetworkService and never starts KmpTorService
-        // (see NodeDomainModule) — so the base observeTorState() would be a dead no-op here. Tor and
-        // network failures surface through observeApplicationState() -> State.FAILED instead.
+        // The node DOES run kmp-tor: NetworkServiceFacade.activate() calls kmpTorService.startTor(),
+        // and bisq2 core is configured to use that external Tor. observeTorState() is therefore the
+        // (only) feeder of the Tor bootstrap % (setTorBootstrapProgress) and of torBootstrapFailed on
+        // a Tor start failure — it is NOT a no-op here. Removing it (PR #1579, on a wrong "node never
+        // starts kmp-tor" premise) froze the splash Tor % at 0 and dropped the Tor-failure signal.
+        // App/network failures still surface via observeApplicationState() -> State.FAILED.
+        observeTorState()
         observeApplicationState()
     }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashPresenter.kt
@@ -53,24 +53,35 @@ class NodeSplashPresenter(
     override fun onViewAttached() {
         super.onViewAttached()
 
+        // isBootstrapFailed / torBootstrapFailed are the source of truth for the two failure UIs.
+        // The typed combine below is already at its 6-arg max, so fold the two failure flags into a
+        // single input here rather than inferring Tor failure from SplashPresenter.resolveActiveDialog's
+        // dialog priority (which would silently break this path if that priority were reordered).
+        val failureFlags =
+            combine(
+                nodeApplicationBootstrapFacade.isBootstrapFailed,
+                nodeApplicationBootstrapFacade.torBootstrapFailed,
+            ) { appFailed, torFailed -> BootstrapFailureFlags(appFailed, torFailed) }
+
         presenterScope.launch {
             // 6-arg combine: use the project's typed combine (kotlinx only types up to 5);
-            // imported kotlinx.combine stays for the slow-path collector below.
+            // imported kotlinx.combine stays for the 3-arg slow-path collector below.
             combine(
                 uiState,
                 nodeApplicationBootstrapFacade.bootstrapPhase,
                 nodeApplicationBootstrapFacade.torBootstrapProgress,
                 numConnections,
                 allDataReceived,
-                nodeApplicationBootstrapFacade.isBootstrapFailed,
-            ) { splashUiState, phase, torProgress, peerCount, dataReceived, appBootstrapFailed ->
+                failureFlags,
+            ) { splashUiState, phase, torProgress, peerCount, dataReceived, failure ->
                 buildNodeUiState(
                     splashUiState = splashUiState,
                     phase = phase,
                     torProgress = torProgress,
                     peerCount = peerCount,
                     dataReceived = dataReceived,
-                    appBootstrapFailed = appBootstrapFailed,
+                    appBootstrapFailed = failure.appBootstrapFailed,
+                    torBootstrapFailed = failure.torBootstrapFailed,
                 )
             }.collect { nodeUiState ->
                 _nodeUiState.value = nodeUiState
@@ -85,9 +96,11 @@ class NodeSplashPresenter(
         presenterScope.launch {
             combine(
                 nodeApplicationBootstrapFacade.bootstrapElapsedSeconds,
+                nodeApplicationBootstrapFacade.torBootstrapFailed,
                 nodeApplicationBootstrapFacade.isBootstrapFailed,
-            ) { elapsed, bootstrapFailed ->
-                if (!bootstrapFailed && elapsed >= SLOW_PATH_THRESHOLD_SECONDS) {
+            ) { elapsed, torFailed, bootstrapFailed ->
+                val failed = torFailed || bootstrapFailed
+                if (!failed && elapsed >= SLOW_PATH_THRESHOLD_SECONDS) {
                     SlowPathUiState(isVisible = true, elapsedSeconds = elapsed)
                 } else {
                     SlowPathUiState()
@@ -105,7 +118,13 @@ class NodeSplashPresenter(
         peerCount: Int,
         dataReceived: Boolean,
         appBootstrapFailed: Boolean,
+        torBootstrapFailed: Boolean,
     ): NodeSplashUiState {
+        // A general bootstrap failure supersedes the inline Tor-failure UI, mirroring
+        // SplashPresenter's dialog priority (isBootstrapFailed outranks torBootstrapFailed) —
+        // but sourced from the facade flags so this no longer depends on resolveActiveDialog.
+        val torFailed = torBootstrapFailed && !appBootstrapFailed
+        val title = titleFor(phase, torFailed, appBootstrapFailed)
         val safePeerCount = peerCount.coerceAtLeast(0)
 
         return NodeSplashUiState(
@@ -113,9 +132,10 @@ class NodeSplashPresenter(
                 splashUiState.copy(
                     appNameAndVersion = appNameAndVersion,
                 ),
-            title = titleFor(phase, appBootstrapFailed),
-            subtitle = subtitleFor(phase, appBootstrapFailed),
-            steps = buildSteps(phase, torProgress, safePeerCount, dataReceived),
+            title = title,
+            subtitle = subtitleFor(phase, torFailed, appBootstrapFailed),
+            steps = buildSteps(phase, torProgress, safePeerCount, dataReceived, torFailed),
+            showTorFailureActions = torFailed,
         )
     }
 
@@ -124,13 +144,14 @@ class NodeSplashPresenter(
         torProgress: Int,
         peerCount: Int,
         dataReceived: Boolean,
+        torFailed: Boolean,
     ): List<NodeBootstrapStep> =
         listOf(
             NodeBootstrapStep(
                 icon = NodeBootstrapStepIcon.TOR,
-                label = UiString("mobile.bootstrap.node.step.tor"),
-                detail = torDetail(phase, torProgress),
-                status = torStatus(phase),
+                label = if (torFailed) UiString("mobile.bootstrap.node.step.tor.failed.label") else UiString("mobile.bootstrap.node.step.tor"),
+                detail = torDetail(phase, torProgress, torFailed),
+                status = torStatus(phase, torFailed),
             ),
             NodeBootstrapStep(
                 icon = NodeBootstrapStepIcon.PEERS,
@@ -164,8 +185,12 @@ class NodeSplashPresenter(
             -> true
         }
 
-    private fun torStatus(phase: BootstrapPhase): NodeBootstrapStepStatus =
+    private fun torStatus(
+        phase: BootstrapPhase,
+        torFailed: Boolean,
+    ): NodeBootstrapStepStatus =
         when {
+            torFailed -> NodeBootstrapStepStatus.FAILED
             isTorStageDone(phase) -> NodeBootstrapStepStatus.DONE
             else -> NodeBootstrapStepStatus.IN_PROGRESS
         }
@@ -198,8 +223,10 @@ class NodeSplashPresenter(
     private fun torDetail(
         phase: BootstrapPhase,
         torProgress: Int,
+        torFailed: Boolean,
     ): UiString =
         when {
+            torFailed -> UiString("mobile.bootstrap.node.step.tor.failed.detail")
             isTorStageDone(phase) -> UiString("mobile.bootstrap.node.step.tor.done.detail")
             else -> uiString("mobile.bootstrap.node.step.tor.detail", torProgress)
         }
@@ -236,9 +263,11 @@ class NodeSplashPresenter(
 
     private fun titleFor(
         phase: BootstrapPhase,
+        torFailed: Boolean,
         appBootstrapFailed: Boolean,
     ): UiString =
         when {
+            torFailed -> UiString("mobile.bootstrap.node.title.torFailed")
             appBootstrapFailed -> UiString("mobile.bootstrap.node.title.failed")
             phase == BootstrapPhase.INITIALIZE_NETWORK -> UiString("mobile.bootstrap.node.title.peers")
             phase == BootstrapPhase.INITIALIZE_SERVICES -> UiString("mobile.bootstrap.node.title.data")
@@ -248,14 +277,22 @@ class NodeSplashPresenter(
 
     private fun subtitleFor(
         phase: BootstrapPhase,
+        torFailed: Boolean,
         appBootstrapFailed: Boolean,
     ): UiString =
         when {
+            torFailed -> UiString("mobile.bootstrap.node.subtitle.failed")
             appBootstrapFailed -> UiString("mobile.bootstrap.node.subtitle.appFailed")
             phase == BootstrapPhase.INITIALIZE_SERVICES -> UiString("mobile.bootstrap.node.subtitle.data")
             phase == BootstrapPhase.APP_INITIALIZED -> UiString("mobile.bootstrap.node.subtitle.ready")
             else -> UiString("mobile.bootstrap.node.subtitle")
         }
+
+    // Folds the two facade failure flags into one input so the main combine stays at its 6-arg max.
+    private data class BootstrapFailureFlags(
+        val appBootstrapFailed: Boolean,
+        val torBootstrapFailed: Boolean,
+    )
 
     companion object {
         // Show the slow-path reassurance banner once bootstrap has been running this long

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashScreen.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.uiString
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqProgressBar
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.BisqLogoGrey
@@ -39,6 +41,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.startup.splash.SplashActiveDialog
 import network.bisq.mobile.presentation.startup.splash.SplashDialogs
 import network.bisq.mobile.presentation.startup.splash.SplashUiAction
 import network.bisq.mobile.presentation.startup.splash.SplashUiState
@@ -59,11 +62,18 @@ fun NodeSplashScreen() {
             onAction = presenter::onAction,
         )
         SplashDialogs(
-            uiState = uiState.splashUiState,
+            uiState = uiState.splashUiState.withoutNodeInlineFailureDialog(),
             onAction = presenter::onAction,
         )
     }
 }
+
+private fun SplashUiState.withoutNodeInlineFailureDialog(): SplashUiState =
+    if (activeDialog == SplashActiveDialog.TorBootstrapFailed) {
+        copy(activeDialog = null)
+    } else {
+        this
+    }
 
 @Composable
 private fun NodeBootstrapContent(
@@ -125,6 +135,13 @@ private fun NodeBootstrapContent(
                     )
                     BisqGap.V3()
                     NodeStepList(steps = uiState.steps)
+
+                    if (uiState.showTorFailureActions) {
+                        TorFailureActions(
+                            onRestartTor = { onAction(SplashUiAction.OnRestartTor) },
+                            onPurgeRestart = { onAction(SplashUiAction.OnPurgeRestartTor) },
+                        )
+                    }
 
                     if (slowPath.isVisible) {
                         BisqGap.V2()
@@ -314,11 +331,44 @@ private fun SlowPathBanner(elapsedSeconds: Long) {
     }
 }
 
+@Composable
+private fun TorFailureActions(
+    onRestartTor: () -> Unit,
+    onPurgeRestart: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        BisqGap.V2()
+        BisqButton(
+            text = "mobile.bootstrap.node.failure.restartTor".i18n(),
+            onClick = onRestartTor,
+            fullWidth = true,
+            type = BisqButtonType.Outline,
+        )
+        BisqGap.V1()
+        BisqButton(
+            text = "mobile.bootstrap.node.failure.clearTorData".i18n(),
+            onClick = onPurgeRestart,
+            fullWidth = true,
+            type = BisqButtonType.Danger,
+        )
+        BisqGap.VHalf()
+        BisqText.XSmallLight(
+            text = "mobile.bootstrap.node.failure.hint".i18n(),
+            color = BisqTheme.colors.mid_grey20,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
 private fun previewNodeSplashUiState(
     title: UiString,
     subtitle: UiString = UiString("mobile.bootstrap.node.subtitle"),
     progress: Float,
     steps: List<NodeBootstrapStep>,
+    showTorFailureActions: Boolean = false,
 ): NodeSplashUiState =
     NodeSplashUiState(
         splashUiState =
@@ -329,11 +379,13 @@ private fun previewNodeSplashUiState(
         title = title,
         subtitle = subtitle,
         steps = steps,
+        showTorFailureActions = showTorFailureActions,
     )
 
 private fun previewNodeSteps(
     torStatus: NodeBootstrapStepStatus = NodeBootstrapStepStatus.PENDING,
     torDetail: UiString = UiString(""),
+    torFailed: Boolean = false,
     peersStatus: NodeBootstrapStepStatus = NodeBootstrapStepStatus.PENDING,
     peersDetail: UiString = UiString(""),
     dataStatus: NodeBootstrapStepStatus = NodeBootstrapStepStatus.PENDING,
@@ -343,7 +395,7 @@ private fun previewNodeSteps(
     listOf(
         NodeBootstrapStep(
             icon = NodeBootstrapStepIcon.TOR,
-            label = UiString("mobile.bootstrap.node.step.tor"),
+            label = if (torFailed) UiString("mobile.bootstrap.node.step.tor.failed.label") else UiString("mobile.bootstrap.node.step.tor"),
             detail = torDetail,
             status = torStatus,
         ),
@@ -480,5 +532,25 @@ private fun NodeSplash_SlowPathPreview() {
                     ),
             ),
         slowPath = SlowPathUiState(isVisible = true, elapsedSeconds = 76L),
+    )
+}
+
+@ExcludeFromCoverage
+@Preview(name = "Node bootstrap - Tor failure")
+@Composable
+private fun NodeSplash_TorFailurePreview() {
+    NodeSplashPreview(
+        previewNodeSplashUiState(
+            title = UiString("mobile.bootstrap.node.title.failed"),
+            subtitle = UiString("mobile.bootstrap.node.subtitle.failed"),
+            progress = 0.08f,
+            steps =
+                previewNodeSteps(
+                    torStatus = NodeBootstrapStepStatus.FAILED,
+                    torDetail = UiString("mobile.bootstrap.node.step.tor.failed.detail"),
+                    torFailed = true,
+                ),
+            showTorFailureActions = true,
+        ),
     )
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashUiState.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/startup/splash/NodeSplashUiState.kt
@@ -8,6 +8,7 @@ data class NodeSplashUiState(
     val title: UiString = UiString(""),
     val subtitle: UiString = UiString(""),
     val steps: List<NodeBootstrapStep> = emptyList(),
+    val showTorFailureActions: Boolean = false,
 )
 
 data class SlowPathUiState(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,15 +65,12 @@ coil-compose = "3.4.0"
 # -------------------- Multiplatform Libraries --------------------
 bignum-lib = "0.3.10"
 # kmp-tor for embedded Tor support
-kmp-tor = "2.4.1"
-kmp-tor-resource = "408.17.0"
-## we can't upgrade to 2.5.0 - it breaks iOS
-#kmp-tor = "2.5.0"
-#kmp-tor-resource = "408.19.0"
+kmp-tor = "2.6.0"
+kmp-tor-resource = "409.5.0"
 kermit = "2.1.0"
 kphonenumber = "0.11.0"
 # Sentry KMP — opt-in analytics SDK (issue #525). Communicates with self-hosted
-# GlitchTip backend over Tor (TODO). Currently uses localhost:8000 via SSH
+# GlitchTip backend over Tor
 # tunnel for end-to-end verification.
 sentry-kotlin-multiplatform = "0.26.0"
 


### PR DESCRIPTION
 - upgrade kmp-tor to kotlin 2.4.0 compatible version 2.6.0 (fixes 2.5.0 issues so safe to upgrade for iOS as well)
 - partially reverted code cleanup preventing the inlined tor failure error to be shown and disturbing node bootstrap % progress (#1579 )
 - improvements and fixes on code docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved node startup splash screens to show clearer Tor-related progress and failure states.
  * Added Tor failure actions so users can restart Tor or clear Tor data directly from the splash screen.

* **Bug Fixes**
  * Fixed Tor bootstrap progress and failure reporting during startup, preventing missing or stuck Tor status updates.
  * Made startup messaging and step details more accurate when Tor fails versus general app bootstrap failures.

* **Chores**
  * Updated embedded Tor-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->