### PR TITLE
Guard Transifex workflow_run uploads

### DIFF
--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -10,11 +10,24 @@ on:
   workflow_run:
     workflows: [ BisqApps ]
     types: [ completed ]
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   verify_config:
     name: Verify Transifex configuration
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
@@ -24,6 +37,7 @@ jobs:
         with:
           ref: ${{ env.COMMIT_SHA }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify i18n resource files match Transifex configuration
         run: |
@@ -95,7 +109,12 @@ jobs:
 
   calculate_and_push_sources:
     name: Calculate pushes and push source files
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     needs: verify_config
     runs-on: ubuntu-latest
     outputs:
@@ -109,6 +128,7 @@ jobs:
         with:
           ref: ${{ env.COMMIT_SHA }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if the commit is in the main branch
         id: check_commit
@@ -279,7 +299,13 @@ jobs:
 
   push_translations:
     name: Push translations (${{ matrix.name }})
-    if: needs.calculate_and_push_sources.outputs.t_matrix != '{"include":[]}'
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      needs.calculate_and_push_sources.outputs.t_matrix != '{"include":[]}'
     needs: calculate_and_push_sources
     runs-on: ubuntu-latest
     env:
@@ -297,6 +323,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.COMMIT_SHA }}
+          persist-credentials: false
 
       - name: Install Transifex CLI
         run: |


### PR DESCRIPTION
## Summary

- Limit the `workflow_run` Transifex trigger to `BisqApps` runs on `main`.
- Add job-level guards so Transifex uploads only follow successful `push` builds from the base repository's default branch.
- Keep the existing `pull_request` Transifex configuration check for i18n and `.tx/config` changes.
- Restrict workflow token permissions to read-only contents and avoid persisted checkout credentials.

## Why

Bisq Mobile currently still uses `actions/checkout@v6`, so it has not hit the same checkout guard that recently broke Bisq2 after the `checkout@v7` bump. The workflow has the same latent shape, though: a trusted `workflow_run` path checks out `github.event.workflow_run.head_sha` before proving that the completed `BisqApps` run came from a trusted `main` push.

If checkout is later upgraded to v7, fork PR builds can fail with the same protected checkout error seen in Bisq2. More importantly, the privileged Transifex upload path should not inspect or execute fork PR code with repository secrets available.

This mirrors the Bisq2 fix by skipping the privileged upload path for PR-triggered `workflow_run` events and allowing uploads only after trusted main push builds.

## Verification

- Parsed `.github/workflows/sync_transifex.yml` as YAML locally.
- Ran `git diff --check`.
- Reviewed recent Transifex and `BisqApps` runs: current Mobile Transifex runs are not failing from this yet, but the workflow shape matches the Bisq2 latent issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved translation synchronization workflow safeguards by restricting runs to successful updates from the default branch and repository.
  * Limited pull request-triggered synchronization to pull requests targeting `main`.
  * Enhanced checkout security by preventing credentials from being persisted in workflow environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->