### PR TITLE
Downsample CatHash bitmap layers during decode

### DIFF
--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -174,9 +174,8 @@ actual class PlatformImage(
 ) {
     actual companion object {
         actual fun deserialize(data: ByteArray): PlatformImage {
-            val decodeOptions = BitmapFactory.Options()
             val bitmap =
-                BitmapFactory.decodeByteArray(data, 0, data.size, decodeOptions)
+                BitmapFactory.decodeByteArray(data, 0, data.size)
                     ?: throw IllegalArgumentException("Failed to decode image data")
             return PlatformImage(bitmap.asImageBitmap())
         }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -174,8 +174,9 @@ actual class PlatformImage(
 ) {
     actual companion object {
         actual fun deserialize(data: ByteArray): PlatformImage {
+            val decodeOptions = BitmapFactory.Options()
             val bitmap =
-                BitmapFactory.decodeByteArray(data, 0, data.size)
+                BitmapFactory.decodeByteArray(data, 0, data.size, decodeOptions)
                     ?: throw IllegalArgumentException("Failed to decode image data")
             return PlatformImage(bitmap.asImageBitmap())
         }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtil.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtil.kt
@@ -157,42 +157,4 @@ object AndroidImageUtil : Logging {
         val decodeOptions = BitmapFactory.Options()
         return BitmapFactory.decodeByteArray(data, 0, data.size, decodeOptions)
     }
-
-    fun bitmapToPngByteArray(bitmap: Bitmap): ByteArray {
-        val outputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-        return outputStream.toByteArray()
-    }
-
-    fun decodePngToImageBitmap(pngByteArray: ByteArray): Bitmap {
-        val decodeOptions = BitmapFactory.Options()
-        return BitmapFactory.decodeByteArray(pngByteArray, 0, pngByteArray.size, decodeOptions)
-    }
-
-    fun saveByteArrayAsPng(
-        data: ByteArray,
-        file: File,
-    ) {
-        val bitmap = byteArrayToBitmap(data)
-        if (bitmap != null) {
-            saveBitmapAsPng(bitmap, file)
-        }
-    }
-
-    fun saveBitmapAsPng(
-        bitmap: Bitmap,
-        file: File,
-    ) {
-        FileOutputStream(file).use { fos ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
-        }
-    }
-
-    fun readPngByteArray(file: File): ByteArray? =
-        try {
-            file.readBytes()
-        } catch (e: IOException) {
-            log.e("Reading $file failed", e)
-            null
-        }
 }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtil.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtil.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
 import network.bisq.mobile.domain.utils.Logging
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -42,7 +41,7 @@ object AndroidImageUtil : Logging {
             }
 
         paths.forEach { path ->
-            val bitmap = getImageByPath(context, basePath, path)
+            val bitmap = getImageByPath(context, basePath, path, width, height)
             if (bitmap != null) {
                 // Only scale if necessary to avoid unnecessary operations
                 val scaledBitmap =
@@ -87,15 +86,62 @@ object AndroidImageUtil : Logging {
         }
     }
 
+    internal fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+        reqHeight: Int,
+    ): Int {
+        // Guards the loop below: with a non-positive requested size its condition never fails, so
+        // inSampleSize doubles until it overflows to 0 and the following division throws.
+        if (reqWidth <= 0 || reqHeight <= 0) {
+            return 1
+        }
+
+        val height = options.outHeight
+        val width = options.outWidth
+        if (height <= 0 || width <= 0) {
+            return 1
+        }
+
+        var inSampleSize = 1
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight = height / 2
+            val halfWidth = width / 2
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
+
     internal fun getImageByPath(
         context: Context,
         basePath: String,
         path: String,
+        reqWidth: Int,
+        reqHeight: Int,
     ): Bitmap? =
         try {
             val fullPath = basePath + path
-            val inputStream = context.assets.open(fullPath)
-            BitmapFactory.decodeStream(inputStream)
+            // Bounds-then-sampled decode per
+            // https://developer.android.com/topic/performance/graphics/load-bitmap.
+            // The asset is opened twice because the bounds pass consumes the stream; unlike the
+            // decodeResource form in that guide, a stream cannot be replayed for the second decode.
+            val boundsOptions =
+                BitmapFactory.Options().apply {
+                    inJustDecodeBounds = true
+                }
+            context.assets.open(fullPath).use { inputStream ->
+                BitmapFactory.decodeStream(inputStream, null, boundsOptions)
+            }
+
+            val decodeOptions =
+                BitmapFactory.Options().apply {
+                    inSampleSize = calculateInSampleSize(boundsOptions, reqWidth, reqHeight)
+                }
+            context.assets.open(fullPath).use { inputStream ->
+                BitmapFactory.decodeStream(inputStream, null, decodeOptions)
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             null
@@ -108,8 +154,8 @@ object AndroidImageUtil : Logging {
     }
 
     fun byteArrayToBitmap(data: ByteArray): Bitmap? {
-        val inputStream = ByteArrayInputStream(data)
-        return BitmapFactory.decodeStream(inputStream)
+        val decodeOptions = BitmapFactory.Options()
+        return BitmapFactory.decodeByteArray(data, 0, data.size, decodeOptions)
     }
 
     fun bitmapToPngByteArray(bitmap: Bitmap): ByteArray {
@@ -118,7 +164,10 @@ object AndroidImageUtil : Logging {
         return outputStream.toByteArray()
     }
 
-    fun decodePngToImageBitmap(pngByteArray: ByteArray): Bitmap = BitmapFactory.decodeByteArray(pngByteArray, 0, pngByteArray.size)
+    fun decodePngToImageBitmap(pngByteArray: ByteArray): Bitmap {
+        val decodeOptions = BitmapFactory.Options()
+        return BitmapFactory.decodeByteArray(pngByteArray, 0, pngByteArray.size, decodeOptions)
+    }
 
     fun saveByteArrayAsPng(
         data: ByteArray,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtilTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/utils/AndroidImageUtilTest.kt
@@ -2,6 +2,9 @@ package network.bisq.mobile.presentation.common.ui.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -25,24 +28,134 @@ class AndroidImageUtilTest {
     @Test
     fun `test getImageByPath valid path`() {
         val assetPath = "bisq_logo.png"
-        val bitmap = AndroidImageUtil.getImageByPath(context, AndroidImageUtil.PATH_TO_DRAWABLE, assetPath)
+        val bitmap =
+            AndroidImageUtil.getImageByPath(
+                context,
+                AndroidImageUtil.PATH_TO_DRAWABLE,
+                assetPath,
+                reqWidth = 0,
+                reqHeight = 0,
+            )
         assertNotNull("Image should be loaded", bitmap)
     }
 
     @Test
     fun `test getImageByPath invalid path`() {
         val bitmap =
-            AndroidImageUtil.getImageByPath(context, AndroidImageUtil.PATH_TO_DRAWABLE, "non_existing_image.png")
+            AndroidImageUtil.getImageByPath(
+                context,
+                AndroidImageUtil.PATH_TO_DRAWABLE,
+                "non_existing_image.png",
+                reqWidth = 100,
+                reqHeight = 100,
+            )
         assertNull("Image should be null for an invalid path", bitmap)
     }
 
     @Test
-    fun `test composeImage from multiple paths`() {
-        val paths = arrayOf("images/sample_image.png", "images/sample_overlay.png")
+    fun `getImageByPath downsamples 300px cathash layer to 150px when requesting 120px`() {
+        val bitmap =
+            AndroidImageUtil.getImageByPath(
+                context,
+                AndroidImageUtil.PATH_TO_FILES,
+                "cathash/nose/01.png",
+                reqWidth = 120,
+                reqHeight = 120,
+            )
+
+        assertNotNull("Cathash layer should load", bitmap)
+        assertEquals(150, bitmap!!.width)
+        assertEquals(150, bitmap.height)
+    }
+
+    @Test
+    fun `getImageByPath decodes full 300px cathash layer when requesting 300px`() {
+        val bitmap =
+            AndroidImageUtil.getImageByPath(
+                context,
+                AndroidImageUtil.PATH_TO_FILES,
+                "cathash/nose/01.png",
+                reqWidth = 300,
+                reqHeight = 300,
+            )
+
+        assertNotNull("Cathash layer should load", bitmap)
+        assertEquals(300, bitmap!!.width)
+        assertEquals(300, bitmap.height)
+    }
+
+    @Test
+    fun `test composeImage from multiple cathash layers`() {
+        val paths = arrayOf("cathash/nose/01.png", "cathash/eyes/12.png")
         val composedBitmap =
-            AndroidImageUtil.composeImage(context, AndroidImageUtil.PATH_TO_DRAWABLE, paths, 200, 200)
-        assertEquals("Composed image width should be 200", 200, composedBitmap.width)
-        assertEquals("Composed image height should be 200", 200, composedBitmap.height)
+            AndroidImageUtil.composeImage(
+                context,
+                AndroidImageUtil.PATH_TO_FILES,
+                paths,
+                120,
+                120,
+            )
+        assertEquals(120, composedBitmap.width)
+        assertEquals(120, composedBitmap.height)
+        assertTrue("Composed image should contain drawn pixels", composedBitmap.hasNonTransparentPixels())
+    }
+
+    @Test
+    fun `test composeImage cathash layer at 120px`() {
+        val paths = arrayOf("cathash/bg/bg_0/11.png")
+        val composedBitmap =
+            AndroidImageUtil.composeImage(
+                context,
+                AndroidImageUtil.PATH_TO_FILES,
+                paths,
+                120,
+                120,
+            )
+        assertEquals(120, composedBitmap.width)
+        assertEquals(120, composedBitmap.height)
+        assertTrue("Composed image should contain drawn pixels", composedBitmap.hasNonTransparentPixels())
+    }
+
+    @Test
+    fun `calculateInSampleSize returns 2 when downsampling 300 to 120`() {
+        val options =
+            BitmapFactory.Options().apply {
+                outWidth = 300
+                outHeight = 300
+            }
+        assertEquals(2, AndroidImageUtil.calculateInSampleSize(options, 120, 120))
+    }
+
+    @Test
+    fun `calculateInSampleSize returns 1 when target matches source size`() {
+        val options =
+            BitmapFactory.Options().apply {
+                outWidth = 300
+                outHeight = 300
+            }
+        assertEquals(1, AndroidImageUtil.calculateInSampleSize(options, 300, 300))
+    }
+
+    @Test
+    fun `calculateInSampleSize returns 4 when downsampling 300 to 50`() {
+        val options =
+            BitmapFactory.Options().apply {
+                outWidth = 300
+                outHeight = 300
+            }
+        assertEquals(4, AndroidImageUtil.calculateInSampleSize(options, 50, 50))
+    }
+
+    @Test
+    fun `calculateInSampleSize returns 1 for invalid or zero request size`() {
+        val options =
+            BitmapFactory.Options().apply {
+                outWidth = 300
+                outHeight = 300
+            }
+        assertEquals(1, AndroidImageUtil.calculateInSampleSize(options, 0, 120))
+        assertEquals(1, AndroidImageUtil.calculateInSampleSize(options, 120, 0))
+        assertEquals(1, AndroidImageUtil.calculateInSampleSize(options, -1, -1))
     }
 
     @Test
@@ -74,5 +187,12 @@ class AndroidImageUtilTest {
 
         // Cleanup
         testFile.delete()
+    }
+
+    private fun ImageBitmap.hasNonTransparentPixels(): Boolean {
+        val bitmap = asAndroidBitmap()
+        val pixels = IntArray(bitmap.width * bitmap.height)
+        bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+        return pixels.any { pixel -> pixel ushr 24 != 0 }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1578

- Subsample CatHash PNG layers during decode via `BitmapFactory.Options.inSampleSize` (300→150 at 120px target)
- Two-pass decode follows [Android’s load-bitmap guide](https://developer.android.com/topic/performance/graphics/load-bitmap): bounds pass with inJustDecodeBounds, then calculateInSampleSize() (power-of-two), then decode with inSampleSize set
- Pass `Options` on every CatHash-related `BitmapFactory.decode*` — compose, cache read, and `PlatformImage.deserialize` — to satisfy GP’s static check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved image loading by decoding assets closer to their requested display size.
  * Reduced unnecessary memory usage when displaying smaller images.
  * Enhanced image composition to maintain correct dimensions and visible content across different sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->