### PR TITLE
fix: reconnect overlay appearing while connecting to new trusted node

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityServiceTest.kt
@@ -48,6 +48,7 @@ class ClientConnectivityServiceTest {
         coEvery { webSocketClientService.sendHealthCheck() } returns true
         every { webSocketClientService.isSubscriptionsPending } returns MutableStateFlow(false)
         every { webSocketClientService.failedSubscriptionTopics } returns MutableStateFlow(emptySet())
+        every { webSocketClientService.isAwaitingPairingCredentials } returns MutableStateFlow(false)
         clientConnectivityService = ClientConnectivityService(webSocketClientService, androidPlatformInfo)
         // Reset static averageTripTime via public API: the averaging formula
         // (current + new) / 2 converges quickly to 0, ensuring isSlow() returns false.
@@ -110,6 +111,21 @@ class ClientConnectivityServiceTest {
             delay(300)
 
             assertEquals(ConnectivityService.ConnectivityStatus.RECONNECTING, clientConnectivityService.status.value)
+        }
+
+    @Test
+    fun `checkConnectivity returns DISCONNECTED and skips reconnect when awaiting pairing credentials`() =
+        runBlocking {
+            every { webSocketClientService.isConnected() } returns false
+            every { webSocketClientService.isAwaitingPairingCredentials } returns MutableStateFlow(true)
+            coEvery { webSocketClientService.triggerReconnect() } just Runs
+
+            clientConnectivityService.activate()
+            clientConnectivityService.startMonitoring(period = 100, startDelay = 0)
+            delay(300)
+
+            assertEquals(ConnectivityService.ConnectivityStatus.DISCONNECTED, clientConnectivityService.status.value)
+            coVerify(exactly = 0) { webSocketClientService.triggerReconnect() }
         }
 
     @Test
@@ -597,6 +613,7 @@ class ClientConnectivityServiceTest {
             for (platform in listOf(androidPlatformInfo, iosPlatformInfo)) {
                 clearMocks(webSocketClientService)
                 every { webSocketClientService.isConnected() } returns false
+                every { webSocketClientService.isAwaitingPairingCredentials } returns MutableStateFlow(false)
                 every { webSocketClientService.failedSubscriptionTopics } returns MutableStateFlow(emptySet())
                 coEvery { webSocketClientService.triggerReconnect() } just Runs
                 coEvery { webSocketClientService.forceClientRecreation() } just Runs

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client.trusted_node_setup
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -836,6 +837,23 @@ class TrustedNodeSetupPresenterTest {
 
             // Then
             assertFalse(presenter.uiState.value.showChangeNodeWarning)
+        }
+
+    @Test
+    fun `when OnChangeNodeWarningConfirm action then hides main content before clearing settings`() =
+        runTest(testDispatcher) {
+            coEvery { sensitiveSettingsRepository.clear() } returns Unit
+            setupPresenter()
+            presenter.onAction(TrustedNodeSetupUiAction.OnPairWithNewNodePress)
+            advanceUntilIdle()
+
+            presenter.onAction(TrustedNodeSetupUiAction.OnChangeNodeWarningConfirm)
+            advanceUntilIdle()
+
+            coVerifyOrder {
+                mainPresenter.setIsMainContentVisible(false)
+                sensitiveSettingsRepository.clear()
+            }
         }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientConnectivityService.kt
@@ -192,20 +192,27 @@ open class ClientConnectivityService(
                         // be down even though the TCP socket looks alive (half-open connection).
                         // We must verify with a real round-trip before trusting the connection.
                         if (!connected) {
-                            // A dropped connection ends the current trusted session, so restart
-                            // the health-check grace counter — the next reconnected session must
-                            // get a fresh single-miss tolerance rather than inheriting a stale count.
-                            consecutiveHealthCheckFailures = 0
-                            consecutiveReconnectingCycles++
-                            log.d { "Not connected, consecutiveReconnectingCycles=$consecutiveReconnectingCycles" }
-                            if (shouldForceClientRecreation()) {
-                                log.i { "Forcing client recreation after $consecutiveReconnectingCycles failed cycles (platform=${platformInfo.type})" }
-                                webSocketClientService.forceClientRecreation()
+                            if (webSocketClientService.isAwaitingPairingCredentials.value) {
+                                consecutiveHealthCheckFailures = 0
                                 consecutiveReconnectingCycles = 0
+                                connectionUntrusted = false
+                                ConnectivityStatus.DISCONNECTED
                             } else {
-                                webSocketClientService.triggerReconnect()
+                                // A dropped connection ends the current trusted session, so restart
+                                // the health-check grace counter — the next reconnected session must
+                                // get a fresh single-miss tolerance rather than inheriting a stale count.
+                                consecutiveHealthCheckFailures = 0
+                                consecutiveReconnectingCycles++
+                                log.d { "Not connected, consecutiveReconnectingCycles=$consecutiveReconnectingCycles" }
+                                if (shouldForceClientRecreation()) {
+                                    log.i { "Forcing client recreation after $consecutiveReconnectingCycles failed cycles (platform=${platformInfo.type})" }
+                                    webSocketClientService.forceClientRecreation()
+                                    consecutiveReconnectingCycles = 0
+                                } else {
+                                    webSocketClientService.triggerReconnect()
+                                }
+                                ConnectivityStatus.RECONNECTING
                             }
-                            ConnectivityStatus.RECONNECTING
                         } else {
                             // isConnected() is true but connection is untrusted.
                             // Verify with a health check before restoring trust.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/connectivity.md
@@ -213,7 +213,7 @@ Bootstrap session POST also persists `sessionExpiresAt` (same as renewal).
 5. Identical `HttpClientSettings` — skip WS replacement (avoids churn during Tor startup duplicates).
 6. Healthy live WS + unchanged topology — bootstrap `sessionId` rotation may skip recreation when ≥15m session remains.
 7. Cold start — defer WS creation when persisted session is expired, expiring within 15m, or expiry unknown.
-8. Pairing — blank `sessionId`/`clientId` skips WS creation until credentials exist.
+8. Pairing — blank `sessionId`/`clientId` skips WS creation until credentials exist; health monitor publishes `DISCONNECTED` (not `RECONNECTING`) and does not trigger reconnect while awaiting pairing credentials. Intentional re-pair clears `isMainContentVisible` so reconnect overlays stay suppressed until Dashboard re-arms on Home.
 9. iOS `CancellationException` on disconnect — reconnect only when cause message contains `"Socket is not connected"`; other cancellations are not auto-retried.
 10. iOS SIGSEGV guard — extract `requestId` from raw JSON before deserializing sealed WS messages.
 11. `unSubscribe()` — not implemented (logs warning).

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -112,6 +112,11 @@ class WebSocketClientService(
         _clientRevoked.value = false
     }
 
+    private val _isAwaitingPairingCredentials = MutableStateFlow(false)
+
+    /** True while client or session pairing credentials are blank and WebSocket creation is intentionally skipped. */
+    val isAwaitingPairingCredentials: StateFlow<Boolean> = _isAwaitingPairingCredentials.asStateFlow()
+
     val isTorProxy: Boolean get() = preservedIsTorProxy || currentClientSettings?.isTorProxy == true
 
     private val clientUpdateMutex = Mutex()
@@ -347,8 +352,11 @@ class WebSocketClientService(
                 stateCollectionJob = null
                 currentClientSettings = null
                 _connectionState.value = ConnectionState.Disconnected()
+                _isAwaitingPairingCredentials.value = true
                 return@withLock
             }
+
+            _isAwaitingPairingCredentials.value = false
 
             // Cold start with a short-lived persisted session: wait for bootstrap POST to
             // rotate sessionId before opening WS (avoids connect-then-dispose on renewal).

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenter.kt
@@ -29,7 +29,7 @@ import network.bisq.mobile.presentation.main.MainPresenter
  * Presenter for the Trusted Node Setup screen.
  */
 class TrustedNodeSetupPresenter(
-    mainPresenter: MainPresenter,
+    private val mainPresenter: MainPresenter,
     private val kmpTorService: KmpTorService,
     private val trustedNodeSetupUseCase: TrustedNodeSetupUseCase,
     private val apiAccessService: ApiAccessService,
@@ -324,6 +324,7 @@ class TrustedNodeSetupPresenter(
 
     private fun onChangeNodeWarningConfirm() {
         presenterScope.launch {
+            mainPresenter.setIsMainContentVisible(false)
             sensitiveSettingsRepository.clear()
             pairingQrCode = null
             _uiState.value = TrustedNodeSetupUiState()


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1679

Explicit re-pair clears credentials and disposes the WebSocket, which made the health monitor publish RECONNECTING while isMainContentVisible stayed true. Hence the reconnecting dialog.

 - Clears isMainContentVisible before clearing settings on confirm, so reconnect/lost-connection overlays stay hidden during pairing. Dashboard re-enables the flag on Home after a successful pair.
 - Skips RECONNECTING / reconnect attempts while pairing credentials are blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connectivity handling when pairing credentials are unavailable.
  * Prevented unnecessary reconnection attempts and client recreation during pairing.
  * Kept reconnect overlays hidden until intentional re-pairing is initiated.
  * Hid main content before clearing sensitive settings when changing trusted nodes.
  * Improved trusted-node change transitions for a smoother and safer setup experience.

* **Documentation**
  * Updated pairing and connectivity behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->