### PR TITLE
Kscan 0.9.2 update

### DIFF
--- a/shared/kscan/README.md
+++ b/shared/kscan/README.md
@@ -6,5 +6,5 @@ Mobile.
 
 Based on:
 
-- Commit: [de1ed36860](https://github.com/ismai117/KScan/commit/de1ed36860b074605b510dabe5bcd0fd8e1358ef)
-- Release tag: [0.6.0](https://github.com/ismai117/KScan/releases/tag/0.6.0)
+- Commit: [754b88e8bf](https://github.com/ismai117/KScan/commit/754b88e8bf3841d608308d5bc3f97b7e208cea65)
+- Release tag: [0.9.2](https://github.com/ismai117/KScan/releases/tag/0.9.2)

--- a/shared/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerController.kt
+++ b/shared/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerController.kt
@@ -13,16 +13,21 @@ import androidx.compose.runtime.setValue
  * updates in response to scanner state modifications.
  *
  * @property torchEnabled A boolean indicating whether the torch is currently enabled.
- *                        Defaults to `false`. Can be observed for changes.
+ *                        Defaults to `false`. This property is read-only and can be observed for changes.
+ *                        Use [setTorch] to toggle the torch.
  * @property zoomRatio The current zoom ratio of the scanner. Defaults to `1f`.
- *                     Can be observed for changes. The valid range is typically between 1f and `maxZoomRatio`.
+ *                     This property is read-only and can be observed for changes.
+ *                     The valid range is typically between 1f and [maxZoomRatio].
+ *                     Use [setZoom] to change the zoom level.
  * @property maxZoomRatio The maximum zoom ratio supported by the scanner. Defaults to `1f`.
- *                        This property is read-only from outside the `kscan` package and is set internally.
+ *                        This property is read-only and is set internally.
  */
 class ScannerController {
     var torchEnabled by mutableStateOf(false)
+        internal set
 
     var zoomRatio by mutableFloatStateOf(1f)
+        internal set
 
     var maxZoomRatio by mutableFloatStateOf(1f)
         internal set

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
@@ -8,6 +8,7 @@ import platform.AVFoundation.AVMetadataObjectTypeCode93Code
 import platform.AVFoundation.AVMetadataObjectTypeDataMatrixCode
 import platform.AVFoundation.AVMetadataObjectTypeEAN13Code
 import platform.AVFoundation.AVMetadataObjectTypeEAN8Code
+import platform.AVFoundation.AVMetadataObjectTypeInterleaved2of5Code
 import platform.AVFoundation.AVMetadataObjectTypePDF417Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import platform.AVFoundation.AVMetadataObjectTypeUPCECode
@@ -28,6 +29,7 @@ internal object BarcodeFormatMapper {
             AVMetadataObjectTypePDF417Code to BarcodeFormat.FORMAT_PDF417,
             AVMetadataObjectTypeAztecCode to BarcodeFormat.FORMAT_AZTEC,
             AVMetadataObjectTypeDataMatrixCode to BarcodeFormat.FORMAT_DATA_MATRIX,
+            AVMetadataObjectTypeInterleaved2of5Code to BarcodeFormat.FORMAT_ITF,
         )
 
     private val APP_TO_AV_FORMAT_MAP: Map<BarcodeFormat, AVMetadataObjectType> =

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -207,7 +207,7 @@ class CameraViewController(
         if (rawBytes.isEmpty()) {
             type.toString()
         } else {
-            rawBytes.joinToString(separator = ",") { (it.toInt() and 0xFF).toString() }
+            "${rawBytes.contentHashCode()}:${rawBytes.size}"
         }
 
     private fun barcodeDataFromRawBytes(

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -172,22 +172,14 @@ class CameraViewController(
     private fun processDetectedBarcode(barcodeObject: AVMetadataMachineReadableCodeObject) {
         val value = barcodeObject.stringValue ?: ""
         val type = barcodeObject.type
-        val key = value.ifEmpty { type.toString() }
+        val rawBytes = extractRawBytes(barcodeObject, value)
+        val key = dedupKey(rawBytes, type)
 
         barcodesDetected[key] = (barcodesDetected[key] ?: 0) + 1
 
         if ((barcodesDetected[key] ?: 0) >= 2) {
             val appSpecificFormat = type.toFormat()
-            val rawBytes = extractRawBytes(barcodeObject, value)
-
-            // Build string from rawBytes, replacing null bytes to prevent UI truncation
-            val data =
-                buildString {
-                    for (byte in rawBytes) {
-                        val char = (byte.toInt() and 0xFF).toChar()
-                        append(if (char == '\u0000') ' ' else char)
-                    }
-                }
+            val data = barcodeDataFromRawBytes(rawBytes, value)
 
             val barcode =
                 Barcode(
@@ -207,6 +199,31 @@ class CameraViewController(
             }
         }
     }
+
+    private fun dedupKey(
+        rawBytes: ByteArray,
+        type: AVMetadataObjectType,
+    ): String =
+        if (rawBytes.isEmpty()) {
+            type.toString()
+        } else {
+            rawBytes.joinToString(separator = ",") { (it.toInt() and 0xFF).toString() }
+        }
+
+    private fun barcodeDataFromRawBytes(
+        rawBytes: ByteArray,
+        stringValue: String,
+    ): String =
+        if (0 !in rawBytes) {
+            stringValue
+        } else {
+            buildString {
+                for (byte in rawBytes) {
+                    val char = (byte.toInt() and 0xFF).toChar()
+                    append(if (char == '\u0000') ' ' else char)
+                }
+            }
+        }
 
     /**
      * Extracts raw bytes from a barcode object.

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -17,7 +17,10 @@ import platform.AVFoundation.AVCaptureVideoPreviewLayer
 import platform.AVFoundation.AVLayerVideoGravityResizeAspectFill
 import platform.AVFoundation.AVMetadataMachineReadableCodeObject
 import platform.AVFoundation.AVMetadataObjectType
+import platform.AVFoundation.AVMetadataObjectTypeQRCode
+import platform.AVFoundation.descriptor
 import platform.AVFoundation.videoZoomFactor
+import platform.CoreImage.CIQRCodeDescriptor
 import platform.Foundation.NSLog
 import platform.UIKit.UIApplication
 import platform.UIKit.UIColor
@@ -162,23 +165,35 @@ class CameraViewController(
             }.filter { barcodeObject ->
                 isRequestedFormat(barcodeObject.type)
             }.forEach { barcodeObject ->
-                processDetectedBarcode(barcodeObject.stringValue ?: "", barcodeObject.type)
+                processDetectedBarcode(barcodeObject)
             }
     }
 
-    private fun processDetectedBarcode(
-        value: String,
-        type: AVMetadataObjectType,
-    ) {
-        barcodesDetected[value] = (barcodesDetected[value] ?: 0) + 1
+    private fun processDetectedBarcode(barcodeObject: AVMetadataMachineReadableCodeObject) {
+        val value = barcodeObject.stringValue ?: ""
+        val type = barcodeObject.type
+        val key = value.ifEmpty { type.toString() }
 
-        if ((barcodesDetected[value] ?: 0) >= 2) {
+        barcodesDetected[key] = (barcodesDetected[key] ?: 0) + 1
+
+        if ((barcodesDetected[key] ?: 0) >= 2) {
             val appSpecificFormat = type.toFormat()
+            val rawBytes = extractRawBytes(barcodeObject, value)
+
+            // Build string from rawBytes, replacing null bytes to prevent UI truncation
+            val data =
+                buildString {
+                    for (byte in rawBytes) {
+                        val char = (byte.toInt() and 0xFF).toChar()
+                        append(if (char == '\u0000') ' ' else char)
+                    }
+                }
+
             val barcode =
                 Barcode(
-                    data = value,
+                    data = data,
                     format = appSpecificFormat.toString(),
-                    rawBytes = stringToRawBytes(value),
+                    rawBytes = rawBytes,
                 )
 
             if (!filter(barcode)) return
@@ -191,6 +206,27 @@ class CameraViewController(
                 }
             }
         }
+    }
+
+    /**
+     * Extracts raw bytes from a barcode object.
+     * For QR codes, uses CIQRCodeDescriptor to preserve null bytes.
+     * For other formats, falls back to string conversion.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    private fun extractRawBytes(
+        barcodeObject: AVMetadataMachineReadableCodeObject,
+        fallbackValue: String,
+    ): ByteArray {
+        if (barcodeObject.type == AVMetadataObjectTypeQRCode) {
+            val descriptor = barcodeObject.descriptor as? CIQRCodeDescriptor
+            if (descriptor != null) {
+                val bytes = QRCodePayloadParser.extractRawBytes(descriptor)
+                if (bytes != null) return bytes
+            }
+        }
+        return stringToRawBytes(fallbackValue)
     }
 
     @OptIn(ExperimentalForeignApi::class)

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
@@ -26,6 +26,7 @@ internal object QRCodePayloadParser {
     private const val MODE_NUMERIC = 1
     private const val MODE_ALPHANUMERIC = 2
     private const val MODE_BYTE = 4
+    private const val MODE_ECI = 7
 
     private const val ALPHANUMERIC_TABLE =
         "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
@@ -35,15 +36,12 @@ internal object QRCodePayloadParser {
         val payload = descriptor.errorCorrectedPayload
         val codewords = payload.toByteArray()
         if (codewords.isEmpty()) return null
-        return decodeDataStream(codewords)
+        val symbolVersion = descriptor.symbolVersion.toInt()
+        return decodeDataStream(codewords, symbolVersion)
     }
 
     /**
      * Character-count indicator widths per QR version group (ISO/IEC 18004 Table 3).
-     *
-     * Within a single QR symbol all segments share the same version, so all three
-     * widths must come from the same row. We try each row in turn; the first one
-     * that decodes cleanly and contains at least one byte segment wins.
      */
     private data class VersionWidths(
         val byteCount: Int,
@@ -58,13 +56,21 @@ internal object QRCodePayloadParser {
             VersionWidths(byteCount = 16, alphaCount = 13, numericCount = 14), // v27–40
         )
 
-    internal fun decodeDataStream(codewords: ByteArray): ByteArray? {
-        for (widths in VERSION_GROUPS) {
-            val result = tryDecodeWithWidths(codewords, widths)
-            if (result != null) return result
-        }
-        return null
+    internal fun decodeDataStream(
+        codewords: ByteArray,
+        symbolVersion: Int,
+    ): ByteArray? {
+        val widths = widthsForSymbolVersion(symbolVersion) ?: return null
+        return tryDecodeWithWidths(codewords, widths)
     }
+
+    private fun widthsForSymbolVersion(symbolVersion: Int): VersionWidths? =
+        when {
+            symbolVersion in 1..9 -> VERSION_GROUPS[0]
+            symbolVersion in 10..26 -> VERSION_GROUPS[1]
+            symbolVersion in 27..40 -> VERSION_GROUPS[2]
+            else -> null
+        }
 
     private fun tryDecodeWithWidths(
         codewords: ByteArray,
@@ -122,11 +128,23 @@ internal object QRCodePayloadParser {
                     appendIsoLatin1(result, decoded)
                 }
 
+                MODE_ECI -> {
+                    if (!reader.hasAvailable(8)) {
+                        aborted = true
+                        break
+                    }
+                    val eciFirstByte = reader.readBits(8)
+                    if ((eciFirstByte and 0x80) != 0) {
+                        if (!reader.hasAvailable(8)) {
+                            aborted = true
+                            break
+                        }
+                        reader.readBits(8)
+                    }
+                }
+
                 else -> {
-                    // Kanji, ECI, structured-append, FNC1, or unknown — can't
-                    // safely decode here. Abort this attempt; the next version
-                    // group may still succeed. If all attempts fail we return
-                    // null and the caller falls back to stringValue.
+                    // Kanji, structured-append, FNC1, or unknown — can't safely decode here.
                     aborted = true
                     break
                 }

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
@@ -134,12 +134,21 @@ internal object QRCodePayloadParser {
                         break
                     }
                     val eciFirstByte = reader.readBits(8)
-                    if ((eciFirstByte and 0x80) != 0) {
-                        if (!reader.hasAvailable(8)) {
-                            aborted = true
-                            break
+                    when {
+                        (eciFirstByte and 0xC0) == 0xC0 -> {
+                            if (!reader.hasAvailable(16)) {
+                                aborted = true
+                                break
+                            }
+                            reader.readBits(16)
                         }
-                        reader.readBits(8)
+                        (eciFirstByte and 0x80) != 0 -> {
+                            if (!reader.hasAvailable(8)) {
+                                aborted = true
+                                break
+                            }
+                            reader.readBits(8)
+                        }
                     }
                 }
 

--- a/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
+++ b/shared/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
@@ -1,0 +1,250 @@
+package org.ncgroup.kscan
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.CoreImage.CIQRCodeDescriptor
+import platform.Foundation.NSData
+import platform.posix.memcpy
+
+/**
+ * Parses raw bytes from CIQRCodeDescriptor.errorCorrectedPayload.
+ *
+ * Iterates over all QR data segments (byte, alphanumeric, numeric) and concatenates
+ * their decoded content. Byte segments are appended as raw bytes (preserving null
+ * bytes); alphanumeric and numeric segments are decoded per the QR spec and appended
+ * as their ISO-8859-1 bytes.
+ *
+ * Returns a non-null result only when at least one byte segment was present — the
+ * sole reason this parser exists is to preserve null bytes that
+ * AVMetadataMachineReadableCodeObject.stringValue would silently truncate. For
+ * purely alphanumeric/numeric QRs (or Kanji/unknown modes), returns null so the
+ * caller falls back to stringValue.
+ */
+internal object QRCodePayloadParser {
+    private const val MODE_TERMINATOR = 0
+    private const val MODE_NUMERIC = 1
+    private const val MODE_ALPHANUMERIC = 2
+    private const val MODE_BYTE = 4
+
+    private const val ALPHANUMERIC_TABLE =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
+
+    @OptIn(ExperimentalForeignApi::class)
+    fun extractRawBytes(descriptor: CIQRCodeDescriptor): ByteArray? {
+        val payload = descriptor.errorCorrectedPayload
+        val codewords = payload.toByteArray()
+        if (codewords.isEmpty()) return null
+        return decodeDataStream(codewords)
+    }
+
+    /**
+     * Character-count indicator widths per QR version group (ISO/IEC 18004 Table 3).
+     *
+     * Within a single QR symbol all segments share the same version, so all three
+     * widths must come from the same row. We try each row in turn; the first one
+     * that decodes cleanly and contains at least one byte segment wins.
+     */
+    private data class VersionWidths(
+        val byteCount: Int,
+        val alphaCount: Int,
+        val numericCount: Int,
+    )
+
+    private val VERSION_GROUPS =
+        listOf(
+            VersionWidths(byteCount = 8, alphaCount = 9, numericCount = 10), // v1–9
+            VersionWidths(byteCount = 16, alphaCount = 11, numericCount = 12), // v10–26
+            VersionWidths(byteCount = 16, alphaCount = 13, numericCount = 14), // v27–40
+        )
+
+    internal fun decodeDataStream(codewords: ByteArray): ByteArray? {
+        for (widths in VERSION_GROUPS) {
+            val result = tryDecodeWithWidths(codewords, widths)
+            if (result != null) return result
+        }
+        return null
+    }
+
+    private fun tryDecodeWithWidths(
+        codewords: ByteArray,
+        widths: VersionWidths,
+    ): ByteArray? {
+        val reader = BitReader(codewords)
+        val result = mutableListOf<Byte>()
+        var hadByteSegment = false
+        var aborted = false
+
+        while (reader.hasAvailable(4)) {
+            val mode = reader.readBits(4)
+            if (mode == MODE_TERMINATOR) break
+
+            when (mode) {
+                MODE_BYTE -> {
+                    if (!reader.hasAvailable(widths.byteCount)) {
+                        aborted = true
+                        break
+                    }
+                    val count = reader.readBits(widths.byteCount)
+                    if (count !in 1..4096 || !reader.hasAvailable(count * 8)) {
+                        aborted = true
+                        break
+                    }
+                    hadByteSegment = true
+                    repeat(count) { result.add(reader.readBits(8).toByte()) }
+                }
+
+                MODE_ALPHANUMERIC -> {
+                    if (!reader.hasAvailable(widths.alphaCount)) {
+                        aborted = true
+                        break
+                    }
+                    val count = reader.readBits(widths.alphaCount)
+                    val decoded = decodeAlphanumeric(reader, count)
+                    if (decoded == null) {
+                        aborted = true
+                        break
+                    }
+                    appendIsoLatin1(result, decoded)
+                }
+
+                MODE_NUMERIC -> {
+                    if (!reader.hasAvailable(widths.numericCount)) {
+                        aborted = true
+                        break
+                    }
+                    val count = reader.readBits(widths.numericCount)
+                    val decoded = decodeNumeric(reader, count)
+                    if (decoded == null) {
+                        aborted = true
+                        break
+                    }
+                    appendIsoLatin1(result, decoded)
+                }
+
+                else -> {
+                    // Kanji, ECI, structured-append, FNC1, or unknown — can't
+                    // safely decode here. Abort this attempt; the next version
+                    // group may still succeed. If all attempts fail we return
+                    // null and the caller falls back to stringValue.
+                    aborted = true
+                    break
+                }
+            }
+        }
+
+        return if (!aborted && hadByteSegment && result.isNotEmpty()) {
+            result.toByteArray()
+        } else {
+            null
+        }
+    }
+
+    private fun decodeAlphanumeric(
+        reader: BitReader,
+        count: Int,
+    ): String? {
+        if (count < 0) return null
+        val sb = StringBuilder(count)
+        val pairs = count / 2
+        val remainder = count % 2
+        repeat(pairs) {
+            if (!reader.hasAvailable(11)) return null
+            val v = reader.readBits(11)
+            val hi = v / 45
+            val lo = v % 45
+            if (hi !in ALPHANUMERIC_TABLE.indices ||
+                lo !in ALPHANUMERIC_TABLE.indices
+            ) {
+                return null
+            }
+            sb.append(ALPHANUMERIC_TABLE[hi])
+            sb.append(ALPHANUMERIC_TABLE[lo])
+        }
+        if (remainder == 1) {
+            if (!reader.hasAvailable(6)) return null
+            val v = reader.readBits(6)
+            if (v !in ALPHANUMERIC_TABLE.indices) return null
+            sb.append(ALPHANUMERIC_TABLE[v])
+        }
+        return sb.toString()
+    }
+
+    private fun decodeNumeric(
+        reader: BitReader,
+        count: Int,
+    ): String? {
+        if (count < 0) return null
+        val sb = StringBuilder(count)
+        val triples = count / 3
+        val rem = count % 3
+        repeat(triples) {
+            if (!reader.hasAvailable(10)) return null
+            val value = reader.readBits(10)
+            // QR spec: each 10-bit group encodes exactly 0..999.
+            if (value > 999) return null
+            sb.append(value.toString().padStart(3, '0'))
+        }
+        when (rem) {
+            2 -> {
+                if (!reader.hasAvailable(7)) return null
+                val value = reader.readBits(7)
+                // QR spec: 7-bit tail encodes exactly 0..99.
+                if (value > 99) return null
+                sb.append(value.toString().padStart(2, '0'))
+            }
+            1 -> {
+                if (!reader.hasAvailable(4)) return null
+                val value = reader.readBits(4)
+                // QR spec: 4-bit tail encodes exactly 0..9.
+                if (value > 9) return null
+                sb.append(value.toString())
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun appendIsoLatin1(
+        dest: MutableList<Byte>,
+        s: String,
+    ) {
+        // ISO-8859-1: each code point 0..0xFF maps to a single byte of the same value.
+        // Alphanumeric/numeric segments only produce ASCII, which is a subset.
+        for (ch in s) {
+            dest.add((ch.code and 0xFF).toByte())
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun NSData.toByteArray(): ByteArray {
+        val length = this.length.toInt()
+        if (length == 0) return byteArrayOf()
+
+        val bytes = ByteArray(length)
+        bytes.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), this.bytes, this.length)
+        }
+        return bytes
+    }
+
+    private class BitReader(
+        private val data: ByteArray,
+    ) {
+        private var bitPosition = 0
+
+        fun hasAvailable(bits: Int): Boolean = (data.size * 8 - bitPosition) >= bits
+
+        fun readBits(count: Int): Int {
+            var result = 0
+            repeat(count) {
+                val byteIndex = bitPosition / 8
+                val bitIndex = 7 - (bitPosition % 8)
+                if (byteIndex < data.size) {
+                    result = (result shl 1) or ((data[byteIndex].toInt() shr bitIndex) and 1)
+                }
+                bitPosition++
+            }
+            return result
+        }
+    }
+}

--- a/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
+++ b/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
@@ -2,6 +2,7 @@ package org.ncgroup.kscan
 
 import platform.AVFoundation.AVMetadataObjectTypeCode128Code
 import platform.AVFoundation.AVMetadataObjectTypeEAN13Code
+import platform.AVFoundation.AVMetadataObjectTypeInterleaved2of5Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,6 +60,13 @@ class BarcodeFormatMapperTest {
         val result = BarcodeFormatMapper.toAppFormat(AVMetadataObjectTypeCode128Code)
 
         assertEquals(BarcodeFormat.FORMAT_CODE_128, result)
+    }
+
+    @Test
+    fun `GIVEN interleaved2of5 av type WHEN toAppFormat THEN returns app format`() {
+        val result = BarcodeFormatMapper.toAppFormat(AVMetadataObjectTypeInterleaved2of5Code)
+
+        assertEquals(BarcodeFormat.FORMAT_ITF, result)
     }
 
     @Test

--- a/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
+++ b/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
@@ -233,6 +233,23 @@ class QRCodePayloadParserTest {
         assertContentEquals(data, result)
     }
 
+    @Test
+    fun `GIVEN 24-bit eci then byte segments WHEN decodeDataStream THEN byte data preserved`() {
+        val data = byteArrayOf(0x48, 0x69, 0x21)
+        val payload =
+            buildEciThenBytePayload(
+                data = data,
+                byteCountBits = 8,
+                eciFirstByte = 0xC0,
+                eciContinuationBytes = 2,
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
+
+        assertNotNull(result)
+        assertContentEquals(data, result)
+    }
+
     // region Helpers
 
     private sealed class Segment {
@@ -346,10 +363,13 @@ class QRCodePayloadParserTest {
     private fun buildEciThenBytePayload(
         data: ByteArray,
         byteCountBits: Int,
+        eciFirstByte: Int = 0,
+        eciContinuationBytes: Int = 0,
     ): ByteArray {
         val bits = mutableListOf<Int>()
         bits.addAll(listOf(0, 1, 1, 1)) // Mode: 0111 (ECI)
-        addBits(bits, 0, 8) // 8-bit ECI assignment number
+        addBits(bits, eciFirstByte, 8)
+        repeat(eciContinuationBytes) { addBits(bits, 0, 8) }
         bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100 (byte)
         addBits(bits, data.size, byteCountBits)
         data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }

--- a/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
+++ b/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
@@ -1,0 +1,340 @@
+package org.ncgroup.kscan
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class QRCodePayloadParserTest {
+    @Test
+    fun `GIVEN byte mode payload WHEN decodeDataStream THEN returns correct bytes`() {
+        val payload = buildByteModePayload(byteArrayOf(0x41, 0x42, 0x43))
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(3, result.size)
+        assertContentEquals(byteArrayOf(0x41, 0x42, 0x43), result)
+    }
+
+    @Test
+    fun `GIVEN byte mode with null byte WHEN decodeDataStream THEN preserves null byte`() {
+        val payload =
+            buildByteModePayload(
+                byteArrayOf('H'.code.toByte(), 'i'.code.toByte(), 0x00, '!'.code.toByte()),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(4, result.size)
+        assertEquals('H'.code.toByte(), result[0])
+        assertEquals('i'.code.toByte(), result[1])
+        assertEquals(0x00.toByte(), result[2])
+        assertEquals('!'.code.toByte(), result[3])
+    }
+
+    @Test
+    fun `GIVEN numeric mode WHEN decodeDataStream THEN returns null`() {
+        val payload = buildNumericModePayload("123")
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNull(result) // Numeric can't have null bytes, use stringValue fallback
+    }
+
+    @Test
+    fun `GIVEN alphanumeric mode WHEN decodeDataStream THEN returns null`() {
+        val payload = buildAlphanumericModePayload("AB")
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNull(result) // Alphanumeric can't have null bytes, use stringValue fallback
+    }
+
+    @Test
+    fun `GIVEN empty payload WHEN decodeDataStream THEN returns null`() {
+        assertNull(QRCodePayloadParser.decodeDataStream(byteArrayOf()))
+    }
+
+    @Test
+    fun `GIVEN hello world with null byte WHEN decodeDataStream THEN full data preserved`() {
+        val payload =
+            buildByteModePayload(
+                byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57, 0x6F, 0x72, 0x6C, 0x64),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(11, result.size)
+        assertEquals('H'.code.toByte(), result[0])
+        assertEquals(0x00.toByte(), result[5]) // null byte preserved
+        assertEquals('W'.code.toByte(), result[6])
+        assertEquals('d'.code.toByte(), result[10])
+    }
+
+    @Test
+    fun `GIVEN byte then alphanumeric segments WHEN decodeDataStream THEN concatenated`() {
+        // Real-world pattern: byte segment with a URL prefix (lowercase requires byte
+        // mode) + alphanumeric segment with an uppercase serial (cheaper in
+        // alphanumeric mode).
+        val url = "https://example.com/item?sn="
+        val serial = "ABC123-240101-001"
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte(url.encodeToByteArray()),
+                    Segment.Alphanumeric(serial),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(url + serial, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN byte mode payload with 16-bit count WHEN decodeDataStream THEN retries and decodes`() {
+        val data = "QR v10+ byte segment".encodeToByteArray()
+        val payload = buildByteModePayload(data, countBits = 16)
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertContentEquals(data, result)
+    }
+
+    @Test
+    fun `GIVEN byte then numeric segments WHEN decodeDataStream THEN concatenated`() {
+        val prefix = "ID:"
+        val digits = "1234567" // exercises triples + remainder=1 (4-bit tail)
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte(prefix.encodeToByteArray()),
+                    Segment.Numeric(digits),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + digits, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN byte numeric remainder 2 WHEN decodeDataStream THEN concatenated`() {
+        // remainder=2 exercises the 7-bit numeric tail.
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte("X".encodeToByteArray()),
+                    Segment.Numeric("12345"),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals("X12345", result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN alphanumeric with odd length WHEN decodeDataStream alongside byte THEN concatenated`() {
+        // "ABC" => one 11-bit pair + one 6-bit trailing char.
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte("u=".encodeToByteArray()),
+                    Segment.Alphanumeric("ABC"),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals("u=ABC", result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN 16-bit byte then alphanumeric segments WHEN decodeDataStream THEN concatenated`() {
+        // QR v10-26 uses 16-bit byte count and 11-bit alphanumeric count. Both
+        // widths must come from the same version group — this guards against
+        // mixing widths from different groups when retrying.
+        val prefix = "https://example.com/i/"
+        val suffix = "ABC123-240101"
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte(prefix.encodeToByteArray(), countBits = 16),
+                    Segment.Alphanumeric(suffix, countBits = 11),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + suffix, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN 16-bit byte then numeric segments WHEN decodeDataStream THEN concatenated`() {
+        // QR v10-26 uses 16-bit byte count and 12-bit numeric count.
+        val prefix = "ref="
+        val digits = "987654321"
+        val payload =
+            buildMultiSegmentPayload(
+                listOf(
+                    Segment.Byte(prefix.encodeToByteArray(), countBits = 16),
+                    Segment.Numeric(digits, countBits = 12),
+                ),
+            )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + digits, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN kanji mode WHEN decodeDataStream THEN returns null`() {
+        // Mode 1000 (8) = Kanji. The branch should bail out unconditionally.
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(1, 0, 0, 0)) // Kanji mode
+        addBits(bits, 1, 8) // a plausible count field; never read
+        bits.addAll(listOf(0, 0, 0, 0))
+        val payload = packBits(bits)
+
+        assertNull(QRCodePayloadParser.decodeDataStream(payload))
+    }
+
+    // region Helpers
+
+    private sealed class Segment {
+        class Byte(
+            val data: ByteArray,
+            val countBits: Int = 8,
+        ) : Segment()
+
+        class Alphanumeric(
+            val text: String,
+            val countBits: Int = 9,
+        ) : Segment()
+
+        class Numeric(
+            val digits: String,
+            val countBits: Int = 10,
+        ) : Segment()
+    }
+
+    private fun buildMultiSegmentPayload(segments: List<Segment>): ByteArray {
+        val bits = mutableListOf<Int>()
+        for (seg in segments) {
+            when (seg) {
+                is Segment.Byte -> {
+                    bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100
+                    addBits(bits, seg.data.size, seg.countBits)
+                    seg.data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
+                }
+                is Segment.Alphanumeric -> {
+                    val chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
+                    bits.addAll(listOf(0, 0, 1, 0)) // Mode: 0010
+                    addBits(bits, seg.text.length, seg.countBits)
+                    var i = 0
+                    while (i + 2 <= seg.text.length) {
+                        addBits(
+                            bits,
+                            chars.indexOf(seg.text[i]) * 45 + chars.indexOf(seg.text[i + 1]),
+                            11,
+                        )
+                        i += 2
+                    }
+                    if (seg.text.length - i == 1) {
+                        addBits(bits, chars.indexOf(seg.text[i]), 6)
+                    }
+                }
+                is Segment.Numeric -> {
+                    bits.addAll(listOf(0, 0, 0, 1)) // Mode: 0001
+                    addBits(bits, seg.digits.length, seg.countBits)
+                    var i = 0
+                    while (i + 3 <= seg.digits.length) {
+                        addBits(bits, seg.digits.substring(i, i + 3).toInt(), 10)
+                        i += 3
+                    }
+                    when (seg.digits.length - i) {
+                        2 -> addBits(bits, seg.digits.substring(i).toInt(), 7)
+                        1 -> addBits(bits, seg.digits.substring(i).toInt(), 4)
+                    }
+                }
+            }
+        }
+        bits.addAll(listOf(0, 0, 0, 0)) // Terminator
+        return packBits(bits)
+    }
+
+    private fun buildByteModePayload(
+        data: ByteArray,
+        countBits: Int = 8,
+    ): ByteArray {
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100 (byte)
+        addBits(bits, data.size, countBits)
+        data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
+        bits.addAll(listOf(0, 0, 0, 0)) // Terminator
+        return packBits(bits)
+    }
+
+    private fun buildNumericModePayload(digits: String): ByteArray {
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(0, 0, 0, 1)) // Mode: 0001 (numeric)
+        addBits(bits, digits.length, 10)
+        var i = 0
+        while (i + 3 <= digits.length) {
+            addBits(bits, digits.substring(i, i + 3).toInt(), 10)
+            i += 3
+        }
+        when (digits.length - i) {
+            2 -> addBits(bits, digits.substring(i).toInt(), 7)
+            1 -> addBits(bits, digits.substring(i).toInt(), 4)
+        }
+        bits.addAll(listOf(0, 0, 0, 0))
+        return packBits(bits)
+    }
+
+    private fun buildAlphanumericModePayload(text: String): ByteArray {
+        val chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(0, 0, 1, 0)) // Mode: 0010 (alphanumeric)
+        addBits(bits, text.length, 9)
+        var i = 0
+        while (i + 2 <= text.length) {
+            addBits(bits, chars.indexOf(text[i]) * 45 + chars.indexOf(text[i + 1]), 11)
+            i += 2
+        }
+        if (text.length - i == 1) {
+            addBits(bits, chars.indexOf(text[i]), 6)
+        }
+        bits.addAll(listOf(0, 0, 0, 0))
+        return packBits(bits)
+    }
+
+    private fun addBits(
+        bits: MutableList<Int>,
+        value: Int,
+        count: Int,
+    ) {
+        for (i in (count - 1) downTo 0) bits.add((value shr i) and 1)
+    }
+
+    private fun packBits(bits: List<Int>): ByteArray =
+        bits
+            .chunked(8)
+            .map { chunk ->
+                chunk.foldIndexed(0) { idx, acc, bit -> acc or (bit shl (7 - idx)) }.toByte()
+            }.toByteArray()
+
+    // endregion
+}

--- a/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
+++ b/shared/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
@@ -11,7 +11,7 @@ class QRCodePayloadParserTest {
     fun `GIVEN byte mode payload WHEN decodeDataStream THEN returns correct bytes`() {
         val payload = buildByteModePayload(byteArrayOf(0x41, 0x42, 0x43))
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals(3, result.size)
@@ -25,7 +25,7 @@ class QRCodePayloadParserTest {
                 byteArrayOf('H'.code.toByte(), 'i'.code.toByte(), 0x00, '!'.code.toByte()),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals(4, result.size)
@@ -39,7 +39,7 @@ class QRCodePayloadParserTest {
     fun `GIVEN numeric mode WHEN decodeDataStream THEN returns null`() {
         val payload = buildNumericModePayload("123")
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNull(result) // Numeric can't have null bytes, use stringValue fallback
     }
@@ -48,14 +48,14 @@ class QRCodePayloadParserTest {
     fun `GIVEN alphanumeric mode WHEN decodeDataStream THEN returns null`() {
         val payload = buildAlphanumericModePayload("AB")
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNull(result) // Alphanumeric can't have null bytes, use stringValue fallback
     }
 
     @Test
     fun `GIVEN empty payload WHEN decodeDataStream THEN returns null`() {
-        assertNull(QRCodePayloadParser.decodeDataStream(byteArrayOf()))
+        assertNull(QRCodePayloadParser.decodeDataStream(byteArrayOf(), symbolVersion = 1))
     }
 
     @Test
@@ -65,7 +65,7 @@ class QRCodePayloadParserTest {
                 byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57, 0x6F, 0x72, 0x6C, 0x64),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals(11, result.size)
@@ -90,18 +90,18 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals(url + serial, result.decodeToString())
     }
 
     @Test
-    fun `GIVEN byte mode payload with 16-bit count WHEN decodeDataStream THEN retries and decodes`() {
+    fun `GIVEN byte mode payload with 16-bit count WHEN decodeDataStream THEN decodes with v10 widths`() {
         val data = "QR v10+ byte segment".encodeToByteArray()
         val payload = buildByteModePayload(data, countBits = 16)
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 10)
 
         assertNotNull(result)
         assertContentEquals(data, result)
@@ -119,7 +119,7 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals(prefix + digits, result.decodeToString())
@@ -136,7 +136,7 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals("X12345", result.decodeToString())
@@ -153,7 +153,7 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
 
         assertNotNull(result)
         assertEquals("u=ABC", result.decodeToString())
@@ -174,7 +174,7 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 10)
 
         assertNotNull(result)
         assertEquals(prefix + suffix, result.decodeToString())
@@ -193,7 +193,7 @@ class QRCodePayloadParserTest {
                 ),
             )
 
-        val result = QRCodePayloadParser.decodeDataStream(payload)
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 10)
 
         assertNotNull(result)
         assertEquals(prefix + digits, result.decodeToString())
@@ -208,7 +208,29 @@ class QRCodePayloadParserTest {
         bits.addAll(listOf(0, 0, 0, 0))
         val payload = packBits(bits)
 
-        assertNull(QRCodePayloadParser.decodeDataStream(payload))
+        assertNull(QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1))
+    }
+
+    @Test
+    fun `GIVEN v10 byte count with leading null WHEN decodeDataStream THEN preserves full payload`() {
+        val data = byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04)
+        val payload = buildByteModePayload(data, countBits = 16)
+
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 10)
+
+        assertNotNull(result)
+        assertContentEquals(data, result)
+    }
+
+    @Test
+    fun `GIVEN eci then byte segments WHEN decodeDataStream THEN byte data preserved`() {
+        val data = byteArrayOf(0x48, 0x69)
+        val payload = buildEciThenBytePayload(data, byteCountBits = 8)
+
+        val result = QRCodePayloadParser.decodeDataStream(payload, symbolVersion = 1)
+
+        assertNotNull(result)
+        assertContentEquals(data, result)
     }
 
     // region Helpers
@@ -317,6 +339,20 @@ class QRCodePayloadParserTest {
         if (text.length - i == 1) {
             addBits(bits, chars.indexOf(text[i]), 6)
         }
+        bits.addAll(listOf(0, 0, 0, 0))
+        return packBits(bits)
+    }
+
+    private fun buildEciThenBytePayload(
+        data: ByteArray,
+        byteCountBits: Int,
+    ): ByteArray {
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(0, 1, 1, 1)) // Mode: 0111 (ECI)
+        addBits(bits, 0, 8) // 8-bit ECI assignment number
+        bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100 (byte)
+        addBits(bits, data.size, byteCountBits)
+        data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
         bits.addAll(listOf(0, 0, 0, 0))
         return packBits(bits)
     }


### PR DESCRIPTION
 - resolves #1446 

Changes picked from kscan:

0.9.2 - Multi-segment QRCodePayloadParser (iOS QR raw bytes)
0.9.1 - iOS ITF (Interleaved2of5) format mapping
0.7.1 - ScannerController torch/zoom read-only
0.7.0 - iOS QR raw-byte preservation -> Part of 0.9.2 file pick

Ignored changes:
0.9.1 - scanImage / ImageScanner static image API
0.8.1 - Desktop target


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Interleaved 2 of 5 (ITF) barcodes on iOS.
  * Improved QR code scanning by preserving raw payload bytes, including embedded null bytes.
  * Made scanner torch and zoom values externally read-only, with changes applied through the provided controls.
* **Bug Fixes**
  * Prevented QR code data truncation/inaccurate display by rebuilding display content from preserved raw bytes.
* **Documentation**
  * Updated upstream provenance information for the KScan library.
* **Tests**
  * Added iOS test coverage for ITF mapping and QR raw-payload decoding across multiple payload modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->