### PR TITLE
Feature/new permissions support for node and connect upgrades

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
@@ -145,6 +145,22 @@ class PairingCodeDecoderTest {
     }
 
     @Test
+    fun `decode throws for payload truncated inside permission list`() {
+        // Declares 3 permissions but carries only 1 — must fail as invalid format,
+        // not silently return a partial permission set.
+        val writer = BinaryWriter()
+        BinaryEncodingUtils.writeByte(writer, PairingCode.VERSION)
+        BinaryEncodingUtils.writeString(writer, "test")
+        BinaryEncodingUtils.writeLong(writer, 1700000000000L)
+        BinaryEncodingUtils.writeInt(writer, 3)
+        BinaryEncodingUtils.writeInt(writer, Permission.OFFERBOOK.id)
+
+        assertFailsWith<IllegalStateException> {
+            PairingCodeDecoder.decode(writer.toByteArray())
+        }
+    }
+
+    @Test
     fun `decode handles unknown permission id gracefully`() {
         val writer = BinaryWriter()
         BinaryEncodingUtils.writeByte(writer, PairingCode.VERSION)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
@@ -91,10 +91,10 @@ class PairingCodeDecoderTest {
     }
 
     @Test
-    fun `decode throws for unsupported version`() {
+    fun `decode throws UnsupportedPairingVersionException for unsupported version`() {
         val bytes = encodePairingCode(version = 99)
 
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<UnsupportedPairingVersionException> {
             PairingCodeDecoder.decode(bytes)
         }
     }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoderTest.kt
@@ -100,16 +100,35 @@ class PairingCodeDecoderTest {
     }
 
     @Test
-    fun `decode throws for invalid number of permissions`() {
+    fun `decode throws for permission count above sanity cap`() {
         val writer = BinaryWriter()
         BinaryEncodingUtils.writeByte(writer, PairingCode.VERSION)
         BinaryEncodingUtils.writeString(writer, "test")
         BinaryEncodingUtils.writeLong(writer, 1700000000000L)
-        BinaryEncodingUtils.writeInt(writer, 100) // Invalid: more than Permission.entries.size
+        BinaryEncodingUtils.writeInt(writer, PairingCodeDecoder.MAX_ENCODED_PERMISSIONS + 1)
 
         assertFailsWith<IllegalArgumentException> {
             PairingCodeDecoder.decode(writer.toByteArray())
         }
+    }
+
+    @Test
+    fun `decode accepts more permissions than this app version knows`() {
+        // A newer node grants permissions added after this app was built. The count exceeds
+        // the local enum size; the unknown ids must be skipped, not fail the whole pairing.
+        val writer = BinaryWriter()
+        BinaryEncodingUtils.writeByte(writer, PairingCode.VERSION)
+        BinaryEncodingUtils.writeString(writer, "upgraded-node")
+        BinaryEncodingUtils.writeLong(writer, 1700000000000L)
+        val unknownIds = listOf(Permission.entries.size, Permission.entries.size + 1)
+        BinaryEncodingUtils.writeInt(writer, Permission.entries.size + unknownIds.size)
+        Permission.entries.forEach { BinaryEncodingUtils.writeInt(writer, it.id) }
+        unknownIds.forEach { BinaryEncodingUtils.writeInt(writer, it) }
+
+        val result = PairingCodeDecoder.decode(writer.toByteArray())
+
+        assertEquals("upgraded-node", result.id)
+        assertEquals(Permission.entries.toSet(), result.grantedPermissions)
     }
 
     @Test

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoderTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoderTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import network.bisq.mobile.client.common.domain.access.pairing.PairingCode
 import network.bisq.mobile.client.common.domain.access.pairing.Permission
+import network.bisq.mobile.client.common.domain.access.pairing.UnsupportedPairingVersionException
 import network.bisq.mobile.client.common.domain.utils.BinaryEncodingUtils
 import network.bisq.mobile.client.common.domain.utils.BinaryWriter
 import network.bisq.mobile.data.utils.EnvironmentController
@@ -229,5 +230,47 @@ class PairingQrCodeDecoderTest {
         val result = decoder.decode(bytes)
 
         assertEquals("unique-pairing-id-123", result.pairingCode.id)
+    }
+
+    private fun toBase64(bytes: ByteArray): String = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode(bytes)
+
+    @Test
+    fun `decode string accepts payload with embedded newlines from terminal soft-wrap`() {
+        val base64 = toBase64(encodeQrCode())
+        val wrapped = base64.chunked(60).joinToString("\n")
+
+        val result = decoder.decode(wrapped)
+
+        assertEquals(PairingQrCodeFormat.VERSION, result.version)
+    }
+
+    @Test
+    fun `decode string accepts payload followed by ASCII art QR block`() {
+        // Mirrors a select-all copy of the node's pairing_qr_code.txt: base64 line, blank
+        // lines, then the text-rendered QR.
+        val base64 = toBase64(encodeQrCode())
+        val fileLikeContent = base64 + "\n\n\n" + "█▀▀▀▀▀█ ▀▄█ █▀▀▀▀▀█\n█ ███ █ ▄▀▄ █ ███ █\n"
+
+        val result = decoder.decode(fileLikeContent)
+
+        assertEquals(PairingQrCodeFormat.VERSION, result.version)
+    }
+
+    @Test
+    fun `decode string accepts payload with standard base64 padding appended`() {
+        val base64 = toBase64(encodeQrCode())
+
+        val result = decoder.decode("$base64==")
+
+        assertEquals(PairingQrCodeFormat.VERSION, result.version)
+    }
+
+    @Test
+    fun `decode throws UnsupportedPairingVersionException for unknown QR version`() {
+        val bytes = encodeQrCode(version = 99)
+
+        assertFailsWith<UnsupportedPairingVersionException> {
+            decoder.decode(bytes)
+        }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/ApiAccessService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/ApiAccessService.kt
@@ -4,6 +4,7 @@ import network.bisq.mobile.client.common.domain.access.pairing.PairingCode
 import network.bisq.mobile.client.common.domain.access.pairing.PairingResponse
 import network.bisq.mobile.client.common.domain.access.pairing.PairingService
 import network.bisq.mobile.client.common.domain.access.pairing.Permission
+import network.bisq.mobile.client.common.domain.access.pairing.UnsupportedPairingVersionException
 import network.bisq.mobile.client.common.domain.access.pairing.qr.PairingQrCode
 import network.bisq.mobile.client.common.domain.access.pairing.qr.PairingQrCodeDecoder
 import network.bisq.mobile.client.common.domain.access.utils.ApiAccessUtil.getProxyOptionFromRestUrl
@@ -66,6 +67,9 @@ class ApiAccessService(
         return try {
             val code = pairingQrCodeDecoder.decode(trimmedValue)
             Result.success(code)
+        } catch (e: UnsupportedPairingVersionException) {
+            log.e(e) { "Pairing code version not supported by this app version." }
+            Result.failure(Throwable("mobile.trustedNodeSetup.pairingCode.unsupportedVersion".i18n()))
         } catch (e: Exception) {
             log.e(e) { "Decoding pairing code failed." }
             Result.failure(Throwable("mobile.trustedNodeSetup.pairingCode.invalid".i18n()))

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
@@ -41,8 +41,11 @@ object PairingCodeDecoder {
 
         val permissions = mutableSetOf<Permission>()
         repeat(numPermissions) {
+            // Read outside the try: a truncated payload must fail as invalid format, while an
+            // unknown id (newer node) is skipped as an unknown permission.
+            val permissionId = reader.readInt()
             try {
-                permissions += Permission.Companion.fromId(reader.readInt())
+                permissions += Permission.Companion.fromId(permissionId)
             } catch (e: Exception) {
                 getLogger("").w { "Permission could not be resolved. {${e.message}}" }
             }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
@@ -8,6 +8,12 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalEncodingApi::class)
 object PairingCodeDecoder {
+    // Sanity cap against corrupt input only — deliberately NOT bound to Permission.entries.size:
+    // a newer node may grant permissions this app version does not know yet, and the code must
+    // still decode (unknown ids are skipped below). Bounding by the local enum size would make
+    // pairing fail entirely against upgraded nodes.
+    internal const val MAX_ENCODED_PERMISSIONS = 64
+
     fun decode(base64: String): PairingCode {
         val bytes =
             Base64.UrlSafe
@@ -29,7 +35,7 @@ object PairingCodeDecoder {
             Instant.fromEpochMilliseconds(reader.readLong())
 
         val numPermissions = reader.readInt()
-        require(numPermissions in 0..Permission.entries.size) {
+        require(numPermissions in 0..MAX_ENCODED_PERMISSIONS) {
             "Invalid number of permissions: $numPermissions"
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/PairingCodeDecoder.kt
@@ -26,8 +26,8 @@ object PairingCodeDecoder {
         val reader = BinaryDecodingUtils(bytes)
 
         val version = reader.readByte()
-        require(version == PairingCode.Companion.VERSION) {
-            "Unsupported version"
+        if (version != PairingCode.Companion.VERSION) {
+            throw UnsupportedPairingVersionException("Unsupported pairing code version: $version")
         }
 
         val id = reader.readString()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/UnsupportedPairingVersionException.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/UnsupportedPairingVersionException.kt
@@ -1,0 +1,10 @@
+package network.bisq.mobile.client.common.domain.access.pairing
+
+/**
+ * Thrown when a pairing code or pairing QR payload declares a format version this app
+ * version does not understand. Kept as a distinct type so the UI can tell the user to
+ * update the app instead of showing the generic "invalid format" error.
+ */
+class UnsupportedPairingVersionException(
+    message: String,
+) : IllegalArgumentException(message)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoder.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/pairing/qr/PairingQrCodeDecoder.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.client.common.domain.access.pairing.qr
 
 import network.bisq.mobile.client.common.domain.access.LOCALHOST
 import network.bisq.mobile.client.common.domain.access.pairing.PairingCodeDecoder
+import network.bisq.mobile.client.common.domain.access.pairing.UnsupportedPairingVersionException
 import network.bisq.mobile.client.common.domain.utils.BinaryDecodingUtils
 import network.bisq.mobile.data.utils.EnvironmentController
 import network.bisq.mobile.data.utils.getPlatformInfo
@@ -12,6 +13,9 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 const val LOOPBACK = "127.0.0.1"
 const val ANDROID_LOCALHOST = "10.0.2.2"
 
+private const val URL_SAFE_BASE64_ALPHABET =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
 @OptIn(ExperimentalEncodingApi::class)
 class PairingQrCodeDecoder(
     private val environmentController: EnvironmentController,
@@ -20,16 +24,31 @@ class PairingQrCodeDecoder(
         decode(
             Base64.UrlSafe
                 .withPadding(Base64.PaddingOption.ABSENT)
-                .decode(qrCodeAsBase64),
+                .decode(
+                    sanitize(qrCodeAsBase64),
+                ),
         )
+
+    /**
+     * The node writes the payload as one long line followed by an ASCII-art QR block, and
+     * terminals soft-wrap it, so real-world copies arrive with embedded newlines, trailing
+     * art, or padding. Whitespace is never part of the url-safe base64 alphabet, so joining
+     * the fragments and cutting at the first foreign character recovers exactly the payload.
+     */
+    private fun sanitize(raw: String): String =
+        raw
+            .asSequence()
+            .filterNot { it.isWhitespace() }
+            .takeWhile { it in URL_SAFE_BASE64_ALPHABET }
+            .joinToString("")
 
     fun decode(qrCodeBytes: ByteArray): PairingQrCode {
         val reader = BinaryDecodingUtils(qrCodeBytes)
 
         // ---- Version ----
         val version = reader.readByte()
-        require(version == PairingQrCodeFormat.VERSION) {
-            "Unsupported QR code version: $version"
+        if (version != PairingQrCodeFormat.VERSION) {
+            throw UnsupportedPairingVersionException("Unsupported QR code version: $version")
         }
 
         // ---- PairingCode ----

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -604,6 +604,7 @@ mobile.trustedNodeSetup.version.expectedAPI=Expected API version: {0}
 mobile.trustedNodeSetup.version.nodeAPI=Node API version: {0}
 mobile.trustedNodeSetup.advancedOptions=Advanced options
 mobile.trustedNodeSetup.pairingCode.invalid=Invalid pairing code format. Please ensure you copied the complete pairing code.
+mobile.trustedNodeSetup.pairingCode.unsupportedVersion=This pairing code uses a newer format than this app supports. Please update the app and try again.
 mobile.trustedNodeSetup.pairWithNewNode=Pair with a new trusted node
 mobile.trustedNodeSetup.connectionFailed.message=Could not connect to the trusted node. Please verify the node is running and try again, or pair with a different node.
 mobile.trustedNodeSetup.keystoreError.headline=Security credentials reset


### PR DESCRIPTION
 - contribs to #590 
 - depends on https://github.com/bisq-network/bisq2/pull/4914
 - hardened pairing validation and support for user-facing error when a security permissions change provokes invalid QR codes
 - added AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing and QR code decoding for copied text containing line breaks, padding, or trailing content.
  * Added compatibility for pairing codes containing permission IDs unknown to the current app version.
  * Invalid permission counts continue to be rejected safely.
  * Unsupported pairing-code versions now show a clear localized message recommending an app update.
* **Localization**
  * Added messaging for pairing codes created with newer formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->