### PR TITLE
bugfix/fully_implement_use_animation_settings_and_auto_set_off_in_low_ram_device

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -8,6 +8,7 @@ import network.bisq.mobile.client.settings.faqs.FaqClientPresenter
 import network.bisq.mobile.client.splash.ClientSplashPresenter
 import network.bisq.mobile.client.tabs.more.ClientMiscItemsPresenter
 import network.bisq.mobile.client.trusted_node_setup.TrustedNodeSetupPresenter
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPresenter
 import network.bisq.mobile.presentation.main.AppPresenter
@@ -21,6 +22,9 @@ import org.koin.dsl.module
 
 val clientPresentationModule =
     module {
+        // Connect is a lightweight client with no embedded node, so don't use device-lock.
+        single { AnimationSettings(get(), get(), applyDeviceLock = false) }
+
         single<MainPresenter> {
             ClientMainPresenter(
                 get(),
@@ -77,6 +81,7 @@ val clientPresentationModule =
 
         factory<TopBarPresenter> {
             ClientTopBarPresenter(
+                get(),
                 get(),
                 get(),
                 get(),

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/navigation/ClientRootNavGraph.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/navigation/ClientRootNavGraph.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.client.payment_accounts.presentation.payment_accounts
 import network.bisq.mobile.client.splash.ClientSplashScreen
 import network.bisq.mobile.client.trusted_node_setup.TrustedNodeSetupScreen
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.ErrorState
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.graph.addCommonAppRoutes
@@ -35,6 +36,8 @@ fun ClientRootNavGraph(
     modifier: Modifier = Modifier,
 ) {
     val navigationManager: NavigationManager = koinInject()
+    val animationSettings: AnimationSettings = koinInject()
+    val animationsEnabled: () -> Boolean = { animationSettings.enabled.value }
 
     NavHost(
         modifier = modifier.background(color = BisqTheme.colors.backgroundColor),
@@ -45,8 +48,8 @@ fun ClientRootNavGraph(
             val route: NavRoute.Splash = backStackEntry.toRoute()
             ClientSplashScreen(route)
         }
-        addCommonAppRoutes()
-        addClientAppRoutes()
+        addCommonAppRoutes(animationsEnabled)
+        addClientAppRoutes(animationsEnabled)
     }
 
     DisposableEffect(rootNavController) {
@@ -59,13 +62,13 @@ fun ClientRootNavGraph(
 
 // TODO: Coverage exclusion rationale - NavGraphBuilder extension for Compose navigation.
 @ExcludeFromCoverage
-fun NavGraphBuilder.addClientAppRoutes() {
+fun NavGraphBuilder.addClientAppRoutes(animationsEnabled: () -> Boolean) {
     // Override Support screen with client-specific version
-    addScreen<NavRoute.Support> { ClientSupportScreen() }
+    addScreen<NavRoute.Support>(animationsEnabled = animationsEnabled) { ClientSupportScreen() }
 
     // Client-specific screens
-    addScreen<ClientNavRoute.TrustedNodeSetupSettings> { TrustedNodeSetupScreen(isWorkflow = false) }
-    addScreen<ClientNavRoute.TrustedNodeSetup> { entry ->
+    addScreen<ClientNavRoute.TrustedNodeSetupSettings>(animationsEnabled = animationsEnabled) { TrustedNodeSetupScreen(isWorkflow = false) }
+    addScreen<ClientNavRoute.TrustedNodeSetup>(animationsEnabled = animationsEnabled) { entry ->
         val route = entry.toRoute<ClientNavRoute.TrustedNodeSetup>()
         TrustedNodeSetupScreen(
             showConnectionFailed = route.showConnectionFailed,
@@ -74,12 +77,12 @@ fun NavGraphBuilder.addClientAppRoutes() {
         )
     }
 
-    addScreen<ClientNavRoute.PaymentAccountsMusig> { PaymentAccountsMusigScreen() }
-    addScreen<ClientNavRoute.PaymentAccountsMusigDetail> { backStackEntry ->
+    addScreen<ClientNavRoute.PaymentAccountsMusig>(animationsEnabled = animationsEnabled) { PaymentAccountsMusigScreen() }
+    addScreen<ClientNavRoute.PaymentAccountsMusigDetail>(animationsEnabled = animationsEnabled) { backStackEntry ->
         val route: ClientNavRoute.PaymentAccountsMusigDetail = backStackEntry.toRoute()
         PaymentAccountMusigDetailScreen(accountName = route.accountName)
     }
-    addScreen<ClientNavRoute.CreatePaymentAccount> { backStackEntry ->
+    addScreen<ClientNavRoute.CreatePaymentAccount>(animationsEnabled = animationsEnabled) { backStackEntry ->
         val route: ClientNavRoute.CreatePaymentAccount = backStackEntry.toRoute()
         val accountType = runCatching { PaymentAccountType.valueOf(route.accountTypeName) }.getOrNull()
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/top_bar/ClientTopBarPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/top_bar/ClientTopBarPresenter.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 
@@ -18,11 +19,13 @@ class ClientTopBarPresenter(
     userProfileServiceFacade: UserProfileServiceFacade,
     settingsServiceFacade: SettingsServiceFacade,
     connectivityService: ConnectivityService,
+    animationSettings: AnimationSettings,
     mainPresenter: MainPresenter,
 ) : TopBarPresenter(
         userProfileServiceFacade,
         settingsServiceFacade,
         connectivityService,
+        animationSettings,
         mainPresenter,
     ) {
     private val mappedConnectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus> =

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.presentation.common.platform_settings.PlatformSetting
 import network.bisq.mobile.presentation.common.platform_settings.PlatformSettingsManagerImpl
 import network.bisq.mobile.presentation.common.share.AndroidShareFileService
 import network.bisq.mobile.presentation.common.share.ShareFileService
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPresenter
 import network.bisq.mobile.presentation.main.AppPresenter
@@ -31,7 +32,10 @@ val androidNodePresentationModule =
     module {
         single<ShareFileService> { AndroidShareFileService(androidContext()) }
 
-        factory<SettingsPresenter> { NodeSettingsPresenter(get(), get(), get(), get(), get()) }
+        // Node embeds the full bisq2 stack, so the low-RAM animation lock applies here
+        single { AnimationSettings(get(), get(), applyDeviceLock = true) }
+
+        factory<SettingsPresenter> { NodeSettingsPresenter(get(), get(), get(), get(), get(), get()) }
 
         factory {
             NodeOnboardingPresenter(
@@ -55,7 +59,7 @@ val androidNodePresentationModule =
             )
         }
 
-        factory<TopBarPresenter> { TopBarPresenter(get(), get(), get(), get()) } bind ITopBarPresenter::class
+        factory<TopBarPresenter> { TopBarPresenter(get(), get(), get(), get(), get()) } bind ITopBarPresenter::class
 
         factory<MiscItemsPresenter> { NodeMiscItemsPresenter(get(), get()) }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/presentation/NodeNavGraph.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/presentation/NodeNavGraph.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import network.bisq.mobile.node.settings.backup.presentation.BackupScreen
 import network.bisq.mobile.node.startup.splash.NodeSplashScreen
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.graph.addCommonAppRoutes
 import network.bisq.mobile.presentation.common.ui.navigation.graph.addScreen
@@ -23,14 +24,16 @@ fun NodeNavGraph(
     modifier: Modifier = Modifier,
 ) {
     val navigationManager: NavigationManager = koinInject()
+    val animationSettings: AnimationSettings = koinInject()
+    val animationsEnabled: () -> Boolean = { animationSettings.enabled.value }
 
     NavHost(
         modifier = modifier.background(color = BisqTheme.colors.backgroundColor),
         navController = rootNavController,
         startDestination = NavRoute.Splash(),
     ) {
-        addCommonAppRoutes()
-        addNodeAppRoutes()
+        addCommonAppRoutes(animationsEnabled)
+        addNodeAppRoutes(animationsEnabled)
     }
 
     DisposableEffect(rootNavController) {
@@ -41,9 +44,9 @@ fun NodeNavGraph(
     }
 }
 
-fun NavGraphBuilder.addNodeAppRoutes() {
+fun NavGraphBuilder.addNodeAppRoutes(animationsEnabled: () -> Boolean) {
     composable<NavRoute.Splash> {
         NodeSplashScreen()
     }
-    addScreen<NavRoute.BackupAndRestore> { BackupScreen() }
+    addScreen<NavRoute.BackupAndRestore>(animationsEnabled = animationsEnabled) { BackupScreen() }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/settings/settings/NodeSettingsPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/settings/settings/NodeSettingsPresenter.kt
@@ -4,6 +4,7 @@ import network.bisq.mobile.data.service.common.LanguageServiceFacade
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.repository.SettingsRepository
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.settings.settings.SettingsPresenter
 
@@ -12,12 +13,14 @@ class NodeSettingsPresenter(
     languageServiceFacade: LanguageServiceFacade,
     pushNotificationServiceFacade: PushNotificationServiceFacade,
     settingsRepository: SettingsRepository,
+    animationSettings: AnimationSettings,
     mainPresenter: MainPresenter,
 ) : SettingsPresenter(
         settingsServiceFacade,
         languageServiceFacade,
         pushNotificationServiceFacade,
         settingsRepository,
+        animationSettings,
         mainPresenter,
     ) {
     override val shouldShowPoWAdjustmentFactor: Boolean

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/AndroidDeviceInfoProvider.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/AndroidDeviceInfoProvider.kt
@@ -19,6 +19,14 @@ class AndroidDeviceInfoProvider(
     private val appMemInfo: Debug.MemoryInfo = Debug.MemoryInfo()
     private val runtime = Runtime.getRuntime()
 
+    override fun getTotalRamBytes(): Long =
+        (context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager)
+            ?.let { activityManager ->
+                val memInfo = ActivityManager.MemoryInfo()
+                activityManager.getMemoryInfo(memInfo)
+                memInfo.totalMem
+            } ?: 0L
+
     override fun getDeviceInfo(): String {
         // Memory info
         val na = "data.na".i18n()

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/AndroidDeviceInfoProviderTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/AndroidDeviceInfoProviderTest.kt
@@ -1,0 +1,18 @@
+package network.bisq.mobile.domain.utils
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidDeviceInfoProviderTest {
+    @Test
+    fun `getTotalRamBytes reads a non-negative value from ActivityManager`() {
+        val provider = AndroidDeviceInfoProvider(RuntimeEnvironment.getApplication())
+        // Exercises the ActivityManager.getMemoryInfo path; the exact value is environment-dependent,
+        // the invariant is that it returns a sane (non-negative) byte count without throwing.
+        assertTrue(provider.getTotalRamBytes() >= 0L)
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProvider.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProvider.kt
@@ -2,4 +2,27 @@ package network.bisq.mobile.domain.utils
 
 interface DeviceInfoProvider {
     fun getDeviceInfo(): String
+
+    /**
+     * Total physical RAM in bytes as reported by the OS. This is always LESS than the nominal
+     * capacity because the kernel/firmware reserve a slice, so a "3GB" phone reports ~2.7–2.9 GiB
+     * and a "4GB" phone reports ~3.6–3.8 GiB. Returns 0 when it cannot be determined.
+     */
+    fun getTotalRamBytes(): Long
+
+    /**
+     * True when the device is at/under the low-spec RAM ceiling where heavy Compose navigation
+     * transitions cause heap pressure / ANRs on the offerbook, so animations are
+     * force-disabled. The [LOW_SPEC_RAM_THRESHOLD_BYTES] sits between a nominal-3GB device's
+     * reported total and a nominal-4GB device's, so "3GB or less" is caught and 4GB+ is left alone.
+     * Unknown RAM (0) is treated as NOT low-spec — we don't disable animations on a device we
+     * simply couldn't measure.
+     */
+    fun isLowSpecDevice(): Boolean = getTotalRamBytes() in 1 until LOW_SPEC_RAM_THRESHOLD_BYTES
+
+    companion object {
+        // ~3.2 GiB. Above a nominal-3GB device's reported RAM (~2.8 GiB), below a nominal-4GB
+        // device's (~3.7 GiB). Used to force animations off at 3GB or less.
+        const val LOW_SPEC_RAM_THRESHOLD_BYTES = 3_435_973_837L
+    }
 }

--- a/shared/domain/src/commonMain/resources/mobile/settings.properties
+++ b/shared/domain/src/commonMain/resources/mobile/settings.properties
@@ -29,6 +29,7 @@ settings.notification.clearNotifications=Clear notifications
 
 settings.display.headline=Display settings
 settings.display.useAnimations=Use animations
+settings.display.useAnimations.lockedByDevice=Animations are turned off on low-memory devices to keep Bisq running smoothly
 settings.display.preventStandbyMode=Prevent standby mode
 settings.display.resetDontShowAgain=Reset all 'Don't show again' flags
 

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProviderTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProviderTest.kt
@@ -1,0 +1,42 @@
+package network.bisq.mobile.domain.utils
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DeviceInfoProviderTest {
+    private fun providerWithRam(bytes: Long): DeviceInfoProvider =
+        object : DeviceInfoProvider {
+            override fun getDeviceInfo(): String = ""
+
+            override fun getTotalRamBytes(): Long = bytes
+        }
+
+    @Test
+    fun `nominal 3GB device reports low-spec`() {
+        // A "3GB" device reports ~2.7-2.9 GiB total (kernel reserve).
+        assertTrue(providerWithRam(2_900_000_000L).isLowSpecDevice())
+    }
+
+    @Test
+    fun `nominal 4GB device is not low-spec`() {
+        // A "4GB" device reports ~3.6-3.8 GiB, above the ~3.2 GiB threshold.
+        assertFalse(providerWithRam(3_972_844_748L).isLowSpecDevice())
+    }
+
+    @Test
+    fun `at the threshold is not low-spec`() {
+        assertFalse(providerWithRam(DeviceInfoProvider.LOW_SPEC_RAM_THRESHOLD_BYTES).isLowSpecDevice())
+    }
+
+    @Test
+    fun `just below the threshold is low-spec`() {
+        assertTrue(providerWithRam(DeviceInfoProvider.LOW_SPEC_RAM_THRESHOLD_BYTES - 1).isLowSpecDevice())
+    }
+
+    @Test
+    fun `unknown ram (zero) is not low-spec`() {
+        // We don't disable animations on a device we couldn't measure.
+        assertFalse(providerWithRam(0L).isLowSpecDevice())
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProviderTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DeviceInfoProviderTest.kt
@@ -35,7 +35,7 @@ class DeviceInfoProviderTest {
     }
 
     @Test
-    fun `unknown ram (zero) is not low-spec`() {
+    fun `unknown ram of zero is not low-spec`() {
         // We don't disable animations on a device we couldn't measure.
         assertFalse(providerWithRam(0L).isLowSpecDevice())
     }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/utils/IosDeviceInfoProvider.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/domain/utils/IosDeviceInfoProvider.kt
@@ -5,6 +5,7 @@ import network.bisq.mobile.i18n.i18n
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
 import platform.Foundation.NSNumber
+import platform.Foundation.NSProcessInfo
 import platform.UIKit.UIDevice
 import kotlin.math.pow
 import kotlin.math.round
@@ -12,6 +13,8 @@ import kotlin.math.round
 class IosDeviceInfoProvider :
     DeviceInfoProvider,
     Logging {
+    override fun getTotalRamBytes(): Long = NSProcessInfo.processInfo.physicalMemory.toLong()
+
     @OptIn(ExperimentalForeignApi::class)
     override fun getDeviceInfo(): String {
         val na = "N/A"

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
@@ -263,6 +263,7 @@ class ScreenAnalyticsCoverageTest {
                 languageServiceFacade = mockk(relaxed = true),
                 pushNotificationServiceFacade = mockk(relaxed = true),
                 settingsRepository = mockk(relaxed = true),
+                animationSettings = mockk(relaxed = true),
                 mainPresenter = mainPresenter,
             )
         assertEquals(AnalyticsEvent.ScreenOpened.Settings, presenter.analyticsScreenEvent())

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettingsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettingsTest.kt
@@ -1,0 +1,53 @@
+package network.bisq.mobile.presentation.common.ui.animation
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AnimationSettingsTest {
+    private fun settings(useAnimations: Boolean): SettingsServiceFacade =
+        mockk(relaxed = true) {
+            every { this@mockk.useAnimations } returns MutableStateFlow(useAnimations)
+        }
+
+    private fun device(ramBytes: Long): DeviceInfoProvider =
+        object : DeviceInfoProvider {
+            override fun getDeviceInfo(): String = ""
+
+            override fun getTotalRamBytes(): Long = ramBytes
+        }
+
+    // 3GB device reports ~2.8 GiB; 4GB device reports ~3.7 GiB.
+    private val lowSpecRam = 2_900_000_000L
+    private val capableRam = 3_972_844_748L
+
+    @Test
+    fun `no device lock - enabled follows the user setting (Connect behaviour)`() {
+        val onCapable = AnimationSettings(settings(true), device(lowSpecRam), applyDeviceLock = false)
+        assertFalse(onCapable.lockedByDevice)
+        assertTrue(onCapable.enabled.value)
+
+        val off = AnimationSettings(settings(false), device(lowSpecRam), applyDeviceLock = false)
+        assertFalse(off.lockedByDevice)
+        assertFalse(off.enabled.value)
+    }
+
+    @Test
+    fun `device lock on but capable device - not locked, follows setting`() {
+        val subject = AnimationSettings(settings(true), device(capableRam), applyDeviceLock = true)
+        assertFalse(subject.lockedByDevice)
+        assertTrue(subject.enabled.value)
+    }
+
+    @Test
+    fun `device lock on and low-spec device - forced off even when user setting is on`() {
+        val subject = AnimationSettings(settings(true), device(lowSpecRam), applyDeviceLock = true)
+        assertTrue(subject.lockedByDevice)
+        assertFalse(subject.enabled.value)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/SwitchUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/SwitchUiTest.kt
@@ -1,0 +1,129 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI tests for [BisqSwitch], focused on the disabled-tap routing added for the greyed
+ * animations toggle: a disabled switch should route taps (both on the label and on the
+ * greyed switch itself) to [BisqSwitch.onDisabledTap] rather than silently swallowing them.
+ */
+@RunWith(AndroidJUnit4::class)
+class SwitchUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val label = "Use animations"
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            BisqTheme {
+                content()
+            }
+        }
+    }
+
+    @Test
+    fun `when enabled and switch tapped then toggles`() {
+        val onSwitch = mockk<(Boolean) -> Unit>(relaxed = true)
+        val onDisabledTap = mockk<() -> Unit>(relaxed = true)
+
+        setContent {
+            BisqSwitch(
+                checked = false,
+                label = label,
+                disabled = false,
+                onSwitch = onSwitch,
+                onDisabledTap = onDisabledTap,
+            )
+        }
+
+        composeTestRule.onNode(isToggleable()).performClick()
+
+        verify { onSwitch(true) }
+        verify(exactly = 0) { onDisabledTap() }
+    }
+
+    @Test
+    fun `when disabled and switch itself tapped then routes to onDisabledTap not onSwitch`() {
+        val onSwitch = mockk<(Boolean) -> Unit>(relaxed = true)
+        val onDisabledTap = mockk<() -> Unit>(relaxed = true)
+
+        setContent {
+            BisqSwitch(
+                checked = false,
+                label = label,
+                disabled = true,
+                onSwitch = onSwitch,
+                onDisabledTap = onDisabledTap,
+            )
+        }
+
+        // Tap the greyed Switch region (right edge of the row, not the label). When disabled the
+        // Switch installs no toggleable modifier, so the tap must fall through to the row handler
+        // rather than hitting a dead target.
+        composeTestRule.onNode(hasClickAction()).performTouchInput { click(centerRight) }
+
+        verify { onDisabledTap() }
+        verify(exactly = 0) { onSwitch(any()) }
+    }
+
+    @Test
+    fun `when disabled and label tapped then routes to onDisabledTap`() {
+        val onSwitch = mockk<(Boolean) -> Unit>(relaxed = true)
+        val onDisabledTap = mockk<() -> Unit>(relaxed = true)
+
+        setContent {
+            BisqSwitch(
+                checked = false,
+                label = label,
+                disabled = true,
+                onSwitch = onSwitch,
+                onDisabledTap = onDisabledTap,
+            )
+        }
+
+        composeTestRule.onNodeWithText(label).performClick()
+
+        verify { onDisabledTap() }
+        verify(exactly = 0) { onSwitch(any()) }
+    }
+
+    @Test
+    fun `when disabled without handler then tap is inert`() {
+        val onSwitch = mockk<(Boolean) -> Unit>(relaxed = true)
+
+        setContent {
+            BisqSwitch(
+                checked = false,
+                label = label,
+                disabled = true,
+                onSwitch = onSwitch,
+            )
+        }
+
+        composeTestRule.onNodeWithText(label).performClick()
+
+        verify(exactly = 0) { onSwitch(any()) }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenterTest.kt
@@ -1,0 +1,96 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TopBarPresenterTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+        every { getScreenWidthDp() } returns 480
+        startKoin {
+            modules(
+                module {
+                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
+                    single<NavigationManager> { NoopNavigationManager() }
+                    single { GlobalUiManager(testDispatcher) }
+                },
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+    private fun device(ramBytes: Long): DeviceInfoProvider =
+        object : DeviceInfoProvider {
+            override fun getDeviceInfo(): String = ""
+
+            override fun getTotalRamBytes(): Long = ramBytes
+        }
+
+    private fun animationSettings(
+        userSetting: Boolean,
+        applyDeviceLock: Boolean,
+        ramBytes: Long,
+    ): AnimationSettings {
+        val settings = mockk<SettingsServiceFacade>(relaxed = true)
+        every { settings.useAnimations } returns MutableStateFlow(userSetting)
+        return AnimationSettings(settings, device(ramBytes), applyDeviceLock)
+    }
+
+    private fun presenter(animationSettings: AnimationSettings): TopBarPresenter =
+        TopBarPresenter(
+            userProfileServiceFacade = mockk(relaxed = true),
+            settingsServiceFacade = mockk(relaxed = true),
+            connectivityService = mockk(relaxed = true),
+            animationSettings = animationSettings,
+            mainPresenter = MainPresenterTestFactory.create(),
+        )
+
+    // 3GB device reports ~2.8 GiB (low-spec).
+    private val lowSpecRam = 2_900_000_000L
+
+    @Test
+    fun `showAnimation follows the user setting when device is not locked`() {
+        assertTrue(presenter(animationSettings(userSetting = true, applyDeviceLock = false, ramBytes = lowSpecRam)).showAnimation.value)
+    }
+
+    @Test
+    fun `showAnimation is forced off on a low-spec locked device`() {
+        // User setting is ON but the node-side device lock forces the avatar animation off.
+        assertFalse(presenter(animationSettings(userSetting = true, applyDeviceLock = true, ramBytes = lowSpecRam)).showAnimation.value)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsContentUiTest.kt
@@ -283,6 +283,81 @@ class SettingsContentUiTest {
         verify { mockOnAction(SettingsUiAction.OnCloseOfferWhenTradeTakenChange(true)) }
     }
 
+    // ========== Animations Toggle Tests ==========
+
+    @Test
+    fun `when animations toggle is enabled and tapped then triggers OnUseAnimationsChange action`() {
+        // Given the toggle is interactive and currently off
+        val uiState =
+            SettingsUiState(
+                i18nPairs = i18nPairs,
+                languageCode = "en",
+                supportedLanguageCodes = setOf("en"),
+                closeOfferWhenTradeTaken = true,
+                tradePriceTolerance = DataEntry(value = "5"),
+                useAnimations = false,
+                numDaysAfterRedactingTradeData = DataEntry(value = "90"),
+                powFactor = DataEntry(value = "1"),
+                isFetchingSettings = false,
+            )
+
+        setTestContent {
+            SettingsContent(
+                uiState = uiState,
+                onAction = mockOnAction,
+                isUseAnimationsChangeEnabled = true,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        // When the user taps the toggle label
+        composeTestRule
+            .onNodeWithText("settings.display.useAnimations".i18n())
+            .performScrollTo()
+            .performClick()
+
+        // Then it toggles the setting on
+        verify { mockOnAction(SettingsUiAction.OnUseAnimationsChange(true)) }
+    }
+
+    @Test
+    fun `when animations toggle is device-locked and tapped then explains instead of toggling`() {
+        // Given a low-spec device where the toggle is greyed out
+        val uiState =
+            SettingsUiState(
+                i18nPairs = i18nPairs,
+                languageCode = "en",
+                supportedLanguageCodes = setOf("en"),
+                closeOfferWhenTradeTaken = true,
+                tradePriceTolerance = DataEntry(value = "5"),
+                useAnimations = false,
+                numDaysAfterRedactingTradeData = DataEntry(value = "90"),
+                powFactor = DataEntry(value = "1"),
+                isFetchingSettings = false,
+            )
+
+        setTestContent {
+            SettingsContent(
+                uiState = uiState,
+                onAction = mockOnAction,
+                isUseAnimationsChangeEnabled = false,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        // When the user taps the greyed toggle label
+        composeTestRule
+            .onNodeWithText("settings.display.useAnimations".i18n())
+            .performScrollTo()
+            .performClick()
+
+        // Then an explanation is surfaced and the setting is NOT changed
+        verify { mockOnAction(SettingsUiAction.OnUseAnimationsLockedTap) }
+        verify(exactly = 0) { mockOnAction(ofType<SettingsUiAction.OnUseAnimationsChange>()) }
+    }
+
     // ========== Trade Price Tolerance Tests ==========
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
@@ -35,7 +35,9 @@ import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
@@ -140,14 +142,61 @@ class SettingsPresenterTest {
         }
     }
 
-    private fun createPresenter(): SettingsPresenter =
+    // Capable device by default: no device lock, so animations follow the user setting (this is
+    // also the Connect app's behaviour). Pass a locked instance to exercise the low-spec path.
+    private fun capableAnimationSettings(): AnimationSettings = AnimationSettings(settingsServiceFacade, mockk(relaxed = true), applyDeviceLock = false)
+
+    private fun lockedAnimationSettings(): AnimationSettings {
+        val lowSpecDevice =
+            object : DeviceInfoProvider {
+                override fun getDeviceInfo(): String = ""
+
+                // 3GB device reports ~2.8 GiB, below the low-spec threshold.
+                override fun getTotalRamBytes(): Long = 2_900_000_000L
+            }
+        return AnimationSettings(settingsServiceFacade, lowSpecDevice, applyDeviceLock = true)
+    }
+
+    private fun createPresenter(animationSettings: AnimationSettings = capableAnimationSettings()): SettingsPresenter =
         SettingsPresenter(
             settingsServiceFacade,
             languageServiceFacade,
             pushNotificationServiceFacade,
             settingsRepository,
+            animationSettings,
             mainPresenter,
         )
+
+    @Test
+    fun `when device is low-spec then animations are forced off and toggle is disabled`() =
+        runTest(testDispatcher) {
+            // Given a low-spec (node) device and a stored setting of useAnimations = true
+            coEvery { settingsServiceFacade.getSettings() } returns
+                Result.success(sampleSettings.copy(useAnimations = true))
+
+            // When
+            presenter = createPresenter(lockedAnimationSettings())
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then the toggle is greyed and shown off despite the stored setting being on.
+            assertFalse(presenter.isUseAnimationsChangeEnabled.value)
+            assertFalse(presenter.uiState.value.useAnimations)
+        }
+
+    @Test
+    fun `when device is capable then animations toggle follows stored setting`() =
+        runTest(testDispatcher) {
+            coEvery { settingsServiceFacade.getSettings() } returns
+                Result.success(sampleSettings.copy(useAnimations = true))
+
+            presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            assertTrue(presenter.isUseAnimationsChangeEnabled.value)
+            assertTrue(presenter.uiState.value.useAnimations)
+        }
 
     @Test
     fun `when initial state then has correct default values`() =

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenterTest.kt
@@ -199,6 +199,31 @@ class SettingsPresenterTest {
         }
 
     @Test
+    fun `when locked animations toggle is tapped then shows explanation snackbar`() =
+        runTest(testDispatcher) {
+            // Given a low-spec device where the toggle is greyed out
+            coEvery { settingsServiceFacade.getSettings() } returns Result.success(sampleSettings)
+            presenter = createPresenter(lockedAnimationSettings())
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // When the user taps the disabled toggle
+            presenter.onAction(SettingsUiAction.OnUseAnimationsLockedTap)
+            advanceUntilIdle()
+
+            // Then an explanation is surfaced and the setting is left untouched
+            coVerify {
+                globalUiManager.showSnackbar(
+                    "settings.display.useAnimations.lockedByDevice".i18n(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
+            coVerify(exactly = 0) { settingsServiceFacade.setUseAnimations(any()) }
+        }
+
+    @Test
     fun `when initial state then has correct default values`() =
         runTest(testDispatcher) {
             // Given

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
@@ -19,6 +19,7 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
@@ -77,7 +78,14 @@ class TabContainerPresenterDuplicateCallTest {
             createOfferCoordinator,
             settingsServiceFacade,
             tradeRestrictingAlertServiceFacade,
+            AnimationSettings(settingsServiceFacade, mockk(relaxed = true), applyDeviceLock = false),
         )
+    }
+
+    @Test
+    fun `showAnimation reflects the effective animations flag`() {
+        // buildPresenter wires useAnimations = true with no device lock, so the avatar animation is on.
+        assertTrue(buildPresenter().showAnimation.value)
     }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
@@ -23,6 +23,7 @@ import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFacto
 import network.bisq.mobile.presentation.common.test_utils.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
@@ -97,6 +98,7 @@ class TabContainerPresenterTradeRestrictionTest {
             createOfferCoordinator = createOfferCoordinator,
             settingsServiceFacade = settingsServiceFacade,
             tradeRestrictingAlertServiceFacade = tradeRestrictingAlertServiceFacade,
+            animationSettings = AnimationSettings(settingsServiceFacade, mockk(relaxed = true), applyDeviceLock = false),
         )
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -89,7 +89,7 @@ val presentationModule =
             )
         } bind IAgreementPresenter::class
 
-        factory { TabContainerPresenter(get(), get(), get(), get()) } bind ITabContainerPresenter::class
+        factory { TabContainerPresenter(get(), get(), get(), get(), get()) } bind ITabContainerPresenter::class
 
         factory<ReputationPresenter> { ReputationPresenter(get(), get()) }
 
@@ -136,7 +136,7 @@ val presentationModule =
             )
         }
 
-        factory { SettingsPresenter(get(), get(), get(), get(), get()) }
+        factory { SettingsPresenter(get(), get(), get(), get(), get(), get()) }
 
         factory { IgnoredUsersPresenter(get(), get()) } bind IIgnoredUsersPresenter::class
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettings.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettings.kt
@@ -1,0 +1,40 @@
+package network.bisq.mobile.presentation.common.ui.animation
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+
+/**
+ * Single source of truth for whether UI animations are *effectively* enabled.
+ *
+ * effective = the user's `useAnimations` setting AND the device is not low-spec.
+ *
+ * On low-spec devices ([DeviceInfoProvider.isLowSpecDevice], ~3GB RAM or less) heavy Compose
+ * navigation transitions cause heap pressure / ANRs on the offerbook, so animations
+ * are force-disabled and the settings toggle is greyed out. This is an EFFECTIVE override: the
+ * user's stored preference is left untouched, so it takes effect again if the app ever runs on a
+ * capable device — we never mutate persisted settings here.
+ *
+ * The device lock only applies to the Node app ([applyDeviceLock] = true). Bisq Connect is a
+ * lightweight client with no embedded node, so it has no such heap pressure — there animations
+ * always follow the user setting only ([applyDeviceLock] = false).
+ *
+ * Read [enabled] everywhere an animation should honour the setting, instead of
+ * `settingsServiceFacade.useAnimations` directly.
+ */
+class AnimationSettings(
+    settingsServiceFacade: SettingsServiceFacade,
+    deviceInfoProvider: DeviceInfoProvider,
+    applyDeviceLock: Boolean,
+) {
+    /** True when the device forces animations off regardless of the user setting (toggle greyed). */
+    val lockedByDevice: Boolean = applyDeviceLock && deviceInfoProvider.isLowSpecDevice()
+
+    // Constant "off" flow used when the device lock is active. No coroutine/scope needed: when not
+    // locked we simply pass the user setting through unchanged.
+    private val forcedOff = MutableStateFlow(false)
+
+    val enabled: StateFlow<Boolean> =
+        if (lockedByDevice) forcedOff else settingsServiceFacade.useAnimations
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettings.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/animation/AnimationSettings.kt
@@ -37,4 +37,13 @@ class AnimationSettings(
 
     val enabled: StateFlow<Boolean> =
         if (lockedByDevice) forcedOff else settingsServiceFacade.useAnimations
+
+    /**
+     * The effective animations-enabled value for a given stored [useAnimations] preference.
+     *
+     * Single source of truth for the "user setting AND not device-locked" rule, matching what
+     * [enabled] exposes. Use this when computing effective state from a freshly-read preference
+     * (e.g. a settings screen) instead of re-deriving `useAnimations && !lockedByDevice` inline.
+     */
+    fun isEffectivelyEnabled(useAnimations: Boolean): Boolean = useAnimations && !lockedByDevice
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Switch.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Switch.kt
@@ -29,7 +29,21 @@ fun BisqSwitch(
     onDisabledTap: (() -> Unit)? = null,
 ) {
     Row(
-        modifier = modifier,
+        modifier =
+            modifier.then(
+                // When disabled, route taps anywhere in the row (label AND the greyed Switch area)
+                // to the explanation handler, so the whole control can explain why it can't be
+                // changed rather than only the label. No-op when enabled or when no handler is given.
+                if (disabled && onDisabledTap != null) {
+                    Modifier.clickable(
+                        onClick = onDisabledTap,
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    )
+                } else {
+                    Modifier
+                },
+            ),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -39,26 +53,27 @@ fun BisqSwitch(
                 Modifier
                     .padding(end = BisqUIConstants.ScreenPadding)
                     .weight(1f)
-                    // When disabled, the label stays tappable only if a disabled-tap handler is
-                    // provided, so a greyed toggle can explain why it can't be changed. The Switch
-                    // itself remains non-interactive (greyed) regardless.
-                    .clickable(
-                        enabled = !disabled || onDisabledTap != null,
-                        onClick = {
-                            if (disabled) {
-                                onDisabledTap?.invoke()
-                            } else {
-                                onSwitch?.invoke(!checked)
-                            }
+                    // Only the enabled label toggles. When disabled we must NOT install a (disabled)
+                    // clickable — a disabled clickable still consumes the tap, stopping it from
+                    // reaching the row-level onDisabledTap handler above.
+                    .then(
+                        if (disabled) {
+                            Modifier
+                        } else {
+                            Modifier.clickable(
+                                onClick = { onSwitch?.invoke(!checked) },
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                            )
                         },
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
                     ),
         )
 
         Switch(
             checked = checked,
-            onCheckedChange = onSwitch,
+            // Null when disabled so Material doesn't install its toggleable modifier — otherwise the
+            // greyed switch consumes taps instead of letting them reach the row's onDisabledTap.
+            onCheckedChange = if (disabled) null else onSwitch,
             enabled = !disabled,
             colors =
                 SwitchColors(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Switch.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Switch.kt
@@ -26,6 +26,7 @@ fun BisqSwitch(
     label: String = "",
     disabled: Boolean = false,
     onSwitch: ((Boolean) -> Unit)? = null,
+    onDisabledTap: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier,
@@ -38,11 +39,16 @@ fun BisqSwitch(
                 Modifier
                     .padding(end = BisqUIConstants.ScreenPadding)
                     .weight(1f)
+                    // When disabled, the label stays tappable only if a disabled-tap handler is
+                    // provided, so a greyed toggle can explain why it can't be changed. The Switch
+                    // itself remains non-interactive (greyed) regardless.
                     .clickable(
-                        enabled = !disabled,
+                        enabled = !disabled || onDisabledTap != null,
                         onClick = {
-                            if (onSwitch != null) {
-                                onSwitch(!checked)
+                            if (disabled) {
+                                onDisabledTap?.invoke()
+                            } else {
+                                onSwitch?.invoke(!checked)
                             }
                         },
                         interactionSource = remember { MutableInteractionSource() },

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenter.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.TabNavRoute
@@ -15,13 +16,15 @@ open class TopBarPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val settingsServiceFacade: SettingsServiceFacade,
     protected val connectivityService: ConnectivityService,
+    private val animationSettings: AnimationSettings,
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter),
     ITopBarPresenter {
     override val userProfile: StateFlow<UserProfileVO?> get() = userProfileServiceFacade.selectedUserProfile
     override val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 
-    override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
+    // Effective flag (user setting AND device not low-spec) so the avatar honours the device lock. #1293
+    override val showAnimation: StateFlow<Boolean> get() = animationSettings.enabled
 
     override val connectivityStatus: StateFlow<ConnectivityService.ConnectivityStatus>
         get() = connectivityService.status

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/offer/TakeOfferProgressDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/offer/TakeOfferProgressDialog.kt
@@ -5,28 +5,46 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.bisq_easy
 import bisqapps.shared.presentation.generated.resources.bisq_easy_circle
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.image.RotatingImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.BisqDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import org.jetbrains.compose.resources.painterResource
+import org.koin.compose.koinInject
 
+@ExcludeFromCoverage // Compose dialog; the animation gating is covered via AnimationSettings unit tests
 @Composable
 fun TakeOfferProgressDialog() {
+    val animationSettings: AnimationSettings = koinInject()
+    val animationsEnabled by animationSettings.enabled.collectAsState()
     BisqDialog(dismissOnClickOutside = false) {
         val imageSize = BisqUIConstants.ScreenPadding8X
         Box {
-            RotatingImage(
-                painterResource(Res.drawable.bisq_easy_circle),
-                modifier = Modifier.size(imageSize),
-            )
+            // The spinning ring is an infinite animation; on low-spec devices / animations-off we
+            // render it static to avoid continuous recomposition.
+            if (animationsEnabled) {
+                RotatingImage(
+                    painterResource(Res.drawable.bisq_easy_circle),
+                    modifier = Modifier.size(imageSize),
+                )
+            } else {
+                Image(
+                    painterResource(Res.drawable.bisq_easy_circle),
+                    contentDescription = null,
+                    modifier = Modifier.size(imageSize),
+                )
+            }
             Image(
                 painterResource(Res.drawable.bisq_easy),
                 contentDescription = null,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.presentation.common.ui.navigation.graph
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -15,6 +17,7 @@ import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.NavUtils.getDeepLinkBasePath
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideOverview
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideProcess
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideSecurity
@@ -55,15 +58,17 @@ import kotlin.reflect.KType
 
 const val NAV_ANIM_MS = 300
 
-fun NavGraphBuilder.addCommonAppRoutes() {
-    addScreen<NavRoute.UserAgreement> { UserAgreementScreen() }
-    addScreen<NavRoute.Onboarding> { OnboardingScreen() }
-    addScreen<NavRoute.CreateProfile> { backStackEntry ->
+@ExcludeFromCoverage // declarative nav wiring (like the DI modules); not unit-testable in isolation
+fun NavGraphBuilder.addCommonAppRoutes(animationsEnabled: () -> Boolean) {
+    addScreen<NavRoute.UserAgreement>(animationsEnabled = animationsEnabled) { UserAgreementScreen() }
+    addScreen<NavRoute.Onboarding>(animationsEnabled = animationsEnabled) { OnboardingScreen() }
+    addScreen<NavRoute.CreateProfile>(animationsEnabled = animationsEnabled) { backStackEntry ->
         val route: NavRoute.CreateProfile = backStackEntry.toRoute()
         CreateProfileScreen(route.isOnboarding)
     }
 
     addScreen<NavRoute.TabContainer>(
+        animationsEnabled = animationsEnabled,
         deepLinks =
             listOf(
                 navDeepLink<NavRoute.TabContainer>(
@@ -73,6 +78,7 @@ fun NavGraphBuilder.addCommonAppRoutes() {
     ) { TabContainerScreen() }
 
     addScreen<NavRoute.OpenTrade>(
+        animationsEnabled = animationsEnabled,
         deepLinks =
             listOf(
                 navDeepLink<NavRoute.OpenTrade>(
@@ -86,6 +92,7 @@ fun NavGraphBuilder.addCommonAppRoutes() {
 
     addScreen<NavRoute.TradeChat>(
         navAnimation = NavAnimation.FADE_IN,
+        animationsEnabled = animationsEnabled,
         deepLinks =
             listOf(
                 navDeepLink<NavRoute.TradeChat>(
@@ -98,44 +105,44 @@ fun NavGraphBuilder.addCommonAppRoutes() {
     }
 
     // --- Other Screens ---
-    addScreen<NavRoute.Offerbook> { OfferbookScreen() }
-    addScreen<NavRoute.ChatRules> { ChatRulesScreen() }
-    addScreen<NavRoute.Settings> { SettingsScreen() }
-    addScreen<NavRoute.Support> { SupportScreen() }
-    addScreen<NavRoute.Faqs> { FaqScreen() }
-    addScreen<NavRoute.Reputation> { ReputationScreen() }
-    addScreen<NavRoute.UserProfile> { UserProfileScreen() }
-    addScreen<NavRoute.PaymentAccounts> { PaymentAccountsScreen() }
-    addScreen<NavRoute.IgnoredUsers> { IgnoredUsersScreen() }
-    addScreen<NavRoute.Resources> { ResourcesScreen() }
-    addScreen<NavRoute.UserAgreementDisplay> { UserAgreementDisplayScreen() }
+    addScreen<NavRoute.Offerbook>(animationsEnabled = animationsEnabled) { OfferbookScreen() }
+    addScreen<NavRoute.ChatRules>(animationsEnabled = animationsEnabled) { ChatRulesScreen() }
+    addScreen<NavRoute.Settings>(animationsEnabled = animationsEnabled) { SettingsScreen() }
+    addScreen<NavRoute.Support>(animationsEnabled = animationsEnabled) { SupportScreen() }
+    addScreen<NavRoute.Faqs>(animationsEnabled = animationsEnabled) { FaqScreen() }
+    addScreen<NavRoute.Reputation>(animationsEnabled = animationsEnabled) { ReputationScreen() }
+    addScreen<NavRoute.UserProfile>(animationsEnabled = animationsEnabled) { UserProfileScreen() }
+    addScreen<NavRoute.PaymentAccounts>(animationsEnabled = animationsEnabled) { PaymentAccountsScreen() }
+    addScreen<NavRoute.IgnoredUsers>(animationsEnabled = animationsEnabled) { IgnoredUsersScreen() }
+    addScreen<NavRoute.Resources>(animationsEnabled = animationsEnabled) { ResourcesScreen() }
+    addScreen<NavRoute.UserAgreementDisplay>(animationsEnabled = animationsEnabled) { UserAgreementDisplayScreen() }
 
     // --- Take Offer Screens ---
-    addScreen<NavRoute.TakeOfferTradeAmount>(wizardTransition = false) { TakeOfferTradeAmountScreen() }
-    addScreen<NavRoute.TakeOfferPaymentMethod>(wizardTransition = true) { TakeOfferPaymentMethodScreen() }
-    addScreen<NavRoute.TakeOfferSettlementMethod>(wizardTransition = true) { TakeOfferSettlementMethodScreen() }
-    addScreen<NavRoute.TakeOfferReviewTrade>(wizardTransition = true) { TakeOfferReviewTradeScreen() }
+    addScreen<NavRoute.TakeOfferTradeAmount>(wizardTransition = false, animationsEnabled = animationsEnabled) { TakeOfferTradeAmountScreen() }
+    addScreen<NavRoute.TakeOfferPaymentMethod>(wizardTransition = true, animationsEnabled = animationsEnabled) { TakeOfferPaymentMethodScreen() }
+    addScreen<NavRoute.TakeOfferSettlementMethod>(wizardTransition = true, animationsEnabled = animationsEnabled) { TakeOfferSettlementMethodScreen() }
+    addScreen<NavRoute.TakeOfferReviewTrade>(wizardTransition = true, animationsEnabled = animationsEnabled) { TakeOfferReviewTradeScreen() }
 
     // --- Create Offer Screens ---
-    addScreen<NavRoute.CreateOfferDirection>(wizardTransition = false) { CreateOfferDirectionScreen() }
-    addScreen<NavRoute.CreateOfferMarket>(wizardTransition = true) { CreateOfferMarketScreen() }
-    addScreen<NavRoute.CreateOfferAmount>(wizardTransition = true) { CreateOfferAmountScreen() }
-    addScreen<NavRoute.CreateOfferPrice>(wizardTransition = true) { CreateOfferPriceScreen() }
-    addScreen<NavRoute.CreateOfferPaymentMethod>(wizardTransition = true) { CreateOfferPaymentMethodScreen() }
-    addScreen<NavRoute.CreateOfferSettlementMethod>(wizardTransition = true) { CreateOfferSettlementMethodScreen() }
-    addScreen<NavRoute.CreateOfferReviewOffer>(wizardTransition = true) { CreateOfferReviewOfferScreen() }
+    addScreen<NavRoute.CreateOfferDirection>(wizardTransition = false, animationsEnabled = animationsEnabled) { CreateOfferDirectionScreen() }
+    addScreen<NavRoute.CreateOfferMarket>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferMarketScreen() }
+    addScreen<NavRoute.CreateOfferAmount>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferAmountScreen() }
+    addScreen<NavRoute.CreateOfferPrice>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferPriceScreen() }
+    addScreen<NavRoute.CreateOfferPaymentMethod>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferPaymentMethodScreen() }
+    addScreen<NavRoute.CreateOfferSettlementMethod>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferSettlementMethodScreen() }
+    addScreen<NavRoute.CreateOfferReviewOffer>(wizardTransition = true, animationsEnabled = animationsEnabled) { CreateOfferReviewOfferScreen() }
 
     // --- Trade Guide Screens ---
-    addScreen<NavRoute.TradeGuideOverview>(wizardTransition = false) { TradeGuideOverview() }
-    addScreen<NavRoute.TradeGuideSecurity>(wizardTransition = true) { TradeGuideSecurity() }
-    addScreen<NavRoute.TradeGuideProcess>(wizardTransition = true) { TradeGuideProcess() }
-    addScreen<NavRoute.TradeGuideTradeRules>(wizardTransition = true) { TradeGuideTradeRules() }
+    addScreen<NavRoute.TradeGuideOverview>(wizardTransition = false, animationsEnabled = animationsEnabled) { TradeGuideOverview() }
+    addScreen<NavRoute.TradeGuideSecurity>(wizardTransition = true, animationsEnabled = animationsEnabled) { TradeGuideSecurity() }
+    addScreen<NavRoute.TradeGuideProcess>(wizardTransition = true, animationsEnabled = animationsEnabled) { TradeGuideProcess() }
+    addScreen<NavRoute.TradeGuideTradeRules>(wizardTransition = true, animationsEnabled = animationsEnabled) { TradeGuideTradeRules() }
 
     // --- Wallet Guide Screens ---
-    addScreen<NavRoute.WalletGuideIntro>(wizardTransition = false) { WalletGuideIntro() }
-    addScreen<NavRoute.WalletGuideDownload>(wizardTransition = true) { WalletGuideDownload() }
-    addScreen<NavRoute.WalletGuideNewWallet>(wizardTransition = true) { WalletGuideNewWallet() }
-    addScreen<NavRoute.WalletGuideReceiving>(wizardTransition = true) { WalletGuideReceiving() }
+    addScreen<NavRoute.WalletGuideIntro>(wizardTransition = false, animationsEnabled = animationsEnabled) { WalletGuideIntro() }
+    addScreen<NavRoute.WalletGuideDownload>(wizardTransition = true, animationsEnabled = animationsEnabled) { WalletGuideDownload() }
+    addScreen<NavRoute.WalletGuideNewWallet>(wizardTransition = true, animationsEnabled = animationsEnabled) { WalletGuideNewWallet() }
+    addScreen<NavRoute.WalletGuideReceiving>(wizardTransition = true, animationsEnabled = animationsEnabled) { WalletGuideReceiving() }
 }
 
 enum class NavAnimation {
@@ -144,11 +151,17 @@ enum class NavAnimation {
     SLIDE_IN_FROM_BOTTOM,
 }
 
+@ExcludeFromCoverage // Compose nav transition wiring; behaviour is exercised via the running app, not unit tests
 inline fun <reified T : NavRoute> NavGraphBuilder.addScreen(
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
     wizardTransition: Boolean = false,
     navAnimation: NavAnimation = if (wizardTransition) NavAnimation.FADE_IN else NavAnimation.SLIDE_IN_FROM_RIGHT,
+    // Gate for the "use animations" setting. Evaluated per-navigation, so it reflects
+    // the live effective value. When off, transitions are None: the destination swaps in instantly
+    // and only one screen is composed at a time — avoiding the double-composition heap spike that
+    // ANRs low-RAM devices on the offerbook. Defaults to enabled so any un-threaded caller is safe.
+    noinline animationsEnabled: () -> Boolean = { true },
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
     composable<T>(
@@ -156,20 +169,24 @@ inline fun <reified T : NavRoute> NavGraphBuilder.addScreen(
         deepLinks = deepLinks,
         // 'enter' animation for the 'destination' screen
         enterTransition = {
-            when (navAnimation) {
-                NavAnimation.SLIDE_IN_FROM_RIGHT ->
-                    slideIntoContainer(
-                        AnimatedContentTransitionScope.SlideDirection.Left,
-                        animationSpec = tween(NAV_ANIM_MS),
-                    )
+            if (!animationsEnabled()) {
+                EnterTransition.None
+            } else {
+                when (navAnimation) {
+                    NavAnimation.SLIDE_IN_FROM_RIGHT ->
+                        slideIntoContainer(
+                            AnimatedContentTransitionScope.SlideDirection.Left,
+                            animationSpec = tween(NAV_ANIM_MS),
+                        )
 
-                NavAnimation.SLIDE_IN_FROM_BOTTOM ->
-                    slideIntoContainer(
-                        AnimatedContentTransitionScope.SlideDirection.Up,
-                        animationSpec = tween(NAV_ANIM_MS),
-                    )
+                    NavAnimation.SLIDE_IN_FROM_BOTTOM ->
+                        slideIntoContainer(
+                            AnimatedContentTransitionScope.SlideDirection.Up,
+                            animationSpec = tween(NAV_ANIM_MS),
+                        )
 
-                NavAnimation.FADE_IN -> fadeIn(animationSpec = tween(NAV_ANIM_MS))
+                    NavAnimation.FADE_IN -> fadeIn(animationSpec = tween(NAV_ANIM_MS))
+                }
             }
         },
         exitTransition = {
@@ -181,20 +198,24 @@ inline fun <reified T : NavRoute> NavGraphBuilder.addScreen(
             null
         },
         popExitTransition = {
-            when (navAnimation) {
-                NavAnimation.SLIDE_IN_FROM_RIGHT ->
-                    slideOutOfContainer(
-                        AnimatedContentTransitionScope.SlideDirection.Right,
-                        animationSpec = tween(NAV_ANIM_MS),
-                    )
+            if (!animationsEnabled()) {
+                ExitTransition.None
+            } else {
+                when (navAnimation) {
+                    NavAnimation.SLIDE_IN_FROM_RIGHT ->
+                        slideOutOfContainer(
+                            AnimatedContentTransitionScope.SlideDirection.Right,
+                            animationSpec = tween(NAV_ANIM_MS),
+                        )
 
-                NavAnimation.SLIDE_IN_FROM_BOTTOM ->
-                    slideOutOfContainer(
-                        AnimatedContentTransitionScope.SlideDirection.Down,
-                        animationSpec = tween(NAV_ANIM_MS),
-                    )
+                    NavAnimation.SLIDE_IN_FROM_BOTTOM ->
+                        slideOutOfContainer(
+                            AnimatedContentTransitionScope.SlideDirection.Down,
+                            animationSpec = tween(NAV_ANIM_MS),
+                        )
 
-                NavAnimation.FADE_IN -> fadeOut(animationSpec = tween(NAV_ANIM_MS))
+                    NavAnimation.FADE_IN -> fadeOut(animationSpec = tween(NAV_ANIM_MS))
+                }
             }
         },
     ) { backStackEntry ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
@@ -25,24 +25,27 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.check_circle
-import bisqapps.shared.presentation.generated.resources.requesting_inventory
 import kotlinx.coroutines.delay
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.network_banner.NetworkStatusBannerConstants.ANIMATION_DURATION_MS
 import network.bisq.mobile.presentation.common.ui.network_banner.NetworkStatusBannerConstants.HIDE_DELAY_MS
+import network.bisq.mobile.presentation.common.ui.network_banner.NetworkStatusBannerConstants.STATIC_RING_PROGRESS
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
+@ExcludeFromCoverage // Compose banner; the animations-on/off gating is covered via AnimationSettings unit tests
 @Composable
 fun NetworkStatusBanner() {
     val presenter: NetworkStatusBannerPresenter = koinInject()
@@ -65,6 +68,7 @@ fun NetworkStatusBanner() {
     )
 }
 
+@ExcludeFromCoverage // Compose rendering; static-vs-animated indicator gating covered via AnimationSettings unit tests
 @Composable
 private fun NetworkStatusBannerView(
     allDataReceived: Boolean,
@@ -111,12 +115,15 @@ private fun NetworkStatusBannerView(
             )
         } else {
             // Animations off (user setting or low-spec device lock): the indeterminate spinner
-            // animates continuously, so fall back to a static status icon.
-            Image(
-                painter = painterResource(Res.drawable.requesting_inventory),
-                colorFilter = ColorFilter.tint(BisqTheme.colors.white),
-                contentDescription = "Requesting network data",
+            // animates continuously, so render a static, determinate ring instead — same size,
+            // stroke and colour, just frozen. Drawn by Compose so it stays crisp at any density,
+            // unlike a scaled-up raster status badge.
+            CircularProgressIndicator(
+                progress = { STATIC_RING_PROGRESS },
+                color = BisqTheme.colors.white,
+                trackColor = Color.Transparent,
                 modifier = Modifier.size(20.dp),
+                strokeWidth = 1.dp,
             )
         }
 
@@ -131,6 +138,7 @@ private fun NetworkStatusBannerView(
 /**
  * Controls when the network status banner is visible.
  */
+@ExcludeFromCoverage // Compose visibility state machine; behavioural gating covered via AnimationSettings unit tests
 @Composable
 private fun NetworkStatusBannerContent(
     allDataReceived: Boolean,
@@ -187,6 +195,7 @@ private fun NetworkStatusBannerContent(
  *
  * For production use, always use NetworkStatusBanner() instead.
  */
+@ExcludeFromCoverage // Preview-only helper
 @Composable
 private fun NetworkStatusBannerContentPreview(
     allDataReceived: Boolean,
@@ -237,4 +246,8 @@ private fun NetworkStatusBanner_CompletedPreview() {
 private object NetworkStatusBannerConstants {
     const val HIDE_DELAY_MS = 4000L
     const val ANIMATION_DURATION_MS = 600
+
+    // Fixed sweep for the static (animations-off) ring — a partial arc reads as a frozen spinner
+    // rather than a full "complete" circle.
+    const val STATIC_RING_PROGRESS = 0.25f
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.check_circle
+import bisqapps.shared.presentation.generated.resources.requesting_inventory
 import kotlinx.coroutines.delay
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.network_banner.NetworkStatusBannerConstants.ANIMATION_DURATION_MS
@@ -46,6 +48,9 @@ fun NetworkStatusBanner() {
     val presenter: NetworkStatusBannerPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
+    val animationSettings: AnimationSettings = koinInject()
+    val animationsEnabled by animationSettings.enabled.collectAsState()
+
     val inventoryRequestInfo by presenter.inventoryRequestInfo.collectAsState()
     val allDataReceived by presenter.allDataReceived.collectAsState()
     val numConnections by presenter.numConnections.collectAsState()
@@ -56,6 +61,7 @@ fun NetworkStatusBanner() {
         numConnections = numConnections,
         isMainContentVisible = isMainContentVisible,
         inventoryRequestInfo = inventoryRequestInfo,
+        animationsEnabled = animationsEnabled,
     )
 }
 
@@ -63,6 +69,7 @@ fun NetworkStatusBanner() {
 private fun NetworkStatusBannerView(
     allDataReceived: Boolean,
     inventoryRequestInfo: String,
+    animationsEnabled: Boolean,
 ) {
     val backgroundColor by animateColorAsState(
         targetValue = if (allDataReceived) BisqTheme.colors.primaryDim else BisqTheme.colors.yellow,
@@ -96,11 +103,20 @@ private fun NetworkStatusBannerView(
                 contentDescription = "All data received",
                 modifier = Modifier.size(20.dp),
             )
-        } else {
+        } else if (animationsEnabled) {
             CircularProgressIndicator(
                 color = BisqTheme.colors.white,
                 modifier = Modifier.size(20.dp),
                 strokeWidth = 1.dp,
+            )
+        } else {
+            // Animations off (user setting or low-spec device lock): the indeterminate spinner
+            // animates continuously, so fall back to a static status icon.
+            Image(
+                painter = painterResource(Res.drawable.requesting_inventory),
+                colorFilter = ColorFilter.tint(BisqTheme.colors.white),
+                contentDescription = "Requesting network data",
+                modifier = Modifier.size(20.dp),
             )
         }
 
@@ -121,6 +137,7 @@ private fun NetworkStatusBannerContent(
     numConnections: Int,
     isMainContentVisible: Boolean,
     inventoryRequestInfo: String,
+    animationsEnabled: Boolean,
 ) {
     var shouldBeVisible by remember { mutableStateOf(false) }
 
@@ -157,6 +174,7 @@ private fun NetworkStatusBannerContent(
         NetworkStatusBannerView(
             allDataReceived = allDataReceived,
             inventoryRequestInfo = inventoryRequestInfo,
+            animationsEnabled = animationsEnabled,
         )
     }
 }
@@ -173,10 +191,12 @@ private fun NetworkStatusBannerContent(
 private fun NetworkStatusBannerContentPreview(
     allDataReceived: Boolean,
     inventoryRequestInfo: String,
+    animationsEnabled: Boolean = true,
 ) {
     NetworkStatusBannerView(
         allDataReceived = allDataReceived,
         inventoryRequestInfo = inventoryRequestInfo,
+        animationsEnabled = animationsEnabled,
     )
 }
 
@@ -187,6 +207,18 @@ private fun NetworkStatusBanner_LoadingPreview() {
         NetworkStatusBannerContentPreview(
             allDataReceived = false,
             inventoryRequestInfo = "Requesting initial network data",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NetworkStatusBanner_LoadingNoAnimationPreview() {
+    BisqTheme.Preview {
+        NetworkStatusBannerContentPreview(
+            allDataReceived = false,
+            inventoryRequestInfo = "Requesting initial network data",
+            animationsEnabled = false,
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBanner.kt
@@ -1,7 +1,10 @@
 package network.bisq.mobile.presentation.common.ui.network_banner
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -75,9 +78,12 @@ private fun NetworkStatusBannerView(
     inventoryRequestInfo: String,
     animationsEnabled: Boolean,
 ) {
+    val targetBackground = if (allDataReceived) BisqTheme.colors.primaryDim else BisqTheme.colors.yellow
+    // Animate the colour transition only when animations are enabled; otherwise snap to the target
+    // so nothing tweens on low-spec devices / when the user turned animations off.
     val backgroundColor by animateColorAsState(
-        targetValue = if (allDataReceived) BisqTheme.colors.primaryDim else BisqTheme.colors.yellow,
-        animationSpec = tween(durationMillis = ANIMATION_DURATION_MS),
+        targetValue = targetBackground,
+        animationSpec = if (animationsEnabled) tween(durationMillis = ANIMATION_DURATION_MS) else snap(),
         label = "bannerBgAnim",
     )
 
@@ -168,16 +174,22 @@ private fun NetworkStatusBannerContent(
 
     AnimatedVisibility(
         visible = shouldBeVisible,
+        // Animate the banner in/out only when animations are enabled; otherwise show/hide instantly
+        // so nothing tweens on low-spec devices / when the user turned animations off.
         enter =
-            fadeIn(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS)) +
-                expandVertically(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS)),
+            if (animationsEnabled) {
+                fadeIn(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS)) +
+                    expandVertically(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS))
+            } else {
+                EnterTransition.None
+            },
         exit =
-            fadeOut(
-                animationSpec = tween(durationMillis = ANIMATION_DURATION_MS),
-            ) +
-                shrinkVertically(
-                    animationSpec = tween(durationMillis = ANIMATION_DURATION_MS),
-                ),
+            if (animationsEnabled) {
+                fadeOut(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS)) +
+                    shrinkVertically(animationSpec = tween(durationMillis = ANIMATION_DURATION_MS))
+            } else {
+                ExitTransition.None
+            },
     ) {
         NetworkStatusBannerView(
             allDataReceived = allDataReceived,
@@ -249,5 +261,5 @@ private object NetworkStatusBannerConstants {
 
     // Fixed sweep for the static (animations-off) ring — a partial arc reads as a frozen spinner
     // rather than a full "complete" circle.
-    const val STATIC_RING_PROGRESS = 0.25f
+    const val STATIC_RING_PROGRESS = 0.9f
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
@@ -626,7 +626,7 @@ open class SettingsPresenter(
                                 tradePriceTolerance = it.tradePriceTolerance.updateValue(tradePriceToleranceFormatted),
                                 // Show effective state: forced off (and greyed) on low-spec devices,
                                 // without mutating the stored preference. See #1293.
-                                useAnimations = settings.useAnimations && !animationSettings.lockedByDevice,
+                                useAnimations = animationSettings.isEffectivelyEnabled(settings.useAnimations),
                                 rememberOfferbookFilterPreferences = localSettings.rememberOfferbookFilterPreferences,
                                 numDaysAfterRedactingTradeData = it.numDaysAfterRedactingTradeData.updateValue(numDaysFormatted),
                                 powFactor = it.powFactor.updateValue(powFactorFormatted),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
@@ -198,6 +198,8 @@ open class SettingsPresenter(
             SettingsUiAction.OnTradePriceToleranceSave -> onTradePriceToleranceSave()
             SettingsUiAction.OnTradePriceToleranceCancel -> onTradePriceToleranceCancel()
             is SettingsUiAction.OnUseAnimationsChange -> setUseAnimations(action.value)
+            SettingsUiAction.OnUseAnimationsLockedTap ->
+                showSnackbar("settings.display.useAnimations.lockedByDevice".i18n())
             is SettingsUiAction.OnRememberOfferbookFilterPreferencesChange ->
                 setRememberOfferbookFilterPreferences(action.enabled)
             is SettingsUiAction.OnNumDaysAfterRedactingTradeDataChange ->

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsPresenter.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.i18n.DEFAULT_LANGUAGE_CODE
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
@@ -33,6 +34,7 @@ open class SettingsPresenter(
     private val languageServiceFacade: LanguageServiceFacade,
     private val pushNotificationServiceFacade: PushNotificationServiceFacade,
     private val settingsRepository: SettingsRepository,
+    private val animationSettings: AnimationSettings,
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.Settings
@@ -71,7 +73,10 @@ open class SettingsPresenter(
     val isCloseOfferWhenTradeTakenChangeEnabled: StateFlow<Boolean> =
         _isCloseOfferWhenTradeTakenChangeEnabled.asStateFlow()
 
-    private val _isUseAnimationsChangeEnabled = MutableStateFlow(true)
+    // Starts disabled (greyed) when the device is low-spec: animations are force-off
+    // and the toggle can't be turned on. This reuses the existing in-flight guard flag — on a locked
+    // device setUseAnimations is never invoked, so nothing re-enables it.
+    private val _isUseAnimationsChangeEnabled = MutableStateFlow(!animationSettings.lockedByDevice)
     val isUseAnimationsChangeEnabled: StateFlow<Boolean> = _isUseAnimationsChangeEnabled.asStateFlow()
 
     private val _isIgnorePowChangeEnabled = MutableStateFlow(true)
@@ -617,7 +622,9 @@ open class SettingsPresenter(
                                 supportedLanguageCodes = supportedLangCodes,
                                 closeOfferWhenTradeTaken = settings.closeMyOfferWhenTaken,
                                 tradePriceTolerance = it.tradePriceTolerance.updateValue(tradePriceToleranceFormatted),
-                                useAnimations = settings.useAnimations,
+                                // Show effective state: forced off (and greyed) on low-spec devices,
+                                // without mutating the stored preference. See #1293.
+                                useAnimations = settings.useAnimations && !animationSettings.lockedByDevice,
                                 rememberOfferbookFilterPreferences = localSettings.rememberOfferbookFilterPreferences,
                                 numDaysAfterRedactingTradeData = it.numDaysAfterRedactingTradeData.updateValue(numDaysFormatted),
                                 powFactor = it.powFactor.updateValue(powFactorFormatted),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreen.kt
@@ -258,6 +258,7 @@ fun SettingsContent(
                         checked = uiState.useAnimations,
                         disabled = !isUseAnimationsChangeEnabled,
                         onSwitch = { onAction(SettingsUiAction.OnUseAnimationsChange(it)) },
+                        onDisabledTap = { onAction(SettingsUiAction.OnUseAnimationsLockedTap) },
                     )
 
                     BisqGap.V1()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsUiAction.kt
@@ -30,6 +30,13 @@ sealed interface SettingsUiAction {
         val value: Boolean,
     ) : SettingsUiAction
 
+    /**
+     * User tapped the animations toggle while it is greyed out because the device is
+     * low-spec ([AnimationSettings.lockedByDevice]). The switch itself stays disabled;
+     * this only surfaces an explanation so the greyed state isn't a dead end.
+     */
+    data object OnUseAnimationsLockedTap : SettingsUiAction
+
     data class OnRememberOfferbookFilterPreferencesChange(
         val enabled: Boolean,
     ) : SettingsUiAction

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenter.kt
@@ -8,6 +8,7 @@ import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiState
 import network.bisq.mobile.presentation.common.ui.alert.toAlertNotificationUiState
+import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
@@ -22,9 +23,12 @@ class TabContainerPresenter(
     private val createOfferCoordinator: CreateOfferCoordinator,
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
+    private val animationSettings: AnimationSettings,
 ) : BasePresenter(mainPresenter),
     ITabContainerPresenter {
-    override val showAnimation: StateFlow<Boolean> get() = settingsServiceFacade.useAnimations
+    // Effective flag (user setting AND device not low-spec) so the avatar animation honours the
+    // device lock too, not just the raw setting. See #1293.
+    override val showAnimation: StateFlow<Boolean> get() = animationSettings.enabled
     override val tradesWithUnreadMessages: StateFlow<Map<String, Int>> get() = mainPresenter.tradesWithUnreadMessages
 
     private val _showTradeRestrictedDialog = MutableStateFlow<AlertNotificationUiState?>(null)


### PR DESCRIPTION
 - potentially resolves #1293
 - resolves #1424
 - bind use animations to compose transitions and spinner
 - usages across screen + tests + docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized animation control that locks animations on low-memory devices and keeps the UI toggle informative.
  * Settings now shows a snackbar explanation when the animations toggle is tapped while disabled.
* **Bug Fixes**
  * Navigation transitions, network status banner loading visuals, and the offer progress spinner now immediately switch to non-animated behavior when animations are disabled.
* **Documentation**
  * Added new mobile localization text for the “animations locked by device” message.
* **Tests**
  * Added/updated unit tests for RAM-based device capability and animation-lock behavior across presenters/UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->