### PR TITLE
feature/connect_pair_to_trusted_node_security_hardening

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.android.kt
@@ -1,0 +1,34 @@
+package network.bisq.mobile.client.common.presentation.ui.security
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Adds `FLAG_SECURE` to the host window while this Composable is in the composition and
+ * clears it on dispose. `FLAG_SECURE` makes the OS treat the window as secure: screenshots
+ * and screen recordings are blocked and the Recents/app-switcher thumbnail is blanked.
+ */
+@Composable
+actual fun SecureScreenEffect() {
+    val context = LocalContext.current
+    DisposableEffect(context) {
+        val window = context.findActivity()?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+}
+
+/** Unwraps the host [Activity] from a (possibly wrapped) Compose [Context]. */
+private tailrec fun Context.findActivity(): Activity? =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.android.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.common.presentation.ui.security
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.view.Window
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -12,17 +13,54 @@ import androidx.compose.ui.platform.LocalContext
  * Adds `FLAG_SECURE` to the host window while this Composable is in the composition and
  * clears it on dispose. `FLAG_SECURE` makes the OS treat the window as secure: screenshots
  * and screen recordings are blocked and the Recents/app-switcher thumbnail is blanked.
+ *
+ * Ownership is reference-counted per window (see [SecureFlagOwnership]) so that when several
+ * secure screens share a window the flag is cleared only when the last one leaves — and a
+ * window that was already secured by the host is never touched.
  */
 @Composable
 actual fun SecureScreenEffect() {
     val context = LocalContext.current
     DisposableEffect(context) {
         val window = context.findActivity()?.window
-        window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        window?.let { SecureFlagOwnership.acquire(it) }
         onDispose {
-            window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            window?.let { SecureFlagOwnership.release(it) }
         }
     }
+}
+
+/**
+ * Reference-counts `FLAG_SECURE` ownership per [Window]. All access happens on the Compose
+ * main thread (effects run during composition/decomposition), so a plain map needs no locking.
+ *
+ * A window that already carries `FLAG_SECURE` when the first effect acquires it is treated as
+ * host-owned: we never take ownership and never clear it, so a host-set flag survives our
+ * lifecycle.
+ */
+private object SecureFlagOwnership {
+    private val ownedCounts = HashMap<Window, Int>()
+
+    fun acquire(window: Window) {
+        val count = ownedCounts[window] ?: 0
+        if (count == 0) {
+            if (window.isSecure()) return // host already secured it — do not take ownership
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        ownedCounts[window] = count + 1
+    }
+
+    fun release(window: Window) {
+        val count = ownedCounts[window] ?: return // not owned by us (host-owned or never acquired)
+        if (count <= 1) {
+            ownedCounts.remove(window)
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            ownedCounts[window] = count - 1
+        }
+    }
+
+    private fun Window.isSecure(): Boolean = attributes.flags and WindowManager.LayoutParams.FLAG_SECURE != 0
 }
 
 /** Unwraps the host [Activity] from a (possibly wrapped) Compose [Context]. */

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffectTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffectTest.kt
@@ -1,0 +1,57 @@
+package network.bisq.mobile.client.common.presentation.ui.security
+
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.client.common.test_utils.TestApplication
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies the Android [SecureScreenEffect] toggles `FLAG_SECURE` on the host window in step
+ * with the composition lifecycle, so the pairing screen is protected only while it is shown.
+ */
+@Config(application = TestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class SecureScreenEffectTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun isWindowSecure(): Boolean {
+        val flags = composeTestRule.activity.window.attributes.flags
+        return flags and WindowManager.LayoutParams.FLAG_SECURE != 0
+    }
+
+    @Test
+    fun `when secure screen is shown then window is flagged secure`() {
+        composeTestRule.setContent { SecureScreenEffect() }
+        composeTestRule.waitForIdle()
+
+        assertTrue("FLAG_SECURE should be set while the secure screen is shown", isWindowSecure())
+    }
+
+    @Test
+    fun `when secure screen leaves composition then secure flag is cleared`() {
+        var showSecureScreen by mutableStateOf(true)
+        composeTestRule.setContent {
+            if (showSecureScreen) {
+                SecureScreenEffect()
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertTrue("precondition: window secure while shown", isWindowSecure())
+
+        showSecureScreen = false
+        composeTestRule.waitForIdle()
+
+        assertFalse("FLAG_SECURE should be cleared once the secure screen is gone", isWindowSecure())
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffectTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffectTest.kt
@@ -54,4 +54,46 @@ class SecureScreenEffectTest {
 
         assertFalse("FLAG_SECURE should be cleared once the secure screen is gone", isWindowSecure())
     }
+
+    @Test
+    fun `when two concurrent effects share a window then flag stays until the last one leaves`() {
+        var showFirst by mutableStateOf(true)
+        var showSecond by mutableStateOf(true)
+        composeTestRule.setContent {
+            if (showFirst) SecureScreenEffect()
+            if (showSecond) SecureScreenEffect()
+        }
+        composeTestRule.waitForIdle()
+        assertTrue("precondition: window secure while both shown", isWindowSecure())
+
+        // First owner leaves — the second still needs the flag.
+        showFirst = false
+        composeTestRule.waitForIdle()
+        assertTrue("FLAG_SECURE must remain while another owner is active", isWindowSecure())
+
+        // Last owner leaves — now it may be cleared.
+        showSecond = false
+        composeTestRule.waitForIdle()
+        assertFalse("FLAG_SECURE should be cleared only after the last owner leaves", isWindowSecure())
+    }
+
+    @Test
+    fun `when window is already secured by host then effect preserves the flag on dispose`() {
+        // Host secures the window before any secure screen is shown.
+        composeTestRule.activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+        var showSecureScreen by mutableStateOf(true)
+        composeTestRule.setContent {
+            if (showSecureScreen) {
+                SecureScreenEffect()
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertTrue("precondition: window secure", isWindowSecure())
+
+        showSecureScreen = false
+        composeTestRule.waitForIdle()
+
+        assertTrue("host-owned FLAG_SECURE must survive the effect's lifecycle", isWindowSecure())
+    }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.kt
@@ -1,0 +1,21 @@
+package network.bisq.mobile.client.common.presentation.ui.security
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Marks the enclosing screen as security-sensitive so the OS does not leak its
+ * contents through screenshots, screen recordings, or the app-switcher / Recents
+ * thumbnail.
+ *
+ * Place this at the top of any Composable that renders secrets (e.g. the trusted-node
+ * pairing screen, whose pairing code embeds the Tor client-auth secret, TLS fingerprint
+ * and node URLs). The protection is scoped to the screen: it is applied while the
+ * Composable is in the composition and removed when it leaves, so the rest of the app
+ * keeps normal screenshot behaviour.
+ *
+ * - Android: sets `WindowManager.LayoutParams.FLAG_SECURE` on the host window.
+ * - iOS: covers the window with a blur while the app is inactive/backgrounded so the
+ *   snapshot captured for the app switcher does not expose the content.
+ */
+@Composable
+expect fun SecureScreenEffect()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.kt
@@ -3,19 +3,22 @@ package network.bisq.mobile.client.common.presentation.ui.security
 import androidx.compose.runtime.Composable
 
 /**
- * Marks the enclosing screen as security-sensitive so the OS does not leak its
- * contents through screenshots, screen recordings, or the app-switcher / Recents
- * thumbnail.
+ * Marks the enclosing screen as security-sensitive. The strength of the protection differs
+ * per platform: Android blocks screenshots and screen recording and blanks the app-switcher /
+ * Recents thumbnail; iOS only obscures the app-switcher snapshot and is not equivalent to
+ * Android's `FLAG_SECURE` (it does not block screenshots or screen recording).
  *
  * Place this at the top of any Composable that renders secrets (e.g. the trusted-node
  * pairing screen, whose pairing code embeds the Tor client-auth secret, TLS fingerprint
  * and node URLs). The protection is scoped to the screen: it is applied while the
  * Composable is in the composition and removed when it leaves, so the rest of the app
- * keeps normal screenshot behaviour.
+ * keeps normal behaviour.
  *
- * - Android: sets `WindowManager.LayoutParams.FLAG_SECURE` on the host window.
- * - iOS: covers the window with a blur while the app is inactive/backgrounded so the
- *   snapshot captured for the app switcher does not expose the content.
+ * - Android: sets `WindowManager.LayoutParams.FLAG_SECURE` on the host window — screenshots
+ *   and screen recording are blocked and the Recents thumbnail is blanked.
+ * - iOS: covers the window with a blur only during resign-active / background transitions, so
+ *   the snapshot captured for the app switcher does not expose the content. Screenshots and
+ *   screen recording while the app is active are not prevented.
  */
 @Composable
 expect fun SecureScreenEffect()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.client.common.presentation.ui.security.SecureScreenEffect
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.client.trusted_node_setup.components.SubscriptionsFailedDialog
 import network.bisq.mobile.client.trusted_node_setup.components.SubscriptionsFailedDialogUiState
@@ -62,6 +63,11 @@ fun TrustedNodeSetupScreen(
 ) {
     val presenter: TrustedNodeSetupPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
+
+    // The pairing code shown here embeds the Tor client-auth secret, TLS fingerprint and
+    // node URLs, and the API URL is shown in full. Block screenshots / Recents-thumbnail
+    // leaks while this screen (onboarding pairing and Settings "pair with new node") is shown.
+    SecureScreenEffect()
 
     LaunchedEffect(isWorkflow, showConnectionFailed, showKeystoreError, showSubscriptionsFailed) {
         presenter.initialize(isWorkflow, showConnectionFailed, showKeystoreError, showSubscriptionsFailed)

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/presentation/ui/security/SecureScreenEffect.ios.kt
@@ -1,0 +1,72 @@
+package network.bisq.mobile.client.common.presentation.ui.security
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.interop.LocalUIViewController
+import platform.Foundation.NSNotificationCenter
+import platform.UIKit.NSLayoutConstraint
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
+import platform.UIKit.UIApplicationWillResignActiveNotification
+import platform.UIKit.UIBlurEffect
+import platform.UIKit.UIBlurEffectStyle
+import platform.UIKit.UIVisualEffectView
+
+/**
+ * iOS has no `FLAG_SECURE` equivalent, so instead of trying to block screenshots we protect
+ * the one leak that happens without any user action: the snapshot iOS takes for the app
+ * switcher when the app resigns active. While this Composable is shown we cover the window
+ * with a blur on `willResignActive` and remove it on `didBecomeActive`, so the app-switcher
+ * thumbnail does not expose the on-screen secrets. Observers are removed on dispose.
+ */
+@Composable
+actual fun SecureScreenEffect() {
+    val viewController = LocalUIViewController.current
+
+    DisposableEffect(viewController) {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+        var coverView: UIVisualEffectView? = null
+
+        fun addCover() {
+            if (coverView != null) return
+            val window = viewController.view.window ?: return
+            val blur = UIBlurEffect.effectWithStyle(UIBlurEffectStyle.UIBlurEffectStyleRegular)
+            val effectView = UIVisualEffectView(effect = blur)
+            effectView.translatesAutoresizingMaskIntoConstraints = false
+            window.addSubview(effectView)
+            NSLayoutConstraint.activateConstraints(
+                listOf(
+                    effectView.topAnchor.constraintEqualToAnchor(window.topAnchor),
+                    effectView.bottomAnchor.constraintEqualToAnchor(window.bottomAnchor),
+                    effectView.leadingAnchor.constraintEqualToAnchor(window.leadingAnchor),
+                    effectView.trailingAnchor.constraintEqualToAnchor(window.trailingAnchor),
+                ),
+            )
+            coverView = effectView
+        }
+
+        fun removeCover() {
+            coverView?.removeFromSuperview()
+            coverView = null
+        }
+
+        val resignObserver =
+            notificationCenter.addObserverForName(
+                name = UIApplicationWillResignActiveNotification,
+                `object` = null,
+                queue = null,
+            ) { addCover() }
+
+        val becomeActiveObserver =
+            notificationCenter.addObserverForName(
+                name = UIApplicationDidBecomeActiveNotification,
+                `object` = null,
+                queue = null,
+            ) { removeCover() }
+
+        onDispose {
+            notificationCenter.removeObserver(resignObserver)
+            notificationCenter.removeObserver(becomeActiveObserver)
+            removeCover()
+        }
+    }
+}


### PR DESCRIPTION
### iOS 

<img width="340" height="750" alt="Screenshot 2026-07-28 at 17 25 20" src="https://github.com/user-attachments/assets/56acda5f-daa3-4f93-adc4-aedfff24fa95" />
<img width="312" height="773" alt="Screenshot 2026-07-28 at 17 25 28" src="https://github.com/user-attachments/assets/cbff933a-4fc5-489d-b180-16204555434d" />

### Android

<img width="304" height="656" alt="Screenshot 2026-07-28 at 17 32 37" src="https://github.com/user-attachments/assets/fabf2934-66fa-4b23-b3d1-21c154625256" />
<img width="292" height="650" alt="Screenshot 2026-07-28 at 17 33 04" src="https://github.com/user-attachments/assets/b85710d6-401e-4454-a2b2-b598e495bc13" />
<img width="295" height="663" alt="Screenshot 2026-07-28 at 17 32 46" src="https://github.com/user-attachments/assets/3e316512-985f-45c6-8daa-98577b437671" />


 - resolves #1643
 - maked the pairing screen as security-sensitive for each OS and provide implementations for Android and iOS (prevents leaks like screenshots, app switch sneeks, recorders, etc)
 - made it a reusable composable for future use when MuSig comes in
 - added AI generated tests based on changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection for sensitive trusted-node setup content.
  * Android prevents screenshots, screen recordings, and sensitive recent-app previews.
  * iOS displays a blur overlay when the app moves to the background, protecting app-switcher previews.

* **Tests**
  * Added coverage verifying security protection is enabled and cleared with the screen’s lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->