### PR TITLE
fix(android): disable platform backup, add audited data extraction rules

### DIFF
--- a/apps/clientApp/src/androidMain/AndroidManifest.xml
+++ b/apps/clientApp/src/androidMain/AndroidManifest.xml
@@ -17,7 +17,9 @@
 
     <application
         android:name="network.bisq.mobile.client.main.ClientMainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/apps/clientApp/src/androidMain/res/xml/backup_rules.xml
+++ b/apps/clientApp/src/androidMain/res/xml/backup_rules.xml
@@ -18,8 +18,11 @@
   None of it is safe or useful to back up. Recovery on a new device is done by
   re-pairing with the trusted node, which owns the profile and keys.
 
-  Note: android:allowBackup="false" in the manifest already blocks this path.
-  These rules are the second layer, in case that attribute is ever relaxed.
+  Note: on this API range android:allowBackup="false" does block Auto Backup,
+  `adb backup` and D2D, so these rules are a second layer in case that
+  attribute is ever relaxed. That is specific to API 24-30 - from API 31 the
+  attribute no longer opts out of device-to-device transfer, which is why
+  data_extraction_rules.xml carries a load-bearing <device-transfer> section.
 -->
 <full-backup-content>
     <exclude domain="root" path="." />

--- a/apps/clientApp/src/androidMain/res/xml/backup_rules.xml
+++ b/apps/clientApp/src/androidMain/res/xml/backup_rules.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy backup rules for Android 11 and lower (API 24-30).
+
+  Needed because clientApp minSdk is 24: android:dataExtractionRules is only
+  honoured from API 31, so without this file API 24-30 devices would fall back
+  to "back up everything". That window is also the one where `adb backup` can
+  pull the whole sandbox off a USB-debuggable device without root, and where
+  Auto Backup archives are not guaranteed to be encrypted with the device
+  secret - i.e. exactly the devices where a leak would be worst.
+
+  This must mirror the <cloud-backup> section of res/xml/data_extraction_rules.xml.
+  The full per-file audit and the reasoning for the deny-all policy live in that
+  file; it is not duplicated here so the two cannot drift apart.
+
+  Summary: the sandbox holds trusted-node bearer credentials, trade metadata,
+  Tor state and Keystore-sealed blobs that cannot be decrypted after a restore.
+  None of it is safe or useful to back up. Recovery on a new device is done by
+  re-pairing with the trusted node, which owns the profile and keys.
+
+  Note: android:allowBackup="false" in the manifest already blocks this path.
+  These rules are the second layer, in case that attribute is ever relaxed.
+-->
+<full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="device_root" path="." />
+    <exclude domain="device_file" path="." />
+    <exclude domain="device_database" path="." />
+    <exclude domain="device_sharedpref" path="." />
+</full-backup-content>

--- a/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -7,10 +7,19 @@
   POLICY: nothing leaves the device through the platform backup pipeline.
   ============================================================================
 
-  The manifest also sets android:allowBackup="false", which already blocks
-  cloud backup, D2D transfer and `adb backup`. These rules are kept as a second
-  layer: if allowBackup is ever flipped back to true (directly, or by a library
-  manifest merge), the excludes below still hold, and they document the audit.
+  The manifest also sets android:allowBackup="false", but that attribute alone
+  is NOT sufficient here. On Android 12+ it disables cloud backup (and, on
+  API 24-30, `adb backup`) yet does not disable device-to-device transfer -
+  many OEM D2D implementations migrate the app regardless. See
+  https://developer.android.com/identity/data/autobackup.
+
+  So the two sections below are not decoration:
+    - <cloud-backup>   is a second layer behind allowBackup, and stays correct
+                       if that attribute is ever flipped back to true directly
+                       or by a library manifest merge.
+    - <device-transfer> is the ONLY control that governs D2D on API 31+. It is
+                       load-bearing. Do not remove it on the assumption that
+                       allowBackup="false" covers it.
 
   Two independent reasons drive the deny-all stance:
 
@@ -128,11 +137,14 @@
     </cloud-backup>
 
     <!--
-      Device-to-device transfer. Local and encrypted, so materially safer than
-      the cloud - but still nothing to gain here: the pairing credentials are
-      Keystore-sealed and cannot be transferred, and without them every other
-      file is either stale device state or a cache. The supported migration
-      path is to re-pair with the trusted node on the new device.
+      Device-to-device transfer. This section is the only thing that opts the
+      app out of D2D on API 31+ - android:allowBackup="false" does not.
+
+      D2D is local and encrypted, so materially safer than the cloud, but there
+      is still nothing to gain: the pairing credentials are Keystore-sealed and
+      cannot be transferred, and without them every other file is either stale
+      device state or a cache. The supported migration path is to re-pair with
+      the trusted node on the new device.
     -->
     <device-transfer>
         <exclude domain="root" path="." />

--- a/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Backup / device-transfer policy for the Bisq client app (Android 12+, API 31+).
+  API 24-30 is governed by res/xml/backup_rules.xml instead - keep both in sync.
+
+  ============================================================================
+  POLICY: nothing leaves the device through the platform backup pipeline.
+  ============================================================================
+
+  The manifest also sets android:allowBackup="false", which already blocks
+  cloud backup, D2D transfer and `adb backup`. These rules are kept as a second
+  layer: if allowBackup is ever flipped back to true (directly, or by a library
+  manifest merge), the excludes below still hold, and they document the audit.
+
+  Two independent reasons drive the deny-all stance:
+
+  1. CONFIDENTIALITY. This app stores trusted-node bearer credentials, trade
+     metadata and Tor state. Auto Backup uploads to the user's Google Drive.
+     End-to-end encryption with the device secret is only guaranteed on
+     Android 9+ *with a screen lock configured*; minSdk here is 24, so a
+     meaningful share of installs would upload data that Google can decrypt.
+     Bisq exists so that no third party holds your trading identity - routing
+     it through a cloud provider contradicts the product's threat model.
+
+  2. CORRECTNESS. The two most valuable-looking artifacts are AES-GCM
+     ciphertext sealed with an AndroidKeyStore key. Keystore keys are
+     non-exportable and never travel with a backup, so a restored copy is
+     undecryptable noise on the target device. Restoring buys nothing and
+     forces the app down its "keystore invalidated -> re-pair" path anyway.
+
+  RECOVERY STORY: the client is a thin front-end. Profile, keys, offers, trades
+  and chat all live on the user's trusted node. Re-pairing on a new device
+  restores everything that matters. There is no user data here that only exists
+  on the handset, so there is nothing worth risking a cloud copy for.
+
+  ============================================================================
+  AUDIT - every path under the app sandbox, and why it is excluded
+  ============================================================================
+
+  files/SensitiveSettings.preferences_pb
+      bisqApiUrl, clientId, clientSecret, sessionId, tlsFingerprint - i.e. the
+      bearer credentials for the trusted node. Encrypted at rest via
+      LocalEncryption.android.kt (AndroidKeyStore AES/GCM).
+      -> Credentials. Also unreadable off-device. Never back up.
+
+  files/Settings.preferences_pb
+      UI preferences, but also notificationPermissionState and
+      batteryOptimizationState, which are persisted *mirrors* of OS grants.
+      DashboardPresenter / WelcomeCarouselPresenter read them straight from
+      the DataStore and never re-sync from the OS, so a restored "GRANTED"
+      on a device that never granted the permission silently suppresses the
+      prompt and notifications just never arrive. firstLaunch=false likewise
+      skips onboarding - and since SensitiveSettings cannot be restored, the
+      user would land unpaired in a post-onboarding state. Also carries
+      analyticsEnabled, an opt-in consent flag that should not silently
+      migrate to a new install.
+      -> Device-coupled state. Restoring it produces broken installs.
+
+  files/User.preferences_pb
+      User-authored trade terms and profile statement. Owned by the profile on
+      the trusted node and re-fetched after pairing.
+      -> Redundant, and user-identifying content.
+
+  files/TradeReadStateMap.preferences_pb
+      Trade id -> read message count.
+      -> Leaks the set of trade ids to the cloud. Re-derivable after pairing.
+
+  files/OfferbookFilterConfigs.preferences_pb
+      Saved offerbook filters (markets, payment methods, amount ranges).
+      -> Discloses trading interests. The app exposes an explicit
+         "remember filter preferences" toggle; silently shipping these to a
+         cloud provider would undercut that control.
+
+  files/ConfigCache.preferences_pb
+  files/BankAccountCountryDetailsCache.preferences_pb
+      Caches of data fetched from the node/server.
+      -> Regenerable, and a stale restore can mislead the UI.
+
+  files/tor/
+      kmp-tor data dir: cached consensus, control_auth_cookie,
+      control-port.txt, hidden-service key material.
+      -> Network/device bound and fully regenerable. Worse, the control-plane
+         files are ephemeral: a stale auth cookie makes control-port
+         AUTHENTICATE fail and hangs bootstrap (see KmpTorService).
+
+  files/Bisq2_mobile/
+      Generated CatHash avatar PNGs (BaseClientCatHashService).
+      -> Deterministic from the profile id. Pure backup-quota waste.
+
+  shared_prefs/bisq_push_notification_keystore.xml
+      EncryptedSharedPreferences holding the AES-256 push notification
+      symmetric key, wrapped by a Keystore MasterKey (Tink keyset).
+      -> Key material, and the Tink keyset is unreadable on another device.
+         The key is rotated on every registration anyway.
+
+  cache/            - never included by the platform. No rule needed.
+  no_backup/        - never included by the platform. No rule needed. This is
+                      the correct future home for the Keystore-sealed blobs
+                      above, since they can never survive a restore.
+
+  ============================================================================
+  MAINTENANCE
+  ============================================================================
+  Deny-by-default: every domain is excluded wholesale rather than file by file,
+  so any storage added later is opted out until someone deliberately allows it
+  and records the reasoning here. If you ever add an <include>, note that a
+  single <include> flips the section to allowlist semantics for that domain.
+-->
+<data-extraction-rules>
+
+    <!--
+      Cloud backup (Google Drive). Nothing is eligible.
+      disableIfNoEncryptionCapabilities is redundant while everything is
+      excluded, but it is the correct safety net if this section is ever
+      narrowed: it suppresses the backup entirely on devices that cannot
+      client-side encrypt it.
+    -->
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+
+    <!--
+      Device-to-device transfer. Local and encrypted, so materially safer than
+      the cloud - but still nothing to gain here: the pairing credentials are
+      Keystore-sealed and cannot be transferred, and without them every other
+      file is either stale device state or a cache. The supported migration
+      path is to re-pair with the trusted node on the new device.
+    -->
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+
+</data-extraction-rules>

--- a/apps/nodeApp/src/androidMain/AndroidManifest.xml
+++ b/apps/nodeApp/src/androidMain/AndroidManifest.xml
@@ -18,6 +18,8 @@
     <!-- android:largeHeap: Request larger heap for P2P sync GC pressure reduction caused by bisq2 jars -->
     <application
         android:name="network.bisq.mobile.node.main.NodeMainApplication"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/apps/nodeApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/apps/nodeApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -11,10 +11,19 @@
   POLICY: nothing leaves the device through the platform backup pipeline.
   ============================================================================
 
-  The manifest also sets android:allowBackup="false", which already blocks
-  cloud backup and D2D transfer. These rules are the second layer: if
-  allowBackup is ever flipped back to true (directly, or by a library manifest
-  merge), the excludes below still hold, and they document the audit.
+  The manifest also sets android:allowBackup="false", but that attribute alone
+  is NOT sufficient here. On Android 12+ it disables cloud backup yet does not
+  disable device-to-device transfer - many OEM D2D implementations migrate the
+  app regardless. See https://developer.android.com/identity/data/autobackup.
+  Since nodeApp is minSdk 33, every supported device is in that window.
+
+  So the two sections below are not decoration:
+    - <cloud-backup>   is a second layer behind allowBackup, and stays correct
+                       if that attribute is ever flipped back to true directly
+                       or by a library manifest merge.
+    - <device-transfer> is the ONLY control that keeps db/private off the D2D
+                       pipeline. It is load-bearing. Do not remove it on the
+                       assumption that allowBackup="false" covers it.
 
   The node app runs a full Bisq 2 node on the handset. Unlike the client, the
   private keys really are here - there is no trusted node to re-pair with. That
@@ -135,7 +144,11 @@
     </cloud-backup>
 
     <!--
-      Device-to-device transfer. Excluded as well - see the rationale above.
+      Device-to-device transfer. This section is the only thing that keeps the
+      bisq2 key bundles out of a D2D migration on API 31+ -
+      android:allowBackup="false" does not. Rationale for excluding rather than
+      allowing is above: it would fan out the identity without the user
+      choosing to, and nothing guarantees the source device is retired.
       Phone migration is handled by Settings -> Backup / Restore, which keeps
       the user in control of when their identity is copied.
     -->

--- a/apps/nodeApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/apps/nodeApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Backup / device-transfer policy for the Bisq node app.
+
+  No legacy res/xml/backup_rules.xml counterpart exists here on purpose:
+  nodeApp minSdk is 33, so android:dataExtractionRules (API 31+) governs every
+  supported device and a fullBackupContent file would be dead configuration.
+  If minSdk is ever lowered below 31, add one mirroring <cloud-backup> below.
+
+  ============================================================================
+  POLICY: nothing leaves the device through the platform backup pipeline.
+  ============================================================================
+
+  The manifest also sets android:allowBackup="false", which already blocks
+  cloud backup and D2D transfer. These rules are the second layer: if
+  allowBackup is ever flipped back to true (directly, or by a library manifest
+  merge), the excludes below still hold, and they document the audit.
+
+  The node app runs a full Bisq 2 node on the handset. Unlike the client, the
+  private keys really are here - there is no trusted node to re-pair with. That
+  raises the stakes in both directions:
+
+  1. CONFIDENTIALITY. files/Bisq2_mobile/db/private holds the bisq2 key
+     bundles: identity private keys, the Tor onion private key, payment
+     account details, contracts and private trade chat. Whoever holds that
+     directory *is* the user on the network, and can also impersonate them for
+     their accumulated reputation. Auto Backup uploads to Google Drive; even
+     with client-side encryption, handing a P2P trading identity to a cloud
+     provider is exactly what Bisq exists to avoid.
+
+  2. USER CONTROL. The app already ships the right mechanism:
+     Settings -> Backup (NodeBackupServiceFacade) exports db/private and
+     db/settings as a zip the user can optionally password-encrypt, and
+     NodeMainApplication.maybeRestoreDataDirectory() consumes it on the next
+     launch. That is deliberate, auditable and user-initiated. A silent
+     platform backup would duplicate it without the deliberation.
+
+  Device-to-device transfer is also excluded, even though it is a local
+  encrypted channel and copying db/private is what a phone migration wants.
+  Reasons: it would silently fan out the identity without the user choosing to,
+  and nothing guarantees the source device is retired - two live nodes sharing
+  one identity and onion address conflict on the P2P network. The explicit
+  export/restore flow above covers the migration case with the user in the loop.
+
+  ============================================================================
+  AUDIT - every path under the app sandbox, and why it is excluded
+  ============================================================================
+
+  files/Bisq2_mobile/db/private/
+      bisq2 key bundles (identity + Tor onion private keys), payment accounts,
+      contracts, trades, private chat.
+      -> The crown jewels. Never back up. Use Settings -> Backup instead.
+
+  files/Bisq2_mobile/db/settings/
+      bisq2 settings, favourite markets, don't-show-again flags.
+      -> Low value on its own and meaningless without private/. Excluded so
+         the two always move together through the explicit backup flow.
+
+  files/Bisq2_mobile/db/cache/
+  files/Bisq2_mobile/db/network_db/
+      Public chat channel stores and P2P inventory. Hundreds of MB, and fully
+      re-syncable from the network. NodeBackupServiceFacade explicitly skips
+      both for the same reason.
+      -> Regenerable bulk. Would blow the backup quota for zero benefit.
+         Also the source of the deprecated-enum corruption that
+         maybeCleanupCorruptedChatData() has to repair - stale copies are a
+         liability, not an asset.
+
+  files/Bisq2_mobile/tor/
+      kmp-tor data dir: cached consensus, control_auth_cookie,
+      control-port.txt.
+      -> Regenerable and device/network bound. A stale control auth cookie
+         makes control-port AUTHENTICATE fail and hangs Tor bootstrap
+         (see KmpTorService). The durable onion identity is not here - it
+         lives in the bisq2 key bundle under db/private.
+
+  files/Bisq2_mobile/bisq.log (+ rotations, 1MB x 3)
+      INFO-level logs containing peer onion addresses, trade ids and profile
+      ids.
+      -> PII / network graph. Never leaves the device automatically.
+
+  files/bisq_db_from_backup/
+      Staging directory for a pending user-initiated restore, consumed and
+      deleted on the next launch by maybeRestoreDataDirectory().
+      -> Actively dangerous to back up: a snapshot taken between restore and
+         next launch would replay a stale restore over freshly created keys on
+         the target device.
+
+  files/Settings.preferences_pb
+  files/User.preferences_pb
+  files/TradeReadStateMap.preferences_pb
+  files/OfferbookFilterConfigs.preferences_pb
+      The shared DataStores from :shared:domain dataModule.
+      -> Same verdicts as the client app: Settings mirrors OS permission grants
+         and gates onboarding (restoring it silently suppresses the
+         notification prompt), the rest is either user-identifying content or
+         leaks trade ids / trading interests. See
+         apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml for
+         the field-level breakdown.
+
+  shared_prefs/     - nothing sensitive today; excluded by deny-by-default.
+  cache/            - never included by the platform. No rule needed.
+  no_backup/        - never included by the platform. No rule needed.
+
+  ============================================================================
+  MAINTENANCE
+  ============================================================================
+  Deny-by-default: every domain is excluded wholesale rather than file by file,
+  so storage added later is opted out until someone deliberately allows it and
+  records the reasoning here. This matters concretely - android.conf currently
+  has wallet.enabled = false, and whenever the bisq2 wallet is switched on its
+  seed/keys land under the same data dir. They are covered from day one under
+  these rules. If you ever add an <include>, note that a single <include> flips
+  the section to allowlist semantics for that domain.
+-->
+<data-extraction-rules>
+
+    <!--
+      Cloud backup (Google Drive). Nothing is eligible.
+      disableIfNoEncryptionCapabilities is redundant while everything is
+      excluded, but it is the correct safety net if this section is ever
+      narrowed: it suppresses the backup entirely on devices that cannot
+      client-side encrypt it.
+    -->
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+
+    <!--
+      Device-to-device transfer. Excluded as well - see the rationale above.
+      Phone migration is handled by Settings -> Backup / Restore, which keeps
+      the user in control of when their identity is copied.
+    -->
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

resolves #1645

Both Android apps were uploading their entire sandbox to Google Drive via Auto Backup.

- `clientApp` had `android:allowBackup="true"` with no rules file (Android Studio template boilerplate).
- `nodeApp` had no `allowBackup` attribute at all, which defaults to `true`.

For `nodeApp` that included `files/Bisq2_mobile/db/private/` — the bisq2 key bundles: identity
private keys, the Tor onion private key, payment accounts, contracts and private trade chat.
For `clientApp` it included the trusted-node `clientSecret` and `sessionId`. Because `clientApp`
has `minSdk 24`, it was also extractable via `adb backup` on API 24–30 without root.

This PR audits every path in both sandboxes and blocks the platform backup pipeline.

## Audit result: nothing is safe to back up

Every candidate fails on confidentiality, correctness, or both.

| Path | Verdict |
|---|---|
| `db/private/` (node) | Identity + onion private keys, payment accounts, trades, private chat |
| `SensitiveSettings.preferences_pb` | Trusted-node bearer credentials (`clientSecret`, `sessionId`) |
| `shared_prefs/bisq_push_notification_keystore.xml` | AES-256 push key, Tink keyset |
| `Settings.preferences_pb` | Device-coupled OS permission mirrors + onboarding gate (see below) |
| `User.preferences_pb` | User-authored content; re-fetched from the node |
| `TradeReadStateMap.preferences_pb` | Leaks trade IDs |
| `OfferbookFilterConfigs.preferences_pb` | Leaks trading interests |
| `ConfigCache` / `BankAccountCountryDetailsCache` | Server caches; stale-restore risk |
| `db/cache/`, `db/network_db/` | Hundreds of MB, fully re-syncable |
| `tor/` | Device/network bound; stale control cookie hangs bootstrap |
| `bisq.log` | Peer onion addresses, trade IDs, profile IDs |
| `bisq_db_from_backup/` | Pending-restore staging dir — see below |
| `Bisq2_mobile/` (client) | Generated CatHash avatars; deterministic |

Three findings worth calling out:

**Keystore-sealed data cannot be restored anyway.** `SensitiveSettings.preferences_pb` and the
push-notification prefs are AES-GCM ciphertext sealed with non-exportable AndroidKeyStore keys.
A restored copy is undecryptable noise on the target device, and the app already treats that as
"keystore invalidated → re-pair". Backing it up buys nothing and leaks the ciphertext.

**`Settings.preferences_pb` looks safe but breaks the install.** It persists
`notificationPermissionState` and `batteryOptimizationState` as mirrors of OS grants.
`DashboardPresenter` and `WelcomeCarouselPresenter` read them straight from the DataStore and never
re-sync from the OS, so a restored `GRANTED` on a device that never granted the permission silently
suppresses the prompt and notifications never arrive. `firstLaunch=false` likewise skips onboarding,
and since the pairing credentials cannot be restored, the user lands unpaired in a post-onboarding
state.

**`bisq_db_from_backup/` is actively dangerous to back up.** It is the staging dir for a pending
user-initiated restore, consumed and deleted on next launch by `maybeRestoreDataDirectory()`.
A snapshot taken between restore and next launch would replay a stale restore over freshly created
keys on the target device.

## Device-to-device transfer

Also excluded. It is a local encrypted channel and materially safer than cloud, but:

- For the client, nothing survives without the Keystore-bound credentials.
- For the node, a silent identity copy risks two live nodes sharing one onion address, and the app
  already ships the correct mechanism: **Settings → Backup**, a user-initiated, optionally
  password-encrypted zip via `NodeBackupServiceFacade`.

## Changes

- `apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml` — API 31+, full per-file audit
  in comments
- `apps/clientApp/src/androidMain/res/xml/backup_rules.xml` — required because `clientApp` is
  `minSdk 24` and `dataExtractionRules` only applies from API 31
- `apps/nodeApp/src/androidMain/res/xml/data_extraction_rules.xml` — no legacy counterpart;
  `nodeApp` is `minSdk 33`, so a `fullBackupContent` file would be dead config
- Both manifests: `allowBackup="false"` plus the rules wired in as a second layer, so the excludes
  still hold if that attribute is ever relaxed or overridden by a library manifest merge

Rules are deny-by-default per domain rather than per file, so storage added later is opted out until
someone deliberately allows it and records the reasoning. This matters concretely: `android.conf`
has `wallet.enabled = false` today, and when the bisq2 wallet is switched on its seed lands in the
same data dir — covered from day one.

## User-visible impact

Existing users lose Google Drive backup of app data. Given the contents, that is the intended fix.
Recovery paths are unchanged and remain the supported ones:

- **client**: re-pair with the trusted node, which owns the profile and keys
- **node**: Settings → Backup / Restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Disabled automatic Android cloud backups and device-to-device transfers for sensitive app data.
  * Added backup exclusion rules covering app storage, credentials, metadata, and other private data.
  * Applied consistent backup protections across client and node Android apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->