### PR TITLE
Feature/improve offers sync edge case ux when entering market

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacadeTest.kt
@@ -6,6 +6,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -615,6 +617,42 @@ class ClientOffersServiceFacadeTest : ClientKoinIntegrationTestBase() {
                     .map { it.offerId }
                     .toSet(),
             )
+        }
+
+    /**
+     * The market list advertises NUM_OFFERS; entering a market whose OFFERS snapshot hasn't landed
+     * yet must expose a syncing state (drives an honest loading UI instead of a false "no offers"
+     * against the advertised count), clearing once the cached offers catch up.
+     */
+    @Test
+    fun `syncing state is exposed while advertised count exceeds cached offers and clears when they arrive`() =
+        runTest {
+            val numOffersObserver = WebSocketEventObserver()
+            val offersObserver = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumOffers() } returns numOffersObserver
+            coEvery { apiGateway.subscribeOffers() } returns offersObserver
+            coEvery { apiGateway.getMarkets() } returns Result.success(listOf(brlMarket))
+
+            facade.activate()
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Connected
+            waitUntil { facade.offerbookMarketItems.value.isNotEmpty() }
+            numOffersObserver.setEvent(numOffersEvent("""{"BRL": 1}"""))
+            advanceUntilIdle()
+
+            facade.selectOfferbookMarket(MarketListItem.from(brlMarket, numOffers = 1))
+            runCurrent()
+            // Advertised 1, cached 0 -> the snapshot is pending and the syncing state must expose it
+            facade.isSyncingSelectedMarketOffers
+                .filter { it }
+                .first()
+
+            offersObserver.setEvent(offersEvent(offersPayload(brlMarket, "o1"), sequenceNumber = 1))
+            advanceUntilIdle()
+            // Cached offers caught up with the advertised count -> syncing clears
+            facade.isSyncingSelectedMarketOffers
+                .filter { !it }
+                .first()
         }
 
     private fun offersEvent(

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimitsTest.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.domain.utils
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
@@ -146,6 +147,30 @@ class BisqEasyTradeAmountLimitsTest {
                 )
 
             assertFalse(isInvalid)
+        }
+
+    /**
+     * List callers fetch the (shared) score once and pass it in — the facade must not be hit again
+     * per offer: on the client a getReputation call can be a full websocket round trip.
+     */
+    @Test
+    fun `isBuyOfferInvalid uses the pre-fetched reputation and skips the facade lookup`() =
+        runTest {
+            val reputationServiceFacade = mockk<ReputationServiceFacade>()
+
+            val isInvalid =
+                BisqEasyTradeAmountLimits.isBuyOfferInvalid(
+                    item = buildBuyOfferModel("valid-prefetched"),
+                    useCache = false,
+                    marketPriceServiceFacade = marketServiceWithPrices(),
+                    reputationServiceFacade = reputationServiceFacade,
+                    userProfileId = "seller",
+                    limits = TradeAmountLimitsVO.DEFAULT,
+                    preFetchedReputation = Result.success(ReputationScoreVO(Long.MAX_VALUE, 0.0, 0)),
+                )
+
+            assertFalse(isInvalid)
+            coVerify(exactly = 0) { reputationServiceFacade.getReputation(any()) }
         }
 
     @Test

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/offers/OffersServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/offers/OffersServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.data.service.offers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.data.model.offerbook.MarketListItem
@@ -31,6 +32,25 @@ abstract class OffersServiceFacade :
     // Loading indicator for offerbook data fetch/select cycles
     protected val _isOfferbookLoading = MutableStateFlow(false)
     val isOfferbookLoading: StateFlow<Boolean> get() = _isOfferbookLoading
+
+    // True while the selected market advertises more offers (NUM_OFFERS) than are cached locally
+    // for it — the OFFERS snapshot/reconcile is still inbound (relevant on the client over Tor; on
+    // the node data is local so this settles immediately). Lets the UI show an honest loading state
+    // on an otherwise-empty tab instead of a false "no offers": the market list advertised a count,
+    // and what the user sees must stay accountable to it.
+    val isSyncingSelectedMarketOffers: StateFlow<Boolean> =
+        combine(
+            offerbookListItems,
+            selectedOfferbookMarket,
+            offerbookMarketItems,
+        ) { offers, selectedMarket, marketItems ->
+            val advertised = marketItems.firstOrNull { it.market == selectedMarket.market }?.numOffers ?: 0
+            advertised > offers.size
+        }.stateIn(
+            serviceScope,
+            SharingStarted.WhileSubscribed(5_000, 10_000),
+            false,
+        )
 
     val sortedOfferbookMarketItems: StateFlow<List<MarketListItem>> =
         offerbookMarketItems

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/BisqEasyTradeAmountLimits.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMaxAmount
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMinAmount
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import kotlin.math.roundToLong
@@ -78,6 +79,11 @@ object BisqEasyTradeAmountLimits {
         reputationServiceFacade: ReputationServiceFacade,
         userProfileId: String,
         limits: TradeAmountLimitsVO,
+        // The score is MINE (as prospective seller) for every BUY offer in a list, so callers
+        // iterating many offers should fetch it once and pass it here — on the client a
+        // getReputation call can be a full websocket round trip (debug builds bypass the local
+        // cache), and fetching per offer serializes N network calls before a list can render.
+        preFetchedReputation: Result<ReputationScoreVO>? = null,
     ): Boolean {
         val bisqEasyOffer = item.bisqEasyOffer
         require(bisqEasyOffer.direction == DirectionEnum.BUY)
@@ -107,8 +113,9 @@ object BisqEasyTradeAmountLimits {
         // stem from our own cancellation (e.g. a request timeout) still falls through to the plain
         // failure handling.
         val reputationResult =
-            runCatching { reputationServiceFacade.getReputation(userProfileId) }
-                .getOrElse { Result.failure(it) }
+            preFetchedReputation
+                ?: runCatching { reputationServiceFacade.getReputation(userProfileId) }
+                    .getOrElse { Result.failure(it) }
         if (reputationResult.exceptionOrNull() is CancellationException) {
             currentCoroutineContext().ensureActive()
         }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -276,6 +276,10 @@ mobile.offerbook.filters.selectNone=Select none
 mobile.offerbook.filters.noPaymentMatches=No payment methods match your search
 mobile.offerbook.filters.noSettlementMatches=No settlement methods match your search
 mobile.offerbook.slowLoadingHint=Offers loading — Tor connections take a bit longer
+mobile.offerbook.noOffersToBuy=No offers to buy Bitcoin in this market yet
+mobile.offerbook.noOffersToSell=No offers to sell Bitcoin in this market yet
+mobile.offerbook.showBuyOffers=Show buy offers ({0})
+mobile.offerbook.showSellOffers=Show sell offers ({0})
 
 mobile.settlement.bitcoin=Bitcoin
 mobile.settlement.lightning=Lightning

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.offerbook
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,6 +73,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
         quoteMethods: List<String>,
         baseMethods: List<String>,
         makerId: String = id,
+        direction: DirectionEnum = DirectionEnum.SELL,
     ): OfferItemPresentationModel {
         val market = MarketVO("BTC", "USD", "Bitcoin", "US Dollar")
         val amountSpec = QuoteSideRangeAmountSpecVO(minAmount = 10_0000L, maxAmount = 100_0000L)
@@ -86,7 +88,7 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                 id = id,
                 date = 0L,
                 makerNetworkId = makerNetworkId,
-                direction = DirectionEnum.SELL, // mirror -> BUY
+                direction = direction, // filter matches the MIRRORED (taker's) direction
                 market = market,
                 amountSpec = amountSpec,
                 priceSpec = priceSpec,
@@ -115,7 +117,10 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
         return OfferItemPresentationModel(dto)
     }
 
-    private fun buildPresenterWithOffers(allOffers: List<OfferItemPresentationModel>): OfferbookPresenter {
+    private fun buildPresenterWithOffers(
+        allOffers: List<OfferItemPresentationModel>,
+        reputationService: ReputationServiceFacade = mockk(relaxed = true),
+    ): OfferbookPresenter {
         // --- Mocks and fakes for MainPresenter ---
         val mainPresenter =
             MainPresenterTestFactory.create(applicationLifecycleService = TestApplicationLifecycleService())
@@ -155,7 +160,6 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
 
                 override fun selectMarket(marketListItem: MarketListItem): Result<Unit> = Result.success(Unit)
             }
-        val reputationService = mockk<ReputationServiceFacade>(relaxed = true)
         val takeOfferCoordinator = mockk<TakeOfferCoordinator>(relaxed = true)
         val createOfferCoordinator = mockk<CreateOfferCoordinator>(relaxed = true)
         val tradeRestrictingAlertServiceFacade = mockk<TradeRestrictingAlertServiceFacade>(relaxed = true)
@@ -641,5 +645,61 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
                 },
                 "All visible offers should have WISE or REVOLUT as payment method",
             )
+        }
+
+    /**
+     * Regression for the "offers appear seconds late" field report: every BUY-direction offer needs
+     * MY reputation score (I would be the seller), and the pipeline used to fetch it once PER OFFER —
+     * sequential network round trips on the client (debug builds bypass the local reputation cache),
+     * blocking the list emission for seconds although the offers were already cached. The score must
+     * be fetched at most once per pipeline run and memoized across runs.
+     */
+    @Test
+    fun test_my_reputation_fetched_once_for_buy_offers_and_memoized_across_pipeline_runs() =
+        runTest {
+            val reputationService =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } returns Result.success(ReputationScoreVO(Long.MAX_VALUE, 5.0, 1))
+                }
+            // direction = BUY -> maker buys -> I would sell -> shown on the SELL tab, needs MY score
+            val allOffers =
+                listOf(
+                    makeOffer("b1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                    makeOffer("b2", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("LIGHTNING"), direction = DirectionEnum.BUY),
+                    makeOffer("b3", isMy = false, quoteMethods = listOf("WISE"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                )
+            val presenter = buildPresenterWithOffers(allOffers, reputationService)
+            runCurrent()
+
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            awaitSortedCount(presenter, allOffers.size)
+
+            coVerify(exactly = 1) { reputationService.getReputation(any()) }
+
+            // A further pipeline run (direction toggled away and back) must reuse the memoized score
+            presenter.onSelectDirection(DirectionEnum.BUY)
+            awaitSortedCount(presenter, 0)
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            awaitSortedCount(presenter, allOffers.size)
+
+            coVerify(exactly = 1) { reputationService.getReputation(any()) }
+        }
+
+    /** Control: SELL-direction offers (the maker is the seller) never need my score at all. */
+    @Test
+    fun test_no_reputation_fetch_for_sell_direction_offers() =
+        runTest {
+            val reputationService = mockk<ReputationServiceFacade>(relaxed = true)
+            val allOffers =
+                listOf(
+                    makeOffer("s1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN")),
+                    makeOffer("s2", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("LIGHTNING")),
+                )
+            val presenter = buildPresenterWithOffers(allOffers, reputationService)
+            runCurrent()
+
+            awaitSortedCount(presenter, allOffers.size)
+
+            coVerify(exactly = 0) { reputationService.getReputation(any()) }
         }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -685,9 +686,74 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
             coVerify(exactly = 1) { reputationService.getReputation(any()) }
         }
 
-    /** Control: SELL-direction offers (the maker is the seller) never need my score at all. */
+    /**
+     * Direction-aware empty state: landing on a tab with 0 offers while the other tab has matches
+     * must expose the other tab's count so the UI can offer the switch instead of a bare
+     * "no offers" that reads as broken against the market list's advertised count.
+     */
     @Test
-    fun test_no_reputation_fetch_for_sell_direction_offers() =
+    fun test_opposite_direction_count_exposed_when_selected_tab_is_empty() =
+        runTest {
+            // direction = BUY -> mirror SELL -> these show on the SELL tab; default tab is BUY
+            val allOffers =
+                listOf(
+                    makeOffer("b1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                    makeOffer("b2", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("LIGHTNING"), direction = DirectionEnum.BUY),
+                )
+            val presenter = buildPresenterWithOffers(allOffers)
+            runCurrent()
+
+            awaitSortedCount(presenter, 0)
+            presenter.oppositeDirectionOffersCount
+                .filter { it == allOffers.size }
+                .first()
+
+            // Switching to the tab that has the offers empties the opposite count again
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            awaitSortedCount(presenter, allOffers.size)
+            presenter.oppositeDirectionOffersCount
+                .filter { it == 0 }
+                .first()
+        }
+
+    /**
+     * Regression for "all markets empty": the reputation lookup runs inside the mapLatest collector,
+     * so a facade that THROWS (not just returns a failure Result — e.g. a network-layer exception on
+     * device) must not kill the filtering pipeline. Offers must still display, and the throw must
+     * not be memoized so a later run can recover.
+     */
+    @Test
+    fun test_throwing_reputation_lookup_does_not_kill_the_pipeline() =
+        runTest {
+            val reputationService =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } throws RuntimeException("network layer blew up")
+                }
+            val allOffers =
+                listOf(
+                    makeOffer("b1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                    makeOffer("b2", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("LIGHTNING"), direction = DirectionEnum.BUY),
+                )
+            val presenter = buildPresenterWithOffers(allOffers, reputationService)
+            runCurrent()
+
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            // The pipeline must survive the throw and still emit the offers
+            awaitSortedCount(presenter, allOffers.size)
+
+            // And a later pipeline run must also survive (the throw is not memoized)
+            presenter.onSelectDirection(DirectionEnum.BUY)
+            awaitSortedCount(presenter, 0)
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            awaitSortedCount(presenter, allOffers.size)
+        }
+
+    /**
+     * Control: SELL-direction offers (the maker is the seller) never need my score — the only fetch
+     * is the single attach-time warmup, no matter how many pipeline runs happen.
+     */
+    @Test
+    fun test_pipeline_never_fetches_reputation_for_sell_direction_offers() =
         runTest {
             val reputationService = mockk<ReputationServiceFacade>(relaxed = true)
             val allOffers =
@@ -699,7 +765,60 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
             runCurrent()
 
             awaitSortedCount(presenter, allOffers.size)
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            awaitSortedCount(presenter, 0)
+            presenter.onSelectDirection(DirectionEnum.BUY)
+            awaitSortedCount(presenter, allOffers.size)
 
-            coVerify(exactly = 0) { reputationService.getReputation(any()) }
+            coVerify(exactly = 1) { reputationService.getReputation(any()) }
+        }
+
+    /**
+     * The attach-time warmup pre-fetches my score so the first pipeline run over BUY-direction
+     * offers never pays a network round trip while the UI sits on stale state.
+     */
+    @Test
+    fun test_my_reputation_warmed_up_at_attach() =
+        runTest {
+            val reputationService = mockk<ReputationServiceFacade>(relaxed = true)
+            val presenter = buildPresenterWithOffers(emptyList(), reputationService)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { reputationService.getReputation(any()) }
+            // Keep the presenter referenced so the pipeline stays alive for the duration
+            awaitSortedCount(presenter, 0)
+        }
+
+    /**
+     * While the pipeline recomputes for changed inputs, [OfferbookPresenter.isRefilteringOffers]
+     * must be true so the UI can show progress instead of the PREVIOUS run's stale (empty) state —
+     * the "empty state flashes with a mislabeled switch hint for 1-2s" field report.
+     */
+    @Test
+    fun test_refiltering_state_exposed_while_pipeline_run_is_in_flight() =
+        runTest {
+            val reputationService =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } coAnswers {
+                        delay(500)
+                        Result.success(ReputationScoreVO(Long.MAX_VALUE, 5.0, 1))
+                    }
+                }
+            val allOffers =
+                listOf(
+                    makeOffer("b1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                )
+            val presenter = buildPresenterWithOffers(allOffers, reputationService)
+            runCurrent()
+
+            // Switch to the tab whose run pays the (slow) fetch: the recompute is in flight
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            runCurrent()
+            assertTrue(presenter.isRefilteringOffers.value, "recompute must be flagged while in flight")
+
+            // Once the run lands the flag clears and the offers are published
+            advanceUntilIdle()
+            assertEquals(false, presenter.isRefilteringOffers.value)
+            assertEquals(allOffers.size, presenter.sortedFilteredOffers.value.size)
         }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterFilterTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -787,6 +788,40 @@ class OfferbookPresenterFilterTest : PlatformPresentationKoinTestBase() {
             coVerify(exactly = 1) { reputationService.getReputation(any()) }
             // Keep the presenter referenced so the pipeline stays alive for the duration
             awaitSortedCount(presenter, 0)
+        }
+
+    /**
+     * Race regression: the attach-time warmup and the first pipeline run over BUY-direction offers
+     * can look up the score concurrently on a cold cache. The lookups must coalesce — the second
+     * caller waits for the in-flight fetch and reuses it — never issue a duplicate network request.
+     */
+    @Test
+    fun test_concurrent_warmup_and_pipeline_lookups_coalesce_into_one_fetch() =
+        runTest {
+            val gate = CompletableDeferred<Unit>()
+            val reputationService =
+                mockk<ReputationServiceFacade> {
+                    coEvery { getReputation(any()) } coAnswers {
+                        gate.await()
+                        Result.success(ReputationScoreVO(Long.MAX_VALUE, 5.0, 1))
+                    }
+                }
+            val allOffers =
+                listOf(
+                    makeOffer("b1", isMy = false, quoteMethods = listOf("SEPA"), baseMethods = listOf("MAIN_CHAIN"), direction = DirectionEnum.BUY),
+                )
+            val presenter = buildPresenterWithOffers(allOffers, reputationService)
+            runCurrent() // warmup starts and parks on the gated fetch
+
+            // Pipeline run needs the same score while the warmup fetch is still in flight
+            presenter.onSelectDirection(DirectionEnum.SELL)
+            runCurrent()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { reputationService.getReputation(any()) }
+            assertEquals(allOffers.size, presenter.sortedFilteredOffers.value.size)
         }
 
     /**

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreenTest.kt
@@ -277,6 +277,92 @@ class OfferbookScreenTest {
     }
 
     // -------------------------------------------------------------------------
+    // Direction-aware empty state
+    // -------------------------------------------------------------------------
+
+    /**
+     * A market can advertise offers while the selected tab is legitimately empty (all offers on the
+     * other side). The empty state must name the situation and offer the switch instead of a bare
+     * "there are no offers" that reads as broken against the market list's count.
+     */
+    @Test
+    fun `when tab is empty but other direction has offers then switch hint is shown and dispatches direction change`() {
+        var switched: DirectionEnum? = null
+        composeTestRule.setContent {
+            RenderOfferbookContent(
+                selectedDirection = DirectionEnum.BUY,
+                oppositeDirectionOffersCount = 6,
+                onSelectDirection = { switched = it },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.offerbook.noOffersToBuy".i18n()).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.offerbook.showSellOffers".i18n(6))
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(DirectionEnum.SELL, switched)
+    }
+
+    @Test
+    fun `when tab is empty and other direction is empty too then plain no-offers state is shown`() {
+        composeTestRule.setContent {
+            RenderOfferbookContent(
+                selectedDirection = DirectionEnum.BUY,
+                oppositeDirectionOffersCount = 0,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.offerBookScreen.noOffersSection.thereAreNoOffers".i18n()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.offerbook.showSellOffers".i18n(0)).assertDoesNotExist()
+    }
+
+    /**
+     * When the market advertises more offers than are cached (snapshot still inbound over Tor),
+     * data IS coming — the empty tab must show progress, never a "no offers" state that contradicts
+     * the count the market list just promised.
+     */
+    @Test
+    fun `when market offers are still syncing then empty tab shows progress instead of no-offers state`() {
+        composeTestRule.setContent {
+            RenderOfferbookContent(
+                selectedDirection = DirectionEnum.BUY,
+                showSyncing = true,
+                oppositeDirectionOffersCount = 0,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.offerBookScreen.noOffersSection.thereAreNoOffers".i18n()).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.offerbook.noOffersToBuy".i18n()).assertDoesNotExist()
+        composeTestRule.onNodeWithText("offer.create".i18n()).assertDoesNotExist()
+    }
+
+    /**
+     * While the pipeline recomputes (direction/market/filter change), the on-screen state belongs
+     * to the PREVIOUS run — rendering it as an empty state would flash stale, mislabeled content
+     * (e.g. the opposite direction's switch hint). Progress must show instead.
+     */
+    @Test
+    fun `when refiltering then empty tab shows progress instead of stale empty state`() {
+        composeTestRule.setContent {
+            RenderOfferbookContent(
+                selectedDirection = DirectionEnum.SELL,
+                showRefiltering = true,
+                oppositeDirectionOffersCount = 1,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("mobile.offerbook.noOffersToSell".i18n()).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.offerbook.showBuyOffers".i18n(1)).assertDoesNotExist()
+        composeTestRule.onNodeWithText("offer.create".i18n()).assertDoesNotExist()
+    }
+
+    // -------------------------------------------------------------------------
     // Fixtures
     // -------------------------------------------------------------------------
 
@@ -383,6 +469,9 @@ class OfferbookScreenTest {
         selectedMarket: MarketPriceItem? = null,
         filterUiState: OfferbookFilterUiState = emptyOfferbookFilterUiState(),
         showLoading: Boolean = false,
+        showSyncing: Boolean = false,
+        showRefiltering: Boolean = false,
+        oppositeDirectionOffersCount: Int = 0,
         showDeleteConfirmation: Boolean = false,
         showNotEnoughReputationDialog: Boolean = false,
         showTradeRestrictedDialog: AlertNotificationUiState? = null,
@@ -418,6 +507,9 @@ class OfferbookScreenTest {
                     selectedMarket = selectedMarket,
                     filterUiState = filterUiState,
                     showLoading = showLoading,
+                    showSyncing = showSyncing,
+                    showRefiltering = showRefiltering,
+                    oppositeDirectionOffersCount = oppositeDirectionOffersCount,
                     showDeleteConfirmation = showDeleteConfirmation,
                     showNotEnoughReputationDialog = showNotEnoughReputationDialog,
                     showTradeRestrictedDialog = showTradeRestrictedDialog,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -303,7 +303,18 @@ open class OfferbookPresenter(
                 _availableSettlementMethodIds.value = availableSettlements
 
                 log.d { "OfferbookPresenter filtering results - Market: ${selectedMarket.market.quoteCurrencyCode}, Dir matches: $directionFilteredCount, Ignored: $ignoredUserFilteredCount, OnlyMy: $onlyMyFilteredCount, Methods: $methodFilteredCount, Final: ${filtered.size}" }
-                val processed = filtered.map { offer -> processOffer(offer, selectedProfile) }
+                // Every BUY-direction offer's validity check needs the SAME score (mine, as
+                // prospective seller), so fetch it once per pipeline run instead of once per offer:
+                // on the client, getReputation can be a full websocket round trip (debug builds
+                // bypass the local cache), and per-offer fetching serialized N network calls here —
+                // the list stayed blank for seconds although the offers were already cached.
+                val myReputation =
+                    if (filtered.any { it.bisqEasyOffer.direction == DirectionEnum.BUY }) {
+                        getMyReputation(selectedProfile.id)
+                    } else {
+                        null
+                    }
+                val processed = filtered.map { offer -> processOffer(offer, selectedProfile, myReputation) }
                 val sorted =
                     processed.sortedWith(compareByDescending<OfferItemPresentationModel> { it.bisqEasyOffer.date }.thenBy { it.bisqEasyOffer.id })
                 sorted
@@ -423,9 +434,22 @@ open class OfferbookPresenter(
         }
     }
 
+    // Successful scores are memoized per profile for the presenter's lifetime: the score feeds a
+    // coarse eligibility flag only, and re-fetching on every filter/direction change made each tab
+    // toggle pay a network round trip on client debug builds. Failures (e.g. "not cached yet" on a
+    // cold backend) are deliberately not memoized so the next pipeline run can recover.
+    private val myReputationByProfileId = mutableMapOf<String, Result<ReputationScoreVO>>()
+
+    private suspend fun getMyReputation(profileId: String): Result<ReputationScoreVO> =
+        myReputationByProfileId[profileId]
+            ?: reputationServiceFacade
+                .getReputation(profileId)
+                .also { result -> if (result.isSuccess) myReputationByProfileId[profileId] = result }
+
     private suspend fun processOffer(
         item: OfferItemPresentationModel,
         userProfile: UserProfileVO,
+        myReputation: Result<ReputationScoreVO>?,
     ): OfferItemPresentationModel {
         val offer = item.bisqEasyOffer
 
@@ -463,6 +487,7 @@ open class OfferbookPresenter(
                     reputationServiceFacade = reputationServiceFacade,
                     userProfileId = userProfile.id,
                     limits = configServiceFacade.tradeAmountLimits.value,
+                    preFetchedReputation = myReputation,
                 )
             } else {
                 false

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -1,16 +1,22 @@
 package network.bisq.mobile.presentation.offerbook
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
@@ -85,6 +91,19 @@ open class OfferbookPresenter(
     private val _sortedFilteredOffers = MutableStateFlow<List<OfferItemPresentationModel>>(emptyList())
     val sortedFilteredOffers: StateFlow<List<OfferItemPresentationModel>> = _sortedFilteredOffers.asStateFlow()
 
+    // Offers that would show on the OTHER direction tab under the current filters. Drives the
+    // direction-aware empty state: a market can advertise offers while the selected tab is
+    // legitimately empty (e.g. all offers are sell-side and the user lands on Buy) — without this
+    // hint the screen reads as broken until the user happens to flip the toggle.
+    private val _oppositeDirectionOffersCount = MutableStateFlow(0)
+    val oppositeDirectionOffersCount: StateFlow<Int> = _oppositeDirectionOffersCount.asStateFlow()
+
+    // True while the filtering pipeline is recomputing for changed inputs (market/direction/filter
+    // change). Guards the empty state: without it, the screen keeps rendering the PREVIOUS run's
+    // state until the new run emits — including a stale, mislabeled direction-switch hint.
+    private val _isRefilteringOffers = MutableStateFlow(false)
+    val isRefilteringOffers: StateFlow<Boolean> = _isRefilteringOffers.asStateFlow()
+
     // Baseline available method sets (direction+ignored-user filtered, independent of method selections)
     private val _availablePaymentMethodIds = MutableStateFlow<Set<String>>(emptySet())
     val availablePaymentMethodIds: StateFlow<Set<String>> = _availablePaymentMethodIds.asStateFlow()
@@ -134,6 +153,7 @@ open class OfferbookPresenter(
 
     val selectedUserProfile get() = userProfileServiceFacade.selectedUserProfile
     val isLoading get() = offersServiceFacade.isOfferbookLoading
+    val isSyncingMarketOffers get() = offersServiceFacade.isSyncingSelectedMarketOffers
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -143,6 +163,7 @@ open class OfferbookPresenter(
         launchOfferFiltering()
         launchFilterUiStateDerivation()
         launchSlowLoadingHint()
+        launchMyReputationWarmup()
     }
 
     /**
@@ -232,6 +253,10 @@ open class OfferbookPresenter(
                     settlements = values[6] as Set<String>,
                     onlyMine = values[7] as Boolean,
                 )
+            }.onEach {
+                // Mark the recompute in flight BEFORE mapLatest starts (and possibly suspends on the
+                // one-off reputation fetch), so the UI can guard against rendering stale state.
+                _isRefilteringOffers.value = true
             }.mapLatest { inp ->
                 val offers = inp.offers
                 val direction = inp.direction
@@ -254,18 +279,13 @@ open class OfferbookPresenter(
                 val availablePayments = mutableSetOf<String>()
                 val availableSettlements = mutableSetOf<String>()
 
+                var oppositeDirectionCount = 0
                 for (item in offers) {
                     val offerCurrency = item.bisqEasyOffer.market.quoteCurrencyCode
                     val offerDirection = item.bisqEasyOffer.direction.mirror
                     val isIgnoredUser = isOfferFromIgnoredUserCached(item.bisqEasyOffer)
 
                     log.v { "Offer ${item.offerId} - Currency: $offerCurrency, Direction: $offerDirection, IsIgnored: $isIgnoredUser, isMy=${item.isMyOffer}" }
-
-                    if (offerDirection != direction) {
-                        log.v { "Offer ${item.offerId} filtered out (wrong direction: $offerDirection != $direction)" }
-                        continue
-                    }
-                    directionFilteredCount++
 
                     if (isIgnoredUser) {
                         ignoredUserFilteredCount++
@@ -278,6 +298,21 @@ open class OfferbookPresenter(
                         log.v { "Offer ${item.offerId} filtered out (only my offers enabled)" }
                         continue
                     }
+
+                    if (offerDirection != direction) {
+                        // Count what the OTHER tab would show under the same filters, so the empty
+                        // state can honestly offer the switch (see oppositeDirectionOffersCount).
+                        val oppositePaymentOk =
+                            if (payments.isEmpty() && !hasManualPaymentFilter) true else item.quoteSidePaymentMethods.any { it in payments }
+                        val oppositeSettlementOk =
+                            if (settlements.isEmpty() && !hasManualSettlementFilter) true else item.baseSidePaymentMethods.any { it in settlements }
+                        if (oppositePaymentOk && oppositeSettlementOk) {
+                            oppositeDirectionCount++
+                        }
+                        log.v { "Offer ${item.offerId} filtered out (wrong direction: $offerDirection != $direction)" }
+                        continue
+                    }
+                    directionFilteredCount++
 
                     // Contribute to baseline availability regardless of current method selections
                     availablePayments.addAll(item.quoteSidePaymentMethods)
@@ -317,13 +352,18 @@ open class OfferbookPresenter(
                 val processed = filtered.map { offer -> processOffer(offer, selectedProfile, myReputation) }
                 val sorted =
                     processed.sortedWith(compareByDescending<OfferItemPresentationModel> { it.bisqEasyOffer.date }.thenBy { it.bisqEasyOffer.id })
-                sorted
+                sorted to oppositeDirectionCount
             }.flowOn(computationDispatcher)
-                .collectLatest { sorted ->
-                    if (sorted != null) {
+                .collectLatest { result ->
+                    if (result != null) {
+                        val (sorted, oppositeCount) = result
                         _sortedFilteredOffers.value = sorted
-                        log.d { "OfferbookPresenter final result - ${sorted.size} offers displayed for market" }
+                        _oppositeDirectionOffersCount.value = oppositeCount
+                        log.d { "OfferbookPresenter final result - ${sorted.size} offers displayed for market (other direction: $oppositeCount)" }
                     }
+                    // The run for the latest inputs has landed (or was skipped for lack of a
+                    // profile) — the published state is current again.
+                    _isRefilteringOffers.value = false
                 }
         }
     }
@@ -440,11 +480,36 @@ open class OfferbookPresenter(
     // cold backend) are deliberately not memoized so the next pipeline run can recover.
     private val myReputationByProfileId = mutableMapOf<String, Result<ReputationScoreVO>>()
 
-    private suspend fun getMyReputation(profileId: String): Result<ReputationScoreVO> =
-        myReputationByProfileId[profileId]
-            ?: reputationServiceFacade
-                .getReputation(profileId)
-                .also { result -> if (result.isSuccess) myReputationByProfileId[profileId] = result }
+    // Warm the memoized score before the user reaches a tab that needs it: the first pipeline run
+    // over BUY-direction offers otherwise pays the fetch (a websocket round trip on the client)
+    // while the UI sits on the previous run's state. Idempotent — getMyReputation memoizes.
+    private fun launchMyReputationWarmup() {
+        presenterScope.launch {
+            val profile = userProfileServiceFacade.selectedUserProfile.filterNotNull().first()
+            getMyReputation(profile.id)
+        }
+    }
+
+    private suspend fun getMyReputation(profileId: String): Result<ReputationScoreVO> {
+        myReputationByProfileId[profileId]?.let { return it }
+        // A throwing lookup must NEVER kill the filtering pipeline (it runs inside the mapLatest
+        // collector — an escaped exception stops offer display for the rest of the session). A
+        // failure degrades to "score unknown" downstream, while a genuine cancellation of this
+        // pipeline run (mapLatest supersession) must still propagate: ensureActive() gates the
+        // rethrow, mirroring BisqEasyTradeAmountLimits#isBuyOfferInvalid.
+        val result =
+            runCatching { reputationServiceFacade.getReputation(profileId) }
+                .getOrElse { Result.failure(it) }
+        if (result.exceptionOrNull() is CancellationException) {
+            currentCoroutineContext().ensureActive()
+        }
+        if (result.isSuccess) {
+            myReputationByProfileId[profileId] = result
+        } else {
+            log.w("Fetching my reputation failed; offers stay takeable per the not-cached policy", result.exceptionOrNull())
+        }
+        return result
+    }
 
     private suspend fun processOffer(
         item: OfferItemPresentationModel,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
 import network.bisq.mobile.data.model.offerbook.OfferbookMarket
@@ -490,26 +492,34 @@ open class OfferbookPresenter(
         }
     }
 
-    private suspend fun getMyReputation(profileId: String): Result<ReputationScoreVO> {
-        myReputationByProfileId[profileId]?.let { return it }
-        // A throwing lookup must NEVER kill the filtering pipeline (it runs inside the mapLatest
-        // collector — an escaped exception stops offer display for the rest of the session). A
-        // failure degrades to "score unknown" downstream, while a genuine cancellation of this
-        // pipeline run (mapLatest supersession) must still propagate: ensureActive() gates the
-        // rethrow, mirroring BisqEasyTradeAmountLimits#isBuyOfferInvalid.
-        val result =
-            runCatching { reputationServiceFacade.getReputation(profileId) }
-                .getOrElse { Result.failure(it) }
-        if (result.exceptionOrNull() is CancellationException) {
-            currentCoroutineContext().ensureActive()
+    // Serializes cache access AND coalesces concurrent lookups: the warmup (presenter scope) and
+    // the filtering pipeline (computationDispatcher) can race on a cold cache — without the lock
+    // they issue duplicate network fetches and share a plain map across dispatchers. Holding the
+    // lock across the fetch is deliberate: a concurrent caller waits for the in-flight result and
+    // then hits the cache, paying no more latency than its own fetch would have cost.
+    private val myReputationMutex = Mutex()
+
+    private suspend fun getMyReputation(profileId: String): Result<ReputationScoreVO> =
+        myReputationMutex.withLock {
+            myReputationByProfileId[profileId]?.let { return@withLock it }
+            // A throwing lookup must NEVER kill the filtering pipeline (it runs inside the mapLatest
+            // collector — an escaped exception stops offer display for the rest of the session). A
+            // failure degrades to "score unknown" downstream, while a genuine cancellation of this
+            // pipeline run (mapLatest supersession) must still propagate: ensureActive() gates the
+            // rethrow, mirroring BisqEasyTradeAmountLimits#isBuyOfferInvalid.
+            val result =
+                runCatching { reputationServiceFacade.getReputation(profileId) }
+                    .getOrElse { Result.failure(it) }
+            if (result.exceptionOrNull() is CancellationException) {
+                currentCoroutineContext().ensureActive()
+            }
+            if (result.isSuccess) {
+                myReputationByProfileId[profileId] = result
+            } else {
+                log.w("Fetching my reputation failed; offers stay takeable per the not-cached policy", result.exceptionOrNull())
+            }
+            result
         }
-        if (result.isSuccess) {
-            myReputationByProfileId[profileId] = result
-        } else {
-            log.w("Fetching my reputation failed; offers stay takeable per the not-cached policy", result.exceptionOrNull())
-        }
-        return result
-    }
 
     private suspend fun processOffer(
         item: OfferItemPresentationModel,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.mirror
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.utils.PlatformImage
@@ -66,6 +67,9 @@ fun OfferbookScreen() {
     val isTakeOfferEnabled by presenter.isTakeOfferEnabled.collectAsState()
     val selectedMarket by presenter.selectedMarket.collectAsState()
     val showLoading by presenter.isLoading.collectAsState()
+    val showSyncing by presenter.isSyncingMarketOffers.collectAsState()
+    val showRefiltering by presenter.isRefilteringOffers.collectAsState()
+    val oppositeDirectionOffersCount by presenter.oppositeDirectionOffersCount.collectAsState()
     val filterUiState by presenter.filterUiState.collectAsState()
 
     OfferbookContent(
@@ -74,6 +78,9 @@ fun OfferbookScreen() {
         selectedMarket = selectedMarket,
         filterUiState = filterUiState,
         showLoading = showLoading,
+        showSyncing = showSyncing,
+        showRefiltering = showRefiltering,
+        oppositeDirectionOffersCount = oppositeDirectionOffersCount,
         showDeleteConfirmation = showDeleteConfirmation,
         showNotEnoughReputationDialog = showNotEnoughReputationDialog,
         showTradeRestrictedDialog = showTradeRestrictedDialog,
@@ -110,6 +117,9 @@ internal fun OfferbookContent(
     selectedMarket: MarketPriceItem?,
     filterUiState: OfferbookFilterUiState,
     showLoading: Boolean,
+    showSyncing: Boolean,
+    showRefiltering: Boolean,
+    oppositeDirectionOffersCount: Int,
     showDeleteConfirmation: Boolean,
     showNotEnoughReputationDialog: Boolean,
     showTradeRestrictedDialog: AlertNotificationUiState?,
@@ -184,7 +194,25 @@ internal fun OfferbookContent(
         }
 
         if (sortedFilteredOffers.isEmpty() && !showLoading) {
-            NoOffersSection(onCreateOffer = onCreateOffer)
+            if (showSyncing || showRefiltering) {
+                // Two transient states must never render as a definitive "no offers":
+                //  - syncing: the market advertises more offers than are cached (data inbound)
+                //  - refiltering: the pipeline is recomputing for changed inputs — what's on
+                //    screen is the PREVIOUS run's state (incl. a stale direction-switch hint)
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = BisqTheme.colors.primary)
+                }
+            } else {
+                NoOffersSection(
+                    selectedDirection = selectedDirection,
+                    oppositeDirectionOffersCount = oppositeDirectionOffersCount,
+                    onSwitchDirection = onSelectDirection,
+                    onCreateOffer = onCreateOffer,
+                )
+            }
             return@BisqStaticScaffold
         }
 
@@ -312,17 +340,43 @@ internal fun OfferbookContent(
 }
 
 @Composable
-fun NoOffersSection(onCreateOffer: () -> Unit) {
+fun NoOffersSection(
+    selectedDirection: DirectionEnum,
+    oppositeDirectionOffersCount: Int,
+    onSwitchDirection: (DirectionEnum) -> Unit,
+    onCreateOffer: () -> Unit,
+) {
+    // A market can advertise offers while this tab is legitimately empty (all offers sit on the
+    // other side). Saying only "there are no offers" reads as broken against the market list's
+    // count, so when the other tab has matches we name the situation and offer the switch.
+    val hasOffersOnOtherTab = oppositeDirectionOffersCount > 0
     Column(
         modifier = Modifier.padding(vertical = BisqUIConstants.ScreenPadding4X).fillMaxHeight(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         BisqText.H4LightGrey(
-            text = "mobile.offerBookScreen.noOffersSection.thereAreNoOffers".i18n(), // There are no offers
+            text =
+                when {
+                    !hasOffersOnOtherTab -> "mobile.offerBookScreen.noOffersSection.thereAreNoOffers".i18n() // There are no offers
+                    selectedDirection == DirectionEnum.BUY -> "mobile.offerbook.noOffersToBuy".i18n()
+                    else -> "mobile.offerbook.noOffersToSell".i18n()
+                },
             textAlign = TextAlign.Center,
         )
         BisqGap.V4()
+        if (hasOffersOnOtherTab) {
+            BisqButton(
+                text =
+                    if (selectedDirection == DirectionEnum.BUY) {
+                        "mobile.offerbook.showSellOffers".i18n(oppositeDirectionOffersCount)
+                    } else {
+                        "mobile.offerbook.showBuyOffers".i18n(oppositeDirectionOffersCount)
+                    },
+                onClick = { onSwitchDirection(selectedDirection.mirror) },
+            )
+            BisqGap.V2()
+        }
         BisqButton(
             text = "offer.create".i18n(),
             onClick = onCreateOffer,


### PR DESCRIPTION
<img width="323" height="636" alt="Screenshot 2026-08-07 at 15 06 42" src="https://github.com/user-attachments/assets/4a6fef51-baee-4ef4-91a5-13709121f7da" />
<img width="384" height="751" alt="Screenshot 2026-08-07 at 15 53 08" src="https://github.com/user-attachments/assets/0167a1e6-92ac-4381-8a70-0a05f60a0873" />

 - contribs to #1653
 - this PR improves the overall show offers experience specially for connect apps over Tor
 - Improved empty state on offers tabs with brief text explaining no offers were found + switch tap button offer
 - prefetched reputation to avoid current approach with several rountrips causing a slow load offer (2-5 secs) with no feedback experience (unless already cached)
 - added AI tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offerbook syncing and refiltering indicators to clarify when results are still loading.
  * Empty offerbook states now show available offers in the opposite direction and provide a quick way to switch.
  * Added localized messages for empty buy/sell offerbooks and offer-count filters.

* **Bug Fixes**
  * Improved reputation lookup reuse during offer filtering.
  * Prevented reputation lookup failures from interrupting offer filtering.
  * Improved offer counts and empty-state behavior while markets synchronize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->