### PR TITLE
bugfix/sigterm_crashes_ios_connect

### DIFF
--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/analytics/SentryCocoaNativeSentryInitializer.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/domain/analytics/SentryCocoaNativeSentryInitializer.kt
@@ -4,6 +4,7 @@ package network.bisq.mobile.client.common.domain.analytics
 
 import io.sentry.kotlin.multiplatform.Sentry
 import kotlinx.cinterop.ExperimentalForeignApi
+import network.bisq.mobile.data.utils.ignoreSigPipe
 import network.bisq.mobile.domain.analytics.AnalyticsRedactor
 import network.bisq.mobile.domain.analytics.NativeSentryInitializer
 import network.bisq.mobile.domain.utils.Logging
@@ -104,6 +105,12 @@ class SentryCocoaNativeSentryInitializer :
             setupPrivacy(options, redactor, runtimeOptInProvider)
             setupTransport(options, socksProxyHost, socksProxyPort)
         }
+        // Sentry keeps enableCrashHandler on, and SentryCrash lists SIGPIPE in its fatal-signal
+        // set — installing SentrySDK.start above (re)claims the SIGPIPE disposition and would turn
+        // a benign broken-pipe socket write into a reported crash. Reclaim it to SIG_IGN so those
+        // writes surface as EPIPE instead. The launch-time ignoreSigPipe() in the iOS app entry
+        // covers opted-out users (who never reach this init); this call covers opted-in users.
+        ignoreSigPipe()
         log.d {
             if (socksProxyHost != null) {
                 "Sentry-Cocoa initialized (SOCKS5 $socksProxyHost:$socksProxyPort)"

--- a/iosClient/iosClient/iosClient.swift
+++ b/iosClient/iosClient/iosClient.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import UserNotifications
 import ClientApp
+import Darwin
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
@@ -106,6 +107,14 @@ struct iosClient: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
     init() {
+        // Ignore SIGPIPE process-wide so a socket write to an already-closed peer returns EPIPE
+        // instead of terminating the app (or being reported as a crash by SentryCrash, which lists
+        // SIGPIPE as a fatal signal). iOS Connect churns network connections over Tor, and the
+        // native socket I/O underneath raises SIGPIPE on a broken pipe. This launch-time call
+        // covers opted-out users; the Sentry initializer reclaims it after SentrySDK.start for
+        // opted-in users. See ignoreSigPipe() in shared/domain PlatformDomainAbstractions.ios.kt.
+        signal(SIGPIPE, SIG_IGN)
+
         // Initialize Koin dependency injection
         DependenciesProviderHelper().doInitKoin()
     }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
@@ -90,7 +90,9 @@ import platform.UIKit.systemRedColor
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.posix.SIGABRT
+import platform.posix.SIGPIPE
 import platform.posix.SIG_DFL
+import platform.posix.SIG_IGN
 import platform.posix.memcpy
 import platform.posix.raise
 import platform.posix.signal
@@ -131,6 +133,27 @@ fun exitApp() {
     // and then abort (the default behavior of uncaught kotlin exception)
     signal(SIGABRT, SIG_DFL)
     raise(SIGABRT)
+}
+
+/**
+ * Ignore SIGPIPE process-wide so a socket/pipe write to a peer that already closed its end
+ * returns EPIPE instead of raising signal 13.
+ *
+ * Why this exists: iOS Connect churns network connections (unreliable dead-socket detection +
+ * Tor reconnect loops), and the native socket I/O underneath (kmp-tor / Kotlin/Native networking)
+ * can write to a just-closed connection. With the default disposition SIGPIPE terminates the
+ * process; worse, once Sentry-Cocoa starts, SentryCrash lists SIGPIPE in its fatal-signal set and
+ * reports it as a hard crash (see GlitchTip bisq-connect@0.6.0 SIGPIPE events). Disarming it is
+ * the textbook fix for any BSD-socket app: write() then returns -1/EPIPE which the networking
+ * layer already handles as an ordinary I/O error.
+ *
+ * Must be invoked BOTH at app launch (covers opted-out users, for whom Sentry never installs its
+ * handler) AND right after Sentry init (SentryCrash overwrites the disposition when it installs,
+ * so we reclaim it). Idempotent.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun ignoreSigPipe() {
+    signal(SIGPIPE, SIG_IGN)
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/shared/domain/src/iosTest/kotlin/network/bisq/mobile/data/utils/IgnoreSigPipeIosTest.kt
+++ b/shared/domain/src/iosTest/kotlin/network/bisq/mobile/data/utils/IgnoreSigPipeIosTest.kt
@@ -1,0 +1,65 @@
+package network.bisq.mobile.data.utils
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.set
+import platform.posix.EPIPE
+import platform.posix.SIGPIPE
+import platform.posix.SIG_IGN
+import platform.posix.close
+import platform.posix.errno
+import platform.posix.pipe
+import platform.posix.signal
+import platform.posix.write
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies [ignoreSigPipe] disarms SIGPIPE so a write to a broken pipe surfaces as EPIPE instead
+ * of killing the process — the crash fixed for the GlitchTip bisq-connect@0.6.0 SIGPIPE events.
+ *
+ * Note: if this fix regresses, the [writeToClosedPipe] test does not merely fail an assertion — the
+ * write raises SIGPIPE and, with the default disposition, terminates the whole test process. That
+ * hard failure is itself the regression signal.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class IgnoreSigPipeIosTest {
+    @Test
+    fun `ignoreSigPipe sets the SIGPIPE disposition to SIG_IGN`() {
+        ignoreSigPipe()
+
+        // signal() returns the previous disposition; after ignoreSigPipe() it must be SIG_IGN.
+        val previous = signal(SIGPIPE, SIG_IGN)
+        assertEquals(SIG_IGN, previous, "ignoreSigPipe() should leave SIGPIPE ignored")
+    }
+
+    @Test
+    fun `writing to a pipe with a closed read end yields EPIPE instead of a SIGPIPE crash`() {
+        ignoreSigPipe()
+
+        memScoped {
+            val fds = allocArray<IntVar>(2)
+            assertEquals(0, pipe(fds), "pipe() should succeed")
+            val readEnd = fds[0]
+            val writeEnd = fds[1]
+
+            // Closing the read end makes the pipe "broken": any subsequent write would raise
+            // SIGPIPE under the default disposition.
+            assertEquals(0, close(readEnd), "closing read end should succeed")
+
+            val buf = allocArray<ByteVar>(1)
+            buf[0] = 0.toByte()
+            val rc = write(writeEnd, buf, 1u.convert())
+            val err = errno
+            close(writeEnd)
+
+            assertEquals(-1L, rc, "write to a broken pipe should fail")
+            assertEquals(EPIPE, err, "write to a broken pipe should report EPIPE, not raise SIGPIPE")
+        }
+    }
+}


### PR DESCRIPTION
 - fixes #1598 
 - fixes #1599 
 - implemented ignoreSigPipe, sets the SIGPIPE disposition to SIG_IGN asserts signal() reports the previous disposition as SIG_IGN
 - added launch-time signal(SIGPIPE, SIG_IGN) for sentry init
 - added AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS stability when network connections close unexpectedly.
  * Prevented broken-pipe socket writes from terminating the app or being reported as fatal crashes.
  * Ensured these failures are handled as recoverable I/O errors instead.

* **Tests**
  * Added coverage verifying safe handling of broken-pipe signals and write failures on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->