### PR TITLE
Release/anode 0.10.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.10.0
+node.android.version=0.10.1
 
 client.name=Bisq Connect
 client.android.version=0.7.1
@@ -42,7 +42,7 @@ client.ios.version=0.7.1
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=47
 client.android.version.code=29
-node.android.version.code=47
+node.android.version.code=48
 
 # Networking
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.9.1
+node.android.version=0.10.0
 
 client.name=Bisq Connect
 client.android.version=0.7.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.11"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "3df7da232576b7f418fa2a7fa1a146799e3ee8d1"
+bisq-core-commit = "dc1431e4d8063b23f1c3371388ca32577954735f"
 
 
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing


### PR DESCRIPTION
 - contribs to #1652
 - bump up versions and updated metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android app release version and build number.
  * Applied an updated core platform revision to support the latest release baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->