### PR TITLE
bugfix/improve_job_cancellation_handling_and_consequent_logging

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacadeTest.kt
@@ -1,0 +1,82 @@
+package network.bisq.mobile.client.common.domain.service.user_profile
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.test_utils.TestApplication
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.data.utils.createEmptyImage
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+/**
+ * Covers [ClientUserProfileServiceFacade.getUserProfileIcon]: it composes the avatar on the IO
+ * dispatcher and returns a fallback image (never throwing) when the cat-hash service fails to
+ * produce one.
+ *
+ * Runs under Robolectric because both the composed image and the fallback go through real Android
+ * bitmap decoding (`createEmptyImage` / `PlatformImage.deserialize`). It builds the facade directly
+ * with mocks rather than extending the Koin integration base: `getUserProfileIcon` never touches
+ * `serviceScope`, and [TestApplication] already starts Koin, so a second startKoin would collide.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [28])
+class ClientUserProfileServiceFacadeTest {
+    private val apiGateway: UserProfileApiGateway = mockk(relaxed = true)
+    private val clientCatHashService: ClientCatHashService<PlatformImage> = mockk(relaxed = true)
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun facade() =
+        ClientUserProfileServiceFacade(
+            apiGateway,
+            clientCatHashService,
+            json,
+            webSocketClientService,
+        )
+
+    @Test
+    fun `getUserProfileIcon returns the composed image on success`() =
+        runTest {
+            val composed = createEmptyImage()
+            every { clientCatHashService.getImage(any(), any()) } returns composed
+
+            val result = facade().getUserProfileIcon(createMockUserProfile("Alice"))
+
+            assertEquals(composed, result)
+        }
+
+    @Test
+    fun `getUserProfileIcon returns a fallback image when the cat-hash service throws`() =
+        runTest {
+            every { clientCatHashService.getImage(any(), any()) } throws RuntimeException("compose failed")
+
+            val result = facade().getUserProfileIcon(createMockUserProfile("Bob"))
+
+            // Must degrade to a non-null fallback rather than propagating the failure.
+            assertNotNull(result)
+        }
+
+    @Test
+    fun `getUserProfileIcon rethrows cancellation from the compose call instead of falling back`() =
+        runTest {
+            // getImage is non-suspend, so a cancel-while-suspended can't unblock its IO thread
+            // deterministically; raising the cancellation from the compose call exercises the same
+            // guard that decides propagate-vs-fallback. A genuine cancellation must NOT be masked by
+            // the fallback image.
+            every { clientCatHashService.getImage(any(), any()) } throws CancellationException("cancelled")
+
+            assertFailsWith<CancellationException> {
+                facade().getUserProfileIcon(createMockUserProfile("Cara"))
+            }
+        }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClientTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClientTest.kt
@@ -1,0 +1,68 @@
+package network.bisq.mobile.client.common.domain.websocket.api_proxy
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import org.junit.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the cancellation handling in [WebSocketApiClient.executeRequest]: a [CancellationException]
+ * raised while the calling coroutine is still active (e.g. the request timeout, which is a
+ * TimeoutCancellationException) must be reported as a plain request failure rather than propagated —
+ * only a genuine cancellation of the caller's own job should tear the caller down.
+ */
+class WebSocketApiClientTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `request reports a timeout-style cancellation as a failure while the caller is active`() =
+        runTest {
+            val webSocketClientService =
+                mockk<WebSocketClientService> {
+                    coEvery { sendRequestAndAwaitResponse(any()) } throws CancellationException("request timed out")
+                }
+            val client = WebSocketApiClient(webSocketClientService, json)
+
+            val result = client.get<String>("some/path")
+
+            // Caller job is still active -> ensureActive() is a no-op -> wrapped failure, as before.
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is CancellationException)
+        }
+
+    @Test
+    fun `request propagates a genuine caller cancellation instead of returning a failure`() =
+        runTest {
+            // The request parks until the caller is cancelled, so ensureActive() observes a genuine
+            // cancellation and must tear the caller down rather than hand back a Result.failure.
+            val gate = CompletableDeferred<Unit>()
+            val webSocketClientService =
+                mockk<WebSocketClientService> {
+                    coEvery { sendRequestAndAwaitResponse(any()) } coAnswers {
+                        gate.await()
+                        error("unreachable once cancelled")
+                    }
+                }
+            val client = WebSocketApiClient(webSocketClientService, json)
+
+            var outcome: Result<String>? = null
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    outcome = client.get<String>("some/path")
+                }
+
+            child.cancel()
+            child.join()
+
+            // Cancellation propagated out of get(); it never produced a (mis)reported failure result.
+            assertNull(outcome)
+        }
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -271,10 +271,10 @@ class ClientUserProfileServiceFacade(
         userProfile: UserProfileVO,
         size: Number,
     ): PlatformImage =
-        try {
-            // In case we create the image we want to run it in IO context.
-            // We cache the images in the catHashService if its <=120 px
-            withContext(Dispatchers.IO) {
+        // In case we create the image we want to run it in IO context.
+        // We cache the images in the catHashService if its <=120 px
+        withContext(Dispatchers.IO) {
+            try {
                 val ts = Clock.System.now().toEpochMilliseconds()
                 clientCatHashService.getImage(userProfile, size.toInt()).also {
                     log.d {
@@ -283,10 +283,12 @@ class ClientUserProfileServiceFacade(
                         } ms. User profile ID=${userProfile.id}"
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.e(e) { "Failed to get user profile icon; returning fallback" }
+                fallbackProfileImage()
             }
-        } catch (e: Exception) {
-            log.e(e) { "Failed to get user profile icon; returning fallback" }
-            fallbackProfileImage()
         }
 
     @OptIn(ExperimentalEncodingApi::class)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClient.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/api_proxy/WebSocketApiClient.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.client.common.domain.websocket.api_proxy
 
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.httpclient.exception.UnauthorizedApiAccessException
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
@@ -155,7 +157,14 @@ class WebSocketApiClient(
                 }
             }
         } catch (e: CancellationException) {
-            // no log on cancellation
+            // If OUR job is cancelled, propagate instead of wrapping in Result.failure: a cancelled
+            // caller must stop, not carry on treating its own cancellation as a request failure (which
+            // spams logs and lets superseded work keep running with bogus fallback values).
+            currentCoroutineContext().ensureActive()
+            // Reached only when the coroutine is still active, i.e. this is NOT our cancellation -
+            // e.g. the request timeout (sendRequestAndAwaitResponse uses withTimeout, and
+            // TimeoutCancellationException IS a CancellationException). Keep reporting those as a
+            // plain request failure, as before.
             return Result.failure(e)
         } catch (e: Exception) {
             log.e(e) { "Failed to get WS request result: ${e.message}" }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -10,6 +10,7 @@ import bisq.support.moderator.ModerationRequestService
 import bisq.user.UserService
 import bisq.user.identity.NymIdGenerator
 import bisq.user.profile.UserProfileService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -217,10 +218,10 @@ class NodeUserProfileServiceFacade(
         userProfile: UserProfileVO,
         size: Number,
     ): PlatformImage =
-        try {
-            // In case we create the image we want to run it in IO context.
-            // We cache the images in the catHashService if its <=120 px
-            withContext(Dispatchers.IO) {
+        withContext(Dispatchers.IO) {
+            try {
+                // In case we create the image we want to run it in IO context.
+                // We cache the images in the catHashService if its <=120 px
                 val ts = System.currentTimeMillis()
                 catHashService
                     .getImage(
@@ -229,10 +230,12 @@ class NodeUserProfileServiceFacade(
                     ).also {
                         log.d { "Get userProfileIcon for ${userProfile.userName} took ${System.currentTimeMillis() - ts} ms. User profile ID=${userProfile.id}" }
                     }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.e(e) { "Failed to get user profile icon; returning fallback" }
+                fallbackProfileImage()
             }
-        } catch (e: Exception) {
-            log.e(e) { "Failed to get user profile icon; returning fallback" }
-            fallbackProfileImage()
         }
 
     private fun fallbackProfileImage(): PlatformImage =

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
@@ -1,8 +1,16 @@
 package network.bisq.mobile.domain.utils
 
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory.fromPrice
 import network.bisq.mobile.data.replicated.common.network.AddressByTransportTypeMapVO
@@ -12,16 +20,24 @@ import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideRangeAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationDto
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.data.replicated.security.keys.PubKeyVO
 import network.bisq.mobile.data.replicated.security.keys.PublicKeyVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Covers the required-reputation-score entry points that resolve their config from the injected
- * [TradeAmountLimitsVO]. When market prices are unavailable the amount cannot be converted, so these
- * must degrade to null / "not invalid" rather than throw.
+ * [TradeAmountLimitsVO], plus the [BisqEasyTradeAmountLimits.isBuyOfferInvalid] reputation-fetch
+ * path — including that a cancellation surfaced by the reputation lookup is treated as a plain
+ * failure while the caller is still active (rather than crashing or being swallowed silently).
  */
 class BisqEasyTradeAmountLimitsTest {
     private val market = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
@@ -32,9 +48,22 @@ class BisqEasyTradeAmountLimitsTest {
             every { findUSDMarketPriceItem() } returns null
         }
 
-    private fun buildBuyOffer(): BisqEasyOfferVO =
+    // A priced market service so isBuyOfferInvalid gets past the "required score unavailable"
+    // guard and actually exercises the reputation lookup below it.
+    private fun marketServiceWithPrices(): MarketPriceServiceFacade =
+        mockk(relaxed = true) {
+            every { findMarketPriceItem(any()) } answers {
+                val requested = firstArg<MarketVO>()
+                MarketPriceItem(requested, with(PriceQuoteVOFactory) { fromPrice(100_00L, requested) }, formattedPrice = "100")
+            }
+            every { findUSDMarketPriceItem() } answers {
+                MarketPriceItem(market, with(PriceQuoteVOFactory) { fromPrice(100_00L, market) }, formattedPrice = "100")
+            }
+        }
+
+    private fun buildBuyOffer(id: String = "offer-1"): BisqEasyOfferVO =
         BisqEasyOfferVO(
-            id = "offer-1",
+            id = id,
             date = 0L,
             makerNetworkId =
                 NetworkIdVO(
@@ -50,6 +79,24 @@ class BisqEasyTradeAmountLimitsTest {
             quoteSidePaymentMethodSpecs = emptyList(),
             offerOptions = emptyList(),
             supportedLanguageCodes = emptyList(),
+        )
+
+    private fun buildBuyOfferModel(id: String): OfferItemPresentationModel =
+        OfferItemPresentationModel(
+            OfferItemPresentationDto(
+                bisqEasyOffer = buildBuyOffer(id),
+                isMyOffer = false,
+                userProfile = createMockUserProfile("Alice"),
+                formattedDate = "",
+                formattedQuoteAmount =
+                    FiatVOFactory.run { from(10_0000L, market.quoteCurrencyCode) }.let { "10 USD" },
+                formattedBaseAmount = "",
+                formattedPrice = "",
+                formattedPriceSpec = "",
+                quoteSidePaymentMethods = emptyList(),
+                baseSidePaymentMethods = emptyList(),
+                reputationScore = ReputationScoreVO(0, 0.0, 0),
+            ),
         )
 
     @Test
@@ -79,4 +126,110 @@ class BisqEasyTradeAmountLimitsTest {
 
         assertNull(result)
     }
+
+    @Test
+    fun `isBuyOfferInvalid returns false when seller reputation clears the required score`() =
+        runTest {
+            val reputationServiceFacade =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } returns Result.success(ReputationScoreVO(Long.MAX_VALUE, 0.0, 0))
+                }
+
+            val isInvalid =
+                BisqEasyTradeAmountLimits.isBuyOfferInvalid(
+                    item = buildBuyOfferModel("valid-high-score"),
+                    useCache = false,
+                    marketPriceServiceFacade = marketServiceWithPrices(),
+                    reputationServiceFacade = reputationServiceFacade,
+                    userProfileId = "seller",
+                    limits = TradeAmountLimitsVO.DEFAULT,
+                )
+
+            assertFalse(isInvalid)
+        }
+
+    @Test
+    fun `isBuyOfferInvalid returns true and defaults score to zero when reputation lookup fails`() =
+        runTest {
+            val reputationServiceFacade =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } returns Result.failure(RuntimeException("no reputation"))
+                }
+
+            val isInvalid =
+                BisqEasyTradeAmountLimits.isBuyOfferInvalid(
+                    item = buildBuyOfferModel("invalid-lookup-fail"),
+                    useCache = false,
+                    marketPriceServiceFacade = marketServiceWithPrices(),
+                    reputationServiceFacade = reputationServiceFacade,
+                    userProfileId = "seller",
+                    limits = TradeAmountLimitsVO.DEFAULT,
+                )
+
+            assertTrue(isInvalid)
+        }
+
+    @Test
+    fun `isBuyOfferInvalid treats a cancellation from the reputation lookup as a failure while caller is active`() =
+        runTest {
+            // A CancellationException that does NOT stem from our own cancellation (e.g. a request
+            // timeout) must fall through to the plain failure handling, not propagate or crash.
+            val reputationServiceFacade =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } throws CancellationException("request timed out")
+                }
+
+            val isInvalid =
+                BisqEasyTradeAmountLimits.isBuyOfferInvalid(
+                    item = buildBuyOfferModel("cancel-active"),
+                    useCache = false,
+                    marketPriceServiceFacade = marketServiceWithPrices(),
+                    reputationServiceFacade = reputationServiceFacade,
+                    userProfileId = "seller",
+                    limits = TradeAmountLimitsVO.DEFAULT,
+                )
+
+            // The active test coroutine means ensureActive() is a no-op: score defaults to 0 -> invalid.
+            assertTrue(isInvalid)
+        }
+
+    @Test
+    fun `isBuyOfferInvalid propagates cancellation when the caller is genuinely cancelled`() =
+        runTest {
+            // Reputation lookup parks until the caller is cancelled, so the CancellationException
+            // observed here is a genuine cancellation of our own job (not a timeout) and must propagate.
+            val gate = CompletableDeferred<Unit>()
+            val reputationServiceFacade =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } coAnswers {
+                        gate.await()
+                        Result.success(ReputationScoreVO(0, 0.0, 0))
+                    }
+                }
+            val item = buildBuyOfferModel("cancel-genuine")
+            val marketPriceServiceFacade = marketServiceWithPrices()
+
+            var propagated = false
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        BisqEasyTradeAmountLimits.isBuyOfferInvalid(
+                            item = item,
+                            useCache = false,
+                            marketPriceServiceFacade = marketPriceServiceFacade,
+                            reputationServiceFacade = reputationServiceFacade,
+                            userProfileId = "seller",
+                            limits = TradeAmountLimitsVO.DEFAULT,
+                        )
+                    } catch (e: CancellationException) {
+                        propagated = true
+                        throw e
+                    }
+                }
+
+            child.cancel()
+            child.join()
+
+            assertTrue(propagated)
+        }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
@@ -1,5 +1,8 @@
 package network.bisq.mobile.domain.utils
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import network.bisq.mobile.data.replicated.common.currency.MarketVO
@@ -97,17 +100,26 @@ object BisqEasyTradeAmountLimits {
                 return false
             }
 
-        // Safely get seller's reputation score with proper error handling
+        // Safely get seller's reputation score with proper error handling.
+        // A genuinely cancelled caller (e.g. a superseded mapLatest pipeline run) must propagate its
+        // cancellation - treating it as "no reputation" would log noise and wrongly cache valid offers
+        // as invalid below. ensureActive() gates the rethrow so a CancellationException that does NOT
+        // stem from our own cancellation (e.g. a request timeout) still falls through to the plain
+        // failure handling.
+        val reputationResult =
+            runCatching { reputationServiceFacade.getReputation(userProfileId) }
+                .getOrElse { Result.failure(it) }
+        if (reputationResult.exceptionOrNull() is CancellationException) {
+            currentCoroutineContext().ensureActive()
+        }
         val myScore: Long =
-            runCatching {
-                reputationServiceFacade.getReputation(userProfileId).fold(
-                    onSuccess = { it.totalScore },
-                    onFailure = { exception ->
-                        logger.d("Exception at reputationServiceFacade.getReputation", exception)
-                        0L // Default to zero score on failure
-                    },
-                )
-            }.getOrDefault(0L)
+            reputationResult.fold(
+                onSuccess = { it.totalScore },
+                onFailure = { exception ->
+                    logger.d("Exception at reputationServiceFacade.getReputation", exception)
+                    0L // Default to zero score on failure
+                },
+            )
 
         val isInvalid = myScore < requiredReputationScoreForMinOrFixed
         if (isInvalid) {


### PR DESCRIPTION
 - fixes done whilst testing #1636 
 - fixed noisy ChildCancelledException logs when loading screens with many cat hashes: superseded offerbook pipeline runs (combined flows) had their cancellations swallowed as reputation failures
 - fixed cancelled pipeline runs wrongly caching valid BUY offers as invalid (cancellation was treated as "no reputation" -> score 0 -> addInvalidBuyOffer)
 - WebSocketApiClient no longer wraps our own cancellation into Result.failure; ensureActive() gate keeps request timeouts (TimeoutCancellationException) reporting as plain failures like before
 - moved try/catch inside withContext in user profile icon facades so the cancellation withContext rethrows isn't logged as an error; genuine cancellations now propagate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during profile image loading and WebSocket requests to ensure cancellations propagate appropriately.
  * Preserved fallback profile images when non-cancellation errors occur.
  * Improved trade offer validation to avoid incorrect reputation defaults when operations are cancelled.
* **Tests**
  * Added/extended unit tests covering profile image fallback behavior, WebSocket request cancellation handling, and trade amount limit validation (including cancellation scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->