### PR TITLE
Compose Multiplatform to 1.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
     name: Build & Test (No Secrets)
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        # macos-26 (Xcode 26 / iOS 26 SDK) is required for the iOS link step: Compose Multiplatform 1.11's
+        # ui-uikit references iOS 26-only UIKit symbols (e.g. UIViewLayoutRegion), so linking the iOS test
+        # binary on the older macos-14 image (Xcode 15/16) fails with "Undefined symbols for architecture arm64".
+        os: [ubuntu-latest, macos-26]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -194,7 +197,7 @@ jobs:
         # cinterop bindings reference symbols from the Sentry Cocoa SDK.
         # Without a real `pod install`, the K/N linker fails the iOS test
         # binaries with `ld: framework 'Sentry' not found`. `podInstall`
-        # is a superset of `generateDummyFramework`; macos-14 runners have
+        # is a superset of `generateDummyFramework`; macos-26 runners have
         # CocoaPods preinstalled, so no extra setup is required.
         if: startsWith(matrix.os, 'macos')
         run: ./gradlew :apps:clientApp:podInstall

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacadeTest.kt
@@ -92,6 +92,7 @@ class ClientApplicationBootstrapFacadeTest {
                 kmpTorService,
                 sessionService,
                 connectivityService,
+                testDispatcher,
             )
     }
 
@@ -175,12 +176,8 @@ class ClientApplicationBootstrapFacadeTest {
                 )
 
             facade.onTorStartedOrSkipped()
-            // onTorStartedOrSkipped uses Dispatchers.Default — advanceUntilIdle() won't drive it.
-            val deadline = System.currentTimeMillis() + 2_000L
-            while (settingsFlow.value.sessionId != "new-session-id") {
-                check(System.currentTimeMillis() < deadline) { "Timed out waiting for session renewal" }
-                Thread.sleep(5)
-            }
+            // onTorStartedOrSkipped now runs on the injected testDispatcher, so advanceUntilIdle() drives it.
+            advanceUntilIdle()
 
             assertEquals("new-session-id", settingsFlow.value.sessionId)
             assertEquals(expiresAt, settingsFlow.value.sessionExpiresAt)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/MoneroAccountDetailContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/MoneroAccountDetailContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/OtherCryptoAssetAccountDetailContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/OtherCryptoAssetAccountDetailContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/RevolutAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/RevolutAccountDetailContentTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.client.common.test_utils.TestApplication

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/UserDefinedAccountDetailContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/UserDefinedAccountDetailContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/WiseAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/WiseAccountDetailContentTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.client.common.test_utils.TestApplication

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/ZelleAccountDetailContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/ZelleAccountDetailContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailContentTest.kt
@@ -50,10 +50,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class CashDepositAccountDetailContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
     private lateinit var koinApplication: KoinApplication
 
@@ -104,7 +104,6 @@ class CashDepositAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails())
 
         setTestContent()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Cash Deposit").assertIsDisplayed()
@@ -126,7 +125,6 @@ class CashDepositAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.failure(RuntimeException("boom"))
 
         setTestContent()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("mobile.action.retry".i18n()).assertIsDisplayed()
@@ -149,7 +147,6 @@ class CashDepositAccountDetailContentTest {
                 chargebackRisk = null,
             ),
         )
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onAllNodesWithText("Account owner ID").assertCountEquals(0)
@@ -165,7 +162,6 @@ class CashDepositAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails())
 
         setTestContent(sampleAccount(chargebackRisk = FiatPaymentMethodChargebackRisk.MODERATE))
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail.cas
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/common/AccountDetailDetailsSectionUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/common/AccountDetailDetailsSectionUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/common/AccountDetailFieldRowUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/common/AccountDetailFieldRowUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail.com
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailContentTest.kt
@@ -50,10 +50,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class SameBankAccountDetailContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
     private lateinit var koinApplication: KoinApplication
 
@@ -104,7 +104,6 @@ class SameBankAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails())
 
         setTestContent()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Same Bank").assertIsDisplayed()
@@ -124,7 +123,6 @@ class SameBankAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.failure(RuntimeException("boom"))
 
         setTestContent()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("mobile.action.retry".i18n()).assertIsDisplayed()
@@ -148,7 +146,6 @@ class SameBankAccountDetailContentTest {
                 chargebackRisk = null,
             ),
         )
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onAllNodesWithText("paymentAccounts.holderName".i18n()).assertCountEquals(0)
@@ -165,7 +162,6 @@ class SameBankAccountDetailContentTest {
         coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails())
 
         setTestContent(sampleAccount(chargebackRisk = FiatPaymentMethodChargebackRisk.MODERATE))
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail.sam
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/crypto/SelectCryptoPaymentMethodContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/crypto/SelectCryptoPaymentMethodContentUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/fiat/SelectFiatPaymentMethodContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/fiat/SelectFiatPaymentMethodContentUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/PaymentAccountFormScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/PaymentAccountFormScreenTest.kt
@@ -65,10 +65,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class PaymentAccountFormScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
     private lateinit var koinApplication: KoinApplication
     private lateinit var viewModelStore: ViewModelStore

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/PaymentAccountFormScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/PaymentAccountFormScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormContentTest.kt
@@ -51,10 +51,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class AchTransferFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormContentTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormContentTest.kt
@@ -55,10 +55,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class BankAccountFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
     private lateinit var mainPresenter: MainPresenter
 
@@ -268,7 +268,6 @@ class BankAccountFormContentTest {
     private fun selectUnitedStates() {
         composeTestRule.onNodeWithText("paymentAccounts.createAccount.accountData.country.prompt".i18n()).performClick()
         composeTestRule.onNodeWithText("United States").performClick()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
     }
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormContentTest.kt
@@ -57,10 +57,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class CashDepositFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
     private lateinit var mainPresenter: MainPresenter
 
@@ -156,7 +156,6 @@ class CashDepositFormContentTest {
         setTestContent()
         composeTestRule.onNodeWithText("paymentAccounts.createAccount.accountData.country.prompt".i18n()).performClick()
         composeTestRule.onNodeWithText("United States").performClick()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("paymentAccounts.currency".i18n()).assertIsDisplayed()
@@ -179,7 +178,6 @@ class CashDepositFormContentTest {
         setTestContent()
         composeTestRule.onNodeWithText("paymentAccounts.createAccount.accountData.country.prompt".i18n()).performClick()
         composeTestRule.onNodeWithText("United States").performClick()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("mobile.error.title".i18n()).assertIsDisplayed()
@@ -280,7 +278,6 @@ class CashDepositFormContentTest {
     private fun selectUnitedStates() {
         composeTestRule.onNodeWithText("paymentAccounts.createAccount.accountData.country.prompt".i18n()).performClick()
         composeTestRule.onNodeWithText("United States").performClick()
-        testDispatcher.scheduler.advanceUntilIdle()
         composeTestRule.waitForIdle()
     }
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/crypto/CommonCryptoFormSectionUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/crypto/CommonCryptoFormSectionUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormContentTest.kt
@@ -49,10 +49,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class MoneroFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormContentTest.kt
@@ -49,10 +49,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class OtherCryptoFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormContentTest.kt
@@ -51,10 +51,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class RevolutFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormContentTest.kt
@@ -51,10 +51,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class WiseFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormContentTest.kt
@@ -48,10 +48,10 @@ import kotlin.test.assertNotNull
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ZelleFormContentTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var mainPresenter: MainPresenter
 
     @Before

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/ui/PaymentMethodBackgroundInformationDialogUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/ui/PaymentMethodBackgroundInformationDialogUiTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewScreenTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -72,10 +72,10 @@ import kotlin.test.assertTrue
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class PaymentAccountReviewScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
     private lateinit var globalUiManager: GlobalUiManager
     private lateinit var mainPresenter: MainPresenter

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailContentUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/PaymentAccountsMusigContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/PaymentAccountsMusigContentUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/CryptoPaymentAccountCardUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/CryptoPaymentAccountCardUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/FiatPaymentAccountCardUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/FiatPaymentAccountCardUiTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashScreenTest.kt
@@ -41,10 +41,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
 class ClientSplashScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
     private lateinit var presenter: ClientSplashPresenter
     private lateinit var clientUiState: MutableStateFlow<ClientSplashUiState>
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashScreenTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashScreenTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.client.splash
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupContentUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupContentUiTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/components/SubscriptionsFailedDialogFactoryTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/components/SubscriptionsFailedDialogFactoryTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.client.trusted_node_setup.components
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/bootstrap/ClientApplicationBootstrapFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.bootstrap
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -29,6 +30,11 @@ class ClientApplicationBootstrapFacade(
     kmpTorService: KmpTorService,
     private val sessionService: SessionService,
     private val connectivityService: ConnectivityService,
+    // Dispatcher for the auth/session-resolution work kicked off after Tor is up. Injectable so tests
+    // can pin it to their test scheduler; defaults to Dispatchers.Default in production. Keeping it off
+    // the test scheduler is what made ClientApplicationBootstrapFacadeTest flaky (escaped coroutines
+    // outliving runTest).
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ApplicationBootstrapFacade(kmpTorService) {
     private companion object {
         // How long the completed "Load data" step (✓ / "Ready") is held on screen before navigating,
@@ -82,7 +88,7 @@ class ClientApplicationBootstrapFacade(
 
     fun onTorStartedOrSkipped() {
         onInitialized()
-        serviceScope.launch(Dispatchers.Default) {
+        serviceScope.launch(defaultDispatcher) {
             val currentSettings = sensitiveSettingsRepository.fetch()
 
             val clientAuthState: ClientAuthState =

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/connections/NodeNetworkConnectionsContentTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/connections/NodeNetworkConnectionsContentTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.node.network.presentation.connections
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/my_node/NetworkMyNodeContentTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/my_node/NetworkMyNodeContentTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.node.network.presentation.my_node
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/network/NetworkContentTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/network/NetworkContentTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.node.network.presentation.network
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/docs/testing/catalog.md
+++ b/docs/testing/catalog.md
@@ -15,7 +15,7 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `ClientKoinIntegrationTestBase` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/ClientKoinIntegrationTestBase.kt` | Client facades/services |
 | `NodeKoinIntegrationTestBase` | `apps/nodeApp/src/androidUnitTest/kotlin/.../test_utils/NodeKoinIntegrationTestBase.kt` | Node presenters/facades |
 | `BisqComposeUiTestBase` | `.../test_utils/compose/BisqComposeUiTestBase.kt` | Compose UI, no Koin |
-| `PresentationKoinComposeTestBase` | `.../test_utils/compose/PresentationKoinComposeTestBase.kt` | Compose + `presentationTestModule` |
+| `PresentationKoinComposeTestBase` | `.../test_utils/compose/PresentationKoinComposeTestBase.kt` | Compose + `presentationTestModule` (shared `StandardTestDispatcher`) |
 | `PlatformPresentationKoinComposeTestBase` | `.../test_utils/compose/PlatformPresentationKoinComposeTestBase.kt` | Compose + Koin + platform mocks |
 | `AlertNotificationKoinComposeTestBase` | `.../test_utils/compose/AlertNotificationKoinComposeTestBase.kt` | Alert UI — dedicated Koin module |
 

--- a/docs/testing/recipes.md
+++ b/docs/testing/recipes.md
@@ -91,7 +91,7 @@ class MyScreenUiTest : PresentationKoinComposeTestBase() {
 
 ### Client + TestApplication
 
-Base: `BisqComposeUiTestBase` with Robolectric `@Config(application = TestApplication::class)`. Do **not** call `startKoin` / `createComposeRule` yourself — the leaf base owns Compose setup; `TestApplication.onCreate()` owns Koin. Proof: `PaymentAccountMethodIconUiTest`.
+Base: `BisqComposeUiTestBase` with Robolectric `@Config(application = TestApplication::class)`. Do **not** call `startKoin` / `createComposeRule` yourself — the leaf base owns Compose UI Test v2 setup (`junit4.v2.createComposeRule`); `TestApplication.onCreate()` owns Koin. Proof: `PaymentAccountMethodIconUiTest`.
 
 ```kotlin
 @Config(application = TestApplication::class)
@@ -105,7 +105,7 @@ class MyClientContentUiTest : BisqComposeUiTestBase() {
 }
 ```
 
-Pitfalls: no double `startKoin`; never combine `TestApplication` with `PresentationKoinComposeTestBase` / `ClientKoinIntegrationTestBase`; use `waitForIdle()` not `advanceUntilIdle()` in Compose+Koin tests; use `.i18n()` for localized strings.
+Pitfalls: no double `startKoin`; never combine `TestApplication` with `PresentationKoinComposeTestBase` / `ClientKoinIntegrationTestBase`; use Compose UI Test v2 (`androidx.compose.ui.test.junit4.v2.createComposeRule`) — leaf bases already do; if a test owns both `Dispatchers.setMain(testDispatcher)` and a local compose rule, pass `createComposeRule(effectContext = testDispatcher)` so composition and Main share one scheduler; use `waitForIdle()` not `advanceUntilIdle()` in Compose+Koin tests; use `.i18n()` for localized strings.
 
 ---
 

--- a/docs/testing/recipes.md
+++ b/docs/testing/recipes.md
@@ -49,7 +49,7 @@ Pitfalls: no `startKoin` in test class; no `ClientKoinIntegrationTestBase` for `
 | Presentation + Koin | `PresentationKoinComposeTestBase` / `PlatformPresentationKoinComposeTestBase` |
 | Client + `TestApplication` | `BisqComposeUiTestBase` + `@Config(application = TestApplication::class)` — Koin from Application |
 
-Always set content via `setBisqTestContent` / `setTestContent` (`LocalIsTest` + `BisqTheme`). Proof: `SwitchUiTest`, `LinkButtonUiTest`, `PaymentAccountMethodIconUiTest` (client + `TestApplication`).
+Always set content via `setBisqTestContent` / `setTestContent` (`LocalIsTest` + `BisqTheme`). Leaf-base `setTestContent` calls `waitForIdle()` after set — still `waitForIdle()` after interactions. Proof: `SwitchUiTest`, `LinkButtonUiTest`, `PaymentAccountMethodIconUiTest` (client + `TestApplication`).
 
 ### No Koin
 
@@ -99,13 +99,12 @@ class MyClientContentUiTest : BisqComposeUiTestBase() {
     @Test
     fun `when card renders then shows account name`() {
         setTestContent { MyClientCard(account = sampleAccount()) } // VERIFY
-        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Account A").assertIsDisplayed()
     }
 }
 ```
 
-Pitfalls: no double `startKoin`; never combine `TestApplication` with `PresentationKoinComposeTestBase` / `ClientKoinIntegrationTestBase`; use Compose UI Test v2 (`androidx.compose.ui.test.junit4.v2.createComposeRule`) — leaf bases already do; if a test owns both `Dispatchers.setMain(testDispatcher)` and a local compose rule, pass `createComposeRule(effectContext = testDispatcher)` so composition and Main share one scheduler; use `waitForIdle()` not `advanceUntilIdle()` in Compose+Koin tests; use `.i18n()` for localized strings.
+Pitfalls: no double `startKoin`; never combine `TestApplication` with `PresentationKoinComposeTestBase` / `ClientKoinIntegrationTestBase`; use Compose UI Test v2 (`androidx.compose.ui.test.junit4.v2.createComposeRule`) — leaf bases already do; if a test owns both `Dispatchers.setMain(testDispatcher)` and a local compose rule, pass `createComposeRule(effectContext = testDispatcher)` so composition and Main share one scheduler; leaf-base `setTestContent` already idles — still `waitForIdle()` after clicks/actions; prefer that over `advanceUntilIdle()` in Compose+Koin tests; use `.i18n()` for localized strings.
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 atomicfu = "0.31.0"
-compose-plugin = "1.10.3"
+compose-plugin = "1.11.1"
 ksp = "2.3.9"
 kover = "0.9.7"
 
@@ -49,7 +49,7 @@ kotlinx-coroutines-play-services = "1.10.2"
 # -------------------- AndroidX --------------------
 androidx-core = "1.16.0"
 androidx-activity-compose = "1.13.0"
-androidx-lifecycle = "2.10.0"
+androidx-lifecycle = "2.11.0-beta01"
 androidx-multidex = "2.0.1"
 androidx-core-splashscreen = "1.0.1"
 androidx-navigation-compose = "2.9.2"
@@ -59,7 +59,7 @@ androidx-paging = "3.5.0-rc01"
 
 # -------------------- UI / Compose --------------------
 material-icons-extended =  "1.7.3"
-compose-material3 = "1.10.0-alpha05"
+compose-material3 = "1.11.0-alpha07"
 coil-compose = "3.4.0"
 
 # -------------------- Multiplatform Libraries --------------------
@@ -77,7 +77,7 @@ sentry-kotlin-multiplatform = "0.26.0"
 # -------------------- Testing --------------------
 androidx-test = "1.7.0"
 androidx-test-junit = "1.3.0"
-androidx-test-compose = "1.9.0"
+androidx-test-compose = "1.11.2"
 androidx-test-espresso = "3.7.0"
 robolectric = "4.16"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
-distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/BisqComposeUiTestBase.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/BisqComposeUiTestBase.kt
@@ -21,5 +21,6 @@ abstract class BisqComposeUiTestBase {
 
     protected fun setTestContent(content: @Composable () -> Unit) {
         composeTestRule.setBisqTestContent(content)
+        composeTestRule.waitForIdle()
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/BisqComposeUiTestBase.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/BisqComposeUiTestBase.kt
@@ -1,7 +1,7 @@
 package network.bisq.mobile.presentation.common.test_utils.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeTestSupport.setBisqTestContent

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/PresentationKoinComposeTestBase.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/PresentationKoinComposeTestBase.kt
@@ -1,13 +1,13 @@
 package network.bisq.mobile.presentation.common.test_utils.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeTestSupport.setBisqTestContent
 import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
@@ -22,16 +22,17 @@ import org.koin.core.module.Module
  * [presentationTestModule]. Subclass [PlatformPresentationKoinComposeTestBase] when static
  * platform APIs must be mocked (e.g. [network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp]).
  *
- * Uses [UnconfinedTestDispatcher] so coroutines run eagerly; compose tests pump via
- * [composeTestRule.waitForIdle] rather than [kotlinx.coroutines.test.advanceUntilIdle].
+ * Uses Compose UI Test v2 ([createComposeRule] with [StandardTestDispatcher]) so composition
+ * effects share [testDispatcher] with Koin/Main. Pump the UI via [composeTestRule.waitForIdle]
+ * rather than [kotlinx.coroutines.test.advanceUntilIdle].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 abstract class PresentationKoinComposeTestBase : PresentationKoinTestBase() {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    override val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
-    override val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
 
     override fun onSetup() {
         I18nSupport.setLanguage()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/PresentationKoinComposeTestBase.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/compose/PresentationKoinComposeTestBase.kt
@@ -23,8 +23,9 @@ import org.koin.core.module.Module
  * platform APIs must be mocked (e.g. [network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp]).
  *
  * Uses Compose UI Test v2 ([createComposeRule] with [StandardTestDispatcher]) so composition
- * effects share [testDispatcher] with Koin/Main. Pump the UI via [composeTestRule.waitForIdle]
- * rather than [kotlinx.coroutines.test.advanceUntilIdle].
+ * effects share [testDispatcher] with Koin/Main. [setTestContent] pumps via
+ * [composeTestRule.waitForIdle] after set; call [composeTestRule.waitForIdle] again after
+ * interactions. Prefer that over [kotlinx.coroutines.test.advanceUntilIdle].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -48,6 +49,7 @@ abstract class PresentationKoinComposeTestBase : PresentationKoinTestBase() {
 
     protected fun setTestContent(content: @Composable () -> Unit) {
         composeTestRule.setBisqTestContent(content)
+        composeTestRule.waitForIdle()
     }
 
     /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
@@ -55,10 +55,10 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class AlertNotificationBannerUiTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
 
     @Before
     fun setUp() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
@@ -64,10 +64,10 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class AlertNotificationDialogUiTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
 
     @Before
     fun setUp() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ActionGuardScreenBindingUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ActionGuardScreenBindingUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLockTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/InitialScreenInteractionLockTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSectionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/ListStateSectionUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUiSmokeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextUiSmokeTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.common.ui.components.atoms
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSliderUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/slider/BisqRangeSliderUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.atoms.slider
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/context/LocalExternalUrlOpenerMissingUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/context/LocalExternalUrlOpenerMissingUiTest.kt
@@ -1,7 +1,7 @@
 package network.bisq.mobile.presentation.common.ui.components.context
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import org.junit.Rule

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRowUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/IconTextRowUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.molecules
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import bisqapps.shared.presentation.generated.resources.Res

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/MessageDeliveryInfoAndroidUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/MessageDeliveryInfoAndroidUiTest.kt
@@ -1,7 +1,7 @@
 package network.bisq.mobile.presentation.common.ui.components.molecules.chat
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.data.replicated.network.confidential.ack.MessageDeliveryInfoVO

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterFieldUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/inputfield/SearchWithFilterFieldUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.molecules.inputfie
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.i18n.I18nSupport

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/theme/BisqThemePreviewExternalUrlOpenerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/theme/BisqThemePreviewExternalUrlOpenerUiTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.i18n.I18nSupport

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
@@ -80,10 +80,10 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class OfferbookScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val composeTestRule = createComposeRule(effectContext = testDispatcher)
 
     @Before
     fun setUp() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsScreenWrapperUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsScreenWrapperUiTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.settings.payment_accounts
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.settings.reputation
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationWebLinkDialogUiTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsContentUiTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreenWrapperUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/settings/SettingsScreenWrapperUiTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.settings.settings
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashDialogsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/splash/SplashDialogsTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.startup.splash
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/welcome_carousel/WelcomeCarouselContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/welcome_carousel/WelcomeCarouselContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.tabs.dashboard.welcome_carousel
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/welcome_carousel/WelcomeCarouselWrapperUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/welcome_carousel/WelcomeCarouselWrapperUiTest.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.presentation.tabs.dashboard.welcome_carousel
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.tabs.more
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderContentUiTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4ContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/states/common/State4ContentUiTest.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.trade.trade_detail.states.common
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1584

 - Bump Compose Multiplatform to 1.11.1 with the CMP 1.11 companion chain:
   - compose-material3 1.11.0-alpha07.
   - androidx-lifecycle 2.11.0-beta01.
   - androidx-test-compose 1.11.2.
   - material-icons-extended stays at 1.7.3 (still the upstream pin)
 - Migrate Compose UI tests to junit4.v2.createComposeRule, sharing StandardTestDispatcher with Main via effectContext. This addresses the compose-ui-test / behavioral failures.

Tested Create profile, Create offer, Take offer, Trade flows (partially) in androidNode, androidClient and iosClient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated Compose UI test setup to Compose UI Test v2 (`createComposeRule` v2) across client and node suites.
  * Standardized UI/coroutine synchronization by wiring the rule to the test dispatcher and using `waitForIdle()` instead of manual scheduler advancement in updated tests.
* **Documentation**
  * Updated Compose UI testing guides to reflect v2 ownership and preferred `waitForIdle()` usage, plus clarified dispatcher expectations.
* **Chores**
  * Bumped UI/testing library versions, refreshed the Gradle wrapper, and adjusted CI to use the newer macOS runner for iOS link steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->