### PR TITLE
fix: redact WS session and client ids from debug logs

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
@@ -1,0 +1,50 @@
+package network.bisq.mobile.client.common.domain.access.utils
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketMessage
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiRequest
+
+/**
+ * Redacts sensitive auth headers for log output only. Wire payloads must stay unchanged.
+ */
+object HeaderRedaction {
+    const val REDACTED = "***"
+
+    private val sensitiveHeaderNames = setOf(Headers.CLIENT_ID, Headers.SESSION_ID)
+
+    private val lenientJson = Json { ignoreUnknownKeys = true }
+
+    fun redactSensitiveHeaders(headers: Map<String, String>): Map<String, String> =
+        headers.mapValues { (name, value) ->
+            if (name in sensitiveHeaderNames) REDACTED else value
+        }
+
+    fun redactForLogging(message: WebSocketMessage): String =
+        when (message) {
+            is WebSocketRestApiRequest ->
+                message.copy(headers = redactSensitiveHeaders(message.headers)).toString()
+            else -> message.toString()
+        }
+
+    fun redactRawJsonForLogging(jsonString: String): String {
+        return try {
+            val element = lenientJson.parseToJsonElement(jsonString)
+            if (element !is JsonObject) return jsonString
+            val headersElement = element["headers"] ?: return jsonString
+            if (headersElement !is JsonObject) return jsonString
+            if (headersElement.keys.none { it in sensitiveHeaderNames }) return jsonString
+
+            val redactedHeaders =
+                JsonObject(
+                    headersElement.mapValues { (key, value) ->
+                        if (key in sensitiveHeaderNames) JsonPrimitive(REDACTED) else value
+                    },
+                )
+            JsonObject(element.toMutableMap().apply { put("headers", redactedHeaders) }).toString()
+        } catch (_: Exception) {
+            jsonString
+        }
+    }
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
@@ -11,14 +11,17 @@ import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRest
  */
 object HeaderRedaction {
     const val REDACTED = "***"
+    const val UNPARSEABLE_PAYLOAD = "[unparseable payload]"
 
     private val sensitiveHeaderNames = setOf(Headers.CLIENT_ID, Headers.SESSION_ID)
 
     private val lenientJson = Json { ignoreUnknownKeys = true }
 
+    private fun isSensitiveHeader(name: String): Boolean = sensitiveHeaderNames.any { it.equals(name, ignoreCase = true) }
+
     fun redactSensitiveHeaders(headers: Map<String, String>): Map<String, String> =
         headers.mapValues { (name, value) ->
-            if (name in sensitiveHeaderNames) REDACTED else value
+            if (isSensitiveHeader(name)) REDACTED else value
         }
 
     fun redactForLogging(message: WebSocketMessage): String =
@@ -34,17 +37,18 @@ object HeaderRedaction {
             if (element !is JsonObject) return jsonString
             val headersElement = element["headers"] ?: return jsonString
             if (headersElement !is JsonObject) return jsonString
-            if (headersElement.keys.none { it in sensitiveHeaderNames }) return jsonString
+            if (headersElement.keys.none { isSensitiveHeader(it) }) return jsonString
 
             val redactedHeaders =
                 JsonObject(
                     headersElement.mapValues { (key, value) ->
-                        if (key in sensitiveHeaderNames) JsonPrimitive(REDACTED) else value
+                        if (isSensitiveHeader(key)) JsonPrimitive(REDACTED) else value
                     },
                 )
             JsonObject(element.toMutableMap().apply { put("headers", redactedHeaders) }).toString()
         } catch (_: Exception) {
-            jsonString
+            // Fail closed: never echo an unparseable payload that may contain credentials.
+            UNPARSEABLE_PAYLOAD
         }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientImpl.kt
@@ -41,6 +41,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import network.bisq.mobile.client.common.domain.access.utils.HeaderRedaction
 import network.bisq.mobile.client.common.domain.access.utils.Headers
 import network.bisq.mobile.client.common.domain.httpclient.exception.UnauthorizedApiAccessException
 import network.bisq.mobile.client.common.domain.websocket.exception.IncompatibleHttpApiVersionException
@@ -416,11 +417,11 @@ class WebSocketClientImpl(
             healthCheckRequestIds.add(message.requestId)
         }
         if (!isHealthCheck) {
-            log.d { "Send message $message" }
+            log.d { "Send message ${HeaderRedaction.redactForLogging(message)}" }
         }
         val jsonString: String = json.encodeToString(message)
         if (!isHealthCheck) {
-            log.d { "Send raw text $jsonString" }
+            log.d { "Send raw text ${HeaderRedaction.redactRawJsonForLogging(jsonString)}" }
         }
         session?.send(Frame.Text(jsonString))
     }
@@ -448,7 +449,7 @@ class WebSocketClientImpl(
                         val isHealthCheckResponse =
                             rawRequestId != null && healthCheckRequestIds.remove(rawRequestId)
                         if (!isHealthCheckResponse) {
-                            log.d { "Received raw text $message" }
+                            log.d { "Received raw text ${HeaderRedaction.redactRawJsonForLogging(message)}" }
                         }
 
                         val webSocketMessage: WebSocketMessage =
@@ -457,7 +458,7 @@ class WebSocketClientImpl(
                                 message,
                             )
                         if (!isHealthCheckResponse) {
-                            log.d { "Received webSocketMessage $webSocketMessage" }
+                            log.d { "Received webSocketMessage ${HeaderRedaction.redactForLogging(webSocketMessage)}" }
                         }
                         if (webSocketMessage is WebSocketResponse) {
                             onWebSocketResponse(webSocketMessage, rawRequestId)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/WebSocketClientService.kt
@@ -289,19 +289,14 @@ class WebSocketClientService(
                 if (liveClient.clientId == httpClientSettings.clientId) {
                     val liveSessionExpiresAt = previousSettings.sessionExpiresAt
                     if (SessionValidity.hasMinRemainingValidity(liveSessionExpiresAt)) {
-                        log.d {
-                            "Session id changed in settings " +
-                                "(${liveClient.sessionId} → ${httpClientSettings.sessionId}); " +
-                                "live WS healthy with ≥15m session remaining — skipping recreation"
-                        }
+                        log.d(
+                            "Session id changed in settings; " +
+                                "live WS healthy with ≥15m session remaining — skipping recreation",
+                        )
                         return@withLock
                     }
                 } else {
-                    log.d {
-                        "Client id changed on live client " +
-                            "(${liveClient.clientId} → ${httpClientSettings.clientId}); " +
-                            "recreating WebSocket client"
-                    }
+                    log.d("Client id changed on live client; recreating WebSocket client")
                 }
             }
 

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
@@ -29,6 +29,22 @@ class HeaderRedactionTest {
     }
 
     @Test
+    fun `redactSensitiveHeaders redacts lowercase and mixed-case session and client ids`() {
+        val headers =
+            mapOf(
+                "bisq-session-id" to sessionSecret,
+                "Bisq-Client-ID" to clientSecret,
+                "Content-Type" to "application/json",
+            )
+
+        val redacted = HeaderRedaction.redactSensitiveHeaders(headers)
+
+        assertEquals(HeaderRedaction.REDACTED, redacted["bisq-session-id"])
+        assertEquals(HeaderRedaction.REDACTED, redacted["Bisq-Client-ID"])
+        assertEquals("application/json", redacted["Content-Type"])
+    }
+
+    @Test
     fun `redactForLogging redacts WebSocketRestApiRequest headers`() {
         val request =
             WebSocketRestApiRequest(
@@ -98,5 +114,66 @@ class HeaderRedactionTest {
         val raw = """{"requestId":"1","headers":{"X-Custom":"value"}}"""
 
         assertEquals(raw, HeaderRedaction.redactRawJsonForLogging(raw))
+    }
+
+    @Test
+    fun `redactForLogging redacts lowercase and mixed-case session and client ids`() {
+        val request =
+            WebSocketRestApiRequest(
+                requestId = "req-123",
+                method = "GET",
+                path = "/api/v1/settings",
+                body = "",
+                headers =
+                    mapOf(
+                        "bisq-session-id" to sessionSecret,
+                        "Bisq-Client-ID" to clientSecret,
+                    ),
+            )
+
+        val logged = HeaderRedaction.redactForLogging(request)
+
+        assertFalse(logged.contains(sessionSecret))
+        assertFalse(logged.contains(clientSecret))
+        assertTrue(logged.contains(HeaderRedaction.REDACTED))
+    }
+
+    @Test
+    fun `redactRawJsonForLogging redacts lowercase and mixed-case session and client ids`() {
+        val raw =
+            """
+            {
+              "type": "WebSocketRestApiRequest",
+              "requestId": "req-123",
+              "method": "GET",
+              "path": "/api/v1/settings",
+              "body": "",
+              "headers": {
+                "bisq-session-id": "$sessionSecret",
+                "Bisq-Client-ID": "$clientSecret",
+                "X-Custom": "keep-me"
+              }
+            }
+            """.trimIndent()
+
+        val logged = HeaderRedaction.redactRawJsonForLogging(raw)
+
+        assertFalse(logged.contains(sessionSecret))
+        assertFalse(logged.contains(clientSecret))
+        assertTrue(logged.contains(HeaderRedaction.REDACTED))
+        assertTrue(logged.contains("keep-me"))
+    }
+
+    @Test
+    fun `redactRawJsonForLogging fails closed on malformed JSON containing secrets`() {
+        // Truncated JSON — parse fails, so the original payload must not be logged.
+        val raw =
+            """{"headers":{"Bisq-Session-Id":"$sessionSecret","Bisq-Client-Id":"$clientSecret""""
+
+        val logged = HeaderRedaction.redactRawJsonForLogging(raw)
+
+        assertEquals(HeaderRedaction.UNPARSEABLE_PAYLOAD, logged)
+        assertFalse(logged.contains(sessionSecret))
+        assertFalse(logged.contains(clientSecret))
     }
 }

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
@@ -1,0 +1,102 @@
+package network.bisq.mobile.client.common.domain.access.utils
+
+import network.bisq.mobile.client.common.domain.websocket.messages.SubscriptionRequest
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiRequest
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HeaderRedactionTest {
+    private val sessionSecret = "8abad33f-4d69-421f-8250-e53abd81d04e"
+    private val clientSecret = "8789beb9-3d54-4e69-90d4-355f9e3bc741"
+
+    @Test
+    fun `redactSensitiveHeaders replaces session and client ids`() {
+        val headers =
+            mapOf(
+                Headers.SESSION_ID to sessionSecret,
+                Headers.CLIENT_ID to clientSecret,
+                "Content-Type" to "application/json",
+            )
+
+        val redacted = HeaderRedaction.redactSensitiveHeaders(headers)
+
+        assertEquals(HeaderRedaction.REDACTED, redacted[Headers.SESSION_ID])
+        assertEquals(HeaderRedaction.REDACTED, redacted[Headers.CLIENT_ID])
+        assertEquals("application/json", redacted["Content-Type"])
+    }
+
+    @Test
+    fun `redactForLogging redacts WebSocketRestApiRequest headers`() {
+        val request =
+            WebSocketRestApiRequest(
+                requestId = "req-123",
+                method = "GET",
+                path = "/api/v1/settings",
+                body = "",
+                headers =
+                    mapOf(
+                        Headers.SESSION_ID to sessionSecret,
+                        Headers.CLIENT_ID to clientSecret,
+                        "X-Custom" to "keep-me",
+                    ),
+            )
+
+        val logged = HeaderRedaction.redactForLogging(request)
+
+        assertFalse(logged.contains(sessionSecret))
+        assertFalse(logged.contains(clientSecret))
+        assertTrue(logged.contains(HeaderRedaction.REDACTED))
+        assertTrue(logged.contains("X-Custom=keep-me"))
+        assertTrue(logged.contains("/api/v1/settings"))
+        // Original message must remain untouched for the wire.
+        assertEquals(sessionSecret, request.headers[Headers.SESSION_ID])
+        assertEquals(clientSecret, request.headers[Headers.CLIENT_ID])
+    }
+
+    @Test
+    fun `redactForLogging leaves non-rest messages unchanged`() {
+        val message = SubscriptionRequest(Topic.REPUTATION, null, "sub-1")
+
+        assertEquals(message.toString(), HeaderRedaction.redactForLogging(message))
+    }
+
+    @Test
+    fun `redactRawJsonForLogging redacts sensitive header values`() {
+        val raw =
+            """
+            {
+              "type": "WebSocketRestApiRequest",
+              "requestId": "req-123",
+              "method": "GET",
+              "path": "/api/v1/settings",
+              "body": "",
+              "headers": {
+                "Bisq-Session-Id": "$sessionSecret",
+                "Bisq-Client-Id": "$clientSecret",
+                "X-Custom": "keep-me"
+              }
+            }
+            """.trimIndent()
+
+        val logged = HeaderRedaction.redactRawJsonForLogging(raw)
+
+        assertFalse(logged.contains(sessionSecret))
+        assertFalse(logged.contains(clientSecret))
+        assertTrue(logged.contains(HeaderRedaction.REDACTED))
+        assertTrue(logged.contains("keep-me"))
+        assertTrue(logged.contains("/api/v1/settings"))
+        // Input string is not mutated by reference; verify source still has secrets.
+        assertTrue(raw.contains(sessionSecret))
+        assertTrue(raw.contains(clientSecret))
+    }
+
+    @Test
+    fun `redactRawJsonForLogging returns original when no sensitive headers`() {
+        val raw = """{"requestId":"1","headers":{"X-Custom":"value"}}"""
+
+        assertEquals(raw, HeaderRedaction.redactRawJsonForLogging(raw))
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq-mobile/issues/1644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Sensitive client and session identifiers are now masked in WebSocket and JSON logs.
  * Original request and message contents remain unchanged when sent over the network.
* **Bug Fixes**
  * Improved logging safety while preserving non-sensitive information.
  * Invalid, non-object, or headerless JSON is handled without altering logged content.
  * WebSocket client recreation logs no longer expose identifier values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->