### PR TITLE
Feature/config facade for static data with trade amount limits example

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
@@ -1,0 +1,16 @@
+package network.bisq.mobile.client.common.domain.service.config
+
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientConfigServiceFacadeTest {
+    @Test
+    fun `tradeAmountLimits emits the bundled default`() {
+        val facade = ClientConfigServiceFacade()
+
+        // Until the config endpoint exists, the client must expose the bundled fallback so
+        // trade-amount math is unchanged from when these values were hardcoded.
+        assertEquals(TradeAmountLimitsVO.DEFAULT, facade.tradeAmountLimits.value)
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenterTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.di.clientTestModule
+import network.bisq.mobile.client.common.domain.service.config.ClientConfigServiceFacade
 import network.bisq.mobile.client.common.domain.service.user_profile.ClientUserProfileServiceFacade
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
@@ -173,6 +174,7 @@ class ClientOfferbookPresenterTest {
             userProfileServiceFacade = userProfileServiceFacade,
             tradeRestrictingAlertServiceFacade = tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository = offerbookFilterConfigRepository,
+            configServiceFacade = ClientConfigServiceFacade(),
         )
     }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -29,6 +29,7 @@ import network.bisq.mobile.client.common.domain.service.capabilities.ClientBacke
 import network.bisq.mobile.client.common.domain.service.chat.trade.ClientTradeChatMessagesServiceFacade
 import network.bisq.mobile.client.common.domain.service.chat.trade.TradeChatMessagesApiGateway
 import network.bisq.mobile.client.common.domain.service.common.ClientLanguageServiceFacade
+import network.bisq.mobile.client.common.domain.service.config.ClientConfigServiceFacade
 import network.bisq.mobile.client.common.domain.service.explorer.ClientExplorerServiceFacade
 import network.bisq.mobile.client.common.domain.service.explorer.ExplorerApiGateway
 import network.bisq.mobile.client.common.domain.service.market.ClientMarketPriceServiceFacade
@@ -87,6 +88,7 @@ import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.common.LanguageServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.explorer.ExplorerServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.mediation.MediationServiceFacade
@@ -419,6 +421,8 @@ val clientDomainModule =
                 get(),
             )
         }
+
+        single<ConfigServiceFacade> { ClientConfigServiceFacade() }
 
         single<MessageDeliveryServiceFacade> { ClientMessageDeliveryServiceFacade() }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -63,6 +63,7 @@ val clientPresentationModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
@@ -1,0 +1,22 @@
+package network.bisq.mobile.client.common.domain.service.config
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import network.bisq.mobile.data.service.ServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
+
+/**
+ * Client implementation of [ConfigServiceFacade].
+ *
+ * TODO: fetch the config from the trusted node's config endpoint, cache it (survives restarts), and
+ *  refresh it in the background; fall back to the cached value, then to [TradeAmountLimitsVO.DEFAULT]
+ *  when the node is unreachable or predates the endpoint. For now it emits the bundled default.
+ */
+class ClientConfigServiceFacade :
+    ServiceFacade(),
+    ConfigServiceFacade {
+    private val _tradeAmountLimits = MutableStateFlow(TradeAmountLimitsVO.DEFAULT)
+    override val tradeAmountLimits: StateFlow<TradeAmountLimitsVO> = _tradeAmountLimits.asStateFlow()
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.offerbook
 import network.bisq.mobile.client.common.domain.service.user_profile.ClientUserProfileServiceFacade
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
@@ -22,6 +23,7 @@ class ClientOfferbookPresenter(
     private val userProfileServiceFacade: ClientUserProfileServiceFacade,
     tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
     offerbookFilterConfigRepository: OfferbookFilterConfigRepository,
+    configServiceFacade: ConfigServiceFacade,
 ) : OfferbookPresenter(
         mainPresenter,
         offersServiceFacade,
@@ -32,6 +34,7 @@ class ClientOfferbookPresenter(
         reputationServiceFacade,
         tradeRestrictingAlertServiceFacade,
         offerbookFilterConfigRepository,
+        configServiceFacade,
     ) {
     override fun isOfferFromIgnoredUserCached(offer: BisqEasyOfferVO): Boolean {
         val makerUserProfileId = offer.makerNetworkId.pubKey.id

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.common.LanguageServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.explorer.ExplorerServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.mediation.MediationServiceFacade
@@ -53,6 +54,7 @@ import network.bisq.mobile.node.common.domain.service.capabilities.NodeBackendCa
 import network.bisq.mobile.node.common.domain.service.cat_hash.AndroidNodeCatHashService
 import network.bisq.mobile.node.common.domain.service.chat.trade.NodeTradeChatMessagesServiceFacade
 import network.bisq.mobile.node.common.domain.service.common.NodeLanguageServiceFacade
+import network.bisq.mobile.node.common.domain.service.config.NodeConfigServiceFacade
 import network.bisq.mobile.node.common.domain.service.explorer.NodeExplorerServiceFacade
 import network.bisq.mobile.node.common.domain.service.market_price.NodeMarketPriceServiceFacade
 import network.bisq.mobile.node.common.domain.service.mediation.NodeMediationServiceFacade
@@ -165,7 +167,7 @@ val androidNodeDomainModule =
 
         single<UserProfileServiceFacade> { NodeUserProfileServiceFacade(get()) }
 
-        single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get(), get(), get()) }
+        single<OffersServiceFacade> { NodeOffersServiceFacade(get(), get(), get(), get(), get()) }
 
         single<ExplorerServiceFacade> { NodeExplorerServiceFacade(get()) }
 
@@ -194,6 +196,8 @@ val androidNodeDomainModule =
         single<NodeBackupServiceFacade> { NodeBackupServiceFacade(get(), get()) }
 
         single<ReputationServiceFacade> { NodeReputationServiceFacade(get()) }
+
+        single<ConfigServiceFacade> { NodeConfigServiceFacade() }
 
         single { NodeConnectivityService(get()) } bind ConnectivityService::class
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -59,6 +59,7 @@ val androidNodePresentationModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/config/NodeConfigServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/config/NodeConfigServiceFacade.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.node.common.domain.service.config
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import network.bisq.mobile.data.service.ServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
+
+/**
+ * Node implementation of [ConfigServiceFacade].
+ *
+ * TODO: read the values straight from bisq2 core's BisqEasyTradeAmountLimits (no HTTP, no
+ *  hardcoding) so the node is the single source of truth. For now it emits the bundled default.
+ */
+class NodeConfigServiceFacade :
+    ServiceFacade(),
+    ConfigServiceFacade {
+    private val _tradeAmountLimits = MutableStateFlow(TradeAmountLimitsVO.DEFAULT)
+    override val tradeAmountLimits: StateFlow<TradeAmountLimitsVO> = _tradeAmountLimits.asStateFlow()
+}

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
@@ -43,6 +43,7 @@ import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.amount.spec.AmountSpecVO
 import network.bisq.mobile.data.replicated.offer.price.spec.PriceSpecVO
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OfferFormattingUtil
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
@@ -60,6 +61,7 @@ class NodeOffersServiceFacade(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
+    private val configServiceFacade: ConfigServiceFacade,
 ) : OffersServiceFacade() {
     companion object {
         private val DEFAULT_MARKET = Market("BTC", "USD", "Bitcoin", "US Dollar")
@@ -541,6 +543,7 @@ class NodeOffersServiceFacade(
             BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinOrFixedAmount(
                 marketPriceServiceFacade,
                 offerVO,
+                configServiceFacade.tradeAmountLimits.value,
             )
 
         // If we cannot determine required score (missing market prices), we err on the safe side

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
@@ -1,0 +1,82 @@
+package network.bisq.mobile.domain.utils
+
+import io.mockk.every
+import io.mockk.mockk
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory.fromPrice
+import network.bisq.mobile.data.replicated.common.network.AddressByTransportTypeMapVO
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import network.bisq.mobile.data.replicated.network.identity.NetworkIdVO
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideRangeAmountSpecVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.data.replicated.security.keys.PubKeyVO
+import network.bisq.mobile.data.replicated.security.keys.PublicKeyVO
+import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * Covers the required-reputation-score entry points that resolve their config from the injected
+ * [TradeAmountLimitsVO]. When market prices are unavailable the amount cannot be converted, so these
+ * must degrade to null / "not invalid" rather than throw.
+ */
+class BisqEasyTradeAmountLimitsTest {
+    private val market = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
+
+    private fun marketServiceWithoutPrices(): MarketPriceServiceFacade =
+        mockk(relaxed = true) {
+            every { findMarketPriceItem(any()) } returns null
+            every { findUSDMarketPriceItem() } returns null
+        }
+
+    private fun buildBuyOffer(): BisqEasyOfferVO =
+        BisqEasyOfferVO(
+            id = "offer-1",
+            date = 0L,
+            makerNetworkId =
+                NetworkIdVO(
+                    AddressByTransportTypeMapVO(mapOf()),
+                    PubKeyVO(PublicKeyVO("pub"), keyId = "key", hash = "hash", id = "id"),
+                ),
+            direction = DirectionEnum.BUY,
+            market = market,
+            amountSpec = QuoteSideRangeAmountSpecVO(minAmount = 10_0000L, maxAmount = 100_0000L),
+            priceSpec = FixPriceSpecVO(with(PriceQuoteVOFactory) { fromPrice(100_00L, market) }),
+            protocolTypes = emptyList(),
+            baseSidePaymentMethodSpecs = emptyList(),
+            quoteSidePaymentMethodSpecs = emptyList(),
+            offerOptions = emptyList(),
+            supportedLanguageCodes = emptyList(),
+        )
+
+    @Test
+    fun `findRequiredReputationScoreForMinOrFixedAmount returns null when market price is unavailable`() {
+        val marketPriceServiceFacade = marketServiceWithoutPrices()
+
+        val result =
+            BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinOrFixedAmount(
+                marketPriceServiceFacade,
+                buildBuyOffer(),
+                TradeAmountLimitsVO.DEFAULT,
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `findRequiredReputationScoreForMaxOrFixedAmount returns null when market price is unavailable`() {
+        val marketPriceServiceFacade = marketServiceWithoutPrices()
+
+        val result =
+            BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(
+                marketPriceServiceFacade,
+                buildBuyOffer(),
+                TradeAmountLimitsVO.DEFAULT,
+            )
+
+        assertNull(result)
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/config/TradeAmountLimitsVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/config/TradeAmountLimitsVO.kt
@@ -1,0 +1,35 @@
+package network.bisq.mobile.data.replicated.config
+
+import kotlinx.serialization.Serializable
+import network.bisq.mobile.data.replicated.common.monetary.FiatVO
+import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory.fromFaceValue
+
+/**
+ * Static Bisq Easy trade-amount configuration. These values are fixed for a given bisq2 core/api
+ * version and are the same across the P2P network, so the client should not hardcode them long term.
+ *
+ * TODO: source these from the trusted node's config endpoint (config facade) instead of the bundled
+ *  [DEFAULT] fallback below.
+ */
+@Serializable
+data class TradeAmountLimitsVO(
+    val defaultMinUsdTradeAmount: FiatVO,
+    val maxUsdTradeAmount: FiatVO,
+    val tolerance: Double,
+    val requiredReputationScorePerUsd: Double,
+) {
+    companion object {
+        /**
+         * Bundled fallback, mirrored from bisq2 core's `BisqEasyTradeAmountLimits`. Used until the
+         * config facade can supply the values from the node, and as the permanent offline fallback.
+         */
+        val DEFAULT =
+            TradeAmountLimitsVO(
+                defaultMinUsdTradeAmount = FiatVOFactory.fromFaceValue(6.0, "USD"),
+                maxUsdTradeAmount = FiatVOFactory.fromFaceValue(600.0, "USD"),
+                tolerance = 0.05,
+                requiredReputationScorePerUsd = 200.0,
+            )
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/config/ConfigServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/config/ConfigServiceFacade.kt
@@ -1,0 +1,20 @@
+package network.bisq.mobile.data.service.config
+
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import network.bisq.mobile.data.service.LifeCycleAware
+
+/**
+ * Single source of static bisq2 configuration for the app, so clients don't hardcode/duplicate
+ * values that bisq2 core owns.
+ *
+ * The value always resolves to something usable: the bundled default, then a cached value, then the
+ * live value from the node. The client fetches it over HTTP; the node reads it straight from bisq2
+ * core.
+ *
+ * TODO: back [tradeAmountLimits] with a fetched+cached value (client) / a direct core read (node);
+ *  currently both impls emit [TradeAmountLimitsVO.DEFAULT].
+ */
+interface ConfigServiceFacade : LifeCycleAware {
+    val tradeAmountLimits: StateFlow<TradeAmountLimitsVO>
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
@@ -204,9 +204,8 @@ object BisqEasyTradeAmountLimits {
         limits: TradeAmountLimitsVO,
     ): FiatVO {
         val maxAmountAllowedByReputation = getUsdAmountFromReputationScore(totalScore, limits)
-        val value: Double =
-            minOf(limits.maxUsdTradeAmount.value, maxAmountAllowedByReputation.value).toDouble()
-        return FiatVOFactory.from(value.toLong(), "USD")
+        val value: Long = minOf(limits.maxUsdTradeAmount.value, maxAmountAllowedByReputation.value)
+        return FiatVOFactory.from(value, "USD")
     }
 
     fun getUsdAmountFromReputationScore(

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory.fromFac
 import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOExtensions.toBaseSideMonetary
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOExtensions.toQuoteSideMonetary
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMaxAmount
@@ -28,12 +29,13 @@ object BisqEasyTradeAmountLimits {
     fun getMinAmountValue(
         marketPriceServiceFacade: MarketPriceServiceFacade,
         quoteCurrencyCode: String,
+        limits: TradeAmountLimitsVO,
     ): Long {
         val minFiatAmount =
             fromUsd(
                 marketPriceServiceFacade,
                 MarketVO("BTC", quoteCurrencyCode),
-                DEFAULT_MIN_USD_TRADE_AMOUNT,
+                limits.defaultMinUsdTradeAmount,
             )
         // Round scaled fiat long to whole fiat units (drop sub-unit precision).
         return ((minFiatAmount?.value?.toDouble() ?: 0.0) / FIAT_SCALE_FACTOR).roundToLong() * FIAT_SCALE_FACTOR.toLong()
@@ -42,20 +44,16 @@ object BisqEasyTradeAmountLimits {
     fun getMaxAmountValue(
         marketPriceServiceFacade: MarketPriceServiceFacade,
         quoteCurrencyCode: String,
+        limits: TradeAmountLimitsVO,
     ): Long {
         val maxFiatAmount =
             fromUsd(
                 marketPriceServiceFacade,
                 MarketVO("BTC", quoteCurrencyCode),
-                MAX_USD_TRADE_AMOUNT,
+                limits.maxUsdTradeAmount,
             )
         return ((maxFiatAmount?.value?.toDouble() ?: 0.0) / FIAT_SCALE_FACTOR).roundToLong() * FIAT_SCALE_FACTOR.toLong()
     }
-
-    val TOLERANCE: Double = 0.05
-    val DEFAULT_MIN_USD_TRADE_AMOUNT: FiatVO = FiatVOFactory.fromFaceValue(6.0, "USD")
-    val MAX_USD_TRADE_AMOUNT: FiatVO = FiatVOFactory.fromFaceValue(600.0, "USD")
-    val REQUIRED_REPUTATION_SCORE_PER_USD: Double = 200.0
 
     fun fromUsd(
         marketPriceServiceFacade: MarketPriceServiceFacade,
@@ -76,6 +74,7 @@ object BisqEasyTradeAmountLimits {
         marketPriceServiceFacade: MarketPriceServiceFacade,
         reputationServiceFacade: ReputationServiceFacade,
         userProfileId: String,
+        limits: TradeAmountLimitsVO,
     ): Boolean {
         val bisqEasyOffer = item.bisqEasyOffer
         require(bisqEasyOffer.direction == DirectionEnum.BUY)
@@ -92,6 +91,7 @@ object BisqEasyTradeAmountLimits {
             findRequiredReputationScoreForMinOrFixedAmount(
                 marketPriceServiceFacade,
                 bisqEasyOffer,
+                limits,
             ) ?: run {
                 logger.e { "requiredReputationScoreForMinAmount is null" }
                 return false
@@ -119,35 +119,41 @@ object BisqEasyTradeAmountLimits {
     fun findRequiredReputationScoreForMaxOrFixedAmount(
         marketPriceService: MarketPriceServiceFacade,
         offer: BisqEasyOfferVO,
+        limits: TradeAmountLimitsVO,
     ): Long? {
         val amount = offer.getFixedOrMaxAmount()
         val fiatAmount = FiatVOFactory.from(amount, offer.market.quoteCurrencyCode)
-        return findRequiredReputationScoreByFiatAmount(marketPriceService, offer.market, fiatAmount)
+        return findRequiredReputationScoreByFiatAmount(marketPriceService, offer.market, fiatAmount, limits)
     }
 
     fun findRequiredReputationScoreForMinOrFixedAmount(
         marketPriceService: MarketPriceServiceFacade,
         offer: BisqEasyOfferVO,
+        limits: TradeAmountLimitsVO,
     ): Long? {
         val amount = offer.getFixedOrMinAmount()
         val fiatAmount = FiatVOFactory.from(amount, offer.market.quoteCurrencyCode)
-        return findRequiredReputationScoreByFiatAmount(marketPriceService, offer.market, fiatAmount)
+        return findRequiredReputationScoreByFiatAmount(marketPriceService, offer.market, fiatAmount, limits)
     }
 
     fun findRequiredReputationScoreByFiatAmount(
         marketPriceServiceFacade: MarketPriceServiceFacade,
         market: MarketVO,
         fiat: MonetaryVO,
+        limits: TradeAmountLimitsVO,
     ): Long? {
         val btcAmount = fiatToBtc(marketPriceServiceFacade, market, fiat) ?: return null
         val fiatAmount = btcToUsd(marketPriceServiceFacade, btcAmount) ?: return null
-        return getRequiredReputationScoreByUsdAmount(fiatAmount)
+        return getRequiredReputationScoreByUsdAmount(fiatAmount, limits)
     }
 
-    fun getRequiredReputationScoreByUsdAmount(usdAmount: MonetaryVO): Long {
+    fun getRequiredReputationScoreByUsdAmount(
+        usdAmount: MonetaryVO,
+        limits: TradeAmountLimitsVO,
+    ): Long {
         val value = usdAmount.round(0)
         val faceValue: Double = MonetaryVO.toFaceValue(value, 0)
-        return (faceValue * REQUIRED_REPUTATION_SCORE_PER_USD).toLong()
+        return (faceValue * limits.requiredReputationScorePerUsd).toLong()
     }
 
     fun fiatToBtc(
@@ -182,8 +188,9 @@ object BisqEasyTradeAmountLimits {
         marketPriceServiceFacade: MarketPriceServiceFacade,
         market: MarketVO,
         myReputationScore: Long,
+        limits: TradeAmountLimitsVO,
     ): MonetaryVO? {
-        val maxUsdTradeAmount: FiatVO = getMaxUsdTradeAmount(myReputationScore)
+        val maxUsdTradeAmount: FiatVO = getMaxUsdTradeAmount(myReputationScore, limits)
         val usdMarketPriceItem = marketPriceServiceFacade.findUSDMarketPriceItem() ?: return null
         val defaultMaxBtcTradeAmount =
             usdMarketPriceItem.priceQuote.toBaseSideMonetary(maxUsdTradeAmount)
@@ -192,19 +199,28 @@ object BisqEasyTradeAmountLimits {
         return finalValue
     }
 
-    fun getMaxUsdTradeAmount(totalScore: Long): FiatVO {
-        val maxAmountAllowedByReputation = getUsdAmountFromReputationScore(totalScore)
+    fun getMaxUsdTradeAmount(
+        totalScore: Long,
+        limits: TradeAmountLimitsVO,
+    ): FiatVO {
+        val maxAmountAllowedByReputation = getUsdAmountFromReputationScore(totalScore, limits)
         val value: Double =
-            minOf(MAX_USD_TRADE_AMOUNT.value, maxAmountAllowedByReputation.value).toDouble()
+            minOf(limits.maxUsdTradeAmount.value, maxAmountAllowedByReputation.value).toDouble()
         return FiatVOFactory.from(value.toLong(), "USD")
     }
 
-    fun getUsdAmountFromReputationScore(reputationScore: Long): MonetaryVO {
-        val usdAmount = reputationScore / REQUIRED_REPUTATION_SCORE_PER_USD
+    fun getUsdAmountFromReputationScore(
+        reputationScore: Long,
+        limits: TradeAmountLimitsVO,
+    ): MonetaryVO {
+        val usdAmount = reputationScore / limits.requiredReputationScorePerUsd
         return FiatVOFactory.fromFaceValue(usdAmount, "USD")
     }
 
-    fun withTolerance(makersReputationScore: Long): Long = (makersReputationScore * (1 + TOLERANCE)).toLong()
+    fun withTolerance(
+        makersReputationScore: Long,
+        limits: TradeAmountLimitsVO,
+    ): Long = (makersReputationScore * (1 + limits.tolerance)).toLong()
 
     suspend fun addInvalidBuyOffer(id: String) {
         invalidBuyOffersMutex.withLock {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -353,6 +354,7 @@ class ScreenAnalyticsCoverageTest {
                 mainPresenter = mainPresenter,
                 marketPriceServiceFacade = mockk(relaxed = true),
                 takeOfferCoordinator = mockk(relaxed = true),
+                configServiceFacade = FakeConfigServiceFacade(),
             )
         assertEquals(AnalyticsEvent.ScreenOpened.TakeOfferAmount, presenter.analyticsScreenEvent())
     }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeConfigServiceFacade.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeConfigServiceFacade.kt
@@ -1,0 +1,16 @@
+package network.bisq.mobile.presentation.common.test_utils
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
+
+/**
+ * Test fake for [ConfigServiceFacade]. Emits [TradeAmountLimitsVO.DEFAULT] by default so amount-limit
+ * math in tests keeps the same values it had when the limits were hardcoded.
+ */
+class FakeConfigServiceFacade(
+    limits: TradeAmountLimitsVO = TradeAmountLimitsVO.DEFAULT,
+) : ConfigServiceFacade {
+    override val tradeAmountLimits: StateFlow<TradeAmountLimitsVO> = MutableStateFlow(limits)
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferAmountPresenterTest.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
@@ -125,6 +126,7 @@ class CreateOfferAmountPresenterTest {
                     createOfferCoordinator,
                     mockk<UserProfileServiceFacade>(relaxed = true),
                     mockk<ReputationServiceFacade>(relaxed = true),
+                    FakeConfigServiceFacade(),
                 )
 
             // Let initial init coroutines run
@@ -205,6 +207,7 @@ class CreateOfferAmountPresenterTest {
                     createOfferCoordinator,
                     mockk<UserProfileServiceFacade>(relaxed = true),
                     mockk<ReputationServiceFacade>(relaxed = true),
+                    FakeConfigServiceFacade(),
                 )
 
             // Let initial init coroutines run
@@ -297,6 +300,7 @@ class CreateOfferAmountPresenterTest {
                     createOfferCoordinator,
                     userProfileServiceFacade,
                     reputationServiceFacade,
+                    FakeConfigServiceFacade(),
                 )
             runCurrent()
 
@@ -310,6 +314,7 @@ class CreateOfferAmountPresenterTest {
                     createOfferCoordinator,
                     userProfileServiceFacade,
                     reputationServiceFacade,
+                    FakeConfigServiceFacade(),
                 )
             runCurrent()
 
@@ -378,6 +383,7 @@ class CreateOfferAmountPresenterTest {
                     createOfferCoordinator,
                     userProfileServiceFacade,
                     reputationServiceFacade,
+                    FakeConfigServiceFacade(),
                 )
             runCurrent()
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -57,6 +57,7 @@ import network.bisq.mobile.presentation.common.notification.ForegroundServiceCon
 import network.bisq.mobile.presentation.common.notification.NotificationController
 import network.bisq.mobile.presentation.common.notification.model.NotificationConfig
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeTradeReadStateRepository
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
@@ -404,7 +405,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Select offer
             val dto = makeOfferDto()
@@ -413,7 +414,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             val beforeQuote = presenter.formattedQuoteAmount.value
             val beforeBase = presenter.formattedBaseAmount.value
@@ -473,7 +474,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Select offer
             val dto = makeOfferDto()
@@ -482,7 +483,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             // Act: type "50" (which is $50 = 500_000L in minor units)
             presenter.onTextValueChanged("50")
@@ -518,7 +519,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Select offer
             val dto = makeOfferDto()
@@ -527,7 +528,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             // Act: type "1" (which is $1 = 10_000L, below min of ~$6-10)
             presenter.onTextValueChanged("1")
@@ -560,7 +561,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Select offer
             val dto = makeOfferDto()
@@ -569,7 +570,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             // Act: type ""
             presenter.onTextValueChanged("")
@@ -597,7 +598,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Create an offer with MXN market (which has no price data)
             val amountSpec = QuoteSideRangeAmountSpecVO(minAmount = 10_0000L, maxAmount = 100_0000L)
@@ -640,7 +641,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init, should fail)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             // Act: type "50"
             presenter.onTextValueChanged("50")
@@ -673,7 +674,7 @@ class TakeOfferAmountPresenterTest {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
             // Select offer
             val dto = makeOfferDto()
@@ -682,7 +683,7 @@ class TakeOfferAmountPresenterTest {
 
             // Create Amount presenter (runs init)
             val presenter =
-                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator)
+                TakeOfferAmountPresenter(mainPresenter, marketPriceServiceFacade, takeOfferCoordinator, FakeConfigServiceFacade())
 
             // Act: set slider to 0.5, then quickly call onSliderValueChanged(0.6f) then onSliderValueChanged(0.7f)
             // without advancing time (so 0.7 is pending), then call onSliderDragFinished()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -66,6 +66,7 @@ import network.bisq.mobile.presentation.common.notification.ForegroundServiceCon
 import network.bisq.mobile.presentation.common.notification.NotificationController
 import network.bisq.mobile.presentation.common.notification.model.NotificationConfig
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -271,7 +272,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer with fixed amount
         val fixedAmountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
@@ -305,7 +306,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer with wide range (100_000 to 5_000_000)
         // Trade limits: MIN $6 = 60_000, MAX $600 = 6_000_000
@@ -339,7 +340,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer where range collapses after clamping
         // Offer range: 1_070_000 to 1_075_000 (difference = 5_000, which is < 10_000 slider step)
@@ -369,7 +370,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer with range spec
         val rangeSpec = QuoteSideRangeAmountSpecVO(minAmount = 100_000L, maxAmount = 5_000_000L)
@@ -401,7 +402,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer where min > max trade limit
         // Trade limits: MIN $6 = 60_000, MAX $600 = 6_000_000
@@ -436,7 +437,7 @@ class TakeOfferCoordinatorTest {
         every { getScreenWidthDp() } returns 480
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade)
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
 
         // Act: Select offer with wide range and 2 quote payment methods
         val rangeSpec = QuoteSideRangeAmountSpecVO(minAmount = 100_000L, maxAmount = 5_000_000L)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
@@ -41,6 +41,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -278,6 +279,7 @@ class OfferbookPresenterActionGuardResetTest {
             reputationService,
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
+            configServiceFacade = FakeConfigServiceFacade(),
         )
     }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
@@ -44,6 +44,7 @@ import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -155,6 +156,7 @@ class OfferbookPresenterFilterPersistenceTest {
                 reputationServiceFacade = mockk<ReputationServiceFacade>(relaxed = true),
                 tradeRestrictingAlertServiceFacade = mockk<TradeRestrictingAlertServiceFacade>(relaxed = true),
                 offerbookFilterConfigRepository = repository,
+                configServiceFacade = FakeConfigServiceFacade(),
                 computationDispatcher = testDispatcher,
             )
         presenter.onViewAttached()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -36,6 +36,7 @@ import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformPresentationKoinTestBase
@@ -168,6 +169,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                 reputationService,
                 tradeRestrictingAlertServiceFacade,
                 FakeOfferbookFilterConfigRepository(),
+                configServiceFacade = FakeConfigServiceFacade(),
                 computationDispatcher = testDispatcher,
             )
         offersFlow.value = allOffers
@@ -500,6 +502,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                     mockk(relaxed = true),
                     mockk(relaxed = true),
                     repository,
+                    configServiceFacade = FakeConfigServiceFacade(),
                     computationDispatcher = testDispatcher,
                 )
 
@@ -594,6 +597,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                     reputationService,
                     tradeRestrictingAlertServiceFacade,
                     FakeOfferbookFilterConfigRepository(),
+                    configServiceFacade = FakeConfigServiceFacade(),
                     computationDispatcher = testDispatcher,
                 )
             presenter.onViewAttached()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
@@ -43,6 +43,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -397,6 +398,7 @@ class OfferbookPresenterGuardedActionsTest {
             reputationService,
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
+            configServiceFacade = FakeConfigServiceFacade(),
         )
     }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
@@ -32,6 +32,7 @@ import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -174,6 +175,7 @@ class OfferbookPresenterSlowLoadingHintTest {
             reputationService,
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
+            configServiceFacade = FakeConfigServiceFacade(),
         )
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
@@ -30,6 +30,7 @@ import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -156,6 +157,7 @@ class OfferbookPresenterTradeRestrictionTest {
             reputationService,
             tradeRestrictingAlertServiceFacade,
             FakeOfferbookFilterConfigRepository(),
+            configServiceFacade = FakeConfigServiceFacade(),
         )
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -148,8 +148,8 @@ val presentationModule =
         factory<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get(), get(), get(), get(), get()) }
 
         // Take offer
-        single { TakeOfferCoordinator(get(), get()) }
-        factory { TakeOfferAmountPresenter(get(), get(), get()) }
+        single { TakeOfferCoordinator(get(), get(), get()) }
+        factory { TakeOfferAmountPresenter(get(), get(), get(), get()) }
         factory { TakeOfferPaymentMethodPresenter(get(), get()) }
         factory { TakeOfferReviewPresenter(get(), get(), get()) }
 
@@ -158,7 +158,7 @@ val presentationModule =
         factory { CreateOfferDirectionPresenter(get(), get(), get(), get()) }
         factory { CreateOfferMarketPresenter(get(), get(), get(), get()) }
         factory { CreateOfferPricePresenter(get(), get(), get()) }
-        factory { CreateOfferAmountPresenter(get(), get(), get(), get(), get()) }
+        factory { CreateOfferAmountPresenter(get(), get(), get(), get(), get(), get()) }
         factory { CreateOfferPaymentMethodPresenter(get(), get()) }
         factory { CreateOfferReviewPresenter(get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/create_offer/amount/CreateOfferAmountPresenter.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -26,8 +27,6 @@ import network.bisq.mobile.data.utils.toDoubleOrNullLocaleAware
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.formatters.AmountFormatter
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
-import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.DEFAULT_MIN_USD_TRADE_AMOUNT
-import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.MAX_USD_TRADE_AMOUNT
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.findRequiredReputationScoreByFiatAmount
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.getReputationBasedQuoteSideAmount
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits.withTolerance
@@ -49,6 +48,7 @@ class CreateOfferAmountPresenter(
     private val createOfferCoordinator: CreateOfferCoordinator,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val reputationServiceFacade: ReputationServiceFacade,
+    private val configServiceFacade: ConfigServiceFacade,
 ) : OfferFlowPresenter(mainPresenter) {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.CreateOfferAmount
 
@@ -104,9 +104,11 @@ class CreateOfferAmountPresenter(
     private val _shouldShowWarningIcon = MutableStateFlow(false)
     val shouldShowWarningIcon: StateFlow<Boolean> = _shouldShowWarningIcon.asStateFlow()
 
+    private val tradeAmountLimits get() = configServiceFacade.tradeAmountLimits.value
+
     private var createOfferModel: CreateOfferCoordinator.CreateOfferModel
-    private var minAmount: Long = DEFAULT_MIN_USD_TRADE_AMOUNT.value
-    private var maxAmount: Long = MAX_USD_TRADE_AMOUNT.value
+    private var minAmount: Long = tradeAmountLimits.defaultMinUsdTradeAmount.value
+    private var maxAmount: Long = tradeAmountLimits.maxUsdTradeAmount.value
     private lateinit var priceQuote: PriceQuoteVO
     private lateinit var quoteSideFixedAmount: FiatVO
     private lateinit var baseSideFixedAmount: CoinVO
@@ -162,8 +164,8 @@ class CreateOfferAmountPresenter(
                 "bisqEasy.tradeWizard.amount.headline.seller".i18n()
             }
 
-        minAmount = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
-        maxAmount = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
+        minAmount = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode, tradeAmountLimits)
+        maxAmount = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode, tradeAmountLimits)
 
         formattedMinAmount = AmountFormatter.formatAmount(FiatVOFactory.from(minAmount, quoteCurrencyCode))
         formattedMinAmountWithCode =
@@ -493,6 +495,7 @@ class CreateOfferAmountPresenter(
                 marketPriceServiceFacade,
                 market,
                 fixedOrMinAmount,
+                tradeAmountLimits,
             ) ?: 0L
         _requiredReputation.value = requiredReputation
 
@@ -501,7 +504,7 @@ class CreateOfferAmountPresenter(
         presenterScope.launch {
             val peersScoreByUserProfileId = getPeersScoreByUserProfileId()
             val numPotentialTakers =
-                peersScoreByUserProfileId.filter { (_, value) -> withTolerance(value) >= requiredReputation }.count()
+                peersScoreByUserProfileId.filter { (_, value) -> withTolerance(value, tradeAmountLimits) >= requiredReputation }.count()
             _shouldShowWarningIcon.value = numPotentialTakers == 0
 
             val numSellers = "bisqEasy.tradeWizard.amount.buyer.numSellers".i18nPlural(numPotentialTakers)
@@ -509,8 +512,8 @@ class CreateOfferAmountPresenter(
 
             val highestScore = peersScoreByUserProfileId.maxOfOrNull { it.value } ?: 0L
             val highestPossibleAmountFromSellers =
-                getReputationBasedQuoteSideAmount(marketPriceServiceFacade, market, highestScore)?.value ?: 0
-            val highestPossibleAmountWithTolerance: Float = withTolerance(highestPossibleAmountFromSellers).toFloat()
+                getReputationBasedQuoteSideAmount(marketPriceServiceFacade, market, highestScore, tradeAmountLimits)?.value ?: 0
+            val highestPossibleAmountWithTolerance: Float = withTolerance(highestPossibleAmountFromSellers, tradeAmountLimits).toFloat()
             val range = maxAmount - minAmount
             _rightMarkerValue.value = (highestPossibleAmountWithTolerance - minAmount) / range
 
@@ -552,6 +555,7 @@ class CreateOfferAmountPresenter(
                     marketPriceServiceFacade,
                     market,
                     _requiredReputation.value,
+                    tradeAmountLimits,
                 ) ?: return@launch
 
             // Clamp to a valid [0, 1] fraction: when a low-reputation seller's max allowed amount
@@ -596,7 +600,7 @@ class CreateOfferAmountPresenter(
 
     private suspend fun getNumPotentialTakers(requiredReputationScore: Long): Int =
         getPeersScoreByUserProfileId()
-            .filter { (_, value) -> withTolerance(value) >= requiredReputationScore }
+            .filter { (_, value) -> withTolerance(value, tradeAmountLimits) >= requiredReputationScore }
             .count()
 
     private suspend fun getPeersScoreByUserProfileId(): Map<String, Long> {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideFixedAmoun
 import network.bisq.mobile.data.replicated.offer.amount.spec.RangeAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.price.spec.PriceSpecVOExtensions.getPriceQuoteVO
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.trades.TakeOfferStatus
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
@@ -47,6 +48,7 @@ import network.bisq.mobile.domain.utils.Logging
 class TakeOfferCoordinator(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
+    private val configServiceFacade: ConfigServiceFacade,
 ) : Logging {
     class TakeOfferModel {
         lateinit var offerItemPresentationVO: OfferItemPresentationModel
@@ -97,8 +99,9 @@ class TakeOfferCoordinator(
         var hasEffectiveRange = false
         if (amountSpec is RangeAmountSpecVO) {
             val sliderStep = 10_000L
-            val tradeLimitMin = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
-            val tradeLimitMax = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
+            val limits = configServiceFacade.tradeAmountLimits.value
+            val tradeLimitMin = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode, limits)
+            val tradeLimitMax = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode, limits)
 
             // If market price data is unavailable, getMin/MaxAmountValue return 0.
             // In that case, fall back to showing the amount screen and let

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/amount/TakeOfferAmountPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/amount/TakeOfferAmountPresenter.kt
@@ -14,6 +14,7 @@ import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory.from
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOExtensions.toBaseSideMonetary
 import network.bisq.mobile.data.replicated.offer.amount.spec.RangeAmountSpecVO
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.utils.getGroupingSeparator
 import network.bisq.mobile.data.utils.toDoubleOrNullLocaleAware
@@ -32,6 +33,7 @@ class TakeOfferAmountPresenter(
     mainPresenter: MainPresenter,
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val takeOfferCoordinator: TakeOfferCoordinator,
+    private val configServiceFacade: ConfigServiceFacade,
 ) : OfferFlowPresenter(mainPresenter) {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.TakeOfferAmount
 
@@ -51,6 +53,8 @@ class TakeOfferAmountPresenter(
     private var initializationFailed: Boolean = false
 
     private lateinit var takeOfferModel: TakeOfferCoordinator.TakeOfferModel
+    private val tradeAmountLimits get() = configServiceFacade.tradeAmountLimits.value
+
     private var minAmount: Long = 0L
     private var maxAmount: Long = 0L
 
@@ -77,8 +81,8 @@ class TakeOfferAmountPresenter(
             val rangeAmountSpec: RangeAmountSpecVO =
                 offerListItem.bisqEasyOffer.amountSpec as RangeAmountSpecVO
 
-            minAmount = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
-            maxAmount = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode)
+            minAmount = BisqEasyTradeAmountLimits.getMinAmountValue(marketPriceServiceFacade, quoteCurrencyCode, tradeAmountLimits)
+            maxAmount = BisqEasyTradeAmountLimits.getMaxAmountValue(marketPriceServiceFacade, quoteCurrencyCode, tradeAmountLimits)
 
             minAmount = maxOf(minAmount, rangeAmountSpec.minAmount)
             maxAmount = minOf(maxAmount, rangeAmountSpec.maxAmount)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -30,6 +30,7 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
+import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
@@ -63,6 +64,7 @@ open class OfferbookPresenter(
     private val reputationServiceFacade: ReputationServiceFacade,
     private val tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
     private val offerbookFilterConfigRepository: OfferbookFilterConfigRepository,
+    private val configServiceFacade: ConfigServiceFacade,
     private val computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BasePresenter(mainPresenter) {
     private val _showTradeRestrictedDialog = MutableStateFlow<AlertNotificationUiState?>(null)
@@ -457,6 +459,7 @@ open class OfferbookPresenter(
                     marketPriceServiceFacade = marketPriceServiceFacade,
                     reputationServiceFacade = reputationServiceFacade,
                     userProfileId = userProfile.id,
+                    limits = configServiceFacade.tradeAmountLimits.value,
                 )
             } else {
                 false
@@ -605,16 +608,19 @@ open class OfferbookPresenter(
     ): Boolean =
         withContext(computationDispatcher) {
             val bisqEasyOffer = item.bisqEasyOffer
+            val limits = configServiceFacade.tradeAmountLimits.value
             val requiredReputationScoreForMaxOrFixed =
                 BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(
                     marketPriceServiceFacade,
                     bisqEasyOffer,
+                    limits,
                 )
             require(requiredReputationScoreForMaxOrFixed != null) { "requiredReputationScoreForMaxOrFixedAmount is null" }
             val requiredReputationScoreForMinOrFixed =
                 BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinOrFixedAmount(
                     marketPriceServiceFacade,
                     bisqEasyOffer,
+                    limits,
                 )
             require(requiredReputationScoreForMinOrFixed != null) { "requiredReputationScoreForMinAmount is null" }
 


### PR DESCRIPTION
 - pre refactor + config facade feature impl to achieve #1260 
 - the complete implementation with the api fetch will be done along a bisq2 PR to support it (in backward compatible fashion)
 - on nodeApp side, values will be obtain from the bisq-core jars helping us avoid duplication cross-project wise
 - used **tradeAmountLimits** as the first example and motivation to kickstart this new internal feature
 - previous hardcoded duplicated values now become a DEFAULT VO
 - added TODOs to clearly state next incoming steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized trade amount configuration for minimum and maximum limits, tolerance, and reputation requirements.
  * Offer creation, taking offers, and offerbook validation now use configured trade limits.
  * Added bundled default limits for reliable offline behavior.

* **Bug Fixes**
  * Improved reputation-based offer filtering and amount calculations using consistent configuration values.
  * Safely handles unavailable market prices without producing invalid reputation requirements.

* **Tests**
  * Added coverage for default configuration behavior and missing market-price scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->