### PR TITLE
fix(nodeApp): derive allDataReceived from initialInventoryRequestsCompleted instead of pending-request count

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
@@ -160,9 +160,9 @@ class NodeNetworkServiceFacade(
         val inventoryService = serviceNode.inventoryService.get()
 
         allDataReceivedPin =
-            inventoryService.numPendingInventoryRequests.addObserver { numPendingRequests ->
-                log.d { "Node inventory pending requests: $numPendingRequests" }
-                _allDataReceived.value = numPendingRequests == 0
+            inventoryService.initialInventoryRequestsCompleted.addObserver {
+                log.d { "Node inventory initial requests completed: $it" }
+                _allDataReceived.value = it
             }
     }
 }


### PR DESCRIPTION
This change initiative comes from the comments on this PR: https://github.com/bisq-network/bisq2/pull/4878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network inventory status tracking by accurately recognizing when initial inventory data has finished loading.
  * Added logging to help monitor completion of the initial inventory requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->