### PR TITLE
tests: Add unit tests for OkioSerializer DataStore persistence across domain and client serializers

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -205,6 +205,9 @@ kotlin {
 
             // Koin
             implementation(libs.koin.test)
+
+            // Test utilities
+            implementation(project(sharedTestUtilsModule))
         }
 
         androidMain.dependencies {

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializerTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializerTest.kt
@@ -5,8 +5,7 @@ import androidx.datastore.core.CorruptionException
 import io.ktor.utils.io.core.toByteArray
 import io.mockk.coEvery
 import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import kotlinx.coroutines.flow.MutableStateFlow
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerializationException
 import network.bisq.mobile.client.common.domain.httpclient.BisqProxyOption
@@ -26,10 +25,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: post-decrypt
- * JSON failures surface as [SerializationException], and [SensitiveSettings] has no init validation
- * that would throw plain [IllegalArgumentException] during decode.
- *
  * Keystore invalidation covers every type in [SensitiveSettingsSerializer]'s
  * `isKeystoreInvalidation()` set: direct [AEADBadTagException], direct
  * [KeyPermanentlyInvalidatedException], and nested [BadPaddingException].
@@ -38,7 +33,7 @@ import kotlin.test.assertTrue
 class SensitiveSettingsSerializerTest {
     @Before
     fun setUp() {
-        resetKeystoreInvalidatedFlag()
+        SensitiveSettingsSerializer.resetKeystoreInvalidatedForTest()
         mockkStatic(::encrypt, ::decrypt)
         coEvery { encrypt(any()) } answers {
             val plaintext = firstArg<ByteArray>()
@@ -59,8 +54,8 @@ class SensitiveSettingsSerializerTest {
 
     @After
     fun tearDown() {
-        resetKeystoreInvalidatedFlag()
-        unmockkAll()
+        SensitiveSettingsSerializer.resetKeystoreInvalidatedForTest()
+        unmockkStatic(::encrypt, ::decrypt)
     }
 
     @Test
@@ -125,6 +120,20 @@ class SensitiveSettingsSerializerTest {
 
             assertEquals("Cannot decrypt SensitiveSettings", exception.message)
             assertIs<IllegalStateException>(exception.cause)
+        }
+
+    @Test
+    fun `readFrom wraps IllegalArgumentException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    SensitiveSettingsSerializer.readFrom(
+                        Buffer().write(ByteArray(MOCK_MIN_ENCRYPTED_SIZE_BYTES)),
+                    )
+                }
+
+            assertEquals("Cannot read SensitiveSettings", exception.message)
+            assertIs<IllegalArgumentException>(exception.cause)
         }
 
     @Test
@@ -219,17 +228,5 @@ class SensitiveSettingsSerializerTest {
     private fun assertKeystoreInvalidatedCorruption(exception: CorruptionException) {
         assertTrue(SensitiveSettingsSerializer.keystoreInvalidated.value)
         assertEquals(KEYSTORE_INVALIDATED_MESSAGE, exception.message)
-    }
-
-    private fun resetKeystoreInvalidatedFlag() {
-        try {
-            val field = SensitiveSettingsSerializer::class.java.getDeclaredField("_keystoreInvalidated")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val flow = field.get(SensitiveSettingsSerializer) as MutableStateFlow<Boolean>
-            flow.value = false
-        } catch (_: Exception) {
-            // Ignore if reflection fails — flag may already be false
-        }
     }
 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializerTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializerTest.kt
@@ -1,0 +1,235 @@
+package network.bisq.mobile.client.common.domain.sensitive_settings
+
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import androidx.datastore.core.CorruptionException
+import io.ktor.utils.io.core.toByteArray
+import io.mockk.coEvery
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.client.common.domain.httpclient.BisqProxyOption
+import network.bisq.mobile.data.crypto.decrypt
+import network.bisq.mobile.data.crypto.encrypt
+import network.bisq.mobile.data.datastore.dataStoreJson
+import okio.Buffer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: post-decrypt
+ * JSON failures surface as [SerializationException], and [SensitiveSettings] has no init validation
+ * that would throw plain [IllegalArgumentException] during decode.
+ *
+ * Keystore invalidation covers every type in [SensitiveSettingsSerializer]'s
+ * `isKeystoreInvalidation()` set: direct [AEADBadTagException], direct
+ * [KeyPermanentlyInvalidatedException], and nested [BadPaddingException].
+ * Other unexpected [Exception]s from decrypt are rethrown unchanged.
+ */
+class SensitiveSettingsSerializerTest {
+    @Before
+    fun setUp() {
+        resetKeystoreInvalidatedFlag()
+        mockkStatic(::encrypt, ::decrypt)
+        coEvery { encrypt(any()) } answers {
+            val plaintext = firstArg<ByteArray>()
+            // 12-byte IV prefix + test marker + plaintext (minimum total size matches LocalEncryption).
+            ByteArray(MOCK_IV_LENGTH_BYTES) + MOCK_PAYLOAD_MARKER + plaintext
+        }
+        coEvery { decrypt(any()) } answers {
+            val payload = firstArg<ByteArray>()
+            if (payload.size < MOCK_MIN_ENCRYPTED_SIZE_BYTES) {
+                throw IllegalStateException("Encrypted payload too short to contain IV and authentication tag")
+            }
+            val withoutIv = payload.copyOfRange(MOCK_IV_LENGTH_BYTES, payload.size)
+            require(withoutIv.size >= MOCK_PAYLOAD_MARKER.size)
+            require(withoutIv.copyOfRange(0, MOCK_PAYLOAD_MARKER.size).contentEquals(MOCK_PAYLOAD_MARKER))
+            withoutIv.copyOfRange(MOCK_PAYLOAD_MARKER.size, withoutIv.size)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        resetKeystoreInvalidatedFlag()
+        unmockkAll()
+    }
+
+    @Test
+    fun `defaultValue returns empty SensitiveSettings`() {
+        assertEquals(SensitiveSettings(), SensitiveSettingsSerializer.defaultValue)
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = SensitiveSettingsSerializer.readFrom(Buffer())
+
+            assertEquals(SensitiveSettings(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid encrypted JSON`() =
+        runTest {
+            val expected = sampleSettings()
+            val json = dataStoreJson.encodeToString(SensitiveSettings.serializer(), expected)
+            val encrypted = encrypt(json.toByteArray())
+
+            val result = SensitiveSettingsSerializer.readFrom(Buffer().write(encrypted))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val encrypted = encrypt("not valid json".toByteArray())
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    SensitiveSettingsSerializer.readFrom(Buffer().write(encrypted))
+                }
+
+            assertEquals("Cannot deserialize SensitiveSettings", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips SensitiveSettings`() =
+        runTest {
+            val original = sampleSettings()
+            val buffer = Buffer()
+
+            SensitiveSettingsSerializer.writeTo(original, buffer)
+            val restored = SensitiveSettingsSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    @Test
+    fun `readFrom wraps short payload in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    SensitiveSettingsSerializer.readFrom(
+                        Buffer().write(ByteArray(MOCK_MIN_ENCRYPTED_SIZE_BYTES - 1)),
+                    )
+                }
+
+            assertEquals("Cannot decrypt SensitiveSettings", exception.message)
+            assertIs<IllegalStateException>(exception.cause)
+        }
+
+    @Test
+    fun `readFrom rethrows unexpected decrypt failures`() =
+        runTest {
+            coEvery { decrypt(any()) } throws RuntimeException("unexpected decrypt failure")
+
+            val exception =
+                assertFailsWith<RuntimeException> {
+                    SensitiveSettingsSerializer.readFrom(
+                        Buffer().write(ByteArray(MOCK_MIN_ENCRYPTED_SIZE_BYTES)),
+                    )
+                }
+
+            assertEquals("unexpected decrypt failure", exception.message)
+            assertFalse(SensitiveSettingsSerializer.keystoreInvalidated.value)
+        }
+
+    @Test
+    fun `keystoreInvalidated remains false after successful read`() =
+        runTest {
+            val original = sampleSettings()
+            val buffer = Buffer()
+
+            SensitiveSettingsSerializer.writeTo(original, buffer)
+            SensitiveSettingsSerializer.readFrom(buffer)
+
+            assertFalse(SensitiveSettingsSerializer.keystoreInvalidated.value)
+        }
+
+    @Test
+    fun `readFrom sets keystoreInvalidated when decrypt throws AEADBadTagException`() =
+        runTest {
+            coEvery { decrypt(any()) } throws AEADBadTagException()
+
+            val exception = readFromWithMockDecryptFailure()
+
+            assertKeystoreInvalidatedCorruption(exception)
+            assertIs<AEADBadTagException>(exception.cause)
+        }
+
+    @Test
+    fun `readFrom sets keystoreInvalidated when decrypt throws KeyPermanentlyInvalidatedException`() =
+        runTest {
+            coEvery { decrypt(any()) } throws KeyPermanentlyInvalidatedException()
+
+            val exception = readFromWithMockDecryptFailure()
+
+            assertKeystoreInvalidatedCorruption(exception)
+            assertIs<KeyPermanentlyInvalidatedException>(exception.cause)
+        }
+
+    @Test
+    fun `readFrom sets keystoreInvalidated when decrypt throws BadPaddingException in cause chain`() =
+        runTest {
+            coEvery { decrypt(any()) } throws RuntimeException(BadPaddingException())
+
+            val exception = readFromWithMockDecryptFailure()
+
+            assertKeystoreInvalidatedCorruption(exception)
+            assertIs<RuntimeException>(exception.cause)
+            assertIs<BadPaddingException>(exception.cause?.cause)
+        }
+
+    private fun sampleSettings() =
+        SensitiveSettings(
+            clientName = "test-client",
+            bisqApiUrl = "https://example.com",
+            clientId = "client-id",
+            selectedProxyOption = BisqProxyOption.NONE,
+        )
+
+    private companion object {
+        // Matches LocalEncryption.android.kt: IV_LENGTH_BYTES (12) + GCM tag (128 bits = 16 bytes).
+        const val MOCK_IV_LENGTH_BYTES = 12
+        const val MOCK_GCM_TAG_LENGTH_BYTES = 16
+        const val MOCK_MIN_ENCRYPTED_SIZE_BYTES = MOCK_IV_LENGTH_BYTES + MOCK_GCM_TAG_LENGTH_BYTES
+        val MOCK_PAYLOAD_MARKER = "enc:".toByteArray()
+
+        const val KEYSTORE_INVALIDATED_MESSAGE =
+            "Keystore key invalidated — encrypted SensitiveSettings unrecoverable. " +
+                "User must re-pair with their trusted node."
+    }
+
+    private suspend fun readFromWithMockDecryptFailure(): CorruptionException =
+        assertFailsWith {
+            SensitiveSettingsSerializer.readFrom(
+                Buffer().write(ByteArray(MOCK_MIN_ENCRYPTED_SIZE_BYTES)),
+            )
+        }
+
+    private fun assertKeystoreInvalidatedCorruption(exception: CorruptionException) {
+        assertTrue(SensitiveSettingsSerializer.keystoreInvalidated.value)
+        assertEquals(KEYSTORE_INVALIDATED_MESSAGE, exception.message)
+    }
+
+    private fun resetKeystoreInvalidatedFlag() {
+        try {
+            val field = SensitiveSettingsSerializer::class.java.getDeclaredField("_keystoreInvalidated")
+            field.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val flow = field.get(SensitiveSettingsSerializer) as MutableStateFlow<Boolean>
+            flow.value = false
+        } catch (_: Exception) {
+            // Ignore if reflection fails — flag may already be false
+        }
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
@@ -132,20 +132,8 @@ class ClientSplashPresenterNavigationTest {
         Dispatchers.resetMain()
     }
 
-    /**
-     * Resets the static [SensitiveSettingsSerializer.keystoreInvalidated] flag between tests
-     * using reflection, since there is no public reset method on the object singleton.
-     */
     private fun resetKeystoreInvalidatedFlag() {
-        try {
-            val field = SensitiveSettingsSerializer::class.java.getDeclaredField("_keystoreInvalidated")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val flow = field.get(SensitiveSettingsSerializer) as MutableStateFlow<Boolean>
-            flow.value = false
-        } catch (_: Exception) {
-            // Ignore if reflection fails — flag may already be false
-        }
+        SensitiveSettingsSerializer.resetKeystoreInvalidatedForTest()
     }
 
     private fun createPresenter(): ClientSplashPresenter =
@@ -469,10 +457,7 @@ class ClientSplashPresenterNavigationTest {
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings()
 
             // Simulate the keystoreInvalidated flag being set by the serializer
-            val field = SensitiveSettingsSerializer::class.java.getDeclaredField("_keystoreInvalidated")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            (field.get(SensitiveSettingsSerializer) as MutableStateFlow<Boolean>).value = true
+            SensitiveSettingsSerializer.setKeystoreInvalidatedForTest(true)
 
             val presenter = createPresenter()
             presenter.onViewAttached()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializer.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/sensitive_settings/SensitiveSettingsSerializer.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.sensitive_settings
 
+import androidx.annotation.VisibleForTesting
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
 import io.ktor.utils.io.core.toByteArray
@@ -83,5 +84,15 @@ object SensitiveSettingsSerializer : OkioSerializer<SensitiveSettings> {
         val payload = dataStoreJson.encodeToString(SensitiveSettings.serializer(), t)
         val encryptedPayload = encrypt(payload.toByteArray())
         sink.write(encryptedPayload)
+    }
+
+    @VisibleForTesting
+    internal fun resetKeystoreInvalidatedForTest() {
+        _keystoreInvalidated.value = false
+    }
+
+    @VisibleForTesting
+    internal fun setKeystoreInvalidatedForTest(invalidated: Boolean) {
+        _keystoreInvalidated.value = invalidated
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializer.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializer.kt
@@ -1,35 +1,9 @@
 package network.bisq.mobile.client.payment_accounts.data.model.bank_account_country_details
 
-import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
-import okio.BufferedSink
-import okio.BufferedSource
+import network.bisq.mobile.data.datastore.serializer.jsonDataStoreSerializer
 
-object BankAccountCountryDetailsCacheSerializer : OkioSerializer<BankAccountCountryDetailsCache> {
-    override val defaultValue: BankAccountCountryDetailsCache
-        get() = BankAccountCountryDetailsCache()
-
-    override suspend fun readFrom(source: BufferedSource): BankAccountCountryDetailsCache {
-        if (source.exhausted()) return defaultValue
-        return try {
-            dataStoreJson.decodeFromString(
-                BankAccountCountryDetailsCache.serializer(),
-                source.readUtf8(),
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Cannot deserialize BankAccountCountryDetailsCache", e)
-        } catch (e: IllegalArgumentException) {
-            throw CorruptionException("Cannot read BankAccountCountryDetailsCache", e)
-        }
-    }
-
-    override suspend fun writeTo(
-        t: BankAccountCountryDetailsCache,
-        sink: BufferedSink,
-    ) {
-        val payload = dataStoreJson.encodeToString(BankAccountCountryDetailsCache.serializer(), t)
-        sink.writeUtf8(payload)
-    }
-}
+object BankAccountCountryDetailsCacheSerializer : OkioSerializer<BankAccountCountryDetailsCache> by jsonDataStoreSerializer(
+    defaultValue = BankAccountCountryDetailsCache(),
+    typeName = "BankAccountCountryDetailsCache",
+)

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializerTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializerTest.kt
@@ -1,0 +1,99 @@
+package network.bisq.mobile.client.payment_accounts.data.model.bank_account_country_details
+
+import androidx.datastore.core.CorruptionException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.client.payment_accounts.data.model.fiat.common.BankAccountCountryDetailsDto
+import network.bisq.mobile.client.payment_accounts.data.model.fiat.common.CountryDto
+import network.bisq.mobile.data.datastore.dataStoreJson
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and this
+ * model has no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class BankAccountCountryDetailsCacheSerializerTest {
+    @Test
+    fun `defaultValue returns empty BankAccountCountryDetailsCache`() {
+        assertEquals(
+            BankAccountCountryDetailsCache(),
+            BankAccountCountryDetailsCacheSerializer.defaultValue,
+        )
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = BankAccountCountryDetailsCacheSerializer.readFrom(Buffer())
+
+            assertEquals(BankAccountCountryDetailsCache(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            val expected = sampleCache()
+            val json = dataStoreJson.encodeToString(BankAccountCountryDetailsCache.serializer(), expected)
+
+            val result = BankAccountCountryDetailsCacheSerializer.readFrom(Buffer().writeUtf8(json))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    BankAccountCountryDetailsCacheSerializer.readFrom(Buffer().writeUtf8("{"))
+                }
+
+            assertEquals("Cannot deserialize BankAccountCountryDetailsCache", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips BankAccountCountryDetailsCache`() =
+        runTest {
+            val original = sampleCache()
+            val buffer = Buffer()
+
+            BankAccountCountryDetailsCacheSerializer.writeTo(original, buffer)
+            val restored = BankAccountCountryDetailsCacheSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    private fun sampleCache() =
+        BankAccountCountryDetailsCache(
+            apiVersion = "1.0",
+            detailsByCountryCode =
+                mapOf(
+                    "US" to
+                        BankAccountCountryDetailsDto(
+                            country = CountryDto(code = "US", name = "United States"),
+                            bankAccountValidationSupported = true,
+                            holderIdRequired = false,
+                            holderIdDescription = "Holder ID",
+                            holderIdDescriptionShort = "ID",
+                            bankAccountTypeRequired = false,
+                            bankNameRequired = true,
+                            bankIdRequired = true,
+                            bankIdDescription = "Bank ID",
+                            bankIdDescriptionShort = "BIC",
+                            branchIdRequired = false,
+                            branchIdDescription = "Branch ID",
+                            branchIdDescriptionShort = "Branch",
+                            accountNrDescription = "Account number",
+                            nationalAccountIdRequired = false,
+                            nationalAccountIdDescription = "National Account ID",
+                            nationalAccountIdDescriptionShort = "National ID",
+                        ),
+                ),
+        )
+}

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializerTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/payment_accounts/data/model/bank_account_country_details/BankAccountCountryDetailsCacheSerializerTest.kt
@@ -1,72 +1,48 @@
 package network.bisq.mobile.client.payment_accounts.data.model.bank_account_country_details
 
-import androidx.datastore.core.CorruptionException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationException
 import network.bisq.mobile.client.payment_accounts.data.model.fiat.common.BankAccountCountryDetailsDto
 import network.bisq.mobile.client.payment_accounts.data.model.fiat.common.CountryDto
-import network.bisq.mobile.data.datastore.dataStoreJson
-import okio.Buffer
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
-/**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
- * decode failures surface as [SerializationException] (including JsonDecodingException), and this
- * model has no init validation that would throw plain [IllegalArgumentException] during decode.
- */
 class BankAccountCountryDetailsCacheSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = BankAccountCountryDetailsCacheSerializer,
+            defaultValue = BankAccountCountryDetailsCache(),
+            sampleValue = ::sampleCache,
+            typeName = "BankAccountCountryDetailsCache",
+            kSerializer = BankAccountCountryDetailsCache.serializer(),
+        )
+
     @Test
     fun `defaultValue returns empty BankAccountCountryDetailsCache`() {
-        assertEquals(
-            BankAccountCountryDetailsCache(),
-            BankAccountCountryDetailsCacheSerializer.defaultValue,
-        )
+        support.assertDefaultValue()
     }
 
     @Test
     fun `readFrom returns default when source is exhausted`() =
         runTest {
-            val result = BankAccountCountryDetailsCacheSerializer.readFrom(Buffer())
-
-            assertEquals(BankAccountCountryDetailsCache(), result)
+            support.assertExhaustedReturnsDefault()
         }
 
     @Test
     fun `readFrom deserializes valid JSON`() =
         runTest {
-            val expected = sampleCache()
-            val json = dataStoreJson.encodeToString(BankAccountCountryDetailsCache.serializer(), expected)
-
-            val result = BankAccountCountryDetailsCacheSerializer.readFrom(Buffer().writeUtf8(json))
-
-            assertEquals(expected, result)
+            support.assertDeserializesValidJson()
         }
 
     @Test
     fun `readFrom wraps SerializationException in CorruptionException`() =
         runTest {
-            val exception =
-                assertFailsWith<CorruptionException> {
-                    BankAccountCountryDetailsCacheSerializer.readFrom(Buffer().writeUtf8("{"))
-                }
-
-            assertEquals("Cannot deserialize BankAccountCountryDetailsCache", exception.message)
-            assertIs<SerializationException>(exception.cause)
+            support.assertWrapsSerializationExceptionInCorruptionException()
         }
 
     @Test
     fun `writeTo round trips BankAccountCountryDetailsCache`() =
         runTest {
-            val original = sampleCache()
-            val buffer = Buffer()
-
-            BankAccountCountryDetailsCacheSerializer.writeTo(original, buffer)
-            val restored = BankAccountCountryDetailsCacheSerializer.readFrom(buffer)
-
-            assertEquals(original, restored)
+            support.assertRoundTrip()
         }
 
     private fun sampleCache() =

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/JsonDataStoreSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/JsonDataStoreSerializer.kt
@@ -15,11 +15,13 @@ inline fun <reified T> jsonDataStoreSerializer(
     serializer: KSerializer<T> = serializer(),
 ): OkioSerializer<T> =
     object : OkioSerializer<T> {
+        private val storedDefault: T = defaultValue
+
         override val defaultValue: T
-            get() = defaultValue
+            get() = storedDefault
 
         override suspend fun readFrom(source: BufferedSource): T {
-            if (source.exhausted()) return defaultValue
+            if (source.exhausted()) return storedDefault
             return try {
                 dataStoreJson.decodeFromString(serializer, source.readUtf8())
             } catch (e: SerializationException) {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/JsonDataStoreSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/JsonDataStoreSerializer.kt
@@ -1,0 +1,38 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.okio.OkioSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.serializer
+import network.bisq.mobile.data.datastore.dataStoreJson
+import okio.BufferedSink
+import okio.BufferedSource
+
+inline fun <reified T> jsonDataStoreSerializer(
+    defaultValue: T,
+    typeName: String,
+    serializer: KSerializer<T> = serializer(),
+): OkioSerializer<T> =
+    object : OkioSerializer<T> {
+        override val defaultValue: T
+            get() = defaultValue
+
+        override suspend fun readFrom(source: BufferedSource): T {
+            if (source.exhausted()) return defaultValue
+            return try {
+                dataStoreJson.decodeFromString(serializer, source.readUtf8())
+            } catch (e: SerializationException) {
+                throw CorruptionException("Cannot deserialize $typeName", e)
+            } catch (e: IllegalArgumentException) {
+                throw CorruptionException("Cannot read $typeName", e)
+            }
+        }
+
+        override suspend fun writeTo(
+            t: T,
+            sink: BufferedSink,
+        ) {
+            sink.writeUtf8(dataStoreJson.encodeToString(serializer, t))
+        }
+    }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializer.kt
@@ -1,36 +1,9 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfigs
-import okio.BufferedSink
-import okio.BufferedSource
 
-object OfferbookFilterConfigsSerializer : OkioSerializer<OfferbookFilterConfigs> {
-    override val defaultValue: OfferbookFilterConfigs
-        get() = OfferbookFilterConfigs()
-
-    override suspend fun readFrom(source: BufferedSource): OfferbookFilterConfigs {
-        if (source.exhausted()) return defaultValue
-        return try {
-            dataStoreJson.decodeFromString(
-                OfferbookFilterConfigs.serializer(),
-                source.readUtf8(),
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Cannot deserialize OfferbookFilterConfigs", e)
-        } catch (e: IllegalArgumentException) {
-            throw CorruptionException("Cannot read OfferbookFilterConfigs", e)
-        }
-    }
-
-    override suspend fun writeTo(
-        t: OfferbookFilterConfigs,
-        sink: BufferedSink,
-    ) {
-        val payload = dataStoreJson.encodeToString(OfferbookFilterConfigs.serializer(), t)
-        sink.writeUtf8(payload)
-    }
-}
+object OfferbookFilterConfigsSerializer : OkioSerializer<OfferbookFilterConfigs> by jsonDataStoreSerializer(
+    defaultValue = OfferbookFilterConfigs(),
+    typeName = "OfferbookFilterConfigs",
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializer.kt
@@ -1,36 +1,9 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.Settings
-import okio.BufferedSink
-import okio.BufferedSource
 
-object SettingsSerializer : OkioSerializer<Settings> {
-    override val defaultValue: Settings
-        get() = Settings()
-
-    override suspend fun readFrom(source: BufferedSource): Settings {
-        if (source.exhausted()) return defaultValue
-        return try {
-            dataStoreJson.decodeFromString(
-                Settings.serializer(),
-                source.readUtf8(),
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Cannot deserialize Settings", e)
-        } catch (e: IllegalArgumentException) {
-            throw CorruptionException("Cannot read Settings", e)
-        }
-    }
-
-    override suspend fun writeTo(
-        t: Settings,
-        sink: BufferedSink,
-    ) {
-        val payload = dataStoreJson.encodeToString(Settings.serializer(), t)
-        sink.writeUtf8(payload)
-    }
-}
+object SettingsSerializer : OkioSerializer<Settings> by jsonDataStoreSerializer(
+    defaultValue = Settings(),
+    typeName = "Settings",
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializer.kt
@@ -1,36 +1,9 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.TradeReadStateMap
-import okio.BufferedSink
-import okio.BufferedSource
 
-object TradeReadStateMapSerializer : OkioSerializer<TradeReadStateMap> {
-    override val defaultValue: TradeReadStateMap
-        get() = TradeReadStateMap()
-
-    override suspend fun readFrom(source: BufferedSource): TradeReadStateMap {
-        if (source.exhausted()) return defaultValue
-        return try {
-            dataStoreJson.decodeFromString(
-                TradeReadStateMap.serializer(),
-                source.readUtf8(),
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Cannot deserialize TradeReadStateMap", e)
-        } catch (e: IllegalArgumentException) {
-            throw CorruptionException("Cannot read TradeReadStateMap", e)
-        }
-    }
-
-    override suspend fun writeTo(
-        t: TradeReadStateMap,
-        sink: BufferedSink,
-    ) {
-        val payload = dataStoreJson.encodeToString(TradeReadStateMap.serializer(), t)
-        sink.writeUtf8(payload)
-    }
-}
+object TradeReadStateMapSerializer : OkioSerializer<TradeReadStateMap> by jsonDataStoreSerializer(
+    defaultValue = TradeReadStateMap(),
+    typeName = "TradeReadStateMap",
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializer.kt
@@ -1,36 +1,9 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.User
-import okio.BufferedSink
-import okio.BufferedSource
 
-object UserSerializer : OkioSerializer<User> {
-    override val defaultValue: User
-        get() = User()
-
-    override suspend fun readFrom(source: BufferedSource): User {
-        if (source.exhausted()) return defaultValue
-        return try {
-            dataStoreJson.decodeFromString(
-                User.serializer(),
-                source.readUtf8(),
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Cannot deserialize User", e)
-        } catch (e: IllegalArgumentException) {
-            throw CorruptionException("Cannot read User", e)
-        }
-    }
-
-    override suspend fun writeTo(
-        t: User,
-        sink: BufferedSink,
-    ) {
-        val payload = dataStoreJson.encodeToString(User.serializer(), t)
-        sink.writeUtf8(payload)
-    }
-}
+object UserSerializer : OkioSerializer<User> by jsonDataStoreSerializer(
+    defaultValue = User(),
+    typeName = "User",
+)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializerTest.kt
@@ -1,69 +1,48 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfigs
-import okio.Buffer
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
-/**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
- * decode failures surface as [SerializationException] (including JsonDecodingException), and this
- * model has no init validation that would throw plain [IllegalArgumentException] during decode.
- */
 class OfferbookFilterConfigsSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = OfferbookFilterConfigsSerializer,
+            defaultValue = OfferbookFilterConfigs(),
+            sampleValue = ::sampleConfigs,
+            typeName = "OfferbookFilterConfigs",
+            kSerializer = OfferbookFilterConfigs.serializer(),
+        )
+
     @Test
     fun `defaultValue returns empty OfferbookFilterConfigs`() {
-        assertEquals(OfferbookFilterConfigs(), OfferbookFilterConfigsSerializer.defaultValue)
+        support.assertDefaultValue()
     }
 
     @Test
     fun `readFrom returns default when source is exhausted`() =
         runTest {
-            val result = OfferbookFilterConfigsSerializer.readFrom(Buffer())
-
-            assertEquals(OfferbookFilterConfigs(), result)
+            support.assertExhaustedReturnsDefault()
         }
 
     @Test
     fun `readFrom deserializes valid JSON`() =
         runTest {
-            val expected = sampleConfigs()
-            val json = dataStoreJson.encodeToString(OfferbookFilterConfigs.serializer(), expected)
-
-            val result = OfferbookFilterConfigsSerializer.readFrom(Buffer().writeUtf8(json))
-
-            assertEquals(expected, result)
+            support.assertDeserializesValidJson()
         }
 
     @Test
     fun `readFrom wraps SerializationException in CorruptionException`() =
         runTest {
-            val exception =
-                assertFailsWith<CorruptionException> {
-                    OfferbookFilterConfigsSerializer.readFrom(Buffer().writeUtf8("{"))
-                }
-
-            assertEquals("Cannot deserialize OfferbookFilterConfigs", exception.message)
-            assertIs<SerializationException>(exception.cause)
+            support.assertWrapsSerializationExceptionInCorruptionException()
         }
 
     @Test
     fun `writeTo round trips OfferbookFilterConfigs`() =
         runTest {
-            val original = sampleConfigs()
-            val buffer = Buffer()
-
-            OfferbookFilterConfigsSerializer.writeTo(original, buffer)
-            val restored = OfferbookFilterConfigsSerializer.readFrom(buffer)
-
-            assertEquals(original, restored)
+            support.assertRoundTrip()
         }
 
     private fun sampleConfigs() =

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/OfferbookFilterConfigsSerializerTest.kt
@@ -1,0 +1,83 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.CorruptionException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.data.datastore.dataStoreJson
+import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
+import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfigs
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and this
+ * model has no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class OfferbookFilterConfigsSerializerTest {
+    @Test
+    fun `defaultValue returns empty OfferbookFilterConfigs`() {
+        assertEquals(OfferbookFilterConfigs(), OfferbookFilterConfigsSerializer.defaultValue)
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = OfferbookFilterConfigsSerializer.readFrom(Buffer())
+
+            assertEquals(OfferbookFilterConfigs(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            val expected = sampleConfigs()
+            val json = dataStoreJson.encodeToString(OfferbookFilterConfigs.serializer(), expected)
+
+            val result = OfferbookFilterConfigsSerializer.readFrom(Buffer().writeUtf8(json))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    OfferbookFilterConfigsSerializer.readFrom(Buffer().writeUtf8("{"))
+                }
+
+            assertEquals("Cannot deserialize OfferbookFilterConfigs", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips OfferbookFilterConfigs`() =
+        runTest {
+            val original = sampleConfigs()
+            val buffer = Buffer()
+
+            OfferbookFilterConfigsSerializer.writeTo(original, buffer)
+            val restored = OfferbookFilterConfigsSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    private fun sampleConfigs() =
+        OfferbookFilterConfigs(
+            configsByMarket =
+                mapOf(
+                    "BTC/EUR" to
+                        OfferbookFilterConfig(
+                            selectedPaymentMethodIds = setOf("SEPA"),
+                            selectedSettlementMethodIds = setOf("MAIN_CHAIN"),
+                            onlyMyOffers = true,
+                            hasManualPaymentFilter = true,
+                            hasManualSettlementFilter = false,
+                        ),
+                ),
+        )
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializerTest.kt
@@ -1,68 +1,47 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.Settings
-import okio.Buffer
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
-/**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
- * decode failures surface as [SerializationException] (including JsonDecodingException), and this
- * model has no init validation that would throw plain [IllegalArgumentException] during decode.
- */
 class SettingsSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = SettingsSerializer,
+            defaultValue = Settings(),
+            sampleValue = ::sampleSettings,
+            typeName = "Settings",
+            kSerializer = Settings.serializer(),
+        )
+
     @Test
     fun `defaultValue returns empty Settings`() {
-        assertEquals(Settings(), SettingsSerializer.defaultValue)
+        support.assertDefaultValue()
     }
 
     @Test
     fun `readFrom returns default when source is exhausted`() =
         runTest {
-            val result = SettingsSerializer.readFrom(Buffer())
-
-            assertEquals(Settings(), result)
+            support.assertExhaustedReturnsDefault()
         }
 
     @Test
     fun `readFrom deserializes valid JSON`() =
         runTest {
-            val expected = sampleSettings()
-            val json = dataStoreJson.encodeToString(Settings.serializer(), expected)
-
-            val result = SettingsSerializer.readFrom(Buffer().writeUtf8(json))
-
-            assertEquals(expected, result)
+            support.assertDeserializesValidJson()
         }
 
     @Test
     fun `readFrom wraps SerializationException in CorruptionException`() =
         runTest {
-            val exception =
-                assertFailsWith<CorruptionException> {
-                    SettingsSerializer.readFrom(Buffer().writeUtf8("{"))
-                }
-
-            assertEquals("Cannot deserialize Settings", exception.message)
-            assertIs<SerializationException>(exception.cause)
+            support.assertWrapsSerializationExceptionInCorruptionException()
         }
 
     @Test
     fun `writeTo round trips Settings`() =
         runTest {
-            val original = sampleSettings()
-            val buffer = Buffer()
-
-            SettingsSerializer.writeTo(original, buffer)
-            val restored = SettingsSerializer.readFrom(buffer)
-
-            assertEquals(original, restored)
+            support.assertRoundTrip()
         }
 
     private fun sampleSettings() =

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/SettingsSerializerTest.kt
@@ -1,0 +1,74 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.CorruptionException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.data.datastore.dataStoreJson
+import network.bisq.mobile.data.model.Settings
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and this
+ * model has no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class SettingsSerializerTest {
+    @Test
+    fun `defaultValue returns empty Settings`() {
+        assertEquals(Settings(), SettingsSerializer.defaultValue)
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = SettingsSerializer.readFrom(Buffer())
+
+            assertEquals(Settings(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            val expected = sampleSettings()
+            val json = dataStoreJson.encodeToString(Settings.serializer(), expected)
+
+            val result = SettingsSerializer.readFrom(Buffer().writeUtf8(json))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    SettingsSerializer.readFrom(Buffer().writeUtf8("{"))
+                }
+
+            assertEquals("Cannot deserialize Settings", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips Settings`() =
+        runTest {
+            val original = sampleSettings()
+            val buffer = Buffer()
+
+            SettingsSerializer.writeTo(original, buffer)
+            val restored = SettingsSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    private fun sampleSettings() =
+        Settings(
+            firstLaunch = false,
+            selectedMarketCode = "BTC/EUR",
+            rememberOfferbookFilterPreferences = false,
+        )
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializerTest.kt
@@ -1,0 +1,69 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.CorruptionException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.data.datastore.dataStoreJson
+import network.bisq.mobile.data.model.TradeReadStateMap
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and this
+ * model has no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class TradeReadStateMapSerializerTest {
+    @Test
+    fun `defaultValue returns empty TradeReadStateMap`() {
+        assertEquals(TradeReadStateMap(), TradeReadStateMapSerializer.defaultValue)
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = TradeReadStateMapSerializer.readFrom(Buffer())
+
+            assertEquals(TradeReadStateMap(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            val expected = sampleMap()
+            val json = dataStoreJson.encodeToString(TradeReadStateMap.serializer(), expected)
+
+            val result = TradeReadStateMapSerializer.readFrom(Buffer().writeUtf8(json))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    TradeReadStateMapSerializer.readFrom(Buffer().writeUtf8("{"))
+                }
+
+            assertEquals("Cannot deserialize TradeReadStateMap", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips TradeReadStateMap`() =
+        runTest {
+            val original = sampleMap()
+            val buffer = Buffer()
+
+            TradeReadStateMapSerializer.writeTo(original, buffer)
+            val restored = TradeReadStateMapSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    private fun sampleMap() = TradeReadStateMap(mapOf("trade-1" to 2))
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeReadStateMapSerializerTest.kt
@@ -1,68 +1,47 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.TradeReadStateMap
-import okio.Buffer
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
-/**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
- * decode failures surface as [SerializationException] (including JsonDecodingException), and this
- * model has no init validation that would throw plain [IllegalArgumentException] during decode.
- */
 class TradeReadStateMapSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = TradeReadStateMapSerializer,
+            defaultValue = TradeReadStateMap(),
+            sampleValue = ::sampleMap,
+            typeName = "TradeReadStateMap",
+            kSerializer = TradeReadStateMap.serializer(),
+        )
+
     @Test
     fun `defaultValue returns empty TradeReadStateMap`() {
-        assertEquals(TradeReadStateMap(), TradeReadStateMapSerializer.defaultValue)
+        support.assertDefaultValue()
     }
 
     @Test
     fun `readFrom returns default when source is exhausted`() =
         runTest {
-            val result = TradeReadStateMapSerializer.readFrom(Buffer())
-
-            assertEquals(TradeReadStateMap(), result)
+            support.assertExhaustedReturnsDefault()
         }
 
     @Test
     fun `readFrom deserializes valid JSON`() =
         runTest {
-            val expected = sampleMap()
-            val json = dataStoreJson.encodeToString(TradeReadStateMap.serializer(), expected)
-
-            val result = TradeReadStateMapSerializer.readFrom(Buffer().writeUtf8(json))
-
-            assertEquals(expected, result)
+            support.assertDeserializesValidJson()
         }
 
     @Test
     fun `readFrom wraps SerializationException in CorruptionException`() =
         runTest {
-            val exception =
-                assertFailsWith<CorruptionException> {
-                    TradeReadStateMapSerializer.readFrom(Buffer().writeUtf8("{"))
-                }
-
-            assertEquals("Cannot deserialize TradeReadStateMap", exception.message)
-            assertIs<SerializationException>(exception.cause)
+            support.assertWrapsSerializationExceptionInCorruptionException()
         }
 
     @Test
     fun `writeTo round trips TradeReadStateMap`() =
         runTest {
-            val original = sampleMap()
-            val buffer = Buffer()
-
-            TradeReadStateMapSerializer.writeTo(original, buffer)
-            val restored = TradeReadStateMapSerializer.readFrom(buffer)
-
-            assertEquals(original, restored)
+            support.assertRoundTrip()
         }
 
     private fun sampleMap() = TradeReadStateMap(mapOf("trade-1" to 2))

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializerTest.kt
@@ -1,0 +1,73 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.CorruptionException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.data.datastore.dataStoreJson
+import network.bisq.mobile.data.model.User
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and this
+ * model has no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class UserSerializerTest {
+    @Test
+    fun `defaultValue returns empty User`() {
+        assertEquals(User(), UserSerializer.defaultValue)
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            val result = UserSerializer.readFrom(Buffer())
+
+            assertEquals(User(), result)
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            val expected = sampleUser()
+            val json = dataStoreJson.encodeToString(User.serializer(), expected)
+
+            val result = UserSerializer.readFrom(Buffer().writeUtf8(json))
+
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            val exception =
+                assertFailsWith<CorruptionException> {
+                    UserSerializer.readFrom(Buffer().writeUtf8("{"))
+                }
+
+            assertEquals("Cannot deserialize User", exception.message)
+            assertIs<SerializationException>(exception.cause)
+        }
+
+    @Test
+    fun `writeTo round trips User`() =
+        runTest {
+            val original = sampleUser()
+            val buffer = Buffer()
+
+            UserSerializer.writeTo(original, buffer)
+            val restored = UserSerializer.readFrom(buffer)
+
+            assertEquals(original, restored)
+        }
+
+    private fun sampleUser() =
+        User(
+            tradeTerms = "terms",
+            statement = "statement",
+        )
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/UserSerializerTest.kt
@@ -1,68 +1,47 @@
 package network.bisq.mobile.data.datastore.serializer
 
-import androidx.datastore.core.CorruptionException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationException
-import network.bisq.mobile.data.datastore.dataStoreJson
 import network.bisq.mobile.data.model.User
-import okio.Buffer
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
-/**
- * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
- * decode failures surface as [SerializationException] (including JsonDecodingException), and this
- * model has no init validation that would throw plain [IllegalArgumentException] during decode.
- */
 class UserSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = UserSerializer,
+            defaultValue = User(),
+            sampleValue = ::sampleUser,
+            typeName = "User",
+            kSerializer = User.serializer(),
+        )
+
     @Test
     fun `defaultValue returns empty User`() {
-        assertEquals(User(), UserSerializer.defaultValue)
+        support.assertDefaultValue()
     }
 
     @Test
     fun `readFrom returns default when source is exhausted`() =
         runTest {
-            val result = UserSerializer.readFrom(Buffer())
-
-            assertEquals(User(), result)
+            support.assertExhaustedReturnsDefault()
         }
 
     @Test
     fun `readFrom deserializes valid JSON`() =
         runTest {
-            val expected = sampleUser()
-            val json = dataStoreJson.encodeToString(User.serializer(), expected)
-
-            val result = UserSerializer.readFrom(Buffer().writeUtf8(json))
-
-            assertEquals(expected, result)
+            support.assertDeserializesValidJson()
         }
 
     @Test
     fun `readFrom wraps SerializationException in CorruptionException`() =
         runTest {
-            val exception =
-                assertFailsWith<CorruptionException> {
-                    UserSerializer.readFrom(Buffer().writeUtf8("{"))
-                }
-
-            assertEquals("Cannot deserialize User", exception.message)
-            assertIs<SerializationException>(exception.cause)
+            support.assertWrapsSerializationExceptionInCorruptionException()
         }
 
     @Test
     fun `writeTo round trips User`() =
         runTest {
-            val original = sampleUser()
-            val buffer = Buffer()
-
-            UserSerializer.writeTo(original, buffer)
-            val restored = UserSerializer.readFrom(buffer)
-
-            assertEquals(original, restored)
+            support.assertRoundTrip()
         }
 
     private fun sampleUser() =

--- a/shared/test-utils/build.gradle.kts
+++ b/shared/test-utils/build.gradle.kts
@@ -22,6 +22,12 @@ kotlin {
             // Coroutines for StateFlow in mocks and test dispatchers
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.coroutines.test)
+
+            // DataStore serializer contract tests
+            implementation(libs.androidx.datastore.okio)
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.serialization.core)
+            implementation(libs.kotlinx.serialization.json)
         }
 
         androidMain.dependencies {

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/datastore/JsonDataStoreSerializerTestSupport.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/datastore/JsonDataStoreSerializerTestSupport.kt
@@ -1,0 +1,80 @@
+package network.bisq.mobile.test.datastore
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.okio.OkioSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import network.bisq.mobile.data.datastore.dataStoreJson
+import okio.Buffer
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * Shared contract tests for [network.bisq.mobile.data.datastore.serializer.jsonDataStoreSerializer].
+ *
+ * IllegalArgumentException wrapping ("Cannot read …") is intentionally not tested: [dataStoreJson]
+ * decode failures surface as [SerializationException] (including JsonDecodingException), and these
+ * models have no init validation that would throw plain [IllegalArgumentException] during decode.
+ */
+class JsonDataStoreSerializerTestSupport<T>(
+    private val serializer: OkioSerializer<T>,
+    private val defaultValue: T,
+    private val sampleValue: () -> T,
+    private val typeName: String,
+    private val kSerializer: KSerializer<T>,
+) {
+    fun assertDefaultValue() {
+        assertEquals(defaultValue, serializer.defaultValue)
+    }
+
+    suspend fun assertExhaustedReturnsDefault() {
+        val result = serializer.readFrom(Buffer())
+
+        assertEquals(defaultValue, result)
+    }
+
+    suspend fun assertDeserializesValidJson() {
+        val expected = sampleValue()
+        val json = dataStoreJson.encodeToString(kSerializer, expected)
+
+        val result = serializer.readFrom(Buffer().writeUtf8(json))
+
+        assertEquals(expected, result)
+    }
+
+    suspend fun assertWrapsSerializationExceptionInCorruptionException() {
+        val exception =
+            assertFailsWith<CorruptionException> {
+                serializer.readFrom(Buffer().writeUtf8("{"))
+            }
+
+        assertEquals("Cannot deserialize $typeName", exception.message)
+        assertIs<SerializationException>(exception.cause)
+    }
+
+    suspend fun assertRoundTrip() {
+        val original = sampleValue()
+        val buffer = Buffer()
+
+        serializer.writeTo(original, buffer)
+        val restored = serializer.readFrom(buffer)
+
+        assertEquals(original, restored)
+    }
+}
+
+fun <T> jsonDataStoreSerializerTestSupport(
+    serializer: OkioSerializer<T>,
+    defaultValue: T,
+    sampleValue: () -> T,
+    typeName: String,
+    kSerializer: KSerializer<T>,
+): JsonDataStoreSerializerTestSupport<T> =
+    JsonDataStoreSerializerTestSupport(
+        serializer = serializer,
+        defaultValue = defaultValue,
+        sampleValue = sampleValue,
+        typeName = typeName,
+        kSerializer = kSerializer,
+    )


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1533
 - Add unit tests for all 6 OkioSerializer implementations 
 - Created a `jsonDataStoreSerializer()` factory method to simplify Serializer creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a shared JSON-based DataStore serializer factory and migrated existing persistence serializers to delegate to it.
  * Standardized default-value behavior for exhausted reads and unified corruption/error wrapping for JSON decode failures.
* **Tests**
  * Added shared serializer test support utilities and comprehensive serializer test suites for settings, user, trade read state, offerbook filters, bank account country details, and sensitive settings.
  * Verified decode/round-trip behavior, corruption handling, and sensitive-settings keystore invalidation via dedicated test hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->