### PR TITLE
fix(tests): move shared presentation test bases to :shared:test-utils

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -253,23 +253,6 @@ kotlin {
             // Test utilities
             implementation(project(sharedTestUtilsModule))
         }
-
-        // Share presentation's Android unit-test helpers with clientApp tests.
-        // Graft only the subdirs clientApp consumes — not the test_utils root, so
-        // presentation-only helpers and test classes there cannot break client builds.
-        // Do not use kotlin.include here — it replaces the source set's default **/*
-        // and would drop clientApp's own androidUnitTest sources.
-        androidUnitTest {
-            val presentationUnitTestUtils =
-                project(sharedPresentationModule).projectDir.resolve(
-                    "src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils",
-                )
-            kotlin.srcDirs(
-                presentationUnitTestUtils.resolve("compose"),
-                presentationUnitTestUtils.resolve("coroutines"),
-                presentationUnitTestUtils.resolve("di"),
-            )
-        }
     }
 }
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/network/presentation/connections/ClientNetworkConnectionsContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/network/presentation/connections/ClientNetworkConnectionsContentTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.test.performScrollTo
 import network.bisq.mobile.client.common.test_utils.TestApplication
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
 import network.bisq.mobile.presentation.common.ui.components.network.NetworkConnectionUiItem
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 import org.robolectric.annotation.Config
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/network/presentation/network/ClientNetworkOverviewContentTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/network/presentation/network/ClientNetworkOverviewContentTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.test.performScrollTo
 import network.bisq.mobile.client.common.test_utils.TestApplication
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
 import network.bisq.mobile.presentation.common.ui.components.network.NetworkHealthState
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 import org.robolectric.annotation.Config
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/PaymentAccountMethodIconUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/ui/PaymentAccountMethodIconUiTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import network.bisq.mobile.client.common.presentation.model.account.PaymentTypeVO
 import network.bisq.mobile.client.common.test_utils.TestApplication
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 import org.robolectric.annotation.Config
 

--- a/docs/TESTING_FIXTURES.md
+++ b/docs/TESTING_FIXTURES.md
@@ -46,7 +46,7 @@ Issues hit (KGP + AGP 8.13, Kotlin 2.4):
 | `kotlin.srcDir("src/testFixtures/kotlin")` bridge | Gradle compiled fine; Android Studio did not index `presentation.test.*` or `kotlin.test.*` reliably |
 | Fixtures are Android/JVM-only | Correct for presenter/Compose helpers; `commonTest` / `iosTest` cannot consume them |
 
-Cross-platform bases (`CoroutineTestBase`, `KoinIntegrationTestBase`) stay in `:shared:test-utils` `commonMain`. Android-only presenter/UI/Koin bases belong with presentation tests.
+Cross-platform bases (`CoroutineTestBase`, dispatcher providers, repository mocks) live in `:shared:test-utils` `commonMain`; Android-only bases (`KoinIntegrationTestBase`, presenter/UI/Compose bases) live in its `androidMain` — see [Current approach](#current-approach).
 
 ### 3. Re-check with `enableTestFixturesKotlinSupport` (Jul 2026)
 
@@ -69,25 +69,43 @@ So AGP's experimental Kotlin fixtures support applies to pure `kotlin-android` m
 
 Do not re-enable `testFixtures` on `:shared:presentation` until KGP registers `compile*TestFixturesKotlin` for KMP Android libraries (or AGP built-in Kotlin / a later KGP release documents that path).
 
+### 4. `kotlin.srcDirs` graft from clientApp (removed Jul 2026)
+
+`clientApp` grafted presentation's `test_utils/{compose,coroutines,di}` directories into its own
+`androidUnitTest` source set via `kotlin.srcDirs`. Gradle compiled fine (each module compiles its
+own copy), but the IDE broke: **Android Studio assigns each directory to exactly one module**, and
+the most specific content root wins. The grafted subdirectories were claimed by
+`clientApp.unitTest`, so presentation's own tests could no longer resolve
+`PresentationKoinTestBase` and friends — "Unresolved reference `test_utils`" on every presenter
+test, on every machine, surviving cache invalidation (plus duplicated-PSI `different providers`
+exceptions in `idea.log`). Diagnosed 2026-07-29; do not reintroduce source-dir grafts across
+modules.
+
 ## Current approach
 
-Helpers live in presentation's `androidUnitTest`:
+Android presentation test bases live in `:shared:test-utils` `androidMain`:
 
 ```text
-shared/presentation/src/androidUnitTest/kotlin/.../common/test_utils/
+shared/test-utils/src/androidMain/kotlin/.../test/presentation/
   compose/     BisqComposeUiTestBase, PresentationKoinComposeTestBase, …
   coroutines/  PresentationKoinTestBase, PlatformPresentationKoinTestBase
-  di/          presentationTestModule(...)
+  di/          presentationTestModule(...), NoopNavigationManager
 ```
 
-`:shared:presentation-test-utils` was removed.
+Packages: `network.bisq.mobile.test.presentation.*`.
 
-`clientApp` reuses helpers via `kotlin.srcDirs` grafts in `apps/clientApp/build.gradle.kts` — not a module dependency, so no cycle. Point only at `compose/`, `coroutines/`, and `di/` (not the `test_utils` root). Do **not** use `kotlin.include` on that source set: it replaces the default `**/*` and drops clientApp's own `androidUnitTest` sources.
+`:shared:test-utils` `androidMain` has `api(project(":shared:presentation"))` — a one-way
+dependency on presentation's production code. Presentation's `androidUnitTest` depends back on
+`:shared:test-utils`'s *main* compilation; at source-set granularity this is acyclic
+(`test-utils androidMain → presentation main`; `presentation androidUnitTest → test-utils
+androidMain`), and both Gradle and the IDE handle it. This differs from the removed
+`:shared:presentation-test-utils` era (attempt 1) mainly in that helpers live in the existing
+shared test module and consumers resolve them as a normal module dependency instead of shared
+source directories.
 
-```text
-presentation main ← clientApp (implementation)
-presentation test_utils/{compose,coroutines,di} ← clientApp androidUnitTest (srcDirs graft)
-```
+Presentation-only fakes/factories (`FakeConfigServiceFacade`, `OfferTestFactory`, `StateFlowProbe`,
+…) stay in `shared/presentation/src/androidUnitTest/.../common/test_utils/` — they are not needed
+outside that module.
 
 Explicit `implementation(libs.kotlin.test)` on `androidUnitTest` avoids IDE gaps when only `kotlin-test-junit` is declared.
 
@@ -95,12 +113,11 @@ Explicit `implementation(libs.kotlin.test)` on `androidUnitTest` avoids IDE gaps
 
 Try AGP test fixtures again when **KMP** publishes Kotlin classes into the testFixtures AAR (look for a real `compileDebugTestFixturesKotlin` task on `:shared:presentation`, not only the experimental AGP flag). Migration would be:
 
-1. Move `common/test_utils/{compose,coroutines,di}` → `src/testFixtures/kotlin/`
+1. Move `test-utils/src/androidMain/.../test/presentation/{compose,coroutines,di}` → presentation's `src/testFixtures/kotlin/`
 2. `testFixtures { enable = true }` on `:shared:presentation`
 3. `android.experimental.enableTestFixturesKotlinSupport=true` in `gradle.properties` (until non-experimental)
-4. `clientApp`: `implementation(testFixtures(project(":shared:presentation")))`
-5. Remove `kotlin.srcDirs` graft
-6. Smoke-check: `assembleDebugTestFixtures` → `classes.jar` contains helper `.class` files; presentation + clientApp unit tests still resolve bases in the IDE
+4. Consumers: `implementation(testFixtures(project(":shared:presentation")))`; drop `api(project(":shared:presentation"))` from `:shared:test-utils` `androidMain`
+5. Smoke-check: `assembleDebugTestFixtures` → `classes.jar` contains helper `.class` files; presentation + clientApp unit tests still resolve bases in the IDE
 
 ## References
 

--- a/docs/testing/catalog.md
+++ b/docs/testing/catalog.md
@@ -2,7 +2,7 @@
 
 Ground-truth index of shared test helpers. Do not invent utilities or paths not listed here.
 
-> `:shared:presentation-test-utils` was removed (`2cb248bb`). Helpers live under `shared/presentation/src/androidUnitTest/.../common/test_utils/`.
+> Shared presentation test bases live in `shared/test-utils/src/androidMain/.../test/presentation/` (packages `network.bisq.mobile.test.presentation.*`). Presentation-only fakes/factories stay in `shared/presentation/src/androidUnitTest/.../common/test_utils/`.
 
 ## Leaf bases
 
@@ -10,21 +10,20 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 
 | Base | Path | Use when |
 | --- | --- | --- |
-| `PresentationKoinTestBase` | `shared/presentation/src/androidUnitTest/kotlin/.../test_utils/coroutines/PresentationKoinTestBase.kt` | `:shared:presentation` presenter tests |
-| `PlatformPresentationKoinTestBase` | `.../coroutines/PlatformPresentationKoinTestBase.kt` | + static platform mocks (`getScreenWidthDp`) |
+| `PresentationKoinTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/coroutines/PresentationKoinTestBase.kt` | `:shared:presentation` presenter tests |
+| `PlatformPresentationKoinTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/coroutines/PlatformPresentationKoinTestBase.kt` | + static platform mocks (`getScreenWidthDp`) |
 | `ClientKoinIntegrationTestBase` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/ClientKoinIntegrationTestBase.kt` | Client facades/services |
 | `NodeKoinIntegrationTestBase` | `apps/nodeApp/src/androidUnitTest/kotlin/.../test_utils/NodeKoinIntegrationTestBase.kt` | Node presenters/facades |
-| `BisqComposeUiTestBase` | `.../test_utils/compose/BisqComposeUiTestBase.kt` | Compose UI, no Koin |
-| `PresentationKoinComposeTestBase` | `.../test_utils/compose/PresentationKoinComposeTestBase.kt` | Compose + `presentationTestModule` (shared `StandardTestDispatcher`) |
-| `PlatformPresentationKoinComposeTestBase` | `.../test_utils/compose/PlatformPresentationKoinComposeTestBase.kt` | Compose + Koin + platform mocks |
-| `AlertNotificationKoinComposeTestBase` | `.../test_utils/compose/AlertNotificationKoinComposeTestBase.kt` | Alert UI — dedicated Koin module |
+| `BisqComposeUiTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/compose/BisqComposeUiTestBase.kt` | Compose UI, no Koin |
+| `PresentationKoinComposeTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/compose/PresentationKoinComposeTestBase.kt` | Compose + `presentationTestModule` (shared `StandardTestDispatcher`) |
+| `PlatformPresentationKoinComposeTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/compose/PlatformPresentationKoinComposeTestBase.kt` | Compose + Koin + platform mocks |
 
 ## Key helpers
 
 | Symbol | Path |
 | --- | --- |
-| `BisqComposeTestSupport` | `.../test_utils/compose/BisqComposeTestSupport.kt` |
-| `presentationTestModule(...)` | `.../test_utils/di/PresentationTestModule.kt` |
+| `BisqComposeTestSupport` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/compose/BisqComposeTestSupport.kt` |
+| `presentationTestModule(...)` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/di/PresentationTestModule.kt` |
 | `analyticsTestModule` | `shared/test-utils/src/androidMain/kotlin/.../test/koin/AnalyticsTestModule.kt` |
 | `clientTestModule` | `apps/clientApp/src/androidUnitTest/kotlin/.../client/common/di/TestModule.kt` |
 | `commonTestModule` | `apps/clientApp/src/commonTest/kotlin/.../client/common/di/CommonTestModule.kt` |
@@ -35,8 +34,8 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `FakeAppUpdateLinker` | `.../test_utils/FakeAppUpdateLinker.kt` |
 | `TEST_APP_UPDATE_URL` | `.../test_utils/FakeAppUpdateLinker.kt` |
 | `StateFlowProbe` | `.../test_utils/StateFlowProbe.kt` |
-| `NoopNavigationManager` | `.../test_utils/di/NoopNavigationManager.kt` |
-| `PlatformStaticMocks` | `.../test_utils/coroutines/PlatformStaticMocks.kt` |
+| `NoopNavigationManager` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/di/NoopNavigationManager.kt` |
+| `PlatformStaticMocks` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/coroutines/PlatformStaticMocks.kt` |
 | `FakeConfigServiceFacade` | `shared/presentation/src/androidUnitTest/kotlin/.../test_utils/FakeConfigServiceFacade.kt` |
 | `FakeMarketPriceServiceFacade` | `shared/presentation/src/androidUnitTest/kotlin/.../test_utils/FakeMarketPriceServiceFacade.kt` |
 | `OfferTestFactory` | `shared/presentation/src/androidUnitTest/kotlin/.../test_utils/OfferTestFactory.kt` |

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/AlertNotificationBannerPresenterTest.kt
@@ -29,10 +29,10 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.test_utils.probeStateFlow
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/banner/AlertNotificationBannerUiTest.kt
@@ -35,13 +35,13 @@ import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationBannerPresenter
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/alert/dialog/AlertNotificationDialogUiTest.kt
@@ -42,7 +42,6 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationBannerPresenter
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
@@ -50,6 +49,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationM
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextLinkInteractionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/NoteTextLinkInteractionUiTest.kt
@@ -9,13 +9,13 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import network.bisq.mobile.presentation.common.test_utils.compose.PresentationKoinComposeTestBase
 import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkConfirmationDialogPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.webLinkConfirmationTestModule
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
 import org.junit.Test
 import org.koin.dsl.module
 import kotlin.test.assertEquals

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRatingUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/StarRatingUiTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 
 class StarRatingUiTest : BisqComposeUiTestBase() {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/SwitchUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/SwitchUiTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import io.mockk.mockk
 import io.mockk.verify
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 
 /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/button/LinkButtonUiTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.PresentationKoinComposeTestBase
 import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WebLinkDialogSettingsServiceFake
@@ -20,6 +19,7 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.mo
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.webLinkConfirmationTestModule
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
 import org.junit.Test
 import org.koin.core.module.Module
 import kotlin.test.assertEquals

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/TopBarPresenterTest.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformPresentationKoinTestBase
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
+import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ReconnectingOverlayUiTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import io.mockk.mockk
 import io.mockk.verify
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 
 /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkConfirmationDialogPresenterTest.kt
@@ -9,9 +9,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertTrue
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiIsolatedTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiIsolatedTest.kt
@@ -11,9 +11,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.PresentationKoinComposeTestBase
 import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
 import org.junit.Test
 import org.koin.core.module.Module
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WebLinkDialogUiKoinTest.kt
@@ -16,12 +16,12 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.PresentationKoinComposeTestBase
 import network.bisq.mobile.presentation.common.ui.base.SnackbarPosition
 import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
 import org.junit.Test
 import org.koin.core.module.Module
 import kotlin.test.assertEquals

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/network/ConnectionCardUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/network/ConnectionCardUiTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 
 /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/i18n/LocalLanguageCodeComposeTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/i18n/LocalLanguageCodeComposeTest.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
 import network.bisq.mobile.presentation.common.ui.components.context.LocalLanguageCode
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.After
 import org.junit.Test
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBannerPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/network_banner/NetworkStatusBannerPresenterTest.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.UiString
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterCleanupTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterCleanupTest.kt
@@ -22,9 +22,9 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterLanguageAnalyticsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/main/MainPresenterLanguageAnalyticsTest.kt
@@ -16,8 +16,8 @@ import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.presentationTestModule
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.presentation.di.presentationTestModule
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/direction/CreateOfferDirectionPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/direction/CreateOfferDirectionPresenterTest.kt
@@ -22,11 +22,11 @@ import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformPresentationKoinTestBase
 import network.bisq.mobile.presentation.common.test_utils.probeStateFlow
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
+import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterActionGuardResetTest.kt
@@ -45,13 +45,13 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterPersistenceTest.kt
@@ -48,13 +48,13 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -40,9 +40,9 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformPresentationKoinTestBase
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
+import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
@@ -47,7 +47,6 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
@@ -56,6 +55,7 @@ import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterSlowLoadingHintTest.kt
@@ -36,7 +36,6 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
@@ -44,6 +43,7 @@ import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterTradeRestrictionTest.kt
@@ -38,7 +38,6 @@ import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacad
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
@@ -46,6 +45,7 @@ import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
@@ -44,7 +44,6 @@ import network.bisq.mobile.domain.model.alert.AlertType
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiState
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
@@ -55,6 +54,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.LocalIsTest
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqPresenterTest.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreenContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/faqs/FaqScreenContentUiTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.performScrollTo
 import io.mockk.mockk
 import io.mockk.verify
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Before
 import org.junit.Test
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
@@ -10,8 +10,8 @@ import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformPresentationKoinTestBase
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/payment_accounts/PaymentAccountsContentUiTest.kt
@@ -11,8 +11,8 @@ import io.mockk.verify
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccountPayload
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeUiTestBase
 import network.bisq.mobile.presentation.common.ui.utils.DataEntry
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Before
 import org.junit.Test
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenterTest.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.i18n.I18nSupport
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardPresenterPushNotificationTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/dashboard/DashboardPresenterPushNotificationTest.kt
@@ -29,10 +29,10 @@ import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.presentation.common.notification.NotificationController
 import network.bisq.mobile.presentation.common.platform_settings.PlatformSettingsManager
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
@@ -14,9 +14,9 @@ import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
 import network.bisq.mobile.i18n.UiString
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterDuplicateCallTest.kt
@@ -19,13 +19,13 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterTradeRestrictionTest.kt
@@ -26,7 +26,6 @@ import network.bisq.mobile.presentation.common.test_utils.FakeAppUpdateLinker
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TEST_APP_UPDATE_URL
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.alert.AlertNotificationUiAction
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
@@ -34,6 +33,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationM
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
@@ -32,9 +32,9 @@ import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.presentation.common.notification.NotificationController
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
-import network.bisq.mobile.presentation.common.test_utils.di.NoopNavigationManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
+import network.bisq.mobile.test.presentation.di.NoopNavigationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/test-utils/build.gradle.kts
+++ b/shared/test-utils/build.gradle.kts
@@ -1,8 +1,19 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    // Compose is required for the Android presentation test bases
+    // (BisqComposeTestSupport and friends declare @Composable lambdas).
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+// Compose code lives only in androidMain (test.presentation.*); iOS source sets have
+// no Compose runtime, so keep the Compose compiler off the native targets.
+composeCompiler {
+    targetKotlinPlatforms.set(setOf(KotlinPlatformType.androidJvm))
 }
 
 kotlin {
@@ -37,6 +48,24 @@ kotlin {
             // Koin for KoinIntegrationTestBase — api so subclasses can use KoinTest
             api(libs.koin.core)
             api(libs.koin.test)
+
+            // Presentation test bases (test.presentation.*) — api because base classes
+            // expose presentation types (NavigationManager, GlobalUiManager) to subclasses.
+            // One-way dependency: test-utils androidMain -> presentation main. Presentation's
+            // androidUnitTest depends back on this module's main — acyclic at source-set level.
+            api(project(":shared:presentation"))
+
+            // Compose runtime + rule for the Compose UI test bases; api so subclasses see
+            // ComposeContentTestRule via the exposed composeTestRule property.
+            implementation(libs.compose.runtime)
+            api(libs.androidx.test.compose.junit4)
+            implementation(libs.androidx.test.junit)
+
+            // NoopNavigationManager implements NavigationManager (NavHostController params)
+            implementation(libs.navigation.compose)
+
+            // Presentation test bases create relaxed mocks and static mocks
+            implementation(libs.mockk)
         }
     }
 }

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/BisqComposeTestSupport.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/BisqComposeTestSupport.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.compose
+package network.bisq.mobile.test.presentation.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/BisqComposeUiTestBase.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/BisqComposeUiTestBase.kt
@@ -1,10 +1,10 @@
-package network.bisq.mobile.presentation.common.test_utils.compose
+package network.bisq.mobile.test.presentation.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import network.bisq.mobile.i18n.I18nSupport
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeTestSupport.setBisqTestContent
+import network.bisq.mobile.test.presentation.compose.BisqComposeTestSupport.setBisqTestContent
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/PlatformPresentationKoinComposeTestBase.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/PlatformPresentationKoinComposeTestBase.kt
@@ -1,6 +1,6 @@
-package network.bisq.mobile.presentation.common.test_utils.compose
+package network.bisq.mobile.test.presentation.compose
 
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PlatformStaticMocks
+import network.bisq.mobile.test.presentation.coroutines.PlatformStaticMocks
 
 /**
  * Compose + Koin base for presentation UI tests that also need platform static mocks

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/PresentationKoinComposeTestBase.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/compose/PresentationKoinComposeTestBase.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.compose
+package network.bisq.mobile.test.presentation.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -9,8 +9,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import network.bisq.mobile.i18n.I18nSupport
-import network.bisq.mobile.presentation.common.test_utils.compose.BisqComposeTestSupport.setBisqTestContent
-import network.bisq.mobile.presentation.common.test_utils.coroutines.PresentationKoinTestBase
+import network.bisq.mobile.test.presentation.compose.BisqComposeTestSupport.setBisqTestContent
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.koin.core.context.startKoin

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PlatformPresentationKoinTestBase.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PlatformPresentationKoinTestBase.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.coroutines
+package network.bisq.mobile.test.presentation.coroutines
 
 abstract class PlatformPresentationKoinTestBase : PresentationKoinTestBase() {
     override fun setUpPlatformMocks() {

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PlatformStaticMocks.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PlatformStaticMocks.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.coroutines
+package network.bisq.mobile.test.presentation.coroutines
 
 import io.mockk.every
 import io.mockk.mockkStatic

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PresentationKoinTestBase.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/coroutines/PresentationKoinTestBase.kt
@@ -1,10 +1,10 @@
-package network.bisq.mobile.presentation.common.test_utils.coroutines
+package network.bisq.mobile.test.presentation.coroutines
 
 import io.mockk.mockk
-import network.bisq.mobile.presentation.common.test_utils.di.presentationTestModule
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.test.koin.KoinIntegrationTestBase
+import network.bisq.mobile.test.presentation.di.presentationTestModule
 import org.koin.core.module.Module
 
 /**

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/di/NoopNavigationManager.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/di/NoopNavigationManager.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.di
+package network.bisq.mobile.test.presentation.di
 
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder

--- a/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/di/PresentationTestModule.kt
+++ b/shared/test-utils/src/androidMain/kotlin/network/bisq/mobile/test/presentation/di/PresentationTestModule.kt
@@ -1,4 +1,4 @@
-package network.bisq.mobile.presentation.common.test_utils.di
+package network.bisq.mobile.test.presentation.di
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi


### PR DESCRIPTION
Moves the shared Android presentation test base classes out of `shared/presentation` test sources into `:shared:test-utils` `androidMain`.

Fixes widespread `unresolved reference` errors in test files introduced in https://github.com/bisq-network/bisq-mobile/pull/1594

## Previous structure

The shared presentation test bases — `PresentationKoinTestBase`, `BisqComposeUiTestBase`, etc., — lived in presentation's test source set:

    shared/presentation/src/androidUnitTest/.../common/test_utils/{compose,coroutines,di}/

Test source sets aren't published, so `clientApp` couldn't depend on them as a module. Instead, `apps/clientApp/build.gradle.kts` grafted the three directories into its own `androidUnitTest` source set via `kotlin.srcDirs`.

This messed with how Android studio resolves modules and resulted in:
- `Unresolved reference: test_utils` on every presenter test, on every machine

## New structure

The bases now live in a published source set of the existing shared test module:

    shared/test-utils/src/androidMain/.../test/presentation/{compose,coroutines,di}/

Packages renamed accordingly: `network.bisq.mobile.test.presentation.*`.

Dependency wiring (acyclic at source-set granularity):

    :shared:test-utils  androidMain      ──api──▶  :shared:presentation  main
        PresentationKoinTestBase uses NavigationManager, GlobalUiManager
        BisqComposeTestSupport uses BisqTheme, LocalIsTest

    :shared:presentation androidUnitTest ─────────▶ :shared:test-utils   main
        FaqPresenterTest extends  PresentationKoinTestBase

    :apps:clientApp     androidUnitTest ─────────▶ :shared:test-utils   main
        ClientKoinIntegrationTestBase extends KoinIntegrationTestBase

This change resolve the `unresolved reference`, without introducing cyclic dependencies.

After this merge, will do follow-up PR that makes existing tests make of this test bases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated presentation testing utilities into a shared test-support area.
  * Simplified Android test configuration and standardized test utility references.

* **Documentation**
  * Updated testing fixture guidance and the testing utilities catalog to reflect the new shared structure.

* **Tests**
  * Updated presentation and client application tests to use the reorganized testing foundations without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->