### PR TITLE
Reconnecting dialog in Small devices

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
@@ -1,0 +1,57 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import org.junit.Test
+
+/**
+ * Regression for #1615: on short viewports (e.g. iPhone X) the reconnect action must stay
+ * visible while long details text scrolls.
+ */
+class ReconnectingOverlayUiTest : BisqComposeUiTestBase() {
+    @Test
+    fun `when viewport is short then restart services button stays displayed`() {
+        val onClick = mockk<() -> Unit>(relaxed = true)
+        val buttonText = "mobile.connectivity.reconnecting.restartServices".i18n()
+
+        setTestContent {
+            // Roughly an iPhone X content height after chrome/safe-area, narrow enough that
+            // the long iOS Connect details copy would push a non-sticky button off-screen.
+            Box(modifier = Modifier.size(width = 320.dp, height = 480.dp)) {
+                ReconnectingOverlay(
+                    onClick = onClick,
+                    infoKey = "mobile.connectivity.reconnecting.client.info",
+                    detailsKey = "mobile.connectivity.reconnecting.client.details.ios",
+                    buttonTextKey = "mobile.connectivity.reconnecting.restartServices",
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(buttonText).assertIsDisplayed()
+        composeTestRule.onNodeWithText(buttonText).performClick()
+        verify(exactly = 1) { onClick() }
+    }
+
+    @Test
+    fun `when content fits then title and button are displayed`() {
+        setTestContent {
+            ReconnectingOverlay()
+        }
+
+        composeTestRule
+            .onNodeWithText("mobile.connectivity.reconnecting.title".i18n())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.connectivity.reconnecting.restart".i18n())
+            .assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.dp
 import io.mockk.mockk
 import io.mockk.verify
@@ -19,14 +20,15 @@ import org.junit.Test
  */
 class ReconnectingOverlayUiTest : BisqComposeUiTestBase() {
     @Test
-    fun `when viewport is short then restart services button stays displayed`() {
+    fun `when viewport is short then details scroll and restart services button stays displayed`() {
         val onClick = mockk<() -> Unit>(relaxed = true)
         val buttonText = "mobile.connectivity.reconnecting.restartServices".i18n()
+        val detailsText = "mobile.connectivity.reconnecting.client.details.ios".i18n()
 
         setTestContent {
-            // Roughly an iPhone X content height after chrome/safe-area, narrow enough that
-            // the long iOS Connect details copy would push a non-sticky button off-screen.
-            Box(modifier = Modifier.size(width = 320.dp, height = 480.dp)) {
+            // Short enough that long iOS Connect details must scroll; sticky button stays outside
+            // the scroll viewport (non-sticky layout would push it off-screen).
+            Box(modifier = Modifier.size(width = 320.dp, height = 360.dp)) {
                 ReconnectingOverlay(
                     onClick = onClick,
                     infoKey = "mobile.connectivity.reconnecting.client.info",
@@ -35,6 +37,16 @@ class ReconnectingOverlayUiTest : BisqComposeUiTestBase() {
                 )
             }
         }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(buttonText).assertIsDisplayed()
+
+        // useUnmergedTree: verticalScroll merges descendant text; the unmerged Text node
+        // still has the scrollable Column as a parent for performScrollTo.
+        composeTestRule
+            .onNodeWithText(detailsText, useUnmergedTree = true)
+            .performScrollTo()
+            .assertIsDisplayed()
 
         composeTestRule.onNodeWithText(buttonText).assertIsDisplayed()
         composeTestRule.onNodeWithText(buttonText).performClick()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlay.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlay.kt
@@ -5,18 +5,29 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush.Companion.verticalGradient
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -25,6 +36,8 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+
+private val SCROLL_FADE_HEIGHT = 44.dp
 
 @Composable
 fun ReconnectingOverlay(
@@ -43,9 +56,9 @@ fun ReconnectingOverlay(
                     interactionSource = remember { MutableInteractionSource() },
                 ) { /* consume clicks */ },
     ) {
-        Surface(
-            shape = RoundedCornerShape(BisqUIConstants.ScreenPadding),
-            color = BisqTheme.colors.dark_grey40,
+        // Bound card height to the available viewport so the action button stays sticky
+        // while long reconnect copy (especially iOS Connect) can scroll on small screens.
+        BoxWithConstraints(
             modifier =
                 Modifier
                     .align(Alignment.Center)
@@ -54,47 +67,125 @@ fun ReconnectingOverlay(
                         vertical = BisqUIConstants.ScreenPadding2X,
                     ),
         ) {
-            Column(
-                modifier =
-                    Modifier.padding(
-                        horizontal = BisqUIConstants.ScreenPadding2X,
-                        vertical = BisqUIConstants.ScreenPadding4X,
-                    ),
-                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
+            Surface(
+                shape = RoundedCornerShape(BisqUIConstants.ScreenPadding),
+                color = BisqTheme.colors.dark_grey40,
+                modifier = Modifier.heightIn(max = maxHeight),
             ) {
-                BisqText.H3Light(
-                    text = "mobile.connectivity.reconnecting.title".i18n(),
-                    color = BisqTheme.colors.white,
-                    textAlign = TextAlign.Center,
-                )
+                Column(
+                    modifier =
+                        Modifier.padding(
+                            horizontal = BisqUIConstants.ScreenPadding2X,
+                            vertical = BisqUIConstants.ScreenPadding4X,
+                        ),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    val scrollState = rememberScrollState()
+                    val canScrollForward by remember {
+                        derivedStateOf { scrollState.canScrollForward }
+                    }
 
-                BisqGap.VQuarter()
-                CircularProgressIndicator(
-                    color = BisqTheme.colors.primary,
-                    modifier = Modifier.size(70.dp),
-                    strokeWidth = 1.dp,
-                )
-                BisqGap.VQuarter()
+                    Box(
+                        modifier =
+                            Modifier
+                                .weight(1f, fill = false)
+                                .fillMaxWidth(),
+                    ) {
+                        Column(
+                            modifier = Modifier.verticalScroll(scrollState),
+                            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            BisqText.H3Light(
+                                text = "mobile.connectivity.reconnecting.title".i18n(),
+                                color = BisqTheme.colors.white,
+                                textAlign = TextAlign.Center,
+                            )
 
-                BisqText.LargeLight(
-                    text = infoKey.i18n(),
-                    color = BisqTheme.colors.light_grey50,
-                    textAlign = TextAlign.Center,
-                )
+                            BisqGap.VQuarter()
+                            CircularProgressIndicator(
+                                color = BisqTheme.colors.primary,
+                                modifier = Modifier.size(70.dp),
+                                strokeWidth = 1.dp,
+                            )
+                            BisqGap.VQuarter()
 
-                BisqText.BaseLight(
-                    text = detailsKey.i18n(),
-                    color = BisqTheme.colors.light_grey50,
-                    textAlign = TextAlign.Center,
-                )
-                BisqGap.VHalf()
-                BisqButton(
-                    text = buttonTextKey.i18n(),
-                    type = BisqButtonType.Outline,
-                    onClick = onClick,
-                )
+                            BisqText.LargeLight(
+                                text = infoKey.i18n(),
+                                color = BisqTheme.colors.light_grey50,
+                                textAlign = TextAlign.Center,
+                            )
+
+                            BisqText.BaseLight(
+                                text = detailsKey.i18n(),
+                                color = BisqTheme.colors.light_grey50,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+
+                        // Soft bottom fade when more copy is clipped above the sticky button.
+                        if (canScrollForward) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .height(SCROLL_FADE_HEIGHT)
+                                        .align(Alignment.BottomCenter)
+                                        .background(
+                                            brush =
+                                                verticalGradient(
+                                                    colors =
+                                                        listOf(
+                                                            Color.Transparent,
+                                                            BisqTheme.colors.dark_grey40,
+                                                        ),
+                                                ),
+                                        ),
+                            )
+                        }
+                    }
+                    BisqGap.VHalf()
+                    BisqButton(
+                        text = buttonTextKey.i18n(),
+                        type = BisqButtonType.Outline,
+                        onClick = onClick,
+                    )
+                }
             }
         }
+    }
+}
+
+@Preview(name = "iPhone SE — iOS Connect", widthDp = 320, heightDp = 568)
+@Composable
+private fun ReconnectingOverlay_IPhoneSePreview() {
+    BisqTheme.Preview {
+        ReconnectingOverlay(
+            onClick = {},
+            infoKey = "mobile.connectivity.reconnecting.client.info",
+            detailsKey = "mobile.connectivity.reconnecting.client.details.ios",
+            buttonTextKey = "mobile.connectivity.reconnecting.restartServices",
+        )
+    }
+}
+
+@Preview(name = "iPhone X — iOS Connect", widthDp = 375, heightDp = 812)
+@Composable
+private fun ReconnectingOverlay_IPhoneXPreview() {
+    BisqTheme.Preview {
+        ReconnectingOverlay(
+            onClick = {},
+            infoKey = "mobile.connectivity.reconnecting.client.info",
+            detailsKey = "mobile.connectivity.reconnecting.client.details.ios",
+            buttonTextKey = "mobile.connectivity.reconnecting.restartServices",
+        )
+    }
+}
+
+@Preview(name = "Pixel 7 — Node default", widthDp = 412, heightDp = 915)
+@Composable
+private fun ReconnectingOverlay_Pixel7Preview() {
+    BisqTheme.Preview {
+        ReconnectingOverlay(onClick = {})
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlay.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlay.kt
@@ -1,0 +1,100 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+
+@Composable
+fun ReconnectingOverlay(
+    onClick: (() -> Unit)? = null,
+    infoKey: String = "mobile.connectivity.reconnecting.info",
+    detailsKey: String = "mobile.connectivity.reconnecting.details",
+    buttonTextKey: String = "mobile.connectivity.reconnecting.restart",
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(BisqTheme.colors.backgroundColor.copy(alpha = 0.85f))
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) { /* consume clicks */ },
+    ) {
+        Surface(
+            shape = RoundedCornerShape(BisqUIConstants.ScreenPadding),
+            color = BisqTheme.colors.dark_grey40,
+            modifier =
+                Modifier
+                    .align(Alignment.Center)
+                    .padding(
+                        horizontal = BisqUIConstants.ScreenPadding4X,
+                        vertical = BisqUIConstants.ScreenPadding2X,
+                    ),
+        ) {
+            Column(
+                modifier =
+                    Modifier.padding(
+                        horizontal = BisqUIConstants.ScreenPadding2X,
+                        vertical = BisqUIConstants.ScreenPadding4X,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                BisqText.H3Light(
+                    text = "mobile.connectivity.reconnecting.title".i18n(),
+                    color = BisqTheme.colors.white,
+                    textAlign = TextAlign.Center,
+                )
+
+                BisqGap.VQuarter()
+                CircularProgressIndicator(
+                    color = BisqTheme.colors.primary,
+                    modifier = Modifier.size(70.dp),
+                    strokeWidth = 1.dp,
+                )
+                BisqGap.VQuarter()
+
+                BisqText.LargeLight(
+                    text = infoKey.i18n(),
+                    color = BisqTheme.colors.light_grey50,
+                    textAlign = TextAlign.Center,
+                )
+
+                BisqText.BaseLight(
+                    text = detailsKey.i18n(),
+                    color = BisqTheme.colors.light_grey50,
+                    textAlign = TextAlign.Center,
+                )
+                BisqGap.VHalf()
+                BisqButton(
+                    text = buttonTextKey.i18n(),
+                    type = BisqButtonType.Outline,
+                    onClick = onClick,
+                )
+            }
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -1,9 +1,6 @@
 package network.bisq.mobile.presentation.main
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -11,13 +8,9 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -25,12 +18,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -44,14 +34,11 @@ import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.base.SnackbarAction
 import network.bisq.mobile.presentation.common.ui.base.ViewPresenter
 import network.bisq.mobile.presentation.common.ui.components.SwipeBackIOSNavigationHandler
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
-import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.context.LocalAnimationsEnabled
 import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.context.asExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.LoadingOverlay
+import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ReconnectingOverlay
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WarningConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.components.organisms.BisqSnackbar
 import network.bisq.mobile.presentation.common.ui.components.organisms.BisqSnackbarVisuals
@@ -60,7 +47,6 @@ import network.bisq.mobile.presentation.common.ui.navigation.ExternalUriHandler
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.network_banner.NetworkStatusBanner
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
@@ -245,79 +231,6 @@ fun App(
         }
         onDispose {
             ExternalUriHandler.listener = null
-        }
-    }
-}
-
-@Composable
-fun ReconnectingOverlay(
-    onClick: (() -> Unit)? = null,
-    infoKey: String = "mobile.connectivity.reconnecting.info",
-    detailsKey: String = "mobile.connectivity.reconnecting.details",
-    buttonTextKey: String = "mobile.connectivity.reconnecting.restart",
-) {
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .background(BisqTheme.colors.backgroundColor.copy(alpha = 0.85f))
-                .clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                ) { /* consume clicks */ },
-    ) {
-        Surface(
-            shape = RoundedCornerShape(BisqUIConstants.ScreenPadding),
-            color = BisqTheme.colors.dark_grey40,
-            modifier =
-                Modifier
-                    .align(Alignment.Center)
-                    .padding(
-                        horizontal = BisqUIConstants.ScreenPadding4X,
-                        vertical = BisqUIConstants.ScreenPadding2X,
-                    ),
-        ) {
-            Column(
-                modifier =
-                    Modifier.padding(
-                        horizontal = BisqUIConstants.ScreenPadding2X,
-                        vertical = BisqUIConstants.ScreenPadding4X,
-                    ),
-                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                BisqText.H3Light(
-                    text = "mobile.connectivity.reconnecting.title".i18n(),
-                    color = BisqTheme.colors.white,
-                    textAlign = TextAlign.Center,
-                )
-
-                BisqGap.VQuarter()
-                CircularProgressIndicator(
-                    color = BisqTheme.colors.primary,
-                    modifier = Modifier.size(70.dp),
-                    strokeWidth = 1.dp,
-                )
-                BisqGap.VQuarter()
-
-                BisqText.LargeLight(
-                    text = infoKey.i18n(),
-                    color = BisqTheme.colors.light_grey50,
-                    textAlign = TextAlign.Center,
-                )
-
-                BisqText.BaseLight(
-                    text = detailsKey.i18n(),
-                    color = BisqTheme.colors.light_grey50,
-                    textAlign = TextAlign.Center,
-                )
-                BisqGap.VHalf()
-                BisqButton(
-                    text = buttonTextKey.i18n(),
-                    type = BisqButtonType.Outline,
-                    onClick = onClick,
-                )
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1615

 - Refactored `ReconnectingOverlay` to it's own file.

iPhone X preview:
<img width="438" height="936" alt="11_iphone_x" src="https://github.com/user-attachments/assets/33d4ad9a-ecfb-4f7b-9984-e9b869d0fcbc" />

Small screen Android Emulator:
<img width="353" height="619" alt="10_android_360x640" src="https://github.com/user-attachments/assets/b6577e24-f2d1-416b-a3b0-41fa27d7bc15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new reconnecting overlay with progress messaging, scrollable details, and a localized “restart services” action.
  * Included device-size previews for the overlay UI.
* **Bug Fixes**
  * Improved overlay usability on shorter screens so the restart action remains visible while content scrolls.
* **Tests**
  * Added UI coverage to verify overlay text visibility, scroll behavior, and restart-button click handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->