### PR TITLE
chore/android_17_apps_compile_sdk_upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,9 @@ kotlin.native.memory.maxHeapSize=8g
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.suppressUnsupportedCompileSdk=35
+# AGP 8.13.2 is tested up to compileSdk 36.1; 37 builds and runs fine (validated on API 37
+# emulator). Revisit when upgrading to an AGP release tested with 37 (see issue #1393).
+android.suppressUnsupportedCompileSdk=35,37.0
 android.enableR8.fullMode=true
 #android.enableR8.retrace=true
 #android.enableR8.debug=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kover = "0.9.7"
 #noinspection AndroidGradlePluginVersion - we need to stick to it based on https://developer.android.com/build/kotlin-support
 agp = "8.13.2"
 android-ndk = "26.1.10909125"
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-targetSdk = "36"
 android-minSdk = "24"
 # TODO analyse lowering back to API 31 when Bisq2 full J17 support is returned and we can get rid of desugaring


### PR DESCRIPTION
 - resolves #1498 
 - bump android compile SDK to API 37 
 - no code changes needed 👍 
 - AGP 9.x upgrade deliberately deferred -> 8.13.2 exceeds the documented minimum for SDK 37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android compile SDK to version 37, enabling compatibility with the latest Android platform tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->