### PR TITLE
chore/bisqeasy_trade_model_inmutability

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -346,15 +346,16 @@ class ClientTradesServiceFacade(
         data: TradePropertiesDto,
     ) {
         log.i { "Apply mutable data to trade with ID $tradeId - new state: ${data.tradeState}" }
+        val tradeModel = trade.bisqEasyTradeModel
         data.tradeState?.let {
-            log.i { "Updating trade $tradeId state from ${trade.bisqEasyTradeModel.tradeState.value} to $it" }
-            trade.bisqEasyTradeModel.tradeState.value = it
+            log.i { "Updating trade $tradeId state from ${tradeModel.tradeState.value} to $it" }
+            tradeModel.setTradeState(it)
         }
-        data.tradeCompletedDate?.let { trade.bisqEasyTradeModel.tradeCompletedDate.value = it }
-        data.paymentAccountData?.let { trade.bisqEasyTradeModel.paymentAccountData.value = it }
-        data.bitcoinPaymentData?.let { trade.bisqEasyTradeModel.bitcoinPaymentData.value = it }
-        data.paymentProof?.let { trade.bisqEasyTradeModel.paymentProof.value = it }
-        data.interruptTradeInitiator?.let { trade.bisqEasyTradeModel.interruptTradeInitiator.value = it }
+        data.tradeCompletedDate?.let { tradeModel.setTradeCompletedDate(it) }
+        data.paymentAccountData?.let { tradeModel.setPaymentAccountData(it) }
+        data.bitcoinPaymentData?.let { tradeModel.setBitcoinPaymentData(it) }
+        data.paymentProof?.let { tradeModel.setPaymentProof(it) }
+        data.interruptTradeInitiator?.let { tradeModel.setInterruptTradeInitiator(it) }
     }
 
     private fun findOpenTradeItemModel(tradeId: String): TradeItemPresentationModel? {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/mapping/Mappings.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/mapping/Mappings.kt
@@ -1165,24 +1165,13 @@ class Mappings {
     }
 
     object BisqEasyTradeModelMapping {
+        // The mutable trade fields are seeded from the DTO in the BisqEasyTradeModel constructor
+        // (BisqEasyTradeVOMapping already maps them from the bisq2 model), so no post-construction
+        // initialization is needed here. Live updates are wired via observers in NodeTradesServiceFacade.
         fun fromBisq2Model(value: BisqEasyTrade): BisqEasyTradeModel =
             BisqEasyTradeModel(
                 BisqEasyTradeVOMapping.fromBisq2Model(value),
-            ).apply {
-                // We set initial values if mutable data
-                // We update the data with observers
-                tradeState.value = BisqEasyTradeStateMapping.fromBisq2Model(value.tradeState)
-                interruptTradeInitiator.value =
-                    value.interruptTradeInitiator.get()?.let { RoleMapping.fromBisq2Model(it) }
-                paymentAccountData.value = value.paymentAccountData.get()
-                bitcoinPaymentData.value = value.bitcoinPaymentData.get()
-                paymentProof.value = value.paymentProof.get()
-                errorMessage.value = value.errorMessage
-                errorStackTrace.value = value.errorStackTrace
-                peersErrorMessage.value = value.peersErrorMessage
-                peersErrorStackTrace.value = value.peersErrorStackTrace
-                tradeCompletedDate.value = value.tradeCompletedDate.orElse(null)
-            }
+            )
     }
 
     object BisqEasyTradePartyVOMapping {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -741,24 +741,25 @@ class NodeTradesServiceFacade(
         pins +=
             trade.tradeStateObservable().addObserver { tradeState ->
                 val mappedState = Mappings.BisqEasyTradeStateMapping.fromBisq2Model(tradeState)
-                openTradeItem.bisqEasyTradeModel.tradeState.value = mappedState
-                openTradeItem.bisqEasyTradeModel.tradeCompletedDate.value = trade.tradeCompletedDate.orElse(null)
+                openTradeItem.bisqEasyTradeModel.setTradeState(mappedState)
+                openTradeItem.bisqEasyTradeModel.setTradeCompletedDate(trade.tradeCompletedDate.orElse(null))
                 if (mappedState.isFinalState) {
                     _openTradeItems.update { list -> list.filter { it.tradeId != trade.id } }
                     bumpClosedTradesTick()
                 }
             }
+        val tradeModel = openTradeItem.bisqEasyTradeModel
         pins +=
-            trade.interruptTradeInitiator.bindNonNullTo(openTradeItem.bisqEasyTradeModel.interruptTradeInitiator) {
-                Mappings.RoleMapping.fromBisq2Model(it)
+            trade.interruptTradeInitiator.bindNonNullTo({ Mappings.RoleMapping.fromBisq2Model(it) }) {
+                tradeModel.setInterruptTradeInitiator(it)
             }
-        pins += trade.paymentAccountData.bindNonNullTo(openTradeItem.bisqEasyTradeModel.paymentAccountData)
-        pins += trade.bitcoinPaymentData.bindNonNullTo(openTradeItem.bisqEasyTradeModel.bitcoinPaymentData)
-        pins += trade.paymentProof.bindNonNullTo(openTradeItem.bisqEasyTradeModel.paymentProof)
-        pins += trade.errorMessageObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.errorMessage)
-        pins += trade.errorStackTraceObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.errorStackTrace)
-        pins += trade.peersErrorMessageObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.peersErrorMessage)
-        pins += trade.peersErrorStackTraceObservable().bindNonNullTo(openTradeItem.bisqEasyTradeModel.peersErrorStackTrace)
+        pins += trade.paymentAccountData.bindNonNullTo(tradeModel::setPaymentAccountData)
+        pins += trade.bitcoinPaymentData.bindNonNullTo(tradeModel::setBitcoinPaymentData)
+        pins += trade.paymentProof.bindNonNullTo(tradeModel::setPaymentProof)
+        pins += trade.errorMessageObservable().bindNonNullTo(tradeModel::setErrorMessage)
+        pins += trade.errorStackTraceObservable().bindNonNullTo(tradeModel::setErrorStackTrace)
+        pins += trade.peersErrorMessageObservable().bindNonNullTo(tradeModel::setPeersErrorMessage)
+        pins += trade.peersErrorStackTraceObservable().bindNonNullTo(tradeModel::setPeersErrorStackTrace)
 
         pins +=
             channel.isInMediationObservable().addObserver { isInMediation ->

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensions.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensions.kt
@@ -41,3 +41,33 @@ fun <B : Any, D> ReadOnlyObservable<B>.bindNonNullTo(
             target.value = map(value)
         }
     }
+
+/**
+ * Like [bindTo] but pushes each value into [set] instead of a [MutableStateFlow].
+ *
+ * Use this to bridge into a model that only exposes read-only state plus explicit
+ * setters (e.g. `BisqEasyTradeModel`), keeping the backing flow encapsulated.
+ */
+fun <T> ReadOnlyObservable<T>.bindTo(set: (T) -> Unit): Pin =
+    addObserver { value ->
+        set(value)
+    }
+
+/** Like [bindNonNullTo] but pushes each non-null value into [set]. */
+fun <T : Any> ReadOnlyObservable<T>.bindNonNullTo(set: (T) -> Unit): Pin =
+    addObserver { value ->
+        if (value != null) {
+            set(value)
+        }
+    }
+
+/** Like [bindNonNullTo] with map but pushes each transformed non-null value into [set]. */
+fun <B : Any, D> ReadOnlyObservable<B>.bindNonNullTo(
+    map: (B) -> D,
+    set: (D) -> Unit,
+): Pin =
+    addObserver { value ->
+        if (value != null) {
+            set(map(value))
+        }
+    }

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensionsTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/ObservableExtensionsTest.kt
@@ -69,4 +69,48 @@ class ObservableExtensionsTest {
         observable.set(8)
         assertEquals("v7", target.value, "unbound pin must stop propagation")
     }
+
+    @Test
+    fun `bindTo with setter pushes current value at subscription and follows updates`() {
+        val observable = Observable("a")
+        val received = mutableListOf<String>()
+
+        val pin = observable.bindTo { received += it }
+
+        assertEquals(listOf("a"), received)
+        observable.set("b")
+        assertEquals(listOf("a", "b"), received)
+
+        pin.unbind()
+        observable.set("c")
+        assertEquals(listOf("a", "b"), received, "unbound pin must stop propagation")
+    }
+
+    @Test
+    fun `bindNonNullTo with setter ignores null current value at subscription`() {
+        val observable = Observable<String>()
+        val received = mutableListOf<String>()
+
+        observable.bindNonNullTo { received += it }
+
+        assertEquals(emptyList(), received)
+        observable.set("a")
+        assertEquals(listOf("a"), received)
+    }
+
+    @Test
+    fun `bindNonNullTo with map and setter ignores nulls and transforms values`() {
+        val observable = Observable<Int>()
+        val received = mutableListOf<String>()
+
+        val pin = observable.bindNonNullTo({ "v$it" }) { received += it }
+
+        assertEquals(emptyList(), received)
+        observable.set(7)
+        assertEquals(listOf("v7"), received)
+
+        pin.unbind()
+        observable.set(8)
+        assertEquals(listOf("v7"), received, "unbound pin must stop propagation")
+    }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/replicated/trade/bisq_easy/BisqEasyTradeModelTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/replicated/trade/bisq_easy/BisqEasyTradeModelTest.kt
@@ -1,0 +1,110 @@
+package network.bisq.mobile.data.replicated.trade.bisq_easy
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.replicated.contract.RoleEnum
+import network.bisq.mobile.data.replicated.trade.TradeRoleEnum
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class BisqEasyTradeModelTest {
+    private fun model(
+        tradeState: BisqEasyTradeStateEnum = BisqEasyTradeStateEnum.INIT,
+        interruptTradeInitiator: RoleEnum? = null,
+        paymentAccountData: String? = null,
+        bitcoinPaymentData: String? = null,
+        paymentProof: String? = null,
+        errorMessage: String? = null,
+        errorStackTrace: String? = null,
+        peersErrorMessage: String? = null,
+        peersErrorStackTrace: String? = null,
+        tradeCompletedDate: Long? = null,
+    ): BisqEasyTradeModel {
+        val dto = mockk<BisqEasyTradeDto>(relaxed = true)
+        every { dto.tradeRole } returns TradeRoleEnum.BUYER_AS_TAKER
+        every { dto.tradeState } returns tradeState
+        every { dto.interruptTradeInitiator } returns interruptTradeInitiator
+        every { dto.paymentAccountData } returns paymentAccountData
+        every { dto.bitcoinPaymentData } returns bitcoinPaymentData
+        every { dto.paymentProof } returns paymentProof
+        every { dto.errorMessage } returns errorMessage
+        every { dto.errorStackTrace } returns errorStackTrace
+        every { dto.peersErrorMessage } returns peersErrorMessage
+        every { dto.peersErrorStackTrace } returns peersErrorStackTrace
+        every { dto.tradeCompletedDate } returns tradeCompletedDate
+        return BisqEasyTradeModel(dto)
+    }
+
+    @Test
+    fun `mutable trade state is not exposed as MutableStateFlow`() {
+        val model = model()
+        assertFalse(model.tradeState is MutableStateFlow<*>, "tradeState must be read-only")
+        assertFalse(model.interruptTradeInitiator is MutableStateFlow<*>, "interruptTradeInitiator must be read-only")
+        assertFalse(model.paymentAccountData is MutableStateFlow<*>, "paymentAccountData must be read-only")
+        assertFalse(model.bitcoinPaymentData is MutableStateFlow<*>, "bitcoinPaymentData must be read-only")
+        assertFalse(model.paymentProof is MutableStateFlow<*>, "paymentProof must be read-only")
+        assertFalse(model.errorMessage is MutableStateFlow<*>, "errorMessage must be read-only")
+        assertFalse(model.errorStackTrace is MutableStateFlow<*>, "errorStackTrace must be read-only")
+        assertFalse(model.peersErrorMessage is MutableStateFlow<*>, "peersErrorMessage must be read-only")
+        assertFalse(model.peersErrorStackTrace is MutableStateFlow<*>, "peersErrorStackTrace must be read-only")
+        assertFalse(model.tradeCompletedDate is MutableStateFlow<*>, "tradeCompletedDate must be read-only")
+    }
+
+    @Test
+    fun `initial values are seeded from the dto`() {
+        val model =
+            model(
+                tradeState = BisqEasyTradeStateEnum.TAKER_SENT_TAKE_OFFER_REQUEST,
+                interruptTradeInitiator = RoleEnum.MAKER,
+                paymentAccountData = "account",
+                bitcoinPaymentData = "bc1qaddr",
+                paymentProof = "txid",
+                errorMessage = "err",
+                errorStackTrace = "trace",
+                peersErrorMessage = "peer-err",
+                peersErrorStackTrace = "peer-trace",
+                tradeCompletedDate = 42L,
+            )
+
+        assertEquals(BisqEasyTradeStateEnum.TAKER_SENT_TAKE_OFFER_REQUEST, model.tradeState.value)
+        assertEquals(RoleEnum.MAKER, model.interruptTradeInitiator.value)
+        assertEquals("account", model.paymentAccountData.value)
+        assertEquals("bc1qaddr", model.bitcoinPaymentData.value)
+        assertEquals("txid", model.paymentProof.value)
+        assertEquals("err", model.errorMessage.value)
+        assertEquals("trace", model.errorStackTrace.value)
+        assertEquals("peer-err", model.peersErrorMessage.value)
+        assertEquals("peer-trace", model.peersErrorStackTrace.value)
+        assertEquals(42L, model.tradeCompletedDate.value)
+    }
+
+    @Test
+    fun `setters update the exposed state`() {
+        val model = model()
+
+        model.setTradeState(BisqEasyTradeStateEnum.BTC_CONFIRMED)
+        model.setInterruptTradeInitiator(RoleEnum.TAKER)
+        model.setPaymentAccountData("account")
+        model.setBitcoinPaymentData("bc1qaddr")
+        model.setPaymentProof("txid")
+        model.setErrorMessage("err")
+        model.setErrorStackTrace("trace")
+        model.setPeersErrorMessage("peer-err")
+        model.setPeersErrorStackTrace("peer-trace")
+        model.setTradeCompletedDate(99L)
+
+        assertEquals(BisqEasyTradeStateEnum.BTC_CONFIRMED, model.tradeState.value)
+        assertEquals(RoleEnum.TAKER, model.interruptTradeInitiator.value)
+        assertEquals("account", model.paymentAccountData.value)
+        assertEquals("bc1qaddr", model.bitcoinPaymentData.value)
+        assertEquals("txid", model.paymentProof.value)
+        assertEquals("err", model.errorMessage.value)
+        assertEquals("trace", model.errorStackTrace.value)
+        assertEquals("peer-err", model.peersErrorMessage.value)
+        assertEquals("peer-trace", model.peersErrorStackTrace.value)
+        assertEquals(99L, model.tradeCompletedDate.value)
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/trade/bisq_easy/BisqEasyTradeModel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/trade/bisq_easy/BisqEasyTradeModel.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.data.replicated.trade.bisq_easy
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.data.replicated.contract.BisqEasyContractVO
 import network.bisq.mobile.data.replicated.contract.RoleEnum
 import network.bisq.mobile.data.replicated.identity.IdentityVO
@@ -57,21 +59,80 @@ class BisqEasyTradeModel(
             return id.substring(0, 8)
         }
 
-    // MutableStateFlow
-    val tradeState: MutableStateFlow<BisqEasyTradeStateEnum> = MutableStateFlow(bisqEasyTradeDto.tradeState)
+    // Mutable trade data. Backed by private MutableStateFlow and exposed as read-only StateFlow;
+    // updates go through the setters below so state can only be mutated via the owning model.
+    // Kept as per-field flows (rather than a single snapshot) to preserve fine-grained observation:
+    // a consumer watching only tradeState is not notified when e.g. errorStackTrace changes.
+    private val _tradeState: MutableStateFlow<BisqEasyTradeStateEnum> = MutableStateFlow(bisqEasyTradeDto.tradeState)
+    val tradeState: StateFlow<BisqEasyTradeStateEnum> = _tradeState.asStateFlow()
 
     // The role who cancelled or rejected the trade
-    val interruptTradeInitiator: MutableStateFlow<RoleEnum?> = MutableStateFlow(bisqEasyTradeDto.interruptTradeInitiator)
-    val paymentAccountData: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.paymentAccountData)
+    private val _interruptTradeInitiator: MutableStateFlow<RoleEnum?> = MutableStateFlow(bisqEasyTradeDto.interruptTradeInitiator)
+    val interruptTradeInitiator: StateFlow<RoleEnum?> = _interruptTradeInitiator.asStateFlow()
+
+    private val _paymentAccountData: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.paymentAccountData)
+    val paymentAccountData: StateFlow<String?> = _paymentAccountData.asStateFlow()
 
     // btc address in case of mainChain, or LN invoice if LN is used
-    val bitcoinPaymentData: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.bitcoinPaymentData)
+    private val _bitcoinPaymentData: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.bitcoinPaymentData)
+    val bitcoinPaymentData: StateFlow<String?> = _bitcoinPaymentData.asStateFlow()
 
     // txId in case of mainChain, or preimage if LN is used
-    val paymentProof: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.paymentProof)
-    val errorMessage: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.errorMessage)
-    val errorStackTrace: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.errorStackTrace)
-    val peersErrorMessage: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.peersErrorMessage)
-    val peersErrorStackTrace: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.peersErrorStackTrace)
-    val tradeCompletedDate: MutableStateFlow<Long?> = MutableStateFlow(bisqEasyTradeDto.tradeCompletedDate)
+    private val _paymentProof: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.paymentProof)
+    val paymentProof: StateFlow<String?> = _paymentProof.asStateFlow()
+
+    private val _errorMessage: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.errorMessage)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    private val _errorStackTrace: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.errorStackTrace)
+    val errorStackTrace: StateFlow<String?> = _errorStackTrace.asStateFlow()
+
+    private val _peersErrorMessage: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.peersErrorMessage)
+    val peersErrorMessage: StateFlow<String?> = _peersErrorMessage.asStateFlow()
+
+    private val _peersErrorStackTrace: MutableStateFlow<String?> = MutableStateFlow(bisqEasyTradeDto.peersErrorStackTrace)
+    val peersErrorStackTrace: StateFlow<String?> = _peersErrorStackTrace.asStateFlow()
+
+    private val _tradeCompletedDate: MutableStateFlow<Long?> = MutableStateFlow(bisqEasyTradeDto.tradeCompletedDate)
+    val tradeCompletedDate: StateFlow<Long?> = _tradeCompletedDate.asStateFlow()
+
+    fun setTradeState(value: BisqEasyTradeStateEnum) {
+        _tradeState.value = value
+    }
+
+    fun setInterruptTradeInitiator(value: RoleEnum?) {
+        _interruptTradeInitiator.value = value
+    }
+
+    fun setPaymentAccountData(value: String?) {
+        _paymentAccountData.value = value
+    }
+
+    fun setBitcoinPaymentData(value: String?) {
+        _bitcoinPaymentData.value = value
+    }
+
+    fun setPaymentProof(value: String?) {
+        _paymentProof.value = value
+    }
+
+    fun setErrorMessage(value: String?) {
+        _errorMessage.value = value
+    }
+
+    fun setErrorStackTrace(value: String?) {
+        _errorStackTrace.value = value
+    }
+
+    fun setPeersErrorMessage(value: String?) {
+        _peersErrorMessage.value = value
+    }
+
+    fun setPeersErrorStackTrace(value: String?) {
+        _peersErrorStackTrace.value = value
+    }
+
+    fun setTradeCompletedDate(value: Long?) {
+        _tradeCompletedDate.value = value
+    }
 }


### PR DESCRIPTION
 - resolves #1560 
 - made BisqEasyTradeModel immutable
 - applied necessary changes in usages
 - added AI generated tests to ensure behaviour is kept

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trade information updates are now handled more consistently, helping keep displayed status, payment details, errors, and completion information synchronized.
  * Observable trade data is protected from unintended external modification while remaining responsive to updates.
  * Added support for connecting observable values to update callbacks, including optional value mapping.

* **Tests**
  * Expanded coverage for observable updates, trade model initialization, read-only state exposure, and setter-driven changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->