### PR TITLE
bugfix/auth_cookie_tor_hang_after_kmptor_lib_bump_preventable

### DIFF
--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -164,7 +164,7 @@ buildConfig {
         buildConfigField("BUILD_TS", System.currentTimeMillis())
         buildConfigField("BISQ_CORE_VERSION", bisqCoreVersion)
         // Note: Update when updating kmp-tor lib
-        buildConfigField("TOR_VERSION", "0.4.8.17") // is TOR DAEMON version
+        buildConfigField("TOR_VERSION", "0.4.9.05") // is TOR DAEMON version
         // Analytics dev-only override (issue #525). See client BuildConfig above
         // for the full rationale. Node app gets its own DSN pointing at GlitchTip
         // project id=2 (bisq-easy-node-android). Same semantics: release builds

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceCleanupTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceCleanupTest.kt
@@ -1,0 +1,61 @@
+package network.bisq.mobile.data.service.network
+
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [KmpTorService.cleanStaleControlState] removes only the ephemeral control-plane files
+ * (which cause the "515 Authentication cookie did not match expected value" hang when stale) and
+ * leaves the persistent Tor data — notably the onion service identity keys — untouched.
+ */
+class KmpTorServiceCleanupTest {
+    private fun createTorDir(): Pair<KmpTorService, File> {
+        val root = Files.createTempDirectory("kmpTorCleanup").toFile().apply { deleteOnExit() }
+        val torDir = File(root, "tor").apply { mkdirs() }
+        val service = KmpTorService(root.absolutePath.toPath())
+        return service to torDir
+    }
+
+    @Test
+    fun `cleanStaleControlState removes stale control files`() =
+        runTest {
+            val (service, torDir) = createTorDir()
+            val cookie = File(torDir, "control_auth_cookie").apply { writeText("stale-cookie") }
+            val controlPort = File(torDir, "control-port.txt").apply { writeText("PORT=127.0.0.1:9051") }
+            val controlPortBackup = File(torDir, "control-port-backup.txt").apply { writeText("PORT=127.0.0.1:9051") }
+
+            service.cleanStaleControlState()
+
+            assertFalse(cookie.exists(), "control auth cookie should be deleted")
+            assertFalse(controlPort.exists(), "control-port file should be deleted")
+            assertFalse(controlPortBackup.exists(), "control-port backup file should be deleted")
+        }
+
+    @Test
+    fun `cleanStaleControlState preserves onion identity and other data dir contents`() =
+        runTest {
+            val (service, torDir) = createTorDir()
+            File(torDir, "control_auth_cookie").writeText("stale-cookie")
+            val keysDir = File(torDir, "keys").apply { mkdirs() }
+            val onionKey = File(keysDir, "hs_ed25519_secret_key").apply { writeText("onion-identity") }
+            val cachedDescriptors = File(torDir, "cached-microdescs").apply { writeText("descriptors") }
+
+            service.cleanStaleControlState()
+
+            assertTrue(onionKey.exists(), "onion identity key must survive cleanup")
+            assertTrue(cachedDescriptors.exists(), "unrelated data dir files must survive cleanup")
+        }
+
+    @Test
+    fun `cleanStaleControlState is a no-op when nothing to clean`() =
+        runTest {
+            val (service, _) = createTorDir()
+            // No control files present — must not throw.
+            service.cleanStaleControlState()
+        }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/network/NetworkServiceFacadeTest.kt
@@ -81,6 +81,55 @@ class NetworkServiceFacadeTest : KoinTest {
             // Should not throw - exception is caught and logged
             facade.ensureTorRunning()
         }
+
+    @Test
+    fun `activate does not start tor when disabled`() =
+        runTest {
+            val facade = createFacade(torEnabled = false)
+            facade.activate()
+            coVerify(exactly = 0) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate starts tor once when it succeeds first attempt`() =
+        runTest {
+            val facade = createFacade(torEnabled = true)
+            coEvery { kmpTorService.startTor(any(), any()) } returns true
+            facade.activate()
+            coVerify(exactly = 1) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate retries after a failed start and stops once tor is up`() =
+        runTest {
+            val facade = createFacade(torEnabled = true)
+            // First attempt fails (e.g. stale cookie AUTHENTICATE), second succeeds after cleanup.
+            coEvery { kmpTorService.startTor(any(), any()) } returnsMany listOf(false, true)
+            facade.activate()
+            coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate gives up after max attempts and returns without hanging`() =
+        runTest {
+            val facade = createFacade(torEnabled = true)
+            // Always fails: activate must return (not suspend forever waiting for Started).
+            coEvery { kmpTorService.startTor(any(), any()) } returns false
+            facade.activate()
+            // MAX_TOR_START_ATTEMPTS = 3 (private const in NetworkServiceFacade).
+            coVerify(exactly = 3) { kmpTorService.startTor(any(), any()) }
+        }
+
+    @Test
+    fun `activate keeps retrying when a start attempt throws`() =
+        runTest {
+            val facade = createFacade(torEnabled = true)
+            // Non-cancellation throw on first attempt is caught and treated as a failed attempt,
+            // then the second attempt succeeds.
+            coEvery { kmpTorService.startTor(any(), any()) } throws RuntimeException("tor error") andThen true
+            facade.activate()
+            coVerify(exactly = 2) { kmpTorService.startTor(any(), any()) }
+        }
 }
 
 private class TestNetworkServiceFacade(

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -124,6 +124,11 @@ class KmpTorService(
                         _state.value = TorState.Starting
                         val newStartDefer =
                             serviceScope.async {
+                                // Remove ephemeral control-plane leftovers from a previous run before
+                                // starting, so kmp-tor's control AUTHENTICATE can't read a stale cookie
+                                // (which fails with "515 Authentication cookie did not match expected
+                                // value" and hangs bootstrap). Preserves onion identity — see method doc.
+                                cleanStaleControlState()
                                 val runtime = getTorRuntime()
                                 withTimeout(daemonStartTimeoutMs) {
                                     runtime.startDaemonAsync()
@@ -410,7 +415,7 @@ class KmpTorService(
     ) {
         try {
             val torDir = getTorDir()
-            val cookieFile = torDir / "control_auth_cookie"
+            val cookieFile = getControlAuthCookieFile()
             val configContent =
                 buildString {
                     appendLine("UseExternalTor 1")
@@ -505,6 +510,44 @@ class KmpTorService(
     private fun getControlPortFile(): Path = getTorDir() / "control-port.txt"
 
     private fun getControlPortBackupFile(): Path = getTorDir() / "control-port-backup.txt"
+
+    private fun getControlAuthCookieFile(): Path = getTorDir() / "control_auth_cookie"
+
+    /**
+     * Removes ephemeral control-plane files left over from a previous (possibly unclean) Tor run:
+     * the control auth cookie and the control-port files. Tor regenerates all of these on every
+     * daemon start; a stale cookie makes kmp-tor's control-port AUTHENTICATE fail with
+     * "515 Authentication cookie did not match expected value", which hangs bootstrap.
+     *
+     * Deliberately does NOT touch the rest of the Tor data directory (onion service keys, cached
+     * descriptors), so the node's persistent onion identity is preserved. Contrast with
+     * [purgeWorkingDir], which wipes everything and rotates the onion address.
+     *
+     * Best-effort: a file that can't be deleted is logged and skipped rather than failing the start.
+     *
+     * `internal` (not `private`) so the same-module test can verify the preserve-identity contract
+     * without starting a real Tor daemon.
+     */
+    internal suspend fun cleanStaleControlState() {
+        val staleFiles =
+            listOf(
+                getControlAuthCookieFile(),
+                getControlPortFile(),
+                getControlPortBackupFile(),
+            )
+        withContext(Dispatchers.IO) {
+            staleFiles.forEach { path ->
+                try {
+                    if (FileSystem.SYSTEM.exists(path)) {
+                        FileSystem.SYSTEM.delete(path)
+                        log.i { "Removed stale Tor control file before start: ${path.name}" }
+                    }
+                } catch (e: Exception) {
+                    log.w(e) { "Failed to remove stale Tor control file ${path.name}; continuing" }
+                }
+            }
+        }
+    }
 
     /**
      * Deletes the Tor working directory (including cache) to allow a fresh start on next run.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/NetworkServiceFacade.kt
@@ -1,10 +1,9 @@
 package network.bisq.mobile.data.service.network
 
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import network.bisq.mobile.data.service.LifeCycleAware
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.domain.utils.Logging
@@ -14,6 +13,14 @@ abstract class NetworkServiceFacade(
 ) : ServiceFacade(),
     LifeCycleAware,
     Logging {
+    companion object {
+        // Bounded retry for the daemon start: a stale control-auth cookie fails the first
+        // AUTHENTICATE, and the per-attempt cleanup in KmpTorService.startTor() clears it so a
+        // subsequent attempt succeeds. Kept small — genuine failures should surface, not loop.
+        private const val MAX_TOR_START_ATTEMPTS = 3
+        private const val TOR_START_RETRY_DELAY_MS = 1_000L
+    }
+
     abstract val numConnections: StateFlow<Int>
     abstract val allDataReceived: StateFlow<Boolean>
 
@@ -23,19 +30,40 @@ abstract class NetworkServiceFacade(
         super<ServiceFacade>.activate()
 
         if (isTorEnabled()) {
-            try {
-                kmpTorService.startTor()
-            } catch (e: Exception) {
-                log.e(e) { "Tor service failed to start" }
-                // ApplicationBootstrapFacade observes tor state & triggers dialog in SplashPresenter
-                currentCoroutineContext().ensureActive()
-            }
-            // suspend until tor is started
-            // this is fine because:
-            // - we restart tor till it starts
-            // - or close the app otherwise
-            kmpTorService.state.filter { it is KmpTorService.TorState.Started }.first()
+            startTorWithRetries()
         }
+    }
+
+    /**
+     * Starts Tor, retrying a bounded number of times, and returns once it is started or all attempts
+     * are exhausted. Each [KmpTorService.startTor] attempt first clears stale control-plane files, so
+     * a leftover control-auth cookie that fails AUTHENTICATE ("515 Authentication cookie did not
+     * match expected value") on one attempt is gone by the next.
+     *
+     * We rely on [KmpTorService.startTor]'s own return value (it already suspends until bootstrapped
+     * or failed). The previous implementation additionally waited indefinitely for
+     * [KmpTorService.TorState.Started], which hung forever — splash frozen at "Starting Tor 0%" —
+     * when the daemon failed to start. If all attempts fail we return rather than hang;
+     * ApplicationBootstrapFacade observes the Tor state and its stage timeout surfaces the failure
+     * dialog / retry to the user.
+     */
+    private suspend fun startTorWithRetries() {
+        repeat(MAX_TOR_START_ATTEMPTS) { attempt ->
+            val started =
+                try {
+                    kmpTorService.startTor()
+                } catch (e: Exception) {
+                    log.e(e) { "Tor service failed to start (attempt ${attempt + 1}/$MAX_TOR_START_ATTEMPTS)" }
+                    currentCoroutineContext().ensureActive()
+                    false
+                }
+            if (started) return
+            if (attempt < MAX_TOR_START_ATTEMPTS - 1) {
+                log.w { "Tor did not start (attempt ${attempt + 1}/$MAX_TOR_START_ATTEMPTS); retrying in ${TOR_START_RETRY_DELAY_MS}ms" }
+                delay(TOR_START_RETRY_DELAY_MS)
+            }
+        }
+        log.e { "Tor failed to start after $MAX_TOR_START_ATTEMPTS attempts; bootstrap will surface the failure" }
     }
 
     override suspend fun deactivate() {


### PR DESCRIPTION
 - handled auth-cookie exception thrown by kmp-tor 2.6.0 when its the case with stale cookie files by clearing them up
 - added retry tor bootstrap mechanism with 3 retries to avoid hanging the user there until timeout when skippable
 - added AI generated related tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Tor startup handling to retry a limited number of times instead of waiting indefinitely, making app startup more resilient.
  * Added automatic cleanup of stale Tor control files before launching Tor to reduce connection and authentication issues.

* **Bug Fixes**
  * Improved recovery when Tor fails to start on the first attempt or throws a transient error.
  * Preserved existing Tor identity and cached data while removing only temporary control-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->