### PR TITLE
Platform-aware update URLs for OnUpdateNow

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.android.kt
@@ -7,7 +7,9 @@ import network.bisq.mobile.client.common.domain.utils.ClientVersionProvider
 import network.bisq.mobile.client.main.AndroidClientMainPresenter
 import network.bisq.mobile.client.onboarding.ClientOnboardingPresenter
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
+import network.bisq.mobile.data.utils.AndroidAppUpdateLinker
 import network.bisq.mobile.data.utils.AndroidUrlLauncher
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.utils.AndroidDeviceInfoProvider
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
@@ -26,6 +28,7 @@ import org.koin.dsl.module
 val androidClientPresentationModule =
     module {
         single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
+        single<AppUpdateLinker> { AndroidAppUpdateLinker(androidContext()) }
         single {
             val context = androidContext()
             val filesDir = context.filesDir.absolutePath

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenterTest.kt
@@ -32,6 +32,8 @@ import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
+import network.bisq.mobile.data.utils.AppUpdateUrls
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
@@ -165,6 +167,9 @@ class ClientOfferbookPresenterTest {
         coEvery { offerbookFilterConfigRepository.getConfig(any()) } returns OfferbookFilterConfig()
         coEvery { offerbookFilterConfigRepository.setConfig(any(), any()) } returns Unit
 
+        val appUpdateLinker = mockk<AppUpdateLinker>()
+        every { appUpdateLinker.getUpdateUrl() } returns AppUpdateUrls.GITHUB_RELEASES
+
         return ClientOfferbookPresenter(
             mainPresenter = mainPresenter,
             offersServiceFacade = offersService,
@@ -175,6 +180,7 @@ class ClientOfferbookPresenterTest {
             userProfileServiceFacade = userProfileServiceFacade,
             tradeRestrictingAlertServiceFacade = tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository = offerbookFilterConfigRepository,
+            appUpdateLinker = appUpdateLinker,
             configServiceFacade =
                 mockk<ConfigServiceFacade> {
                     every { tradeAmountLimits } returns MutableStateFlow(TradeAmountLimitsVO.DEFAULT)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -64,6 +64,7 @@ val clientPresentationModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/offerbook/ClientOfferbookPresenter.kt
@@ -7,6 +7,7 @@ import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
@@ -24,6 +25,7 @@ class ClientOfferbookPresenter(
     tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
     offerbookFilterConfigRepository: OfferbookFilterConfigRepository,
     configServiceFacade: ConfigServiceFacade,
+    appUpdateLinker: AppUpdateLinker,
 ) : OfferbookPresenter(
         mainPresenter,
         offersServiceFacade,
@@ -35,6 +37,7 @@ class ClientOfferbookPresenter(
         tradeRestrictingAlertServiceFacade,
         offerbookFilterConfigRepository,
         configServiceFacade,
+        appUpdateLinker,
     ) {
     override fun isOfferFromIgnoredUserCached(offer: BisqEasyOfferVO): Boolean {
         val makerUserProfileId = offer.makerNetworkId.pubKey.id

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -10,6 +10,8 @@ import network.bisq.mobile.data.service.AppForegroundController
 import network.bisq.mobile.data.service.ForegroundDetector
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
+import network.bisq.mobile.data.utils.IOSAppUpdateLinker
 import network.bisq.mobile.data.utils.IOSUrlLauncher
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.analytics.NativeSentryInitializer
@@ -73,6 +75,7 @@ val iosClientDomainModule =
             )
         }
         single<UrlLauncher> { IOSUrlLauncher() }
+        single<AppUpdateLinker> { IOSAppUpdateLinker() }
         single<VersionProvider> { ClientVersionProvider() }
 
         // Native Sentry SDK initializer. Unconditionally bound — the

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -27,7 +27,9 @@ import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.data.utils.AndroidAppUpdateLinker
 import network.bisq.mobile.data.utils.AndroidUrlLauncher
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.analytics.AnalyticsBootstrapConfig
 import network.bisq.mobile.domain.analytics.AnalyticsService
@@ -204,6 +206,7 @@ val androidNodeDomainModule =
         single<BackendCapabilitiesService> { DefaultBackendCapabilitiesService(get()) }
 
         single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
+        single<AppUpdateLinker> { AndroidAppUpdateLinker(androidContext()) }
 
         single<NodeApplicationLifecycleService> {
             NodeApplicationLifecycleService(

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -60,6 +60,7 @@ val androidNodePresentationModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,7 @@ Agents: [AGENTS.md](../AGENTS.md) → [docs/testing/README.md](testing/README.md
 ## Rules
 
 - Mirror production package paths in test source sets.
-- Extend a leaf base — do not copy inline `startKoin` / `Dispatchers.setMain` from unmigrated siblings (~80% of existing tests are legacy).
+- When the [decision tree](#decision-tree) / [catalog](testing/catalog.md) lists a leaf base for that layer, extend it — do not copy inline `startKoin` / `Dispatchers.setMain` from unmigrated siblings (~80% of existing tests are legacy). Layers with no cataloged leaf base (domain `commonTest`, domain `androidUnitTest` Robolectric) need no leaf base — do not invent a base.
 - Grep [catalog.md](testing/catalog.md) and `*TestFactory.kt` / `*TestSupport.kt` before creating mocks.
 - Assert behavior (state, side effects, visible UI) — not implementation details.
 - Read production control flow before writing assertions — do not invent branch behavior from comments or names (`IS_DEBUG`, “dev mode”, etc.).
@@ -32,6 +32,7 @@ Android-only APIs cannot go in `commonTest`. iOS: `iosSimulatorArm64Test` (macOS
 ```text
 Changed file layer?
 ├── Pure Kotlin → commonTest (*Test.kt); ServiceFacades: inline setMain + testModule → recipes.md#domain
+├── Domain Android-only API (androidMain) → androidUnitTest + @RunWith(RobolectricTestRunner) — no leaf base
 ├── Presenter (:shared:presentation) → *PresenterTest.kt, PresentationKoinTestBase / PlatformPresentationKoinTestBase → recipes.md#presenter
 ├── Composable (:shared:presentation) → *UiTest.kt, BisqComposeUiTestBase or PresentationKoinComposeTestBase → recipes.md#compose
 ├── Client facade/service → ClientKoinIntegrationTestBase → recipes.md#client

--- a/docs/testing/catalog.md
+++ b/docs/testing/catalog.md
@@ -30,6 +30,8 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `TestApplication` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/TestApplication.kt` |
 | `TestDoubles` | `apps/clientApp/src/androidUnitTest/kotlin/.../client/test_utils/TestDoubles.kt` |
 | `MainPresenterTestFactory` | `.../test_utils/MainPresenterTestFactory.kt` |
+| `FakeAppUpdateLinker` | `.../test_utils/FakeAppUpdateLinker.kt` |
+| `TEST_APP_UPDATE_URL` | `.../test_utils/FakeAppUpdateLinker.kt` |
 | `StateFlowProbe` | `.../test_utils/StateFlowProbe.kt` |
 | `NoopNavigationManager` | `.../test_utils/di/NoopNavigationManager.kt` |
 | `PlatformStaticMocks` | `.../test_utils/coroutines/PlatformStaticMocks.kt` |

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -99,6 +99,40 @@ class AndroidUrlLauncher(
     }
 }
 
+class AndroidAppUpdateLinker(
+    private val context: Context,
+    private val installingPackageNameProvider: (Context) -> String? = ::resolveInstallingPackageName,
+) : AppUpdateLinker {
+    private companion object {
+        private const val GOOGLE_PLAY_INSTALLER = "com.android.vending"
+        private const val GOOGLE_PLAY_FEEDBACK = "com.google.android.feedback"
+
+        fun resolveInstallingPackageName(context: Context): String? =
+            runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    context.packageManager
+                        .getInstallSourceInfo(context.packageName)
+                        .installingPackageName
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getInstallerPackageName(context.packageName)
+                }
+            }.getOrNull()
+    }
+
+    override fun getUpdateUrl(): String =
+        if (isGooglePlayInstall()) {
+            AppUpdateUrls.playStoreDetailsUrl(context.packageName)
+        } else {
+            AppUpdateUrls.GITHUB_RELEASES
+        }
+
+    private fun isGooglePlayInstall(): Boolean {
+        val installer = runCatching { installingPackageNameProvider(context) }.getOrNull() ?: return false
+        return installer == GOOGLE_PLAY_INSTALLER || installer == GOOGLE_PLAY_FEEDBACK
+    }
+}
+
 class AndroidPlatformInfo : PlatformInfo {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
     override val type = PlatformType.ANDROID

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -70,6 +70,13 @@ class AndroidUrlLauncher(
     private val log = getLogger("AndroidUrlLauncher")
 
     override suspend fun openUrl(url: String): Boolean {
+        if (tryOpenUrl(url)) return true
+        val fallback = playStoreHttpsFallback(url) ?: return false
+        log.w { "No handler for market:// URL; falling back to Play Store HTTPS listing" }
+        return tryOpenUrl(fallback)
+    }
+
+    private fun tryOpenUrl(url: String): Boolean {
         val safeUrl = sanitizeUrlForLog(url)
         val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -83,6 +90,13 @@ class AndroidUrlLauncher(
             log.e(e) { "Failed to open URL: $safeUrl" }
             return false
         }
+    }
+
+    private fun playStoreHttpsFallback(url: String): String? {
+        val uri = runCatching { url.toUri() }.getOrNull() ?: return null
+        if (uri.scheme != "market") return null
+        val packageName = uri.getQueryParameter("id")?.takeIf { it.isNotBlank() } ?: return null
+        return AppUpdateUrls.playStoreDetailsUrl(packageName)
     }
 
     private fun sanitizeUrlForLog(rawUrl: String): String {
@@ -122,7 +136,7 @@ class AndroidAppUpdateLinker(
 
     override fun getUpdateUrl(): String =
         if (isGooglePlayInstall()) {
-            AppUpdateUrls.playStoreDetailsUrl(context.packageName)
+            AppUpdateUrls.playStoreMarketUrl(context.packageName)
         } else {
             AppUpdateUrls.GITHUB_RELEASES
         }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidAppUpdateLinkerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidAppUpdateLinkerTest.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.data.utils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,25 +15,25 @@ class AndroidAppUpdateLinkerTest {
     }
 
     @Test
-    fun `returns Play Store URL when installed from Google Play`() {
+    fun `returns Play Store market deep link when installed from Google Play`() {
         val context = RuntimeEnvironment.getApplication()
         val linker =
             AndroidAppUpdateLinker(context) { GOOGLE_PLAY_INSTALLER }
 
         assertEquals(
-            AppUpdateUrls.playStoreDetailsUrl(context.packageName),
+            AppUpdateUrls.playStoreMarketUrl(context.packageName),
             linker.getUpdateUrl(),
         )
     }
 
     @Test
-    fun `returns Play Store URL when installed from Google Play feedback installer`() {
+    fun `returns Play Store market deep link when installed from Google Play feedback installer`() {
         val context = RuntimeEnvironment.getApplication()
         val linker =
             AndroidAppUpdateLinker(context) { GOOGLE_PLAY_FEEDBACK }
 
         assertEquals(
-            AppUpdateUrls.playStoreDetailsUrl(context.packageName),
+            AppUpdateUrls.playStoreMarketUrl(context.packageName),
             linker.getUpdateUrl(),
         )
     }
@@ -52,6 +53,23 @@ class AndroidAppUpdateLinkerTest {
             AndroidAppUpdateLinker(context) {
                 throw RuntimeException("PackageManager lookup failed")
             }
+
+        assertEquals(AppUpdateUrls.GITHUB_RELEASES, linker.getUpdateUrl())
+    }
+
+    @Test
+    fun `default installer lookup on API R+ returns GitHub releases under Robolectric`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker = AndroidAppUpdateLinker(context)
+
+        assertEquals(AppUpdateUrls.GITHUB_RELEASES, linker.getUpdateUrl())
+    }
+
+    @Test
+    @Config(sdk = [28])
+    fun `default installer lookup on pre-R API returns GitHub releases under Robolectric`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker = AndroidAppUpdateLinker(context)
 
         assertEquals(AppUpdateUrls.GITHUB_RELEASES, linker.getUpdateUrl())
     }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidAppUpdateLinkerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidAppUpdateLinkerTest.kt
@@ -1,0 +1,58 @@
+package network.bisq.mobile.data.utils
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidAppUpdateLinkerTest {
+    private companion object {
+        private const val GOOGLE_PLAY_INSTALLER = "com.android.vending"
+        private const val GOOGLE_PLAY_FEEDBACK = "com.google.android.feedback"
+    }
+
+    @Test
+    fun `returns Play Store URL when installed from Google Play`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker =
+            AndroidAppUpdateLinker(context) { GOOGLE_PLAY_INSTALLER }
+
+        assertEquals(
+            AppUpdateUrls.playStoreDetailsUrl(context.packageName),
+            linker.getUpdateUrl(),
+        )
+    }
+
+    @Test
+    fun `returns Play Store URL when installed from Google Play feedback installer`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker =
+            AndroidAppUpdateLinker(context) { GOOGLE_PLAY_FEEDBACK }
+
+        assertEquals(
+            AppUpdateUrls.playStoreDetailsUrl(context.packageName),
+            linker.getUpdateUrl(),
+        )
+    }
+
+    @Test
+    fun `returns GitHub releases when installer is unknown`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker = AndroidAppUpdateLinker(context) { null }
+
+        assertEquals(AppUpdateUrls.GITHUB_RELEASES, linker.getUpdateUrl())
+    }
+
+    @Test
+    fun `returns GitHub releases when installer lookup throws`() {
+        val context = RuntimeEnvironment.getApplication()
+        val linker =
+            AndroidAppUpdateLinker(context) {
+                throw RuntimeException("PackageManager lookup failed")
+            }
+
+        assertEquals(AppUpdateUrls.GITHUB_RELEASES, linker.getUpdateUrl())
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidUrlLauncherTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/utils/AndroidUrlLauncherTest.kt
@@ -63,16 +63,61 @@ class AndroidUrlLauncherTest {
         assertEquals("https://bisq.network", intent.dataString)
     }
 
+    @Test
+    fun `openUrl falls back from market deep link to Play Store HTTPS when market has no handler`() {
+        val packageName = "network.bisq.mobile.client"
+        val context =
+            TestContext { intent ->
+                if (intent.data?.scheme == "market") {
+                    ActivityNotFoundException("No Play Store")
+                } else {
+                    null
+                }
+            }
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = runBlocking { launcher.openUrl(AppUpdateUrls.playStoreMarketUrl(packageName)) }
+
+        assertTrue(result)
+        assertEquals(2, context.startActivityCalls)
+        assertEquals(AppUpdateUrls.playStoreDetailsUrl(packageName), context.lastIntent?.dataString)
+    }
+
+    @Test
+    fun `openUrl returns false when market deep link and HTTPS fallback both fail`() {
+        val packageName = "network.bisq.mobile.client"
+        val context = TestContext(ActivityNotFoundException("No handler"))
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = runBlocking { launcher.openUrl(AppUpdateUrls.playStoreMarketUrl(packageName)) }
+
+        assertFalse(result)
+        assertEquals(2, context.startActivityCalls)
+    }
+
+    @Test
+    fun `openUrl does not fall back for non-market URLs`() {
+        val context = TestContext(ActivityNotFoundException("No handler"))
+        val launcher = AndroidUrlLauncher(context)
+
+        val result = runBlocking { launcher.openUrl("https://bisq.network") }
+
+        assertFalse(result)
+        assertEquals(1, context.startActivityCalls)
+    }
+
     private class TestContext(
-        private val exceptionToThrow: Exception? = null,
+        private val exceptionForIntent: (Intent) -> Exception? = { null },
     ) : ContextWrapper(RuntimeEnvironment.getApplication()) {
         var startActivityCalls: Int = 0
         var lastIntent: Intent? = null
 
+        constructor(exceptionToThrow: Exception) : this({ exceptionToThrow })
+
         override fun startActivity(intent: Intent) {
             startActivityCalls++
             lastIntent = intent
-            exceptionToThrow?.let { throw it }
+            exceptionForIntent(intent)?.let { throw it }
         }
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/AppUpdateUrls.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/AppUpdateUrls.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.data.utils
+
+object AppUpdateUrls {
+    const val GITHUB_RELEASES = "https://github.com/bisq-network/bisq-mobile/releases"
+
+    const val BISQ_CONNECT_IOS_INSTALL_PAGE =
+        "https://bisq-network.github.io/bisq-mobile/"
+
+    fun playStoreDetailsUrl(packageName: String): String = "https://play.google.com/store/apps/details?id=$packageName"
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/AppUpdateUrls.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/AppUpdateUrls.kt
@@ -6,5 +6,9 @@ object AppUpdateUrls {
     const val BISQ_CONNECT_IOS_INSTALL_PAGE =
         "https://bisq-network.github.io/bisq-mobile/"
 
+    /** Prefer this on Android so the Play Store app opens directly when present. */
+    fun playStoreMarketUrl(packageName: String): String = "market://details?id=$packageName"
+
+    /** HTTPS listing — used when [playStoreMarketUrl] cannot be handled. */
     fun playStoreDetailsUrl(packageName: String): String = "https://play.google.com/store/apps/details?id=$packageName"
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
@@ -19,6 +19,10 @@ interface UrlLauncher {
     suspend fun openUrl(url: String): Boolean
 }
 
+interface AppUpdateLinker {
+    fun getUpdateUrl(): String
+}
+
 expect fun formatDateTime(dateTime: LocalDateTime): String
 
 expect fun encodeURIParam(param: String): String

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
@@ -402,6 +402,10 @@ class IOSUrlLauncher : UrlLauncher {
     private fun sanitizeUrlForLog(rawUrl: String): String = rawUrl.take(256).ifEmpty { "invalid-url" }
 }
 
+class IOSAppUpdateLinker : AppUpdateLinker {
+    override fun getUpdateUrl(): String = AppUpdateUrls.BISQ_CONNECT_IOS_INSTALL_PAGE
+}
+
 class IOSPlatformInfo : PlatformInfo {
     override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
     override val type = PlatformType.IOS

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeAppUpdateLinker.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeAppUpdateLinker.kt
@@ -1,0 +1,12 @@
+package network.bisq.mobile.presentation.common.test_utils
+
+import network.bisq.mobile.data.utils.AppUpdateLinker
+
+/** Sentinel URL for presenter tests — must not match production release destinations. */
+const val TEST_APP_UPDATE_URL = "https://example.test/bisq-app-update"
+
+class FakeAppUpdateLinker(
+    private val updateUrl: String = TEST_APP_UPDATE_URL,
+) : AppUpdateLinker {
+    override fun getUpdateUrl(): String = updateUrl
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenterTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +18,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
@@ -24,12 +26,13 @@ import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.probeStateFlow
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
@@ -88,7 +91,7 @@ class AlertNotificationBannerPresenterTest {
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(true)
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()
@@ -108,7 +111,7 @@ class AlertNotificationBannerPresenterTest {
             val alertServiceFacade = FakeAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             presenter.onAction(AlertNotificationUiAction.OnDismissAlertNotification("warn"))
 
             assertEquals("warn", alertServiceFacade.lastDismissedAlertId)
@@ -121,7 +124,7 @@ class AlertNotificationBannerPresenterTest {
             val alertServiceFacade = FakeAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()
@@ -147,7 +150,7 @@ class AlertNotificationBannerPresenterTest {
             val alertServiceFacade = FakeAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()
@@ -174,20 +177,28 @@ class AlertNotificationBannerPresenterTest {
         }
 
     @Test
-    fun `update now opens releases url`() =
+    fun `update now opens app update url`() =
         runTest(testDispatcher) {
+            val appUpdateLinker = mockk<AppUpdateLinker>()
+            every { appUpdateLinker.getUpdateUrl() } returns TEST_APP_UPDATE_URL
             val urlLauncher = mockk<UrlLauncher>(relaxed = true)
             coEvery { urlLauncher.openUrl(any()) } returns true
             val alertsFlow = MutableStateFlow(listOf(alert(id = "emergency", type = AlertType.EMERGENCY, date = 5L)))
             val alertServiceFacade = FakeAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create(urlLauncher = urlLauncher)
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter =
+                AlertNotificationBannerPresenter(
+                    mainPresenter,
+                    alertServiceFacade,
+                    appUpdateLinker,
+                )
 
             presenter.onAction(AlertNotificationUiAction.OnUpdateNow)
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { urlLauncher.openUrl(BisqLinks.BISQ_MOBILE_RELEASES) }
+            verify(exactly = 1) { appUpdateLinker.getUpdateUrl() }
+            coVerify(exactly = 1) { urlLauncher.openUrl(TEST_APP_UPDATE_URL) }
         }
 
     @Test
@@ -198,7 +209,7 @@ class AlertNotificationBannerPresenterTest {
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(false)
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()
@@ -229,7 +240,7 @@ class AlertNotificationBannerPresenterTest {
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(true)
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()
@@ -280,7 +291,7 @@ class AlertNotificationBannerPresenterTest {
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(true)
 
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertServiceFacade, FakeAppUpdateLinker())
             val uiStateProbe = probeStateFlow(presenter.uiState)
 
             advanceUntilIdle()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
@@ -33,6 +33,7 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationBannerPresenter
@@ -101,7 +102,7 @@ class AlertNotificationBannerUiTest {
             val alertFacade = MutableAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(true)
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade, FakeAppUpdateLinker())
 
             composeTestRule.setContent {
                 CompositionLocalProvider(LocalIsTest provides true) {
@@ -157,7 +158,7 @@ class AlertNotificationBannerUiTest {
             val alertFacade = MutableAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
             mainPresenter.setIsMainContentVisible(true)
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade, FakeAppUpdateLinker())
 
             composeTestRule.setContent {
                 CompositionLocalProvider(LocalIsTest provides true) {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +30,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
@@ -37,7 +39,9 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationBannerPresenter
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
@@ -45,7 +49,6 @@ import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
 import org.junit.After
 import org.junit.Before
@@ -98,6 +101,8 @@ class AlertNotificationDialogUiTest {
     @Test
     fun `update dialog renders version details and supports update plus dismiss`() =
         runTest(testDispatcher) {
+            val appUpdateLinker = mockk<AppUpdateLinker>()
+            every { appUpdateLinker.getUpdateUrl() } returns TEST_APP_UPDATE_URL
             val urlLauncher = mockk<UrlLauncher>(relaxed = true)
             coEvery { urlLauncher.openUrl(any()) } returns true
             val alertsFlow =
@@ -116,7 +121,12 @@ class AlertNotificationDialogUiTest {
                 )
             val alertFacade = MutableAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create(urlLauncher = urlLauncher)
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade)
+            val presenter =
+                AlertNotificationBannerPresenter(
+                    mainPresenter,
+                    alertFacade,
+                    appUpdateLinker,
+                )
 
             presenter.onAction(AlertNotificationUiAction.ExpandAlertNotification("update"))
 
@@ -137,7 +147,8 @@ class AlertNotificationDialogUiTest {
 
             composeTestRule.onNodeWithText("mobile.alert.update.button".i18n()).performClick()
             advanceUntilIdle()
-            coVerify(exactly = 1) { urlLauncher.openUrl(BisqLinks.BISQ_MOBILE_RELEASES) }
+            coVerify(exactly = 1) { urlLauncher.openUrl(TEST_APP_UPDATE_URL) }
+            verify(exactly = 1) { appUpdateLinker.getUpdateUrl() }
 
             composeTestRule
                 .onNode(
@@ -169,7 +180,7 @@ class AlertNotificationDialogUiTest {
                 )
             val alertFacade = MutableAlertNotificationsServiceFacade(alertsFlow)
             val mainPresenter = MainPresenterTestFactory.create()
-            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade)
+            val presenter = AlertNotificationBannerPresenter(mainPresenter, alertFacade, FakeAppUpdateLinker())
 
             presenter.onAction(AlertNotificationUiAction.ExpandAlertNotification("halt"))
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
@@ -41,6 +41,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
@@ -280,6 +281,7 @@ class OfferbookPresenterActionGuardResetTest {
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
             configServiceFacade = FakeConfigServiceFacade(),
+            appUpdateLinker = FakeAppUpdateLinker(),
         )
     }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
@@ -44,6 +44,7 @@ import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
@@ -157,6 +158,7 @@ class OfferbookPresenterFilterPersistenceTest {
                 tradeRestrictingAlertServiceFacade = mockk<TradeRestrictingAlertServiceFacade>(relaxed = true),
                 offerbookFilterConfigRepository = repository,
                 configServiceFacade = FakeConfigServiceFacade(),
+                appUpdateLinker = FakeAppUpdateLinker(),
                 computationDispatcher = testDispatcher,
             )
         presenter.onViewAttached()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -36,6 +36,7 @@ import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
@@ -170,6 +171,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                 tradeRestrictingAlertServiceFacade,
                 FakeOfferbookFilterConfigRepository(),
                 configServiceFacade = FakeConfigServiceFacade(),
+                appUpdateLinker = FakeAppUpdateLinker(),
                 computationDispatcher = testDispatcher,
             )
         offersFlow.value = allOffers
@@ -503,6 +505,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                     mockk(relaxed = true),
                     repository,
                     configServiceFacade = FakeConfigServiceFacade(),
+                    appUpdateLinker = FakeAppUpdateLinker(),
                     computationDispatcher = testDispatcher,
                 )
 
@@ -598,6 +601,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                     tradeRestrictingAlertServiceFacade,
                     FakeOfferbookFilterConfigRepository(),
                     configServiceFacade = FakeConfigServiceFacade(),
+                    appUpdateLinker = FakeAppUpdateLinker(),
                     computationDispatcher = testDispatcher,
                 )
             presenter.onViewAttached()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
@@ -43,6 +43,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
@@ -399,6 +400,7 @@ class OfferbookPresenterGuardedActionsTest {
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
             configServiceFacade = FakeConfigServiceFacade(),
+            appUpdateLinker = FakeAppUpdateLinker(),
         )
     }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
@@ -32,6 +32,7 @@ import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
@@ -176,6 +177,7 @@ class OfferbookPresenterSlowLoadingHintTest {
             tradeRestrictingAlertServiceFacade,
             offerbookFilterConfigRepository,
             configServiceFacade = FakeConfigServiceFacade(),
+            appUpdateLinker = FakeAppUpdateLinker(),
         )
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
@@ -1,10 +1,12 @@
 package network.bisq.mobile.presentation.offerbook
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,13 +27,16 @@ import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
@@ -105,13 +110,19 @@ class OfferbookPresenterTradeRestrictionTest {
         }
     }
 
-    private fun buildPresenter(activeAlert: AuthorizedAlertData? = null): OfferbookPresenter {
-        val urlLauncher = mockk<UrlLauncher>()
-        coEvery { urlLauncher.openUrl(any()) } returns true
+    private fun buildPresenter(
+        activeAlert: AuthorizedAlertData? = null,
+        urlLauncher: UrlLauncher? = null,
+        appUpdateLinker: AppUpdateLinker = FakeAppUpdateLinker(),
+    ): OfferbookPresenter {
+        val resolvedUrlLauncher =
+            urlLauncher ?: mockk<UrlLauncher>().also { launcher ->
+                coEvery { launcher.openUrl(any()) } returns true
+            }
         val mainPresenter =
             MainPresenterTestFactory.create(
                 applicationLifecycleService = TestApplicationLifecycleService(),
-                urlLauncher = urlLauncher,
+                urlLauncher = resolvedUrlLauncher,
             )
 
         val offersFlow =
@@ -158,6 +169,7 @@ class OfferbookPresenterTradeRestrictionTest {
             tradeRestrictingAlertServiceFacade,
             FakeOfferbookFilterConfigRepository(),
             configServiceFacade = FakeConfigServiceFacade(),
+            appUpdateLinker = appUpdateLinker,
         )
     }
 
@@ -210,9 +222,18 @@ class OfferbookPresenterTradeRestrictionTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `OnUpdateNow clears showTradeRestrictedDialog`() =
+    fun `OnUpdateNow clears showTradeRestrictedDialog and opens update URL`() =
         runTest(testDispatcher) {
-            val presenter = buildPresenter(activeAlert = makeAlert())
+            val appUpdateLinker = mockk<AppUpdateLinker>()
+            every { appUpdateLinker.getUpdateUrl() } returns TEST_APP_UPDATE_URL
+            val urlLauncher = mockk<UrlLauncher>()
+            coEvery { urlLauncher.openUrl(any()) } returns true
+            val presenter =
+                buildPresenter(
+                    activeAlert = makeAlert(),
+                    urlLauncher = urlLauncher,
+                    appUpdateLinker = appUpdateLinker,
+                )
 
             presenter.createOffer()
             advanceUntilIdle()
@@ -222,6 +243,8 @@ class OfferbookPresenterTradeRestrictionTest {
             advanceUntilIdle()
 
             assertNull(presenter.showTradeRestrictedDialog.value)
+            verify(exactly = 1) { appUpdateLinker.getUpdateUrl() }
+            coVerify(exactly = 1) { urlLauncher.openUrl(TEST_APP_UPDATE_URL) }
         }
 
     // -------------------------------------------------------------------------

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
@@ -78,6 +79,7 @@ class TabContainerPresenterDuplicateCallTest {
             createOfferCoordinator,
             settingsServiceFacade,
             tradeRestrictingAlertServiceFacade,
+            FakeAppUpdateLinker(),
             AnimationSettings(settingsServiceFacade, mockk(relaxed = true), applyDeviceLock = false),
         )
     }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
@@ -1,10 +1,12 @@
 package network.bisq.mobile.presentation.tabs.tab
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,11 +17,14 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
+import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
+import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
@@ -75,14 +80,19 @@ class TabContainerPresenterTradeRestrictionTest {
     // Helpers
     // -------------------------------------------------------------------------
 
-    private fun buildPresenter(activeAlert: AuthorizedAlertData? = null): TabContainerPresenter {
-        // Relaxed UrlLauncher defaults openUrl to false → cannot-open snackbar → GlobalUiManager Koin; these tests are about dialog state, not URL failure.
-        val urlLauncher = mockk<UrlLauncher>()
-        coEvery { urlLauncher.openUrl(any()) } returns true
+    private fun buildPresenter(
+        activeAlert: AuthorizedAlertData? = null,
+        urlLauncher: UrlLauncher? = null,
+        appUpdateLinker: AppUpdateLinker = FakeAppUpdateLinker(),
+    ): TabContainerPresenter {
+        val resolvedUrlLauncher =
+            urlLauncher ?: mockk<UrlLauncher>().also { launcher ->
+                coEvery { launcher.openUrl(any()) } returns true
+            }
         val mainPresenter =
             MainPresenterTestFactory.create(
                 applicationLifecycleService = TestApplicationLifecycleService(),
-                urlLauncher = urlLauncher,
+                urlLauncher = resolvedUrlLauncher,
             )
         val createOfferCoordinator = mockk<CreateOfferCoordinator>(relaxed = true)
 
@@ -98,6 +108,7 @@ class TabContainerPresenterTradeRestrictionTest {
             createOfferCoordinator = createOfferCoordinator,
             settingsServiceFacade = settingsServiceFacade,
             tradeRestrictingAlertServiceFacade = tradeRestrictingAlertServiceFacade,
+            appUpdateLinker = appUpdateLinker,
             animationSettings = AnimationSettings(settingsServiceFacade, mockk(relaxed = true), applyDeviceLock = false),
         )
     }
@@ -152,9 +163,18 @@ class TabContainerPresenterTradeRestrictionTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `OnUpdateNow clears showTradeRestrictedDialog`() =
+    fun `OnUpdateNow clears showTradeRestrictedDialog and opens update URL`() =
         runTest(testDispatcher) {
-            val presenter = buildPresenter(activeAlert = makeAlert())
+            val appUpdateLinker = mockk<AppUpdateLinker>()
+            every { appUpdateLinker.getUpdateUrl() } returns TEST_APP_UPDATE_URL
+            val urlLauncher = mockk<UrlLauncher>()
+            coEvery { urlLauncher.openUrl(any()) } returns true
+            val presenter =
+                buildPresenter(
+                    activeAlert = makeAlert(),
+                    urlLauncher = urlLauncher,
+                    appUpdateLinker = appUpdateLinker,
+                )
             presenter.createOffer()
             advanceUntilIdle()
             assertNotNull(presenter.showTradeRestrictedDialog.value)
@@ -163,6 +183,8 @@ class TabContainerPresenterTradeRestrictionTest {
             advanceUntilIdle()
 
             assertNull(presenter.showTradeRestrictedDialog.value)
+            verify(exactly = 1) { appUpdateLinker.getUpdateUrl() }
+            coVerify(exactly = 1) { urlLauncher.openUrl(TEST_APP_UPDATE_URL) }
         }
 
     // -------------------------------------------------------------------------

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -80,7 +80,7 @@ val presentationModule =
         single<GlobalUiManager> { GlobalUiManager() }
 
         factory<NetworkStatusBannerPresenter> { NetworkStatusBannerPresenter(get(), get()) }
-        factory<AlertNotificationBannerPresenter> { AlertNotificationBannerPresenter(get(), get()) }
+        factory<AlertNotificationBannerPresenter> { AlertNotificationBannerPresenter(get(), get(), get()) }
 
         factory<UserAgreementPresenter> {
             UserAgreementPresenter(
@@ -89,7 +89,7 @@ val presentationModule =
             )
         } bind IAgreementPresenter::class
 
-        factory { TabContainerPresenter(get(), get(), get(), get(), get()) } bind ITabContainerPresenter::class
+        factory { TabContainerPresenter(get(), get(), get(), get(), get(), get()) } bind ITabContainerPresenter::class
 
         factory<ReputationPresenter> { ReputationPresenter(get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenter.kt
@@ -7,15 +7,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.presentation.common.ui.alert.banner.AlertNotificationBannerUiState
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.main.MainPresenter
 
 @Stable
 class AlertNotificationBannerPresenter(
     mainPresenter: MainPresenter,
     private val alertNotificationsServiceFacade: AlertNotificationsServiceFacade,
+    private val appUpdateLinker: AppUpdateLinker,
 ) : BasePresenter(mainPresenter) {
     private val currentAlertDialogId = MutableStateFlow<String?>(null)
 
@@ -47,7 +48,7 @@ class AlertNotificationBannerPresenter(
         when (action) {
             is AlertNotificationUiAction.OnDismissAlertNotification -> dismissAlert(action.alertId)
             is AlertNotificationUiAction.ExpandAlertNotification -> expandAlert(action.alertId)
-            AlertNotificationUiAction.OnUpdateNow -> navigateToUrl(BisqLinks.BISQ_MOBILE_RELEASES)
+            AlertNotificationUiAction.OnUpdateNow -> navigateToUrl(appUpdateLinker.getUpdateUrl())
             AlertNotificationUiAction.OnCloseDialog -> currentAlertDialogId.value = null
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.presentation.common.ui.utils
 
+import network.bisq.mobile.data.utils.AppUpdateUrls
+
 object BisqLinks {
     const val BISQ_EASY_WIKI_URL = "https://bisq.wiki/Bisq_Easy"
     const val FREQUENTLY_ASKED_QUESTIONS_URL = "https://bisq.wiki/Frequently_asked_questions"
@@ -9,7 +11,7 @@ object BisqLinks {
     const val BLUE_WALLET_TUTORIAL_2_URL = "https://www.youtube.com/watch?v=imMX7i4qpmg"
     const val BISQ_MOBILE_GH = "https://github.com/bisq-network/bisq-mobile"
     const val BISQ_MOBILE_GH_ISSUES = "https://github.com/bisq-network/bisq-mobile/issues"
-    const val BISQ_MOBILE_RELEASES = "https://github.com/bisq-network/bisq-mobile/releases"
+    const val BISQ_MOBILE_RELEASES = AppUpdateUrls.GITHUB_RELEASES
     const val WEBPAGE = "https://bisq.network/"
     const val LICENSE = "https://github.com/bisq-network/bisq-mobile/blob/main/LICENSE"
     const val DAO = "https://bisq.network/dao"

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -35,6 +35,7 @@ import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.domain.formatters.AmountFormatter
 import network.bisq.mobile.domain.formatters.PriceSpecFormatter
@@ -65,6 +66,7 @@ open class OfferbookPresenter(
     private val tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
     private val offerbookFilterConfigRepository: OfferbookFilterConfigRepository,
     private val configServiceFacade: ConfigServiceFacade,
+    private val appUpdateLinker: AppUpdateLinker,
     private val computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BasePresenter(mainPresenter) {
     private val _showTradeRestrictedDialog = MutableStateFlow<AlertNotificationUiState?>(null)
@@ -866,7 +868,7 @@ open class OfferbookPresenter(
         when (action) {
             AlertNotificationUiAction.OnUpdateNow -> {
                 _showTradeRestrictedDialog.value = null
-                navigateToUrl(BisqLinks.BISQ_MOBILE_RELEASES)
+                navigateToUrl(appUpdateLinker.getUpdateUrl())
             }
             AlertNotificationUiAction.OnCloseDialog -> _showTradeRestrictedDialog.value = null
             else -> Unit

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenter.kt
@@ -5,13 +5,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.data.utils.AppUpdateLinker
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiState
 import network.bisq.mobile.presentation.common.ui.alert.toAlertNotificationUiState
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 
@@ -23,6 +23,7 @@ class TabContainerPresenter(
     private val createOfferCoordinator: CreateOfferCoordinator,
     private val settingsServiceFacade: SettingsServiceFacade,
     private val tradeRestrictingAlertServiceFacade: TradeRestrictingAlertServiceFacade,
+    private val appUpdateLinker: AppUpdateLinker,
     private val animationSettings: AnimationSettings,
 ) : BasePresenter(mainPresenter),
     ITabContainerPresenter {
@@ -64,7 +65,7 @@ class TabContainerPresenter(
         when (action) {
             AlertNotificationUiAction.OnUpdateNow -> {
                 _showTradeRestrictedDialog.value = null
-                navigateToUrl(BisqLinks.BISQ_MOBILE_RELEASES)
+                navigateToUrl(appUpdateLinker.getUpdateUrl())
             }
             AlertNotificationUiAction.OnCloseDialog -> _showTradeRestrictedDialog.value = null
             else -> Unit


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1334
 - Routes “Update now” by install source - Play (market://, HTTPS fallback), iOS install page, or GitHub releases for APK/other — instead of always opening the releases page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Update now” actions now route to a platform-appropriate destination (Google Play for Android, Bisq Connect install page for iOS) instead of a fixed link.
* **Bug Fixes**
  * Android link launching now adds a safer fallback for Play Store “market://” deep links (retry via HTTPS/details when needed).
  * Improved handling of ignored users when using cached offer data.
* **Tests**
  * Added/updated tests to verify platform-specific update-link selection and fallback navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->