### PR TITLE
Refactor/quick wins to eliminate code dups + bugfixes

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -2,9 +2,6 @@ package network.bisq.mobile.client.common.di
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -110,7 +107,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.analytics.AnalyticsSettingsBaseline
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
-import network.bisq.mobile.domain.analytics.SentryAnalyticsService
+import network.bisq.mobile.domain.analytics.createBufferedAnalyticsService
 import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
@@ -240,31 +237,10 @@ val clientDomainModule =
         // and evict by FIFO with no clearnet leak.
         single<AnalyticsSocksPortProvider> { KmpTorSocksPortProvider(get()) }
         single {
-            // Independent scope so the buffer's periodic flusher survives any
-            // individual feature-scope cancellation. SupervisorJob so a single
-            // failed enqueue doesn't kill the flusher. Reused for the
-            // settings-derived analyticsEnabled StateFlow so its hot-share
-            // lives exactly as long as the BufferedAnalyticsService instance.
-            val analyticsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-            val settingsRepository = get<SettingsRepository>()
-            // Hot StateFlow view of `Settings.analyticsEnabled`. Backed by
-            // DataStore so a settings flip from any UI surface propagates
-            // immediately to this `.value` read in the runtime gate.
-            val analyticsEnabledFlow = settingsRepository.analyticsEnabledIn(analyticsScope)
-            BufferedAnalyticsService(
-                downstream =
-                    SentryAnalyticsService(
-                        nativeInitializer = get(),
-                        // Two gates AND'd together:
-                        //  1) Dev-only build flag — release builds const-fold
-                        //     this to true at BuildConfig generation time.
-                        //  2) User-settings toggle — flipped from Settings UI.
-                        // Both must be true for the SDK to emit anything.
-                        runtimeOptInProvider = {
-                            BuildConfig.ANALYTICS_DEV_ENABLED && analyticsEnabledFlow.value
-                        },
-                    ),
-                scope = analyticsScope,
+            createBufferedAnalyticsService(
+                settingsRepository = get(),
+                nativeInitializer = get(),
+                analyticsDevEnabled = BuildConfig.ANALYTICS_DEV_ENABLED,
             )
         }
         single<AnalyticsService> { get<BufferedAnalyticsService>() }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsRepositoryImpl.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsRepositoryImpl.kt
@@ -1,33 +1,13 @@
 package network.bisq.mobile.client.common.domain.sensitive_settings
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.IOException
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.data.repository.DataStoreRepository
 
 class SensitiveSettingsRepositoryImpl(
-    private val sensitiveSettingsStore: DataStore<SensitiveSettings>,
-) : SensitiveSettingsRepository,
-    Logging {
-    override val data: Flow<SensitiveSettings>
-        get() =
-            sensitiveSettingsStore.data.catch { exception ->
-                if (exception is IOException) {
-                    log.e("Error reading SensitiveSettings datastore", exception)
-                    emit(SensitiveSettings())
-                } else {
-                    throw exception
-                }
-            }
+    sensitiveSettingsStore: DataStore<SensitiveSettings>,
+) : DataStoreRepository<SensitiveSettings>(sensitiveSettingsStore),
+    SensitiveSettingsRepository {
+    override fun createDefault() = SensitiveSettings()
 
-    override suspend fun update(transform: suspend (t: SensitiveSettings) -> SensitiveSettings) {
-        sensitiveSettingsStore.updateData(transform)
-    }
-
-    override suspend fun clear() {
-        sensitiveSettingsStore.updateData {
-            SensitiveSettings()
-        }
-    }
+    override suspend fun update(transform: suspend (t: SensitiveSettings) -> SensitiveSettings) = set(transform)
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -3,9 +3,6 @@ package network.bisq.mobile.node.common.di
 import android.app.ActivityManager
 import android.content.Context
 import android.os.Debug
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.data.service.AppForegroundController
 import network.bisq.mobile.data.service.ForegroundDetector
@@ -37,8 +34,8 @@ import network.bisq.mobile.domain.analytics.AnalyticsSettingsBaseline
 import network.bisq.mobile.domain.analytics.AnalyticsSocksPortProvider
 import network.bisq.mobile.domain.analytics.BufferedAnalyticsService
 import network.bisq.mobile.domain.analytics.NativeSentryInitializer
-import network.bisq.mobile.domain.analytics.SentryAnalyticsService
 import network.bisq.mobile.domain.analytics.SentryJavaNativeSentryInitializer
+import network.bisq.mobile.domain.analytics.createBufferedAnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.utils.AndroidDeviceInfoProvider
@@ -135,19 +132,10 @@ val androidNodeDomainModule =
         // valid future optimization; the current provider is kept for coherence with bisq2's routing.
         single<AnalyticsSocksPortProvider> { Bisq2SocksPortProvider(get()) }
         single {
-            // See ClientDomainModule for the matching pattern + rationale.
-            val analyticsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-            val settingsRepository = get<SettingsRepository>()
-            val analyticsEnabledFlow = settingsRepository.analyticsEnabledIn(analyticsScope)
-            BufferedAnalyticsService(
-                downstream =
-                    SentryAnalyticsService(
-                        nativeInitializer = get(),
-                        runtimeOptInProvider = {
-                            BuildNodeConfig.ANALYTICS_DEV_ENABLED && analyticsEnabledFlow.value
-                        },
-                    ),
-                scope = analyticsScope,
+            createBufferedAnalyticsService(
+                settingsRepository = get(),
+                nativeInitializer = get(),
+                analyticsDevEnabled = BuildNodeConfig.ANALYTICS_DEV_ENABLED,
             )
         }
         single<AnalyticsService> { get<BufferedAnalyticsService>() }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeAlertNotificationsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeAlertNotificationsServiceFacade.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.node.common.domain.service.alert
 
 import bisq.common.observable.Pin
-import bisq.common.observable.collection.CollectionObserver
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -9,7 +8,6 @@ import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.node.common.domain.mapping.alert.toDomainOrNull
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData as BisqAuthorizedAlertData
 
 class NodeAlertNotificationsServiceFacade(
     private val provider: AndroidApplicationService.Provider,
@@ -24,23 +22,8 @@ class NodeAlertNotificationsServiceFacade(
     override suspend fun activate() {
         super.activate()
 
-        refreshAlerts()
-        unconsumedAlertsPin =
-            alertNotificationsService.unconsumedAlerts.addObserver(
-                object : CollectionObserver<BisqAuthorizedAlertData> {
-                    override fun onAdded(bisqAuthorizedAlertData: BisqAuthorizedAlertData) {
-                        refreshAlerts()
-                    }
-
-                    override fun onRemoved(element: Any) {
-                        refreshAlerts()
-                    }
-
-                    override fun onCleared() {
-                        refreshAlerts()
-                    }
-                },
-            )
+        // The Runnable observer fires once at subscription, covering the initial refresh
+        unconsumedAlertsPin = alertNotificationsService.unconsumedAlerts.addObserver(Runnable { refreshAlerts() })
     }
 
     override suspend fun deactivate() {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeTradeRestrictingAlertServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeTradeRestrictingAlertServiceFacade.kt
@@ -3,7 +3,6 @@ package network.bisq.mobile.node.common.domain.service.alert
 import bisq.bonded_roles.release.AppType
 import bisq.bonded_roles.security_manager.alert.AuthorizedAlertDataUtils
 import bisq.common.observable.Pin
-import bisq.common.observable.collection.CollectionObserver
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,7 +10,6 @@ import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.node.common.domain.mapping.alert.toDomainOrNull
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData as BisqAuthorizedAlertData
 
 class NodeTradeRestrictingAlertServiceFacade(
     private val provider: AndroidApplicationService.Provider,
@@ -26,23 +24,8 @@ class NodeTradeRestrictingAlertServiceFacade(
     override suspend fun activate() {
         super.activate()
 
-        refreshAlert()
-        unconsumedAlertsPin =
-            alertService.authorizedAlertDataSet.addObserver(
-                object : CollectionObserver<BisqAuthorizedAlertData> {
-                    override fun onAdded(bisqAuthorizedAlertData: BisqAuthorizedAlertData) {
-                        refreshAlert()
-                    }
-
-                    override fun onRemoved(element: Any) {
-                        refreshAlert()
-                    }
-
-                    override fun onCleared() {
-                        refreshAlert()
-                    }
-                },
-            )
+        // The Runnable observer fires once at subscription, covering the initial refresh
+        unconsumedAlertsPin = alertService.authorizedAlertDataSet.addObserver(Runnable { refreshAlert() })
     }
 
     override suspend fun deactivate() {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeTradeRestrictingAlertServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/alert/NodeTradeRestrictingAlertServiceFacade.kt
@@ -29,10 +29,11 @@ class NodeTradeRestrictingAlertServiceFacade(
     }
 
     override suspend fun deactivate() {
+        // Tear down our own state before delegating to the base (mirror of activate()).
         unconsumedAlertsPin?.unbind()
         unconsumedAlertsPin = null
-        super.deactivate()
         _alert.value = null
+        super.deactivate()
     }
 
     private fun refreshAlert() {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
+import network.bisq.mobile.node.common.domain.utils.bindTo
 import java.util.Locale
 
 class NodeSettingsServiceFacade(
@@ -152,42 +153,32 @@ class NodeSettingsServiceFacade(
         }
 
     // Misc
-    private var tradeRulesConfirmedPin: Pin? = null
-    private var cookieChangedPin: Pin? = null
+    private val pins = mutableListOf<Pin>()
 
     override suspend fun activate() {
         super<ServiceFacade>.activate()
-        settingsService.languageTag.addObserver { code: String? ->
-            // Normalise the raw bisq2 code (`en_US`, `pt_BR`, `pcm`) into the
-            // canonical Transifex form (`en`, `pt-BR`, `pcm-NG`) BEFORE
-            // publishing into the wire flow. Without this, downstream observers
-            // (UI language selector, analytics) see codes that don't match the
-            // supported-code set and silently drop them.
-            //
-            // The `code: String?` is load-bearing: bisq2 fires this observer
-            // synchronously on subscription with the CURRENT value, which is
-            // null when settings haven't loaded from disk yet (verified in
-            // bisq2 Observable.java:42-50). The previous `(String) -> Unit`
-            // signature NPE'd inside `normalizeLanguageCode(code)`, which bisq2
-            // silently caught — leaving _languageCode.value stuck at the empty
-            // initial state. With null tolerated and the helper's blank-input
-            // branch returning "en", we end up with a real language for the
-            // analytics baseline AND any downstream observer.
-            _languageCode.value = normalizeLanguageCode(code.orEmpty())
-        }
-        tradeRulesConfirmedPin =
-            settingsService.bisqEasyTradeRulesConfirmed.addObserver { isConfirmed ->
-                _tradeRulesConfirmed.value = isConfirmed
+        pins +=
+            settingsService.languageTag.bindTo(_languageCode) { code ->
+                // Normalise the raw bisq2 code (`en_US`, `pt_BR`, `pcm`) into the
+                // canonical Transifex form (`en`, `pt-BR`, `pcm-NG`) BEFORE
+                // publishing into the wire flow. Without this, downstream observers
+                // (UI language selector, analytics) see codes that don't match the
+                // supported-code set and silently drop them.
+                //
+                // The null tolerance (`code.orEmpty()`) is load-bearing: bisq2 fires
+                // this observer synchronously on subscription with the CURRENT value,
+                // which is null when settings haven't loaded from disk yet (verified
+                // in bisq2 Observable.java:42-50). An NPE here is silently caught by
+                // bisq2 — leaving _languageCode.value stuck at the empty initial
+                // state. With null tolerated and the helper's blank-input branch
+                // returning "en", we end up with a real language for the analytics
+                // baseline AND any downstream observer.
+                normalizeLanguageCode(code.orEmpty())
             }
-        settingsService.useAnimations.addObserver { value ->
-            _useAnimations.value = value
-        }
-        settingsService.difficultyAdjustmentFactor.addObserver { value ->
-            _difficultyAdjustmentFactor.value = value
-        }
-        settingsService.ignoreDiffAdjustmentFromSecManager.addObserver { value ->
-            _ignoreDiffAdjustmentFromSecManager.value = value
-        }
+        pins += settingsService.bisqEasyTradeRulesConfirmed.bindTo(_tradeRulesConfirmed)
+        pins += settingsService.useAnimations.bindTo(_useAnimations)
+        pins += settingsService.difficultyAdjustmentFactor.bindTo(_difficultyAdjustmentFactor)
+        pins += settingsService.ignoreDiffAdjustmentFromSecManager.bindTo(_ignoreDiffAdjustmentFromSecManager)
 
         _showWebLinkConfirmation.value =
             dontShowAgainService.showAgain(
@@ -197,7 +188,7 @@ class NodeSettingsServiceFacade(
             settingsService.cookie
                 .asBoolean(CookieKey.PERMIT_OPENING_BROWSER)
                 .orElse(false)
-        cookieChangedPin =
+        pins +=
             settingsService.cookieChanged.addObserver { value ->
                 _permitOpeningBrowser.value =
                     settingsService.cookie
@@ -207,8 +198,8 @@ class NodeSettingsServiceFacade(
     }
 
     override suspend fun deactivate() {
-        tradeRulesConfirmedPin?.unbind()
-        cookieChangedPin?.unbind()
+        pins.forEach { it.unbind() }
+        pins.clear()
 
         super<ServiceFacade>.deactivate()
     }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
+import network.bisq.mobile.node.common.domain.utils.bindNonNullTo
 import network.bisq.mobile.node.common.domain.utils.bindTo
 import java.util.Locale
 
@@ -175,10 +176,14 @@ class NodeSettingsServiceFacade(
                 // baseline AND any downstream observer.
                 normalizeLanguageCode(code.orEmpty())
             }
-        pins += settingsService.bisqEasyTradeRulesConfirmed.bindTo(_tradeRulesConfirmed)
-        pins += settingsService.useAnimations.bindTo(_useAnimations)
-        pins += settingsService.difficultyAdjustmentFactor.bindTo(_difficultyAdjustmentFactor)
-        pins += settingsService.ignoreDiffAdjustmentFromSecManager.bindTo(_ignoreDiffAdjustmentFromSecManager)
+        // bindNonNullTo: these bisq2 observables are null-initialized (SettingsStore uses
+        // `new Observable<>()`) and fire synchronously at subscription with that null before
+        // settings load from disk. bindTo would push null into these non-null StateFlows; ignore
+        // it instead and keep the sensible defaults until a real value arrives.
+        pins += settingsService.bisqEasyTradeRulesConfirmed.bindNonNullTo(_tradeRulesConfirmed)
+        pins += settingsService.useAnimations.bindNonNullTo(_useAnimations)
+        pins += settingsService.difficultyAdjustmentFactor.bindNonNullTo(_difficultyAdjustmentFactor)
+        pins += settingsService.ignoreDiffAdjustmentFromSecManager.bindNonNullTo(_ignoreDiffAdjustmentFromSecManager)
 
         _showWebLinkConfirmation.value =
             dontShowAgainService.showAgain(

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -55,6 +55,7 @@ import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.mapping.TradeItemPresentationDtoFactory
 import network.bisq.mobile.node.common.domain.mapping.trade.toClosedTradeListItem
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
+import network.bisq.mobile.node.common.domain.utils.bindNonNullTo
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 import kotlin.time.Duration.Companion.seconds
@@ -713,54 +714,16 @@ class NodeTradesServiceFacade(
                 }
             }
         pins +=
-            trade.interruptTradeInitiator.addObserver { interruptTradeInitiator ->
-                if (interruptTradeInitiator != null) {
-                    openTradeItem.bisqEasyTradeModel.interruptTradeInitiator.value =
-                        Mappings.RoleMapping.fromBisq2Model(interruptTradeInitiator)
-                }
+            trade.interruptTradeInitiator.bindNonNullTo(openTradeItem.bisqEasyTradeModel.interruptTradeInitiator) {
+                Mappings.RoleMapping.fromBisq2Model(it)
             }
-        pins +=
-            trade.paymentAccountData.addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.paymentAccountData.value = value
-                }
-            }
-        pins +=
-            trade.bitcoinPaymentData.addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.bitcoinPaymentData.value = value
-                }
-            }
-        pins +=
-            trade.paymentProof.addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.paymentProof.value = value
-                }
-            }
-        pins +=
-            trade.errorMessageObservable().addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.errorMessage.value = value
-                }
-            }
-        pins +=
-            trade.errorStackTraceObservable().addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.errorStackTrace.value = value
-                }
-            }
-        pins +=
-            trade.peersErrorMessageObservable().addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.peersErrorMessage.value = value
-                }
-            }
-        pins +=
-            trade.peersErrorStackTraceObservable().addObserver { value ->
-                if (value != null) {
-                    openTradeItem.bisqEasyTradeModel.peersErrorStackTrace.value = value
-                }
-            }
+        pins += trade.paymentAccountData.bindNonNullTo(openTradeItem.bisqEasyTradeModel.paymentAccountData)
+        pins += trade.bitcoinPaymentData.bindNonNullTo(openTradeItem.bisqEasyTradeModel.bitcoinPaymentData)
+        pins += trade.paymentProof.bindNonNullTo(openTradeItem.bisqEasyTradeModel.paymentProof)
+        pins += trade.errorMessageObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.errorMessage)
+        pins += trade.errorStackTraceObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.errorStackTrace)
+        pins += trade.peersErrorMessageObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.peersErrorMessage)
+        pins += trade.peersErrorStackTraceObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.peersErrorStackTrace)
 
         pins +=
             channel.isInMediationObservable().addObserver { isInMediation ->

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensions.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensions.kt
@@ -1,0 +1,43 @@
+package network.bisq.mobile.node.common.domain.utils
+
+import bisq.common.observable.Pin
+import bisq.common.observable.ReadOnlyObservable
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Bridges a bisq2 [ReadOnlyObservable] into a [MutableStateFlow].
+ *
+ * Bisq2 observables invoke the observer synchronously at subscription with the CURRENT
+ * value, which may be null before data has been loaded from disk. Use [bindNonNullTo]
+ * (or handle null inside [map]) when the target flow must not see that null.
+ */
+fun <T> ReadOnlyObservable<T>.bindTo(target: MutableStateFlow<T>): Pin =
+    addObserver { value ->
+        target.value = value
+    }
+
+fun <B, D> ReadOnlyObservable<B>.bindTo(
+    target: MutableStateFlow<D>,
+    map: (B) -> D,
+): Pin =
+    addObserver { value ->
+        target.value = map(value)
+    }
+
+/** Like [bindTo] but null emissions are ignored instead of overwriting the target. */
+fun <T : Any> ReadOnlyObservable<T>.bindNonNullTo(target: MutableStateFlow<in T>): Pin =
+    addObserver { value ->
+        if (value != null) {
+            target.value = value
+        }
+    }
+
+fun <B : Any, D> ReadOnlyObservable<B>.bindNonNullTo(
+    target: MutableStateFlow<D>,
+    map: (B) -> D,
+): Pin =
+    addObserver { value ->
+        if (value != null) {
+            target.value = map(value)
+        }
+    }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
@@ -11,7 +11,7 @@ import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 // TODO Temporary flag — flip to true once the Network Info screens are complete (issue #1524).
-private const val NETWORK_INFO_ENABLED = false
+private const val NETWORK_INFO_ENABLED = true
 
 class NodeMiscItemsPresenter(
     userProfileService: UserProfileServiceFacade,

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
@@ -11,7 +11,7 @@ import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 // TODO Temporary flag — flip to true once the Network Info screens are complete (issue #1524).
-private const val NETWORK_INFO_ENABLED = true
+private const val NETWORK_INFO_ENABLED = false
 
 class NodeMiscItemsPresenter(
     userProfileService: UserProfileServiceFacade,

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacadeBindingTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacadeBindingTest.kt
@@ -1,0 +1,146 @@
+package network.bisq.mobile.node.common.domain.service.settings
+
+import androidx.core.util.Supplier
+import bisq.common.observable.Observable
+import bisq.settings.Cookie
+import bisq.settings.DontShowAgainKey
+import bisq.settings.DontShowAgainService
+import bisq.settings.SettingsService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
+import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import java.util.Optional
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the Observable→StateFlow bridging in [NodeSettingsServiceFacade.activate],
+ * in particular that ALL observer pins are retained and unbound in deactivate().
+ * Before the bindTo refactor, 4 of the 6 observers were never unbound, so they
+ * kept mutating the facade's flows (and accumulated) across activate cycles.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NodeSettingsServiceFacadeBindingTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val languageTagObservable = Observable("en")
+    private val tradeRulesConfirmedObservable = Observable(false)
+    private val useAnimationsObservable = Observable(true)
+    private val difficultyAdjustmentFactorObservable = Observable(1.0)
+    private val ignoreDiffAdjustmentObservable = Observable(false)
+    private val cookieChangedObservable = Observable(false)
+
+    private lateinit var facade: NodeSettingsServiceFacade
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        I18nSupport.setLanguage()
+        startKoin {
+            modules(
+                module {
+                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
+                },
+            )
+        }
+
+        val cookieMock =
+            mockk<Cookie> {
+                every { asBoolean(any()) } returns Optional.of(false)
+            }
+        val settingsServiceMock = mockk<SettingsService>()
+        every { settingsServiceMock.languageTag } returns languageTagObservable
+        every { settingsServiceMock.bisqEasyTradeRulesConfirmed } returns tradeRulesConfirmedObservable
+        every { settingsServiceMock.useAnimations } returns useAnimationsObservable
+        every { settingsServiceMock.difficultyAdjustmentFactor } returns difficultyAdjustmentFactorObservable
+        every { settingsServiceMock.ignoreDiffAdjustmentFromSecManager } returns ignoreDiffAdjustmentObservable
+        every { settingsServiceMock.cookieChanged } returns cookieChangedObservable
+        every { settingsServiceMock.cookie } returns cookieMock
+        val dontShowAgainServiceMock =
+            mockk<DontShowAgainService> {
+                every { showAgain(any<DontShowAgainKey>()) } returns true
+            }
+        val provider =
+            AndroidApplicationService.Provider().apply {
+                settingsService = Supplier { settingsServiceMock }
+                dontShowAgainService = Supplier { dontShowAgainServiceMock }
+            }
+        facade = NodeSettingsServiceFacade(provider)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `activate bridges bisq2 observables into facade flows`() =
+        runTest(testDispatcher) {
+            facade.activate()
+
+            languageTagObservable.set("de")
+            tradeRulesConfirmedObservable.set(true)
+            useAnimationsObservable.set(false)
+            difficultyAdjustmentFactorObservable.set(2.5)
+            ignoreDiffAdjustmentObservable.set(true)
+
+            assertEquals("de", facade.languageCode.value)
+            assertEquals(true, facade.tradeRulesConfirmed.value)
+            assertEquals(false, facade.useAnimations.value)
+            assertEquals(2.5, facade.difficultyAdjustmentFactor.value)
+            assertEquals(true, facade.ignoreDiffAdjustmentFromSecManager.value)
+
+            facade.deactivate()
+        }
+
+    @Test
+    fun `deactivate unbinds ALL observers`() =
+        runTest(testDispatcher) {
+            facade.activate()
+            facade.deactivate()
+
+            languageTagObservable.set("fr")
+            tradeRulesConfirmedObservable.set(true)
+            useAnimationsObservable.set(false)
+            difficultyAdjustmentFactorObservable.set(3.0)
+            ignoreDiffAdjustmentObservable.set(true)
+            cookieChangedObservable.set(true)
+
+            // Values from activation time — none of the post-deactivate updates leaked through
+            assertEquals("en", facade.languageCode.value)
+            assertEquals(false, facade.tradeRulesConfirmed.value)
+            assertEquals(true, facade.useAnimations.value)
+            assertEquals(1.0, facade.difficultyAdjustmentFactor.value)
+            assertEquals(false, facade.ignoreDiffAdjustmentFromSecManager.value)
+            assertEquals(false, facade.permitOpeningBrowser.value)
+        }
+
+    @Test
+    fun `facade can be re-activated after deactivate and bridges again`() =
+        runTest(testDispatcher) {
+            facade.activate()
+            facade.deactivate()
+            facade.activate()
+
+            useAnimationsObservable.set(false)
+
+            assertEquals(false, facade.useAnimations.value)
+
+            facade.deactivate()
+        }
+}

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensionsTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensionsTest.kt
@@ -1,0 +1,72 @@
+package network.bisq.mobile.node.common.domain.utils
+
+import bisq.common.observable.Observable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ObservableExtensionsTest {
+    @Test
+    fun `bindTo pushes current value at subscription and follows updates`() {
+        val observable = Observable("a")
+        val target = MutableStateFlow("initial")
+
+        val pin = observable.bindTo(target)
+
+        assertEquals("a", target.value)
+        observable.set("b")
+        assertEquals("b", target.value)
+
+        pin.unbind()
+        observable.set("c")
+        assertEquals("b", target.value, "unbound pin must stop propagation")
+    }
+
+    @Test
+    fun `bindTo with map transforms values`() {
+        val observable = Observable(1)
+        val target = MutableStateFlow("")
+
+        val pin = observable.bindTo(target) { "v$it" }
+
+        assertEquals("v1", target.value)
+        observable.set(2)
+        assertEquals("v2", target.value)
+
+        pin.unbind()
+        observable.set(3)
+        assertEquals("v2", target.value, "unbound pin must stop propagation")
+    }
+
+    @Test
+    fun `bindNonNullTo ignores null current value at subscription`() {
+        // bisq2 observables fire synchronously at subscription with the CURRENT
+        // value, which is null before first set — bindNonNullTo must not
+        // overwrite the target with it.
+        val observable = Observable<String>()
+        val target = MutableStateFlow("initial")
+
+        observable.bindNonNullTo(target)
+
+        assertEquals("initial", target.value)
+        observable.set("a")
+        assertEquals("a", target.value)
+    }
+
+    @Test
+    fun `bindNonNullTo with map ignores nulls and transforms values`() {
+        val observable = Observable<Int>()
+        val target = MutableStateFlow<String?>(null)
+
+        val pin = observable.bindNonNullTo(target) { "v$it" }
+
+        assertNull(target.value)
+        observable.set(7)
+        assertEquals("v7", target.value)
+
+        pin.unbind()
+        observable.set(8)
+        assertEquals("v7", target.value, "unbound pin must stop propagation")
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
@@ -1,0 +1,167 @@
+package network.bisq.mobile.domain.analytics
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import network.bisq.mobile.data.model.BatteryOptimizationState
+import network.bisq.mobile.data.model.PermissionState
+import network.bisq.mobile.data.model.Settings
+import network.bisq.mobile.data.model.market.MarketFilter
+import network.bisq.mobile.data.model.market.MarketSortBy
+import network.bisq.mobile.domain.repository.SettingsRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+
+/**
+ * Covers the gate wiring done by [createBufferedAnalyticsService]: the
+ * runtimeOptInProvider handed to the SDK must be the AND of the dev build flag
+ * and the LIVE user-settings toggle (a settings flip propagates without
+ * rebuilding the service).
+ */
+class BufferedAnalyticsServiceFactoryTest {
+    private class FakeInitializer : NativeSentryInitializer {
+        var capturedOptInProvider: (() -> Boolean)? = null
+
+        override fun init(
+            dsn: String,
+            environment: String,
+            release: String,
+            redactor: AnalyticsRedactor,
+            isDebug: Boolean,
+            socksProxyHost: String?,
+            socksProxyPort: Int?,
+            runtimeOptInProvider: () -> Boolean,
+        ) {
+            capturedOptInProvider = runtimeOptInProvider
+        }
+    }
+
+    private class FakeSettingsRepository(
+        initial: Settings,
+    ) : SettingsRepository {
+        private val settings = MutableStateFlow(initial)
+        override val data: Flow<Settings> get() = settings
+
+        fun setAnalytics(value: Boolean) {
+            settings.update { it.copy(analyticsEnabled = value) }
+        }
+
+        override suspend fun setFirstLaunch(value: Boolean) = Unit
+
+        override suspend fun setShowChatRulesWarnBox(value: Boolean) = Unit
+
+        override suspend fun setSelectedMarketCode(value: String) = Unit
+
+        override suspend fun setNotificationPermissionState(value: PermissionState) = Unit
+
+        override suspend fun setBatteryOptimizationPermissionState(value: BatteryOptimizationState) = Unit
+
+        override suspend fun update(transform: suspend (t: Settings) -> Settings) = Unit
+
+        override suspend fun clear() = Unit
+
+        override suspend fun setMarketSortBy(value: MarketSortBy) = Unit
+
+        override suspend fun setMarketFilter(value: MarketFilter) = Unit
+
+        override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) = Unit
+
+        override suspend fun setPermitOpeningBrowser(value: Boolean) = Unit
+
+        override suspend fun setAnalyticsEnabled(value: Boolean) = Unit
+
+        override suspend fun setAnalyticsPromptSeen(value: Boolean) = Unit
+
+        override suspend fun setAnalyticsBaselineSent(value: Boolean) = Unit
+
+        override suspend fun setRememberOfferbookFilterPreferences(value: Boolean) = Unit
+    }
+
+    private fun buildAndCaptureProvider(
+        repository: FakeSettingsRepository,
+        analyticsDevEnabled: Boolean,
+    ): () -> Boolean {
+        val initializer = FakeInitializer()
+        val service =
+            createBufferedAnalyticsService(
+                settingsRepository = repository,
+                nativeInitializer = initializer,
+                analyticsDevEnabled = analyticsDevEnabled,
+            )
+        service.init(
+            dsn = "https://key@glitchtip.example/1",
+            environment = "test",
+            release = "test@1",
+            isDebug = true,
+            socksProxyHost = null,
+            socksProxyPort = null,
+        )
+        val provider = initializer.capturedOptInProvider
+        assertNotNull(provider, "factory must thread the opt-in provider into the native SDK init")
+        return provider
+    }
+
+    /**
+     * The settings-derived StateFlow inside the factory is collected eagerly on
+     * Dispatchers.Default, so propagation is asynchronous — poll with a timeout.
+     */
+    private fun awaitCondition(
+        message: String,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        fail(message)
+    }
+
+    @Test
+    fun `provider is false when dev flag is off even if user opted in`() {
+        val repository = FakeSettingsRepository(Settings(analyticsEnabled = true))
+
+        val provider = buildAndCaptureProvider(repository, analyticsDevEnabled = false)
+
+        // Give the settings flow time to propagate — the dev gate must still win
+        Thread.sleep(100)
+        assertFalse(provider(), "dev flag off must gate emission regardless of user opt-in")
+    }
+
+    @Test
+    fun `provider is false while user has not opted in`() {
+        val repository = FakeSettingsRepository(Settings(analyticsEnabled = false))
+
+        val provider = buildAndCaptureProvider(repository, analyticsDevEnabled = true)
+
+        Thread.sleep(100)
+        assertFalse(provider(), "user opt-out must gate emission")
+    }
+
+    @Test
+    fun `provider becomes true when dev flag is on and user opted in`() {
+        val repository = FakeSettingsRepository(Settings(analyticsEnabled = true))
+
+        val provider = buildAndCaptureProvider(repository, analyticsDevEnabled = true)
+
+        awaitCondition("provider should turn true once the settings flow propagates") { provider() }
+    }
+
+    @Test
+    fun `runtime settings flip propagates to the provider without rebuilding`() {
+        val repository = FakeSettingsRepository(Settings(analyticsEnabled = false))
+
+        val provider = buildAndCaptureProvider(repository, analyticsDevEnabled = true)
+
+        Thread.sleep(100)
+        assertFalse(provider(), "starts opted out")
+
+        repository.setAnalytics(true)
+        awaitCondition("opt-in flip should propagate to the provider") { provider() }
+
+        repository.setAnalytics(false)
+        awaitCondition("opt-out flip should propagate to the provider") { !provider() }
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryImplTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/SettingsRepositoryImplTest.kt
@@ -10,7 +10,11 @@ import io.mockk.slot
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.model.BatteryOptimizationState
+import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.model.Settings
+import network.bisq.mobile.data.model.market.MarketFilter
+import network.bisq.mobile.data.model.market.MarketSortBy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -278,5 +282,24 @@ class SettingsRepositoryImplTest {
             val updated = updateSlot.captured(originalSettings)
             assertEquals(true, updated.analyticsPromptSeen)
             assertEquals(false, updated.analyticsEnabled, "promptSeen flip must NOT enable analytics — privacy contract")
+        }
+
+    @Test
+    fun `remaining setters each delegate to datastore updateData`() =
+        runTest {
+            coEvery { mockDataStore.updateData(any()) } returns Settings()
+
+            repository.setSelectedMarketCode("BTC/USD")
+            repository.setNotificationPermissionState(PermissionState.entries.first())
+            repository.setBatteryOptimizationPermissionState(BatteryOptimizationState.entries.first())
+            repository.setMarketSortBy(MarketSortBy.entries.first())
+            repository.setMarketFilter(MarketFilter.entries.first())
+            repository.setDontShowAgainHyperlinksOpenInBrowser(true)
+            repository.setPermitOpeningBrowser(true)
+            repository.setAnalyticsBaselineSent(true)
+            repository.setRememberOfferbookFilterPreferences(true)
+            repository.update { it }
+
+            coVerify(exactly = 10) { mockDataStore.updateData(any()) }
         }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/DataStoreRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/DataStoreRepository.kt
@@ -1,0 +1,39 @@
+package network.bisq.mobile.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import network.bisq.mobile.domain.utils.Logging
+
+/**
+ * Base class for DataStore-backed repositories.
+ *
+ * Provides the [data] flow that falls back to [createDefault] when the datastore
+ * fails to read with an [IOException], plus [set] for one-line field updates and
+ * a default [clear] implementation.
+ */
+abstract class DataStoreRepository<T>(
+    protected val store: DataStore<T>,
+) : Logging {
+    protected abstract fun createDefault(): T
+
+    val data: Flow<T>
+        get() =
+            store.data.catch { exception ->
+                if (exception is IOException) {
+                    log.e("Error reading datastore", exception)
+                    emit(createDefault())
+                } else {
+                    throw exception
+                }
+            }
+
+    protected suspend fun set(transform: suspend (T) -> T) {
+        store.updateData(transform)
+    }
+
+    open suspend fun clear() {
+        store.updateData { createDefault() }
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/SettingsRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/SettingsRepositoryImpl.kt
@@ -1,117 +1,44 @@
 package network.bisq.mobile.data.repository
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.IOException
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import network.bisq.mobile.data.model.BatteryOptimizationState
 import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.data.model.market.MarketFilter
 import network.bisq.mobile.data.model.market.MarketSortBy
 import network.bisq.mobile.domain.repository.SettingsRepository
-import network.bisq.mobile.domain.utils.Logging
 
 open class SettingsRepositoryImpl(
-    private val settingsStore: DataStore<Settings>,
-) : SettingsRepository,
-    Logging {
-    override val data: Flow<Settings>
-        get() =
-            settingsStore.data.catch { exception ->
-                if (exception is IOException) {
-                    log.e("Error reading Settings datastore", exception)
-                    emit(Settings())
-                } else {
-                    throw exception
-                }
-            }
+    settingsStore: DataStore<Settings>,
+) : DataStoreRepository<Settings>(settingsStore),
+    SettingsRepository {
+    override fun createDefault() = Settings()
 
-    override suspend fun setFirstLaunch(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(firstLaunch = value)
-        }
-    }
+    override suspend fun setFirstLaunch(value: Boolean) = set { it.copy(firstLaunch = value) }
 
-    override suspend fun setShowChatRulesWarnBox(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(showChatRulesWarnBox = value)
-        }
-    }
+    override suspend fun setShowChatRulesWarnBox(value: Boolean) = set { it.copy(showChatRulesWarnBox = value) }
 
-    override suspend fun setSelectedMarketCode(value: String) {
-        settingsStore.updateData {
-            it.copy(selectedMarketCode = value)
-        }
-    }
+    override suspend fun setSelectedMarketCode(value: String) = set { it.copy(selectedMarketCode = value) }
 
-    override suspend fun setNotificationPermissionState(value: PermissionState) {
-        settingsStore.updateData {
-            it.copy(notificationPermissionState = value)
-        }
-    }
+    override suspend fun setNotificationPermissionState(value: PermissionState) = set { it.copy(notificationPermissionState = value) }
 
-    override suspend fun setBatteryOptimizationPermissionState(value: BatteryOptimizationState) {
-        settingsStore.updateData {
-            it.copy(batteryOptimizationState = value)
-        }
-    }
+    override suspend fun setBatteryOptimizationPermissionState(value: BatteryOptimizationState) = set { it.copy(batteryOptimizationState = value) }
 
-    override suspend fun update(transform: suspend (t: Settings) -> Settings) {
-        settingsStore.updateData(transform)
-    }
+    override suspend fun update(transform: suspend (t: Settings) -> Settings) = set(transform)
 
-    override suspend fun clear() {
-        settingsStore.updateData {
-            Settings()
-        }
-    }
+    override suspend fun setMarketSortBy(value: MarketSortBy) = set { it.copy(marketSortBy = value) }
 
-    override suspend fun setMarketSortBy(value: MarketSortBy) {
-        settingsStore.updateData {
-            it.copy(marketSortBy = value)
-        }
-    }
+    override suspend fun setMarketFilter(value: MarketFilter) = set { it.copy(marketFilter = value) }
 
-    override suspend fun setMarketFilter(value: MarketFilter) {
-        settingsStore.updateData {
-            it.copy(marketFilter = value)
-        }
-    }
+    override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) = set { it.copy(dontShowAgainHyperlinksOpenInBrowser = value) }
 
-    override suspend fun setDontShowAgainHyperlinksOpenInBrowser(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(dontShowAgainHyperlinksOpenInBrowser = value)
-        }
-    }
+    override suspend fun setPermitOpeningBrowser(value: Boolean) = set { it.copy(cookiePermitOpeningBrowser = value) }
 
-    override suspend fun setPermitOpeningBrowser(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(cookiePermitOpeningBrowser = value)
-        }
-    }
+    override suspend fun setAnalyticsEnabled(value: Boolean) = set { it.copy(analyticsEnabled = value) }
 
-    override suspend fun setAnalyticsEnabled(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(analyticsEnabled = value)
-        }
-    }
+    override suspend fun setAnalyticsPromptSeen(value: Boolean) = set { it.copy(analyticsPromptSeen = value) }
 
-    override suspend fun setAnalyticsPromptSeen(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(analyticsPromptSeen = value)
-        }
-    }
+    override suspend fun setAnalyticsBaselineSent(value: Boolean) = set { it.copy(analyticsBaselineSent = value) }
 
-    override suspend fun setAnalyticsBaselineSent(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(analyticsBaselineSent = value)
-        }
-    }
-
-    override suspend fun setRememberOfferbookFilterPreferences(value: Boolean) {
-        settingsStore.updateData {
-            it.copy(rememberOfferbookFilterPreferences = value)
-        }
-    }
+    override suspend fun setRememberOfferbookFilterPreferences(value: Boolean) = set { it.copy(rememberOfferbookFilterPreferences = value) }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/TradeReadStateRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/TradeReadStateRepositoryImpl.kt
@@ -1,27 +1,14 @@
 package network.bisq.mobile.data.repository
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.IOException
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import network.bisq.mobile.data.model.TradeReadStateMap
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
-import network.bisq.mobile.domain.utils.Logging
 
 class TradeReadStateRepositoryImpl(
-    private val tradeReadStateMapStore: DataStore<TradeReadStateMap>,
-) : TradeReadStateRepository,
-    Logging {
-    override val data: Flow<TradeReadStateMap>
-        get() =
-            tradeReadStateMapStore.data.catch { exception ->
-                if (exception is IOException) {
-                    log.e("Error reading TradeReadStateMap datastore", exception)
-                    emit(TradeReadStateMap(emptyMap()))
-                } else {
-                    throw exception
-                }
-            }
+    tradeReadStateMapStore: DataStore<TradeReadStateMap>,
+) : DataStoreRepository<TradeReadStateMap>(tradeReadStateMapStore),
+    TradeReadStateRepository {
+    override fun createDefault() = TradeReadStateMap(emptyMap())
 
     override suspend fun setCount(
         tradeId: String,
@@ -30,13 +17,11 @@ class TradeReadStateRepositoryImpl(
         require(tradeId.isNotBlank()) { "tradeId cannot be blank" }
         require(count >= 0) { "count must be >= 0" }
 
-        tradeReadStateMapStore.updateData { it.copy(it.map + (tradeId to count)) }
+        set { it.copy(it.map + (tradeId to count)) }
     }
 
     override suspend fun clearId(tradeId: String) {
         require(tradeId.isNotBlank()) { "tradeId cannot be blank" }
-        tradeReadStateMapStore.updateData {
-            it.copy(it.map - tradeId)
-        }
+        set { it.copy(it.map - tradeId) }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/UserRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/UserRepositoryImpl.kt
@@ -1,47 +1,18 @@
 package network.bisq.mobile.data.repository
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.IOException
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import network.bisq.mobile.data.model.User
 import network.bisq.mobile.domain.repository.UserRepository
-import network.bisq.mobile.domain.utils.Logging
 
 class UserRepositoryImpl(
-    private val userStore: DataStore<User>,
-) : UserRepository,
-    Logging {
-    override val data: Flow<User>
-        get() =
-            userStore.data.catch { exception ->
-                if (exception is IOException) {
-                    log.e("Error reading User datastore", exception)
-                    emit(User())
-                } else {
-                    throw exception
-                }
-            }
+    userStore: DataStore<User>,
+) : DataStoreRepository<User>(userStore),
+    UserRepository {
+    override fun createDefault() = User()
 
-    override suspend fun updateTerms(value: String) {
-        userStore.updateData {
-            it.copy(tradeTerms = value)
-        }
-    }
+    override suspend fun updateTerms(value: String) = set { it.copy(tradeTerms = value) }
 
-    override suspend fun updateStatement(value: String) {
-        userStore.updateData {
-            it.copy(statement = value)
-        }
-    }
+    override suspend fun updateStatement(value: String) = set { it.copy(statement = value) }
 
-    override suspend fun update(value: User) {
-        userStore.updateData {
-            value
-        }
-    }
-
-    override suspend fun clear() {
-        userStore.updateData { User() }
-    }
+    override suspend fun update(value: User) = set { value }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactory.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactory.kt
@@ -1,0 +1,43 @@
+package network.bisq.mobile.domain.analytics
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import network.bisq.mobile.domain.repository.SettingsRepository
+
+/**
+ * Builds the [BufferedAnalyticsService] wrapping a [SentryAnalyticsService] — the single
+ * analytics wiring shared by the client and node DI modules; see those modules for the
+ * app-specific rationale (DSN selection, SOCKS port source).
+ *
+ * Two gates AND'd together on every emit:
+ *  1. [analyticsDevEnabled] — dev-only build flag; release builds const-fold it to true
+ *     at BuildConfig generation time.
+ *  2. User-settings toggle — flipped from the Settings UI, no rebuild required.
+ */
+fun createBufferedAnalyticsService(
+    settingsRepository: SettingsRepository,
+    nativeInitializer: NativeSentryInitializer,
+    analyticsDevEnabled: Boolean,
+): BufferedAnalyticsService {
+    // Independent scope so the buffer's periodic flusher survives any
+    // individual feature-scope cancellation. SupervisorJob so a single
+    // failed enqueue doesn't kill the flusher. Reused for the
+    // settings-derived analyticsEnabled StateFlow so its hot-share
+    // lives exactly as long as the BufferedAnalyticsService instance.
+    val analyticsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    // Hot StateFlow view of `Settings.analyticsEnabled`. Backed by
+    // DataStore so a settings flip from any UI surface propagates
+    // immediately to this `.value` read in the runtime gate.
+    val analyticsEnabledFlow = settingsRepository.analyticsEnabledIn(analyticsScope)
+    return BufferedAnalyticsService(
+        downstream =
+            SentryAnalyticsService(
+                nativeInitializer = nativeInitializer,
+                runtimeOptInProvider = {
+                    analyticsDevEnabled && analyticsEnabledFlow.value
+                },
+            ),
+        scope = analyticsScope,
+    )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSectionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSectionUiTest.kt
@@ -1,0 +1,78 @@
+package network.bisq.mobile.presentation.common.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ListStateSectionUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme { content() }
+            }
+        }
+    }
+
+    @Test
+    fun `full state - icon, headline title, subtitle and button render, and button dispatches`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        setContent {
+            ListStateSection(
+                title = "No trades yet",
+                subtitle = "Your completed trades will show up here",
+                icon = { BisqText.BaseLight("ICON") },
+                buttonText = "Browse offers",
+                onButtonClick = onClick,
+            )
+        }
+        composeTestRule.onNodeWithText("ICON").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No trades yet").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Your completed trades will show up here").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Browse offers").performClick()
+        verify(exactly = 1) { onClick() }
+    }
+
+    @Test
+    fun `minimal state - non-headline title, no icon, no subtitle, grey button renders`() {
+        setContent {
+            ListStateSection(
+                title = "No results match your search",
+                useHeadlineStyle = false,
+                buttonText = "Clear search",
+                buttonType = BisqButtonType.Grey,
+            )
+        }
+        composeTestRule.onNodeWithText("No results match your search").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Clear search").assertIsDisplayed()
+    }
+
+    @Test
+    fun `title only renders without icon, subtitle or button`() {
+        setContent { ListStateSection(title = "Nothing here") }
+        composeTestRule.onNodeWithText("Nothing here").assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSliderUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSliderUiTest.kt
@@ -1,0 +1,74 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms.slider
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for issue #1571: [BisqRangeSlider] must not crash when handed an inverted or
+ * non-finite value range. Material3's RangeSlider runs the thumbs through coerceIn during measure
+ * and throws IllegalArgumentException on inverted/NaN bounds; the wrapper sanitizes inputs so these
+ * compose without throwing (before the fix, measuring these would crash the whole screen).
+ */
+@RunWith(AndroidJUnit4::class)
+class BisqRangeSliderUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val tag = "range_slider"
+
+    private fun render(
+        value: ClosedFloatingPointRange<Float>,
+        valueRange: ClosedFloatingPointRange<Float>,
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme {
+                    BisqRangeSlider(
+                        value = value,
+                        onValueChange = {},
+                        modifier = Modifier.testTag(tag),
+                        valueRange = valueRange,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `inverted value range does not crash and still renders`() {
+        // reputation-based max collapsing below 0 → valueRange = 0f..negative (the crash case)
+        render(value = 0.1f..0.9f, valueRange = 0f..(-0.5f))
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(tag).assertExists()
+    }
+
+    @Test
+    fun `selection outside a shrunken range does not crash and still renders`() {
+        render(value = 0.1f..0.9f, valueRange = 0f..0.05f)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(tag).assertExists()
+    }
+
+    @Test
+    fun `non-finite bounds do not crash and still render`() {
+        render(value = Float.NaN..Float.NaN, valueRange = 0f..Float.NaN)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(tag).assertExists()
+    }
+
+    @Test
+    fun `valid range renders normally`() {
+        render(value = 0.25f..0.75f, valueRange = 0f..1f)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(tag).assertExists()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRowUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRowUiTest.kt
@@ -1,0 +1,44 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.backup
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IconTextRowUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme { content() }
+            }
+        }
+    }
+
+    @Test
+    fun `renders the icon and the text`() {
+        setContent {
+            IconTextRow(icon = Res.drawable.backup, text = "Encrypted backups")
+        }
+        composeTestRule.onNodeWithText("Encrypted backups").assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterFieldUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterFieldUiTest.kt
@@ -1,0 +1,63 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules.inputfield
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SearchWithFilterFieldUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        I18nSupport.setLanguage()
+    }
+
+    private fun setContent(content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIsTest provides true) {
+                BisqTheme { content() }
+            }
+        }
+    }
+
+    @Test
+    fun `inactive filter renders the search field with its placeholder`() {
+        setContent {
+            SearchWithFilterField(
+                value = "",
+                onValueChange = {},
+                isFilterActive = false,
+                onFilterClick = {},
+                placeholder = "Search here",
+            )
+        }
+        composeTestRule.onNodeWithText("Search here").assertIsDisplayed()
+    }
+
+    @Test
+    fun `active filter renders the field with its current value (green icon branch)`() {
+        setContent {
+            SearchWithFilterField(
+                value = "bitcoin",
+                onValueChange = {},
+                isFilterActive = true,
+                onFilterClick = {},
+                placeholder = "Search here",
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("bitcoin").assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
@@ -44,6 +44,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CreateOfferAmountPresenterTest {
@@ -312,5 +314,78 @@ class CreateOfferAmountPresenterTest {
             runCurrent()
 
             assertEquals(savedMinText, recreatedPresenter.formattedQuoteSideMinRangeAmount.value)
+        }
+
+    @Test
+    fun seller_with_reputation_below_market_min_clamps_slider_max_and_does_not_crash() =
+        runTest(testDispatcher) {
+            val marketUSD = MarketVOFactory.USD
+            val marketUSDItem =
+                MarketPriceItem(
+                    marketUSD,
+                    with(PriceQuoteVOFactory) { fromPrice(100_00L, marketUSD) },
+                    formattedPrice = "100 USD",
+                )
+            val prices = mapOf(marketUSD to marketUSDItem)
+
+            val marketPriceServiceFacade =
+                mockk<MarketPriceServiceFacade>(relaxed = true).apply {
+                    every { findMarketPriceItem(any()) } answers {
+                        val arg = firstArg<MarketVO>()
+                        prices.values.firstOrNull { it.market.baseCurrencyCode == arg.baseCurrencyCode && it.market.quoteCurrencyCode == arg.quoteCurrencyCode }
+                    }
+                    every { findUSDMarketPriceItem() } returns prices[marketUSD]
+                    every { refreshSelectedFormattedMarketPrice() } returns Unit
+                    every { selectMarket(any()) } returns Result.success(Unit)
+                }
+
+            mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
+            every { getScreenWidthDp() } returns 480
+
+            val mainPresenter =
+                MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
+            val createOfferCoordinator =
+                CreateOfferCoordinator(
+                    marketPriceServiceFacade,
+                    mockk<OffersServiceFacade>(relaxed = true),
+                    mockk<SettingsServiceFacade>(relaxed = true),
+                )
+            createOfferCoordinator.createOfferModel =
+                CreateOfferCoordinator.CreateOfferModel().also { m ->
+                    m.market = marketUSD
+                    m.direction = DirectionEnum.SELL
+                    m.amountType = CreateOfferCoordinator.AmountType.RANGE_AMOUNT
+                }
+
+            val userProfile = createMockUserProfile("seller-profile")
+            val userProfileServiceFacade =
+                mockk<UserProfileServiceFacade>(relaxed = true).apply {
+                    every { selectedUserProfile } returns MutableStateFlow(userProfile)
+                }
+            // Zero reputation -> reputation-based max amount is ~0, below the market minimum, so the
+            // raw slider fraction (amount - min) / range is negative. Pre-fix this produced an
+            // inverted RangeSlider valueRange (0f..negative) and crashed on measure (issue #1571).
+            val reputationServiceFacade =
+                mockk<ReputationServiceFacade>(relaxed = true).apply {
+                    coEvery { getReputation(userProfile.id) } returns
+                        Result.success(ReputationScoreVO(totalScore = 0L, fiveSystemScore = 0.0, ranking = 0))
+                }
+
+            val presenter =
+                CreateOfferAmountPresenter(
+                    mainPresenter,
+                    marketPriceServiceFacade,
+                    createOfferCoordinator,
+                    userProfileServiceFacade,
+                    reputationServiceFacade,
+                )
+            runCurrent()
+
+            val repMax = presenter.reputationBasedMaxSliderValue.value
+            assertNotNull(repMax)
+            // Clamped into a valid [0, 1] fraction instead of going negative.
+            assertTrue(repMax in 0f..1f, "reputation-based max slider value must be clamped, was $repMax")
+            // The selected max stays within the reputation-based bound.
+            assertTrue(presenter.maxRangeSliderValue.value <= repMax)
         }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSection.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSection.kt
@@ -43,8 +43,10 @@ fun ListStateSection(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = verticalArrangement,
     ) {
-        icon?.invoke()
-        BisqGap.V2()
+        if (icon != null) {
+            icon()
+            BisqGap.V2()
+        }
         if (useHeadlineStyle) {
             BisqText.H5Light(text = title, textAlign = TextAlign.Center)
         } else {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSection.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSection.kt
@@ -1,0 +1,98 @@
+package network.bisq.mobile.presentation.common.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+
+/**
+ * Standard empty / no-results / error message section for list screens:
+ * optional icon, centered title, optional subtitle and action button.
+ */
+@Composable
+fun ListStateSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    useHeadlineStyle: Boolean = true,
+    icon: (@Composable () -> Unit)? = null,
+    buttonText: String? = null,
+    buttonType: BisqButtonType = BisqButtonType.Default,
+    onButtonClick: () -> Unit = {},
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    verticalPadding: Dp = BisqUIConstants.ScreenPadding3X,
+) {
+    Column(
+        modifier =
+            modifier.padding(
+                horizontal = BisqUIConstants.ScreenPadding2X,
+                vertical = verticalPadding,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = verticalArrangement,
+    ) {
+        icon?.invoke()
+        BisqGap.V2()
+        if (useHeadlineStyle) {
+            BisqText.H5Light(text = title, textAlign = TextAlign.Center)
+        } else {
+            BisqText.BaseLight(text = title, textAlign = TextAlign.Center)
+        }
+        if (subtitle != null) {
+            BisqGap.V1()
+            BisqText.SmallLightGrey(text = subtitle, textAlign = TextAlign.Center)
+        }
+        if (buttonText != null) {
+            if (subtitle != null) {
+                BisqGap.V2()
+            } else {
+                BisqGap.V1()
+            }
+            BisqButton(
+                text = buttonText,
+                type = buttonType,
+                onClick = onButtonClick,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ListStateSection_EmptyPreview() {
+    BisqTheme.Preview {
+        ListStateSection(
+            title = "No trades yet",
+            subtitle = "Your completed trades will show up here.",
+            buttonText = "Browse offers",
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ListStateSection_NoResultsPreview() {
+    BisqTheme.Preview {
+        ListStateSection(
+            title = "No results match your search",
+            useHeadlineStyle = false,
+            buttonText = "Clear search",
+            buttonType = BisqButtonType.Grey,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSlider.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSlider.kt
@@ -31,7 +31,26 @@ fun BisqRangeSlider(
     onValueChangeFinished: (() -> Unit)? = null,
     enabled: Boolean = true,
 ) {
-    val thumbColor = if (enabled) BisqTheme.colors.primary else BisqTheme.colors.mid_grey20
+    // Guard against inverted / non-finite ranges (issue #1571): Material3 RangeSlider runs the
+    // thumb values through coerceIn during measure, which throws IllegalArgumentException when the
+    // bounds are inverted (end < start) or non-finite (NaN/Infinity) — e.g. a reputation-based max
+    // that collapses below the selected min. Sanitize here so a bad caller state degrades to a
+    // disabled slider instead of crashing the whole screen.
+    val boundsUsable =
+        valueRange.start.isFinite() &&
+            valueRange.endInclusive.isFinite() &&
+            valueRange.endInclusive > valueRange.start
+    val safeValueRange = if (boundsUsable) valueRange else 0f..1f
+    val safeStart =
+        (if (value.start.isFinite()) value.start else safeValueRange.start)
+            .coerceIn(safeValueRange.start, safeValueRange.endInclusive)
+    val safeEnd =
+        (if (value.endInclusive.isFinite()) value.endInclusive else safeValueRange.endInclusive)
+            .coerceIn(safeStart, safeValueRange.endInclusive)
+    val safeValue = safeStart..safeEnd
+    val effectivelyEnabled = enabled && boundsUsable
+
+    val thumbColor = if (effectivelyEnabled) BisqTheme.colors.primary else BisqTheme.colors.mid_grey20
 
     val customThumb: @Composable (RangeSliderState) -> Unit = { _ ->
         Box(
@@ -47,12 +66,12 @@ fun BisqRangeSlider(
     }
 
     RangeSlider(
-        value = value,
+        value = safeValue,
         onValueChange = onValueChange,
         modifier = modifier,
-        valueRange = valueRange,
+        valueRange = safeValueRange,
         onValueChangeFinished = onValueChangeFinished,
-        enabled = enabled,
+        enabled = effectivelyEnabled,
         startThumb = customThumb,
         endThumb = customThumb,
         colors =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRow.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRow.kt
@@ -1,0 +1,34 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+/** A single line of icon + text, e.g. for feature/benefit bullet lists. */
+@Composable
+fun IconTextRow(
+    icon: DrawableResource,
+    text: String,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 30.dp,
+    gap: Dp = 15.dp,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(painterResource(icon), null, Modifier.size(iconSize))
+        Spacer(modifier = Modifier.width(gap))
+        BisqText.BaseLight(text)
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchField.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.presentation.common.ui.components.molecules.inputfie
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -34,7 +35,7 @@ fun BisqSearchField(
     fieldModifier: Modifier = Modifier,
     label: String = "",
     placeholder: String = "action.search".i18n(),
-    rightSuffix: (@Composable () -> Unit)? = null,
+    rightSuffix: (@Composable RowScope.() -> Unit)? = null,
     disabled: Boolean = false,
 ) {
     // Custom layout: text field is measured first and dictates the height.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterField.kt
@@ -1,0 +1,85 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules.inputfield
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.GreenSortIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SortIcon
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+
+/**
+ * [BisqSearchField] with the standard filter/sort button suffix.
+ * The icon renders green while a filter is active.
+ */
+@Composable
+fun SearchWithFilterField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    isFilterActive: Boolean,
+    onFilterClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "action.search".i18n(),
+) {
+    BisqSearchField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        modifier = modifier,
+        rightSuffix = {
+            BisqButton(
+                iconOnly = {
+                    if (isFilterActive) {
+                        GreenSortIcon()
+                    } else {
+                        SortIcon()
+                    }
+                },
+                onClick = onFilterClick,
+                type = BisqButtonType.Clear,
+                modifier = Modifier.weight(1f),
+            )
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun SearchWithFilterField_InactivePreview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            var textState by remember { mutableStateOf("") }
+            SearchWithFilterField(
+                value = textState,
+                onValueChange = { textState = it },
+                isFilterActive = false,
+                onFilterClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SearchWithFilterField_ActivePreview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            var textState by remember { mutableStateOf("bitcoin") }
+            SearchWithFilterField(
+                value = textState,
+                onValueChange = { textState = it },
+                isFilterActive = true,
+                onFilterClick = {},
+            )
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
@@ -554,9 +554,27 @@ class CreateOfferAmountPresenter(
                     _requiredReputation.value,
                 ) ?: return@launch
 
-            val reputationBasedMaxValue = (amount.value.toFloat() - minAmount) / range
+            // Clamp to a valid [0, 1] fraction: when a low-reputation seller's max allowed amount
+            // is below the market minimum this would go negative (or NaN when range == 0), which
+            // produces an inverted slider valueRange (0f..negative) that crashes Material3's
+            // RangeSlider during measure (issue #1571).
+            val reputationBasedMaxValue =
+                if (range > 0L) {
+                    ((amount.value.toFloat() - minAmount) / range).coerceIn(0f, 1f)
+                } else {
+                    0f
+                }
             _reputationBasedMaxSliderValue.value = reputationBasedMaxValue
             _rightMarkerValue.value = reputationBasedMaxValue
+
+            // Keep the selected range within the reputation-based bounds so the slider never
+            // receives a selection outside [0, max].
+            if (_maxRangeSliderValue.value > reputationBasedMaxValue) {
+                _maxRangeSliderValue.value = reputationBasedMaxValue
+            }
+            if (_minRangeSliderValue.value > _maxRangeSliderValue.value) {
+                _minRangeSliderValue.value = _maxRangeSliderValue.value
+            }
 
             _formattedReputationBasedMaxAmount.value =
                 AmountFormatter.formatAmount(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListScreen.kt
@@ -42,19 +42,17 @@ import network.bisq.mobile.data.utils.createEmptyImage
 import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
 import network.bisq.mobile.domain.model.trade.TradeOutcome
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.ListStateSection
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
 import network.bisq.mobile.presentation.common.ui.components.atoms.StarPainters
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.GreenSortIcon
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SortIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.atoms.rememberStarPainters
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqStaticLayout
 import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethods
 import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileRow
-import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
+import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.SearchWithFilterField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
@@ -111,24 +109,12 @@ fun ClosedTradeListScreen() {
     ) {
         BisqGap.V1()
 
-        BisqSearchField(
+        SearchWithFilterField(
             value = uiState.searchQuery,
             onValueChange = { presenter.onAction(ClosedTradeListUiAction.OnSearchQueryChange(it)) },
             placeholder = "mobile.tradeHistory.search.placeholder".i18n(),
-            rightSuffix = {
-                BisqButton(
-                    iconOnly = {
-                        if (uiState.isFilterActive) {
-                            GreenSortIcon()
-                        } else {
-                            SortIcon()
-                        }
-                    },
-                    onClick = { presenter.onAction(ClosedTradeListUiAction.OnShowFilterSheet) },
-                    type = BisqButtonType.Clear,
-                    modifier = Modifier.weight(1f),
-                )
-            },
+            isFilterActive = uiState.isFilterActive,
+            onFilterClick = { presenter.onAction(ClosedTradeListUiAction.OnShowFilterSheet) },
         )
 
         TradeResultBar(
@@ -413,37 +399,25 @@ private fun ClosedTradeListEmptyState(
     onBrowseOffers: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .padding(
-                    horizontal = BisqUIConstants.ScreenPadding2X,
-                    vertical = BisqUIConstants.ScreenPadding4X,
-                ),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    ListStateSection(
+        title = "mobile.tradeHistory.empty.noTrades".i18n(),
+        subtitle = "mobile.tradeHistory.empty.noTrades.sub".i18n(),
+        icon = {
+            Box(
+                modifier =
+                    Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
+                        .background(BisqTheme.colors.dark_grey40),
+                contentAlignment = Alignment.Center,
+            ) { BisqText.H4LightGrey("?") }
+        },
+        buttonText = "action.browseOffers".i18n(),
+        onButtonClick = onBrowseOffers,
         verticalArrangement = Arrangement.Center,
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .size(64.dp)
-                    .clip(RoundedCornerShape(BisqUIConstants.BorderRadius))
-                    .background(BisqTheme.colors.dark_grey40),
-            contentAlignment = Alignment.Center,
-        ) { BisqText.H4LightGrey("?") }
-        BisqGap.V2()
-        BisqText.H5Light(
-            text = "mobile.tradeHistory.empty.noTrades".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V1()
-        BisqText.SmallLightGrey(
-            text = "mobile.tradeHistory.empty.noTrades.sub".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V2()
-        BisqButton(text = "action.browseOffers".i18n(), onClick = onBrowseOffers)
-    }
+        verticalPadding = BisqUIConstants.ScreenPadding4X,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -451,28 +425,14 @@ private fun ClosedTradeListNoResultsState(
     onClearSearch: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .padding(
-                    horizontal = BisqUIConstants.ScreenPadding2X,
-                    vertical = BisqUIConstants.ScreenPadding3X,
-                ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Top,
-    ) {
-        BisqGap.V2()
-        BisqText.BaseLight(
-            text = "mobile.tradeHistory.empty.noResults".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V1()
-        BisqButton(
-            text = "action.clearSearch".i18n(),
-            type = BisqButtonType.Grey,
-            onClick = onClearSearch,
-        )
-    }
+    ListStateSection(
+        title = "mobile.tradeHistory.empty.noResults".i18n(),
+        useHeadlineStyle = false,
+        buttonText = "action.clearSearch".i18n(),
+        buttonType = BisqButtonType.Grey,
+        onButtonClick = onClearSearch,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -480,33 +440,14 @@ private fun ClosedTradeListErrorState(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .padding(
-                    horizontal = BisqUIConstants.ScreenPadding2X,
-                    vertical = BisqUIConstants.ScreenPadding3X,
-                ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Top,
-    ) {
-        BisqGap.V2()
-        BisqText.H5Light(
-            text = "mobile.tradeHistory.error.title".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V1()
-        BisqText.SmallLightGrey(
-            text = "mobile.tradeHistory.error.sub".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V2()
-        BisqButton(
-            text = "mobile.tradeHistory.error.retry".i18n(),
-            type = BisqButtonType.Grey,
-            onClick = onRetry,
-        )
-    }
+    ListStateSection(
+        title = "mobile.tradeHistory.error.title".i18n(),
+        subtitle = "mobile.tradeHistory.error.sub".i18n(),
+        buttonText = "mobile.tradeHistory.error.retry".i18n(),
+        buttonType = BisqButtonType.Grey,
+        onButtonClick = onRetry,
+        modifier = modifier,
+    )
 }
 
 // -------------------------------------------------------------------------------------

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListScreen.kt
@@ -1,17 +1,12 @@
 package network.bisq.mobile.presentation.tabs.my_trades.open
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -39,23 +34,21 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.ListStateSection
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.GreenSortIcon
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SortIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollLayout
+import network.bisq.mobile.presentation.common.ui.components.molecules.IconTextRow
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.InformationConfirmationDialog
-import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
+import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.SearchWithFilterField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.tabs.my_trades.open.components.OpenTradeListItem
 import network.bisq.mobile.presentation.tabs.my_trades.open.components.OpenTradesFilterSheet
 import network.bisq.mobile.presentation.tabs.my_trades.shared.TradeResultBar
-import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
 @Composable
@@ -137,24 +130,12 @@ private fun OpenTradeListContent(
             } else {
                 Column(modifier = Modifier.fillMaxSize()) {
                     BisqGap.V1()
-                    BisqSearchField(
+                    SearchWithFilterField(
                         value = uiState.searchQuery,
                         onValueChange = { onAction(OpenTradeListUiAction.OnSearchQueryChange(it)) },
                         placeholder = "mobile.tradeHistory.search.placeholder".i18n(),
-                        rightSuffix = {
-                            BisqButton(
-                                iconOnly = {
-                                    if (uiState.isFilterActive) {
-                                        GreenSortIcon()
-                                    } else {
-                                        SortIcon()
-                                    }
-                                },
-                                onClick = { onAction(OpenTradeListUiAction.OnShowFilterSheet) },
-                                type = BisqButtonType.Clear,
-                                modifier = Modifier.weight(1f),
-                            )
-                        },
+                        isFilterActive = uiState.isFilterActive,
+                        onFilterClick = { onAction(OpenTradeListUiAction.OnShowFilterSheet) },
                     )
 
                     TradeResultBar(
@@ -260,28 +241,14 @@ private fun OpenTradeListNoResultsState(
     onClearSearch: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .padding(
-                    horizontal = BisqUIConstants.ScreenPadding2X,
-                    vertical = BisqUIConstants.ScreenPadding3X,
-                ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Top,
-    ) {
-        BisqGap.V2()
-        BisqText.BaseLight(
-            text = "mobile.tradeHistory.empty.noResults".i18n(),
-            textAlign = TextAlign.Center,
-        )
-        BisqGap.V1()
-        BisqButton(
-            text = "action.clearSearch".i18n(),
-            type = BisqButtonType.Grey,
-            onClick = onClearSearch,
-        )
-    }
+    ListStateSection(
+        title = "mobile.tradeHistory.empty.noResults".i18n(),
+        useHeadlineStyle = false,
+        buttonText = "action.clearSearch".i18n(),
+        buttonType = BisqButtonType.Grey,
+        onButtonClick = onClearSearch,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -304,17 +271,17 @@ fun WelcomeToFirstTradePane(onOpenTradeGuide: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.Start,
         ) {
-            IconWithTextLine(
-                image = Res.drawable.reputation,
-                title = "bisqEasy.openTrades.welcome.line1".i18n(),
+            IconTextRow(
+                icon = Res.drawable.reputation,
+                text = "bisqEasy.openTrades.welcome.line1".i18n(),
             )
-            IconWithTextLine(
-                image = Res.drawable.fiat_btc,
-                title = "bisqEasy.openTrades.welcome.line2".i18n(),
+            IconTextRow(
+                icon = Res.drawable.fiat_btc,
+                text = "bisqEasy.openTrades.welcome.line2".i18n(),
             )
-            IconWithTextLine(
-                image = Res.drawable.thumbs_up,
-                title = "bisqEasy.openTrades.welcome.line3".i18n(),
+            IconTextRow(
+                icon = Res.drawable.thumbs_up,
+                text = "bisqEasy.openTrades.welcome.line3".i18n(),
             )
         }
         BisqGap.V1()
@@ -322,18 +289,6 @@ fun WelcomeToFirstTradePane(onOpenTradeGuide: () -> Unit) {
             text = "bisqEasy.tradeGuide.open".i18n(),
             onClick = onOpenTradeGuide,
         )
-    }
-}
-
-@Composable
-fun IconWithTextLine(
-    image: DrawableResource,
-    title: String,
-) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Image(painterResource(image), null, Modifier.size(30.dp))
-        Spacer(modifier = Modifier.width(15.dp))
-        BisqText.BaseLight(title)
     }
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/offers/OfferbookMarketScreen.kt
@@ -20,14 +20,10 @@ import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
 import network.bisq.mobile.data.replicated.common.currency.MarketVOExtensions.marketCodes
 import network.bisq.mobile.presentation.common.ui.components.MarketCard
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.GreenSortIcon
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.SortIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqStaticLayout
 import network.bisq.mobile.presentation.common.ui.components.molecules.bottom_sheet.BisqBottomSheet
-import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
+import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.SearchWithFilterField
 import network.bisq.mobile.presentation.common.ui.components.organisms.market.MarketFilters
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
@@ -59,23 +55,11 @@ internal fun OfferbookMarketScreenContent(
         contentPadding = PaddingValues(all = BisqUIConstants.Zero),
         verticalArrangement = Arrangement.Top,
     ) {
-        BisqSearchField(
+        SearchWithFilterField(
             value = searchText,
             onValueChange = { onAction(OfferbookMarketUiAction.OnSearchTextChanged(it)) },
-            rightSuffix = {
-                BisqButton(
-                    iconOnly = {
-                        if (uiState.filter == MarketFilter.WithOffers) {
-                            GreenSortIcon()
-                        } else {
-                            SortIcon()
-                        }
-                    },
-                    onClick = { showFilterDialog = true },
-                    type = BisqButtonType.Clear,
-                    modifier = Modifier.weight(1f),
-                )
-            },
+            isFilterActive = uiState.filter == MarketFilter.WithOffers,
+            onFilterClick = { showFilterDialog = true },
         )
 
         BisqGap.V1()


### PR DESCRIPTION
 - fixes #1571 
 - added nodeApp Observable→StateFlow bridges bindTo / bindNonNullTo extensions returning the Pin.
 - fixed NodeSettingsServiceFacade observers whose pins were never retained or unbound (observers accumulated across activate/deactivate cycles) — now all pins are collected and unbound in deactivate(); clear ups code dups
 - cleared up analytics DI dedup: the buffer-scope + opt-in-gate wiring now lives once in createBufferedAnalyticsService()
 - added UI molecules: SearchWithFilterField replaced the identical search+filter-button block in the closed/open trade lists and the offerbook market screen (BisqSearchField.rightSuffix is now RowScope-scoped so suffix buttons can use weight()); ListStateSection absorbed the 4 near-identical empty/no-results/error columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable search-with-filter controls and standardized list empty, no-results, and error states.
  * Added reusable icon-and-text rows for improved screen consistency.

* **Bug Fixes**
  * Prevented range sliders from crashing with invalid, non-finite, or out-of-bounds values.
  * Improved settings, alert, and trade state synchronization during activation and deactivation.
  * Analytics now respects both build configuration and user opt-in settings.

* **Refactor**
  * Streamlined data persistence and observable state binding for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->