### PR TITLE
Feature/node bisq core logging for debug builds configurable

### DIFF
--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -468,6 +468,9 @@ dependencies {
     implementation(libs.koin.compose)
     implementation(libs.koin.android)
     implementation(libs.logging.kermit)
+    // Compile-classpath access to the logback API the bisq2 jars already ship at runtime
+    // (their POMs publish it runtime-scoped), for Bisq2LogcatAppender / Bisq2LoggingSetup.
+    implementation(libs.logging.logback.classic)
 }
 
 // -------------------- Build Tasks Configuration --------------------

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -156,6 +156,15 @@ android {
         buildConfigField("String", "APP_VERSION", "\"${version}\"")
         buildConfigField("String", "SHARED_VERSION", "\"${sharedVersion}\"")
 
+        // bisq2 core root log level, only honored in debug builds (release/profile silence the
+        // core - see Bisq2LoggingSetup). Default in gradle.properties, per-dev override via
+        // BISQ2_LOG_LEVEL in local.properties. Defined in defaultConfig because the consuming
+        // code compiles in every variant.
+        val bisq2LogLevel =
+            localProperties.getProperty("BISQ2_LOG_LEVEL")
+                ?: (project.findProperty("node.bisq2.log.level") as? String ?: "INFO")
+        buildConfigField("String", "BISQ2_LOG_LEVEL", "\"$bisq2LogLevel\"")
+
         // Memory management configuration
         // Default: extended heap. Turn false to test for mem leaks reducing heap size.
         manifestPlaceholders["largeHeap"] = "true"

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LogcatAppender.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LogcatAppender.kt
@@ -1,0 +1,49 @@
+package network.bisq.mobile.node.common.domain.logging
+
+import android.util.Log
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.ThrowableProxyUtil
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * Routes bisq2 core (slf4j/logback) log events into Android logcat with proper priorities.
+ *
+ * Everything is emitted under the single fixed [TAG] so devs can isolate the whole core with one
+ * logcat filter (`adb logcat -s Bisq2`); the originating logger's short name is prefixed to the
+ * message instead of the tag (pre-API-26 tags are length-limited, and per-logger tags would make
+ * "show me everything from the core" filtering harder, not easier).
+ *
+ * Why an appender instead of letting the jar-bundled logback.xml ConsoleAppender print to stdout
+ * (issue #767): the console route dies in SystemOutFilter (logback writes via OutputStream.write,
+ * see there), and even unfiltered it would reach logcat as ANSI-escape noise at Info priority under
+ * the generic "System.out" tag. Logcat is the native sink; this writes to it directly.
+ */
+class Bisq2LogcatAppender : AppenderBase<ILoggingEvent>() {
+    companion object {
+        const val TAG = "Bisq2"
+    }
+
+    override fun append(event: ILoggingEvent) {
+        val message =
+            buildString {
+                append('[')
+                append(shortLoggerName(event.loggerName))
+                append("] ")
+                append(event.formattedMessage)
+                event.throwableProxy?.let {
+                    append('\n')
+                    append(ThrowableProxyUtil.asString(it))
+                }
+            }
+        when (event.level.toInt()) {
+            Level.ERROR_INT -> Log.e(TAG, message)
+            Level.WARN_INT -> Log.w(TAG, message)
+            Level.INFO_INT -> Log.i(TAG, message)
+            Level.DEBUG_INT -> Log.d(TAG, message)
+            else -> Log.v(TAG, message)
+        }
+    }
+
+    private fun shortLoggerName(loggerName: String?): String = loggerName?.substringAfterLast('.') ?: "unknown"
+}

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetup.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetup.kt
@@ -1,0 +1,71 @@
+package network.bisq.mobile.node.common.domain.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Programmatic logback configuration for the bisq2 core jars embedded in the node app (issue #767).
+ *
+ * The core logs via slf4j -> logback-classic and auto-configures from the logback.xml BUNDLED IN
+ * the bisq:common jar: a ConsoleAppender (ANSI-colored) whose output the app's SystemOutFilter
+ * swallowed, so core logs never reached logcat. We reset that configuration and attach
+ * [Bisq2LogcatAppender] instead - programmatically rather than by shadowing the jar's logback.xml
+ * with our own, because classpath resource ordering across jars is undefined on Android while this
+ * is deterministic (and keeps levels runtime-mutable for a future dev-settings toggle).
+ *
+ * Must run BEFORE the first bisq2 service starts logging (see NodeMainApplication.onCreated).
+ */
+object Bisq2LoggingSetup {
+    /**
+     * ============================ TWEAK ME (debug builds) =============================
+     * The bisq2 core is very verbose by default (the jar's logback.xml leaves root at DEBUG).
+     * [DEBUG_ROOT_LEVEL] is the baseline; [DEBUG_LOGGER_LEVELS] raises/lowers specific subtrees.
+     * Chasing something specific? Set its package to DEBUG/TRACE here - entries win over root.
+     * ==================================================================================
+     */
+    val DEBUG_ROOT_LEVEL: Level = Level.INFO
+    val DEBUG_LOGGER_LEVELS: Map<String, Level> =
+        mapOf(
+            // Per-connection / inventory-request chatter floods logcat at INFO during bootstrap.
+            "bisq.network" to Level.WARN,
+            // Tor bootstrap progress is useful; kmp-tor noise is already handled app-side.
+            "bisq.network.tor" to Level.INFO,
+        )
+
+    /**
+     * Reconfigures logback for the embedded bisq2 core.
+     *
+     * Debug builds: core logs flow to logcat under the fixed `Bisq2` tag ([Bisq2LogcatAppender])
+     * with the levels above. Release builds: the core stays fully silent (root OFF) - core logs can
+     * carry peer/onion addresses, and release System.out is already hard-blocked; this keeps the
+     * privacy posture identical on the logback route.
+     *
+     * @return true if logback was found and reconfigured, false when the slf4j binding is not
+     *         logback (nothing to do - e.g. unit-test environments with a different binding).
+     */
+    fun setup(isDebugBuild: Boolean): Boolean {
+        val loggerContext = LoggerFactory.getILoggerFactory() as? LoggerContext ?: return false
+        // Drop the jar-bundled configuration (ANSI ConsoleAppender writing into the stdout filter).
+        loggerContext.reset()
+
+        val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+        if (!isDebugBuild) {
+            rootLogger.level = Level.OFF
+            return true
+        }
+
+        val appender =
+            Bisq2LogcatAppender().apply {
+                context = loggerContext
+                start()
+            }
+        rootLogger.level = DEBUG_ROOT_LEVEL
+        rootLogger.addAppender(appender)
+        DEBUG_LOGGER_LEVELS.forEach { (loggerName, level) ->
+            loggerContext.getLogger(loggerName).level = level
+        }
+        return true
+    }
+}

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetup.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetup.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.node.common.domain.logging
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
+import network.bisq.mobile.node.BuildConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -21,11 +22,14 @@ object Bisq2LoggingSetup {
     /**
      * ============================ TWEAK ME (debug builds) =============================
      * The bisq2 core is very verbose by default (the jar's logback.xml leaves root at DEBUG).
-     * [DEBUG_ROOT_LEVEL] is the baseline; [DEBUG_LOGGER_LEVELS] raises/lowers specific subtrees.
-     * Chasing something specific? Set its package to DEBUG/TRACE here - entries win over root.
+     * [DEBUG_ROOT_LEVEL] is the baseline - set it WITHOUT touching code via
+     * `BISQ2_LOG_LEVEL=DEBUG` in local.properties (default lives in gradle.properties as
+     * `node.bisq2.log.level`; unparseable values fall back to INFO).
+     * [DEBUG_LOGGER_LEVELS] raises/lowers specific subtrees. Chasing something specific?
+     * Set its package to DEBUG/TRACE here - entries win over root.
      * ==================================================================================
      */
-    val DEBUG_ROOT_LEVEL: Level = Level.INFO
+    val DEBUG_ROOT_LEVEL: Level = Level.toLevel(BuildConfig.BISQ2_LOG_LEVEL, Level.INFO)
     val DEBUG_LOGGER_LEVELS: Map<String, Level> =
         mapOf(
             // Per-connection / inventory-request chatter floods logcat at INFO during bootstrap.

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/main/NodeMainApplication.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/main/NodeMainApplication.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.data.utils.EnvironmentController
 import network.bisq.mobile.node.common.di.androidNodeDomainModule
 import network.bisq.mobile.node.common.di.androidNodePresentationModule
+import network.bisq.mobile.node.common.domain.logging.Bisq2LoggingSetup
 import network.bisq.mobile.node.common.domain.utils.moveDirReplace
 import network.bisq.mobile.node.settings.backup.domain.BACKUP_FILE_NAME
 import network.bisq.mobile.presentation.common.di.presentationModule
@@ -34,6 +35,11 @@ class NodeMainApplication : MainApplication() {
     override fun getKoinModules(): List<Module> = listOf(dataModule, androidNodeDomainModule, presentationModule, androidNodePresentationModule)
 
     override fun onCreated() {
+        // Route bisq2 core (slf4j/logback) logs to logcat in debug builds / silence them in release
+        // (issue #767). Must run before any bisq2 service logs - i.e. before setupBisqCoreStatics()
+        // and the lifecycle service below - so the jar-bundled logback config never takes effect.
+        Bisq2LoggingSetup.setup(isDebug())
+
         // Use runBlocking for essential system initialization that must complete before app continues
         // This is acceptable here because:
         // 1. It's Application.onCreate() - the right place for critical setup

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LogcatAppenderTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LogcatAppenderTest.kt
@@ -1,0 +1,111 @@
+package network.bisq.mobile.node.common.domain.logging
+
+import android.util.Log
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.LoggingEvent
+import network.bisq.mobile.node.common.test_utils.TestApplication
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers [Bisq2LogcatAppender]: logback level -> logcat priority mapping, the fixed `Bisq2` tag with
+ * the short logger name folded into the message, and throwable stack traces reaching logcat.
+ */
+@Config(application = TestApplication::class)
+@RunWith(RobolectricTestRunner::class)
+class Bisq2LogcatAppenderTest {
+    private val loggerContext = LoggerContext()
+    private lateinit var appender: Bisq2LogcatAppender
+
+    @Before
+    fun setUp() {
+        ShadowLog.clear()
+        appender =
+            Bisq2LogcatAppender().apply {
+                context = loggerContext
+                start()
+            }
+    }
+
+    private fun event(
+        level: Level,
+        message: String,
+        loggerName: String = "bisq.network.p2p.node.Node",
+        throwable: Throwable? = null,
+    ): LoggingEvent =
+        LoggingEvent(
+            Bisq2LogcatAppenderTest::class.java.name,
+            loggerContext.getLogger(loggerName),
+            level,
+            message,
+            throwable,
+            null,
+        )
+
+    private fun singleLogged(): ShadowLog.LogItem {
+        val items = ShadowLog.getLogsForTag(Bisq2LogcatAppender.TAG)
+        assertEquals(1, items.size, "exactly one logcat entry expected under the Bisq2 tag")
+        return items.first()
+    }
+
+    @Test
+    fun `error events map to logcat ERROR priority`() {
+        appender.doAppend(event(Level.ERROR, "boom"))
+
+        assertEquals(Log.ERROR, singleLogged().type)
+    }
+
+    @Test
+    fun `warn events map to logcat WARN priority`() {
+        appender.doAppend(event(Level.WARN, "careful"))
+
+        assertEquals(Log.WARN, singleLogged().type)
+    }
+
+    @Test
+    fun `info events map to logcat INFO priority`() {
+        appender.doAppend(event(Level.INFO, "fyi"))
+
+        assertEquals(Log.INFO, singleLogged().type)
+    }
+
+    @Test
+    fun `debug events map to logcat DEBUG priority`() {
+        appender.doAppend(event(Level.DEBUG, "details"))
+
+        assertEquals(Log.DEBUG, singleLogged().type)
+    }
+
+    @Test
+    fun `trace events map to logcat VERBOSE priority`() {
+        appender.doAppend(event(Level.TRACE, "very detailed"))
+
+        assertEquals(Log.VERBOSE, singleLogged().type)
+    }
+
+    @Test
+    fun `message carries the short logger name under the fixed Bisq2 tag`() {
+        appender.doAppend(event(Level.INFO, "Bootstrap complete", loggerName = "bisq.network.NetworkService"))
+
+        val item = singleLogged()
+        assertEquals(Bisq2LogcatAppender.TAG, item.tag)
+        assertEquals("[NetworkService] Bootstrap complete", item.msg)
+    }
+
+    @Test
+    fun `throwable stack trace is appended to the message`() {
+        appender.doAppend(event(Level.ERROR, "it broke", throwable = IllegalStateException("root cause here")))
+
+        val msg = singleLogged().msg
+        assertTrue(msg.contains("it broke"))
+        assertTrue(msg.contains("IllegalStateException"), "throwable type must be included")
+        assertTrue(msg.contains("root cause here"), "throwable message must be included")
+    }
+}

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetupTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/logging/Bisq2LoggingSetupTest.kt
@@ -1,0 +1,92 @@
+package network.bisq.mobile.node.common.domain.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import network.bisq.mobile.node.common.test_utils.TestApplication
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers [Bisq2LoggingSetup] against the REAL slf4j binding the node app ships (logback-classic,
+ * pulled transitively by the bisq2 jars): debug builds get the logcat appender + tuned levels,
+ * release builds silence the core entirely, and an actual slf4j log call lands in logcat end to end.
+ */
+@Config(application = TestApplication::class)
+@RunWith(RobolectricTestRunner::class)
+class Bisq2LoggingSetupTest {
+    private val loggerContext get() = LoggerFactory.getILoggerFactory() as LoggerContext
+
+    @After
+    fun tearDown() {
+        // Leave no configuration behind for other tests sharing the slf4j static state.
+        loggerContext.reset()
+    }
+
+    @Test
+    fun `debug setup attaches the logcat appender with the tuned levels`() {
+        assertTrue(Bisq2LoggingSetup.setup(isDebugBuild = true), "logback must be the resolved binding in node tests")
+
+        val root = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+        assertEquals(Bisq2LoggingSetup.DEBUG_ROOT_LEVEL, root.level)
+        assertTrue(
+            root.iteratorForAppenders().asSequence().any { it is Bisq2LogcatAppender },
+            "the logcat appender must be attached to the root logger",
+        )
+        Bisq2LoggingSetup.DEBUG_LOGGER_LEVELS.forEach { (loggerName, level) ->
+            assertEquals(level, loggerContext.getLogger(loggerName).level, "tuned level for $loggerName")
+        }
+    }
+
+    @Test
+    fun `release setup silences the core and attaches nothing`() {
+        assertTrue(Bisq2LoggingSetup.setup(isDebugBuild = false))
+
+        val root = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+        assertEquals(Level.OFF, root.level)
+        assertFalse(root.iteratorForAppenders().hasNext(), "release builds must not route core logs anywhere")
+    }
+
+    @Test
+    fun `after debug setup a real slf4j log call reaches logcat`() {
+        ShadowLog.clear()
+        Bisq2LoggingSetup.setup(isDebugBuild = true)
+
+        LoggerFactory.getLogger("bisq.some.core.Component").info("core says hi")
+
+        val items = ShadowLog.getLogsForTag(Bisq2LogcatAppender.TAG)
+        assertEquals(1, items.size)
+        assertEquals("[Component] core says hi", items.first().msg)
+    }
+
+    @Test
+    fun `after debug setup a suppressed-package log call below its tuned level does not reach logcat`() {
+        ShadowLog.clear()
+        Bisq2LoggingSetup.setup(isDebugBuild = true)
+
+        // bisq.network is tuned to WARN precisely because its INFO chatter floods logcat.
+        LoggerFactory.getLogger("bisq.network.SomeChattyService").info("per-connection noise")
+        LoggerFactory.getLogger("bisq.network.SomeChattyService").warn("actual problem")
+
+        val messages = ShadowLog.getLogsForTag(Bisq2LogcatAppender.TAG).map { it.msg }
+        assertEquals(listOf("[SomeChattyService] actual problem"), messages)
+    }
+
+    @Test
+    fun `after release setup a real slf4j log call is fully silenced`() {
+        ShadowLog.clear()
+        Bisq2LoggingSetup.setup(isDebugBuild = false)
+
+        LoggerFactory.getLogger("bisq.some.core.Component").error("even errors stay out of logcat")
+
+        assertTrue(ShadowLog.getLogsForTag(Bisq2LogcatAppender.TAG).isEmpty())
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,6 +44,12 @@ client.ios.version.code=47
 client.android.version.code=29
 node.android.version.code=48
 
+# Logging
+
+## bisq2 core root log level in node debug builds (TRACE/DEBUG/INFO/WARN/ERROR/OFF).
+## Per-dev override: BISQ2_LOG_LEVEL=DEBUG in local.properties.
+node.bisq2.log.level=INFO
+
 # Networking
 
 ## Defaults for connectivity when not set by user

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,10 @@ bignum-lib = "0.3.10"
 kmp-tor = "2.6.0"
 kmp-tor-resource = "409.5.0"
 kermit = "2.1.0"
+# Keep in sync with the logback-classic the bisq2 jars pull transitively (they pin it strictly);
+# a mismatch fails resolution loudly, which is the desired failure mode. Used by the nodeApp only,
+# to compile against the logback API for routing bisq2 core logs to logcat (issue #767).
+logback = "1.5.32"
 kphonenumber = "0.11.0"
 # Sentry KMP — opt-in analytics SDK (issue #525). Communicates with self-hosted
 # GlitchTip backend over Tor
@@ -179,6 +183,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # -------------------- Multiplatform Libraries --------------------
 logging-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
+logging-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kmp-tor-runtime = { module = "io.matthewnelson.kmp-tor:runtime", version.ref = "kmp-tor" }
 kmp-tor-resource-exec = { module = "io.matthewnelson.kmp-tor:resource-exec-tor-gpl", version.ref = "kmp-tor-resource" }
 kmp-tor-resource-noexec = { module = "io.matthewnelson.kmp-tor:resource-noexec-tor-gpl", version.ref = "kmp-tor-resource" }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/SystemOutFilter.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/SystemOutFilter.kt
@@ -180,6 +180,69 @@ class SystemOutFilter(
         }
     }
 
+    // ------------------------------------------------------------------------------------------------
+    // Raw-byte writes. PrintStream inherits these from FilterOutputStream, which would drain them into
+    // the NullOutputStream this class is constructed with - a silent black hole. That is not a
+    // theoretical path: logback's ConsoleAppender (the bisq2 jars bundle a logback.xml using it) emits
+    // exclusively via OutputStream.write(byte[], off, len), never print/println, so every bisq2 core
+    // log line was discarded wholesale - debug and release alike (issue #767). Buffer bytes into lines
+    // and route each completed line through the same filter logic as println().
+    // ------------------------------------------------------------------------------------------------
+
+    private val lineBuffer = StringBuilder()
+
+    @Synchronized
+    override fun write(b: Int) {
+        appendBytes(byteArrayOf(b.toByte()), 0, 1)
+    }
+
+    @Synchronized
+    override fun write(
+        buf: ByteArray,
+        off: Int,
+        len: Int,
+    ) {
+        appendBytes(buf, off, len)
+    }
+
+    @Synchronized
+    override fun flush() {
+        // Emit any buffered partial line so content is not held back indefinitely (writers like
+        // logback flush after each event).
+        if (lineBuffer.isNotEmpty()) {
+            val partial = lineBuffer.toString()
+            lineBuffer.setLength(0)
+            emitLine(partial)
+        }
+        originalStream.flush()
+    }
+
+    private fun appendBytes(
+        buf: ByteArray,
+        off: Int,
+        len: Int,
+    ) {
+        lineBuffer.append(String(buf, off, len))
+        var newlineIndex = lineBuffer.indexOf("\n")
+        while (newlineIndex >= 0) {
+            // Drop the newline itself; emitLine prints with println.
+            val endExclusive = if (newlineIndex > 0 && lineBuffer[newlineIndex - 1] == '\r') newlineIndex - 1 else newlineIndex
+            emitLine(lineBuffer.substring(0, endExclusive))
+            lineBuffer.delete(0, newlineIndex + 1)
+            newlineIndex = lineBuffer.indexOf("\n")
+        }
+    }
+
+    private fun emitLine(line: String) {
+        if (shouldFilter(line)) {
+            if (isDebugBuild) {
+                originalStream.println("[$tag][FILTERED] $line")
+            }
+        } else {
+            originalStream.println(line)
+        }
+    }
+
     private fun shouldFilter(content: String?): Boolean {
         if (content == null) return false
         return FILTER_REGEX.containsMatchIn(content)

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/SystemOutFilter.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/domain/utils/SystemOutFilter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.domain.utils
 
+import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.io.PrintStream
 
@@ -189,7 +190,11 @@ class SystemOutFilter(
     // and route each completed line through the same filter logic as println().
     // ------------------------------------------------------------------------------------------------
 
-    private val lineBuffer = StringBuilder()
+    // Bytes are buffered raw and decoded only once a full line is available, so a multi-byte
+    // UTF-8 character split across write() calls survives intact. UTF-8 matches logback's
+    // effective console encoding here (no explicit charset configured -> platform default,
+    // which is UTF-8 on Android).
+    private val lineBuffer = ByteArrayOutputStream()
 
     @Synchronized
     override fun write(b: Int) {
@@ -209,9 +214,9 @@ class SystemOutFilter(
     override fun flush() {
         // Emit any buffered partial line so content is not held back indefinitely (writers like
         // logback flush after each event).
-        if (lineBuffer.isNotEmpty()) {
-            val partial = lineBuffer.toString()
-            lineBuffer.setLength(0)
+        if (lineBuffer.size() > 0) {
+            val partial = String(lineBuffer.toByteArray(), Charsets.UTF_8)
+            lineBuffer.reset()
             emitLine(partial)
         }
         originalStream.flush()
@@ -222,14 +227,18 @@ class SystemOutFilter(
         off: Int,
         len: Int,
     ) {
-        lineBuffer.append(String(buf, off, len))
-        var newlineIndex = lineBuffer.indexOf("\n")
-        while (newlineIndex >= 0) {
-            // Drop the newline itself; emitLine prints with println.
-            val endExclusive = if (newlineIndex > 0 && lineBuffer[newlineIndex - 1] == '\r') newlineIndex - 1 else newlineIndex
-            emitLine(lineBuffer.substring(0, endExclusive))
-            lineBuffer.delete(0, newlineIndex + 1)
-            newlineIndex = lineBuffer.indexOf("\n")
+        for (i in off until off + len) {
+            val byte = buf[i]
+            if (byte == '\n'.code.toByte()) {
+                val bytes = lineBuffer.toByteArray()
+                lineBuffer.reset()
+                // Drop a trailing CR so CRLF lines emit clean; emitLine prints with println.
+                val endExclusive =
+                    if (bytes.isNotEmpty() && bytes[bytes.size - 1] == '\r'.code.toByte()) bytes.size - 1 else bytes.size
+                emitLine(String(bytes, 0, endExclusive, Charsets.UTF_8))
+            } else {
+                lineBuffer.write(byte.toInt())
+            }
         }
     }
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/SystemOutFilterTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/SystemOutFilterTest.kt
@@ -1,0 +1,152 @@
+package network.bisq.mobile.domain.utils
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers [SystemOutFilter]'s two intake routes: the print/println overrides and - the issue #767
+ * regression - the raw OutputStream write() route that logback's ConsoleAppender (bundled in the
+ * bisq2 jars' logback.xml) uses exclusively. Before the fix, write() bytes drained into the
+ * NullOutputStream the class extends, silently discarding every bisq2 core log line in debug AND
+ * release builds.
+ */
+class SystemOutFilterTest {
+    private val captured = ByteArrayOutputStream()
+    private val originalStream = PrintStream(captured, true)
+
+    private fun debugFilter() = SystemOutFilter(originalStream, isDebugBuild = true, tag = "TestTag")
+
+    private fun releaseFilter() = SystemOutFilter(originalStream, isDebugBuild = false, tag = "TestTag")
+
+    private fun output(): String = captured.toString()
+
+    // ------------------------------- raw write() route (issue #767) -------------------------------
+
+    @Test
+    fun `bytes written via write are emitted instead of being discarded`() {
+        val filter = debugFilter()
+        val line = "2026-01-01 INFO bisq.network.NetworkService: Bootstrapping\n"
+
+        filter.write(line.toByteArray(), 0, line.toByteArray().size)
+
+        assertTrue(output().contains("Bootstrapping"), "write() bytes must reach the original stream, not the null sink")
+    }
+
+    @Test
+    fun `chunked writes are assembled into one line before filtering`() {
+        val filter = debugFilter()
+        val part1 = "half a ".toByteArray()
+        val part2 = "log line\n".toByteArray()
+
+        filter.write(part1, 0, part1.size)
+        assertFalse(output().contains("half a"), "no emit before the line is complete")
+        filter.write(part2, 0, part2.size)
+
+        assertTrue(output().contains("half a log line"))
+    }
+
+    @Test
+    fun `single byte writes accumulate into a line`() {
+        val filter = debugFilter()
+        "ok\n".forEach { filter.write(it.code) }
+
+        assertEquals("ok", output().trim())
+    }
+
+    @Test
+    fun `filtered pattern via write is prefixed in debug builds`() {
+        val filter = debugFilter()
+        val line = "marketPriceByCurrencyMap={...verbose...}\n"
+
+        filter.write(line.toByteArray(), 0, line.toByteArray().size)
+
+        assertTrue(output().contains("[TestTag][FILTERED]"), "debug builds keep filtered content visible, prefixed")
+        assertTrue(output().contains("marketPriceByCurrencyMap"))
+    }
+
+    @Test
+    fun `filtered pattern via write is dropped when not a debug build`() {
+        val filter = releaseFilter()
+        val line = "marketPriceByCurrencyMap={...verbose...}\n"
+
+        filter.write(line.toByteArray(), 0, line.toByteArray().size)
+
+        assertEquals("", output(), "smart-filtering mode outside debug drops filtered lines entirely")
+    }
+
+    @Test
+    fun `non-filtered line via write passes through when not a debug build`() {
+        val filter = releaseFilter()
+        val line = "Important core warning\n"
+
+        filter.write(line.toByteArray(), 0, line.toByteArray().size)
+
+        assertTrue(output().contains("Important core warning"))
+    }
+
+    @Test
+    fun `crlf line endings do not leak carriage returns into the emitted line`() {
+        val filter = debugFilter()
+        val line = "windows style\r\n".toByteArray()
+
+        filter.write(line, 0, line.size)
+
+        assertTrue(output().contains("windows style"))
+        assertFalse(output().contains("\r\r"), "the CR must be stripped, not doubled by println")
+    }
+
+    @Test
+    fun `flush emits a buffered partial line`() {
+        val filter = debugFilter()
+        val partial = "no newline yet".toByteArray()
+
+        filter.write(partial, 0, partial.size)
+        assertFalse(output().contains("no newline yet"))
+        filter.flush()
+
+        assertTrue(output().contains("no newline yet"))
+    }
+
+    @Test
+    fun `multiple lines in one write are each filtered independently`() {
+        val filter = debugFilter()
+        val lines = "clean line\nMarketPrice{noisy}\nanother clean\n".toByteArray()
+
+        filter.write(lines, 0, lines.size)
+
+        val out = output()
+        assertTrue(out.contains("clean line"))
+        assertTrue(out.contains("another clean"))
+        assertTrue(out.contains("[TestTag][FILTERED] MarketPrice{noisy}"))
+    }
+
+    // ------------------------------- print/println route (existing behavior pin) ------------------
+
+    @Test
+    fun `println passes non-filtered content through`() {
+        val filter = debugFilter()
+        filter.println("hello from println")
+
+        assertTrue(output().contains("hello from println"))
+    }
+
+    @Test
+    fun `println prefixes filtered content in debug builds`() {
+        val filter = debugFilter()
+        filter.println("PriceQuote(1234)")
+
+        assertTrue(output().contains("[TestTag][FILTERED] PriceQuote(1234)"))
+    }
+
+    @Test
+    fun `println drops filtered content when not a debug build`() {
+        val filter = releaseFilter()
+        filter.println("PriceQuote(1234)")
+
+        assertEquals("", output())
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/SystemOutFilterTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/SystemOutFilterTest.kt
@@ -96,7 +96,18 @@ class SystemOutFilterTest {
         filter.write(line, 0, line.size)
 
         assertTrue(output().contains("windows style"))
-        assertFalse(output().contains("\r\r"), "the CR must be stripped, not doubled by println")
+        assertFalse(output().contains("\r"), "the CR must be stripped entirely")
+    }
+
+    @Test
+    fun `multi-byte character split across writes is not corrupted`() {
+        val filter = debugFilter()
+        val bytes = "café line\n".toByteArray(Charsets.UTF_8)
+        // 'é' is two bytes in UTF-8 (indices 3..4); split the write between them.
+        filter.write(bytes, 0, 4)
+        filter.write(bytes, 4, bytes.size - 4)
+
+        assertTrue(output().contains("café line"), "a split multi-byte char must decode intact")
     }
 
     @Test


### PR DESCRIPTION
 - resolves #767

Bisq2 core logs never reached logcat: the jar-bundled logback.xml uses a ConsoleAppender that writes raw bytes to System.out, and our SystemOutFilter extends PrintStream over a null sink - so the byte-write path silently discarded every core log line, in debug and release alike.
 
This PR:
  - Fixes SystemOutFilter to buffer raw write() bytes into lines and route them through the same filter logic (the actual regression behind #767)
  - Adds Bisq2LogcatAppender + Bisq2LoggingSetup: resets the jar's logback config programmatically and attaches a native logcat appender under a single Bisq2 tag with proper priorities - debug output now reads like the bisq2 terminal (adb logcat -s Bisq2)
  - Root log level is configurable without code edits: node.bisq2.log.level in gradle.properties (default INFO), per-dev override via BISQ2_LOG_LEVEL in local.properties, also -Pnode.bisq2.log.level=X. Baked into BuildConfig in defaultConfig (consumed by all variants, honored only in debug). Per-package overrides stay in the tweak-me block in Bisq2LoggingSetup
  - Release builds are unaffected: logback root is set to OFF (no appender attached — verified by test), the config knob is only read on  the debug path, and release System.out stays hard-blocked as before. Core logs can carry peer/onion addresses, so the privacy posture is unchanged
  - Adds logback-classic to the nodeApp compile classpath (version pinned to what the bisq2 jars already ship at runtime)
  - Adds related AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Bisq2 logging for Android builds.
  * Routed Bisq2 logs to Android logcat with appropriate severity levels and diagnostic details.
  * Added separate logging behavior for debug and release builds.
  * Added support for local log-level overrides.

* **Bug Fixes**
  * Restored filtering and forwarding for logs written directly to output streams, including partial and multi-line messages.

* **Tests**
  * Added coverage for logcat severity mapping, filtering, formatting, and release-build suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->