### PR TITLE
Release/anode 0.9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.8.3
+node.android.version=0.9.0
 
 client.name=Bisq Connect
 client.android.version=0.6.3
@@ -42,7 +42,7 @@ client.ios.version=0.6.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=46
 client.android.version.code=28
-node.android.version.code=45
+node.android.version.code=46
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.9.0
+node.android.version=0.9.1
 
 client.name=Bisq Connect
 client.android.version=0.6.3
@@ -42,7 +42,7 @@ client.ios.version=0.6.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=46
 client.android.version.code=28
-node.android.version.code=46
+node.android.version.code=47
 
 # Networking
 


### PR DESCRIPTION
 - contribs to #1591 
 - update medatada and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android node native library to version 0.9.1.
  * Bumped the Android node version code to 47.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->