### PR TITLE
bugfix/ios_connect_device_registration_crash

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceIdGenerator.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceIdGenerator.android.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.push_notification
 
+import android.annotation.SuppressLint
 import android.provider.Settings
 import network.bisq.mobile.presentation.main.ApplicationContextProvider
 
@@ -9,7 +10,19 @@ import network.bisq.mobile.presentation.main.ApplicationContextProvider
  * - Is unique per device and user combination
  * - Persists across app reinstalls
  * - Changes on factory reset
+ *
+ * ANDROID_ID here is a stable per-device key for push registration, NOT an advertising/analytics
+ * identifier, so the lint HardwareIds guidance (AdvertisingIdClient / InstanceId) does not apply —
+ * hence the @SuppressLint below.
+ *
+ * TODO: migrate deviceId to a self-generated, persisted random UUID (the API already accepts a
+ *  "persisted UUID" — see PushNotificationApiGateway). It's more privacy-preserving (no device
+ *  hardware id) and would fully remove the iOS transient-nil #1597 root cause. Needs a one-time
+ *  migration for existing installs: read the old ANDROID_ID / identifierForVendor id, unregister
+ *  it on the trusted node, then register the new UUID — otherwise old registrations orphan and
+ *  users get duplicate pushes during the transition.
  */
+@SuppressLint("HardwareIds")
 actual fun getDeviceId(): String {
     val context = ApplicationContextProvider.context
     val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
@@ -402,4 +402,59 @@ class ClientPushNotificationServiceFacadeIntegrationTest {
             assertTrue(result.isFailure)
             assertFalse(facade.isDeviceRegistered.value)
         }
+
+    // ---- Transient device-identifier unavailability (GlitchTip #1597) ----
+    //
+    // iOS UIDevice.identifierForVendor is nil right after a device restart, before the first
+    // unlock, so getDeviceId() throws IllegalStateException. That must NOT crash the app: the
+    // facade's public API is Result-based, so the failure has to surface as Result.failure and
+    // the next registration attempt (auto-register on activate) recovers once the id is available.
+
+    private fun facadeWithFailingDeviceId(): ClientPushNotificationServiceFacade =
+        ClientPushNotificationServiceFacade(
+            apiGateway = apiGateway,
+            settingsRepository = settingsRepository,
+            sensitiveSettingsRepository = sensitiveSettingsRepository,
+            pushNotificationTokenProvider = tokenProvider,
+            userProfileServiceFacade = userProfileServiceFacade,
+            deviceIdProvider =
+                DeviceIdProvider {
+                    throw IllegalStateException(
+                        "Unable to get device identifier. This can happen during device restart. Please try again.",
+                    )
+                },
+        )
+
+    @Test
+    fun `registerForPushNotifications returns failure without throwing when device id unavailable`() =
+        runTest {
+            // Given
+            coEvery { tokenProvider.requestPermission() } returns true
+            coEvery { tokenProvider.requestDeviceToken() } returns Result.success("valid-token")
+            val failingFacade = facadeWithFailingDeviceId()
+
+            // When — must not throw (previously an uncaught IllegalStateException crashed the app)
+            val result = failingFacade.registerForPushNotifications()
+
+            // Then — graceful failure, no server call, not marked registered
+            assertTrue(result.isFailure)
+            assertFalse(failingFacade.isDeviceRegistered.value)
+            coVerify(exactly = 0) { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `unregisterFromPushNotifications returns failure and clears state when device id unavailable`() =
+        runTest {
+            // Given
+            val failingFacade = facadeWithFailingDeviceId()
+
+            // When — must not throw
+            val result = failingFacade.unregisterFromPushNotifications()
+
+            // Then — graceful failure, but local opt-out state is still cleared
+            assertTrue(result.isFailure)
+            assertFalse(failingFacade.isDeviceRegistered.value)
+            assertFalse(settingsRepository.fetch().pushNotificationsEnabled)
+            coVerify(exactly = 0) { apiGateway.unregisterDevice(any()) }
+        }
 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
@@ -113,6 +113,10 @@ class ClientPushNotificationServiceFacadeIntegrationTest {
                 sensitiveSettingsRepository = sensitiveSettingsRepository,
                 pushNotificationTokenProvider = tokenProvider,
                 userProfileServiceFacade = userProfileServiceFacade,
+                // Keep the symmetric-key init's withContext hop under the test scheduler instead of
+                // Dispatchers.Default, so registration tests stay deterministic (runTest adopts the
+                // scheduler of the TestDispatcher set via Dispatchers.setMain above).
+                backgroundDispatcher = testDispatcher,
             )
     }
 
@@ -417,6 +421,7 @@ class ClientPushNotificationServiceFacadeIntegrationTest {
             sensitiveSettingsRepository = sensitiveSettingsRepository,
             pushNotificationTokenProvider = tokenProvider,
             userProfileServiceFacade = userProfileServiceFacade,
+            backgroundDispatcher = testDispatcher,
             deviceIdProvider =
                 DeviceIdProvider {
                     throw IllegalStateException(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -37,6 +37,9 @@ class ClientPushNotificationServiceFacade(
     // tests can pass the test dispatcher and keep it under the test scheduler — otherwise the
     // Dispatchers.Default hop escapes runTest/advanceUntilIdle and makes registration tests flaky.
     private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    // Injectable so tests can drive the transient-nil-identifier failure path (iOS
+    // identifierForVendor after a restart). Production delegates to the platform getDeviceId().
+    private val deviceIdProvider: DeviceIdProvider = DeviceIdProvider { getDeviceId() },
 ) : ServiceFacade(),
     PushNotificationServiceFacade,
     Logging {
@@ -132,6 +135,22 @@ class ClientPushNotificationServiceFacade(
         return registerTokenWithTrustedNode(token)
     }
 
+    /**
+     * Resolves the platform device identifier, converting the transient-unavailability throw into a
+     * [Result.failure] so it degrades to a recoverable error instead of an uncaught crash
+     * (GlitchTip #1597). On iOS `identifierForVendor` is nil right after a device restart, before
+     * the first unlock; the next registration attempt (auto-register on `activate()`) recovers once
+     * the identifier is available. We deliberately do NOT synthesize a fallback id — a random id
+     * would register a phantom device with the trusted node that never matches the real one.
+     */
+    private fun resolveDeviceId(): Result<String> =
+        try {
+            Result.success(deviceIdProvider.getDeviceId())
+        } catch (e: IllegalStateException) {
+            log.w(e) { "Device identifier temporarily unavailable — deferring; will retry when available." }
+            Result.failure(PushNotificationException("Device identifier temporarily unavailable", e))
+        }
+
     private suspend fun registerTokenWithTrustedNode(token: String): Result<Unit> {
         // Get the current user profile (needed for publicKeyBase64)
         val userProfile = userProfileServiceFacade.selectedUserProfile.value
@@ -143,8 +162,10 @@ class ClientPushNotificationServiceFacade(
         // publicKey.encoded is already a base64-encoded String from Bisq2
         val publicKeyBase64 = userProfile.networkId.pubKey.publicKey.encoded
 
-        // Get deterministic device-specific deviceId (based on hardware identifiers)
-        val deviceId = getDeviceId()
+        // Get deterministic device-specific deviceId (based on hardware identifiers). Can be
+        // transiently unavailable on iOS (see resolveDeviceId); surface it as a Result.failure
+        // instead of an uncaught crash — auto-register on the next activate() recovers.
+        val deviceId = resolveDeviceId().getOrElse { return Result.failure(it) }
         _deviceId.value = deviceId
 
         // Get device descriptor and platform dynamically
@@ -191,10 +212,14 @@ class ClientPushNotificationServiceFacade(
     override suspend fun unregisterFromPushNotifications(): Result<Unit> {
         log.i { "Unregistering from push notifications..." }
 
-        // Get deterministic device-specific deviceId (always available from hardware)
-        val deviceIdToUnregister = getDeviceId()
-
-        val apiResult = apiGateway.unregisterDevice(deviceIdToUnregister)
+        // deviceId tells the server which device to unregister. On iOS it can be transiently
+        // unavailable (post-restart, pre-first-unlock); if so we still honor the local opt-out
+        // (state is cleared below) but can't reach the server — treat that as an apiResult failure.
+        val apiResult =
+            resolveDeviceId().fold(
+                onSuccess = { apiGateway.unregisterDevice(it) },
+                onFailure = { Result.failure(it) },
+            )
         // Always update local state regardless of API result
         _isDeviceRegistered.value = false
         _deviceId.value = null

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceIdProvider.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/DeviceIdProvider.kt
@@ -1,0 +1,14 @@
+package network.bisq.mobile.client.common.domain.service.push_notification
+
+/**
+ * Provides the platform device identifier.
+ *
+ * Abstracted behind an interface so the transient-failure path can be exercised in tests: on iOS
+ * `UIDevice.identifierForVendor` is nil right after a device restart, before the first unlock (see
+ * [getDeviceId] actual). Implementations may therefore throw [IllegalStateException] when the
+ * identifier is temporarily unavailable — callers must treat that as a recoverable failure, not a
+ * crash. The production default simply delegates to the platform [getDeviceId] expect/actual.
+ */
+fun interface DeviceIdProvider {
+    fun getDeviceId(): String
+}


### PR DESCRIPTION
 - fixes #1597 
 - defer device id obtention to avoid iOS fresh restart nullability with a new provider
 - added AI generated tests
 - supress android lint warning with a TODO on how to address in the near future, no code changes since its working fine for android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Push notification registration and unregistration now fail gracefully when the device identifier is temporarily unavailable.
  * Prevented crashes during device ID retrieval.
  * Unregistration now clears local notification settings even when server-side removal fails.
* **Documentation**
  * Clarified how the Android device identifier is used for push notification registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->