### PR TITLE
bugfix/1683_node_startup_main_thread_diagnosis

### DIFF
--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceControlPortProbeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceControlPortProbeTest.kt
@@ -1,0 +1,48 @@
+package network.bisq.mobile.data.service.network
+
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.InetSocketAddress
+import io.ktor.network.sockets.aSocket
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+
+/**
+ * Real-socket tests for the bootstrap control-port probe. [KmpTorService] construction is
+ * inert (lazy DI injection, plain state flows), so no Koin setup is needed. The probe's
+ * initial 500ms grace delay runs in real time on Dispatchers.IO — each test takes ~1s.
+ */
+class KmpTorServiceControlPortProbeTest {
+    private fun service() = KmpTorService(baseDir = "build/tmp/kmp-tor-test".toPath())
+
+    @Test
+    fun `returns once the control port accepts a connection`() =
+        runTest {
+            val selector = SelectorManager(Dispatchers.IO)
+            val server = aSocket(selector).tcp().bind("127.0.0.1", 0)
+            try {
+                val port = (server.localAddress as InetSocketAddress).port
+                service().verifyControlPortAccessible(port)
+            } finally {
+                server.close()
+                selector.close()
+            }
+        }
+
+    @Test
+    fun `gives up without throwing after retries when nothing listens on the port`() =
+        runTest {
+            // Bind then release to obtain a local port that is almost certainly closed.
+            val selector = SelectorManager(Dispatchers.IO)
+            val probe = aSocket(selector).tcp().bind("127.0.0.1", 0)
+            val port = (probe.localAddress as InetSocketAddress).port
+            probe.close()
+            try {
+                // Bootstrap continues even when the probe fails — this must not throw.
+                service().verifyControlPortAccessible(port)
+            } finally {
+                selector.close()
+            }
+        }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceControlPortProbeTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/network/KmpTorServiceControlPortProbeTest.kt
@@ -3,10 +3,15 @@ package network.bisq.mobile.data.service.network
 import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.InetSocketAddress
 import io.ktor.network.sockets.aSocket
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 /**
  * Real-socket tests for the bootstrap control-port probe. [KmpTorService] construction is
@@ -19,30 +24,44 @@ class KmpTorServiceControlPortProbeTest {
     @Test
     fun `returns once the control port accepts a connection`() =
         runTest {
-            val selector = SelectorManager(Dispatchers.IO)
-            val server = aSocket(selector).tcp().bind("127.0.0.1", 0)
-            try {
-                val port = (server.localAddress as InetSocketAddress).port
-                service().verifyControlPortAccessible(port)
-            } finally {
-                server.close()
-                selector.close()
+            SelectorManager(Dispatchers.IO).use { selector ->
+                aSocket(selector).tcp().bind("127.0.0.1", 0).use { server ->
+                    val port = (server.localAddress as InetSocketAddress).port
+                    service().verifyControlPortAccessible(port)
+                }
             }
         }
 
     @Test
     fun `gives up without throwing after retries when nothing listens on the port`() =
         runTest {
-            // Bind then release to obtain a local port that is almost certainly closed.
-            val selector = SelectorManager(Dispatchers.IO)
-            val probe = aSocket(selector).tcp().bind("127.0.0.1", 0)
-            val port = (probe.localAddress as InetSocketAddress).port
-            probe.close()
-            try {
+            SelectorManager(Dispatchers.IO).use { selector ->
+                // Bind then release to obtain a local port that is almost certainly closed.
+                val port =
+                    aSocket(selector).tcp().bind("127.0.0.1", 0).use { probe ->
+                        (probe.localAddress as InetSocketAddress).port
+                    }
                 // Bootstrap continues even when the probe fails — this must not throw.
                 service().verifyControlPortAccessible(port)
-            } finally {
-                selector.close()
             }
         }
+
+    @Test
+    fun `propagates cancellation to the caller instead of swallowing it`() {
+        // runBlocking, not runTest: the probe's delays run in real time on Dispatchers.IO, so we
+        // need a real clock to cancel mid-flight. Guards the fix that rethrows CancellationException
+        // ahead of the broad catch — a swallowed cancellation would make this hang or complete.
+        runBlocking {
+            SelectorManager(Dispatchers.IO).use { selector ->
+                val port =
+                    aSocket(selector).tcp().bind("127.0.0.1", 0).use { probe ->
+                        (probe.localAddress as InetSocketAddress).port
+                    }
+                val deferred = async(Dispatchers.IO) { service().verifyControlPortAccessible(port) }
+                delay(100) // well inside the probe's 500ms grace delay
+                deferred.cancel()
+                assertFailsWith<CancellationException> { deferred.await() }
+            }
+        }
+    }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
@@ -105,6 +105,31 @@ class BufferedAnalyticsServiceFactoryTest {
     }
 
     @Test
+    fun `production default send lane forwards init when no dispatcher is injected`() {
+        val repository = SettingsRepositoryMock(Settings(analyticsEnabled = true))
+        val initializer = FakeInitializer()
+        val service =
+            createBufferedAnalyticsService(
+                settingsRepository = repository,
+                nativeInitializer = initializer,
+                analyticsDevEnabled = true,
+            )
+
+        service.init(
+            dsn = "https://key@glitchtip.example/1",
+            environment = "test",
+            release = "test@1",
+            isDebug = true,
+            socksProxyHost = null,
+            socksProxyPort = null,
+        )
+
+        awaitCondition("init should reach the SDK via the default send lane") {
+            initializer.capturedOptInProvider != null
+        }
+    }
+
+    @Test
     fun `runtime settings flip propagates to the provider without rebuilding`() {
         val repository = SettingsRepositoryMock(Settings(analyticsEnabled = false))
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactoryTest.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.domain.analytics
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
@@ -42,6 +43,7 @@ class BufferedAnalyticsServiceFactoryTest {
                 settingsRepository = repository,
                 nativeInitializer = initializer,
                 analyticsDevEnabled = analyticsDevEnabled,
+                sendDispatcher = Dispatchers.Unconfined,
             )
         service.init(
             dsn = "https://key@glitchtip.example/1",

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -471,24 +471,27 @@ class KmpTorService(
         }
     }
 
-    private suspend fun verifyControlPortAccessible(controlPort: Int) {
-        val selectorManager = SelectorManager(Dispatchers.IO)
-        selectorManager.use {
-            delay(500L)
-            repeat(3) { attempt ->
-                try {
-                    log.d { "Trying control port connection..." }
-                    val socket = aSocket(it).tcp().connect("127.0.0.1", controlPort)
-                    socket.close()
-                    log.i { "Verified control port $controlPort is accessible" }
-                    return
-                } catch (_: Exception) {
-                    if (attempt < 2) delay(250)
+    // withContext(IO): the ktor connect performs synchronous socket setup on the calling
+    // thread before suspending — StrictMode caught it as network-on-main during bootstrap
+    private suspend fun verifyControlPortAccessible(controlPort: Int) =
+        withContext(Dispatchers.IO) {
+            val selectorManager = SelectorManager(Dispatchers.IO)
+            selectorManager.use {
+                delay(500L)
+                repeat(3) { attempt ->
+                    try {
+                        log.d { "Trying control port connection..." }
+                        val socket = aSocket(it).tcp().connect("127.0.0.1", controlPort)
+                        socket.close()
+                        log.i { "Verified control port $controlPort is accessible" }
+                        return@withContext
+                    } catch (_: Exception) {
+                        if (attempt < 2) delay(250)
+                    }
                 }
+                log.w { "Control port $controlPort not yet accessible, but continuing anyway" }
             }
-            log.w { "Control port $controlPort not yet accessible, but continuing anyway" }
         }
-    }
 
     private fun getTorDir(): Path {
         val torDir = baseDir / "tor"

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -474,7 +474,7 @@ class KmpTorService(
 
     // withContext(IO): the ktor connect performs synchronous socket setup on the calling
     // thread before suspending — StrictMode caught it as network-on-main during bootstrap
-    private suspend fun verifyControlPortAccessible(controlPort: Int) =
+    internal suspend fun verifyControlPortAccessible(controlPort: Int) =
         withContext(Dispatchers.IO) {
             val selectorManager = SelectorManager(Dispatchers.IO)
             selectorManager.use {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/network/KmpTorService.kt
@@ -11,6 +11,7 @@ import io.matthewnelson.kmp.tor.runtime.core.TorEvent
 import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -485,6 +486,10 @@ class KmpTorService(
                         socket.close()
                         log.i { "Verified control port $controlPort is accessible" }
                         return@withContext
+                    } catch (e: CancellationException) {
+                        // Never swallow cancellation — on the last attempt there is no delay()
+                        // to rethrow it for us, and retrying a cancelled caller is wrong anyway.
+                        throw e
                     } catch (_: Exception) {
                         if (attempt < 2) delay(250)
                     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsService.kt
@@ -94,6 +94,11 @@ class BufferedAnalyticsService(
     // without needing platform-specific @Volatile.
     private val sentryReady = atomic(false)
 
+    // Latest init() outcome, written on the send lane. Gates onSentryReady(): a failed init
+    // must never flip readiness, or the ready-flush would push buffered events into an
+    // uninitialised SDK where they get silently dropped.
+    private val initSucceeded = atomic(false)
+
     private sealed class BufferedItem {
         data class Track(
             val event: AnalyticsEvent,
@@ -136,16 +141,22 @@ class BufferedAnalyticsService(
         // Forwarded on the send lane, not the caller's thread: Sentry.init does heavy disk I/O
         // and the lifecycle service invokes this from a Main-dispatched coroutine mid-bootstrap
         // (StrictMode caught it dropping frames). Ordering with onSentryReady() is preserved by
-        // the lane's FIFO: the ready-flush and any direct sends queue BEHIND this init task, so
-        // nothing reaches the SDK before init has completed — see ApplicationLifecycleService.
+        // the lane's FIFO: the ready-check-and-flush queues BEHIND this init task, so by the
+        // time it runs, initSucceeded reflects THIS init's outcome and a failed init keeps
+        // events buffered instead of flushing them into a dead SDK.
         scope.launch(sendDispatcher) {
-            try {
-                downstream.init(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (t: Throwable) {
-                log.e(t) { "Analytics downstream init failed — events will stay buffered" }
-            }
+            initSucceeded.value =
+                try {
+                    downstream.init(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
+                    true
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (t: Throwable) {
+                    // Class name only — the exception message can embed the DSN (Sentry's
+                    // DSN-parse errors do), and the DSN carries the ingest key.
+                    log.e { "Analytics downstream init failed (${t::class.simpleName}) — events will stay buffered" }
+                    false
+                }
         }
     }
 
@@ -206,9 +217,17 @@ class BufferedAnalyticsService(
      * SDK options.
      */
     fun onSentryReady() {
-        if (!sentryReady.compareAndSet(expect = false, update = true)) return
-        log.d { "Sentry ready — flushing buffered analytics events" }
-        scope.launch(sendDispatcher) { flush() }
+        // Both the gate check and the readiness flip run on the send lane so they observe the
+        // outcome of the init() task queued before them — see init()'s FIFO-ordering comment.
+        scope.launch(sendDispatcher) {
+            if (!initSucceeded.value) {
+                log.w { "onSentryReady ignored — downstream init failed or never ran; events stay buffered" }
+                return@launch
+            }
+            if (!sentryReady.compareAndSet(expect = false, update = true)) return@launch
+            log.d { "Sentry ready — flushing buffered analytics events" }
+            flush()
+        }
     }
 
     /**

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsService.kt
@@ -2,7 +2,10 @@ package network.bisq.mobile.domain.analytics
 
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -48,9 +51,12 @@ import network.bisq.mobile.domain.utils.Logging
  *   in-memory operations, never around calls into the downstream Sentry SDK.
  * - The public [track] / [captureException] / [trackImmediate] /
  *   [captureExceptionImmediate] methods are non-suspending (matching the
- *   [AnalyticsService] contract). They take the fast path when Sentry is
- *   ready (Sentry SDKs are documented thread-safe) or fire-and-forget the
- *   buffer enqueue into [scope] when not — callers never block.
+ *   [AnalyticsService] contract) and NEVER touch the SDK on the caller's
+ *   thread: the Sentry SDK performs disk I/O in `captureMessage`, which
+ *   StrictMode caught running on main at every screen attach.
+ *   Every send/enqueue is fired onto [sendDispatcher] — a parallelism-1 lane,
+ *   so operations execute sequentially in submission order and the FIFO
+ *   guarantees of the buffer policy hold across direct sends and enqueues.
  *
  * ## Lifecycle
  *
@@ -71,8 +77,16 @@ class BufferedAnalyticsService(
     private val scope: CoroutineScope,
     private val maxBuffer: Int = DEFAULT_MAX_BUFFER,
     private val flushIntervalMs: Long = DEFAULT_FLUSH_INTERVAL_MS,
+    sendDispatcher: CoroutineDispatcher? = null,
 ) : AnalyticsService,
     Logging {
+    // Parallelism-1 lane for everything that may call into the Sentry SDK. See the class doc's
+    // thread-safety section: SDK calls do disk I/O and must stay off the caller's thread, and a
+    // single lane keeps sends and buffer operations in submission order. Tests inject an
+    // unconfined dispatcher to keep their eager-execution assertions.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val sendDispatcher: CoroutineDispatcher = sendDispatcher ?: Dispatchers.Default.limitedParallelism(1)
+
     private val buffer = ArrayDeque<BufferedItem>()
     private val mutex = Mutex()
 
@@ -100,7 +114,9 @@ class BufferedAnalyticsService(
         // interfering with `advanceUntilIdle()`. Production code never sets
         // this to zero.
         if (flushIntervalMs > 0) {
-            scope.launch {
+            // On the send lane so a periodic flush cannot interleave with in-flight sends;
+            // delay() suspends without occupying the lane.
+            scope.launch(this.sendDispatcher) {
                 while (isActive) {
                     delay(flushIntervalMs)
                     if (sentryReady.value) flush()
@@ -117,49 +133,67 @@ class BufferedAnalyticsService(
         socksProxyHost: String?,
         socksProxyPort: Int?,
     ) {
-        // Forward init synchronously. Readiness is a separate signal that the
-        // lifecycle service flips via onSentryReady() once Tor is up AND
-        // Sentry.init has completed — see ApplicationLifecycleService.
-        downstream.init(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
+        // Forwarded on the send lane, not the caller's thread: Sentry.init does heavy disk I/O
+        // and the lifecycle service invokes this from a Main-dispatched coroutine mid-bootstrap
+        // (StrictMode caught it dropping frames). Ordering with onSentryReady() is preserved by
+        // the lane's FIFO: the ready-flush and any direct sends queue BEHIND this init task, so
+        // nothing reaches the SDK before init has completed — see ApplicationLifecycleService.
+        scope.launch(sendDispatcher) {
+            try {
+                downstream.init(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                log.e(t) { "Analytics downstream init failed — events will stay buffered" }
+            }
+        }
     }
 
     override fun track(event: AnalyticsEvent) {
-        if (sentryReady.value && tryDirect { downstream.track(event) }) {
-            log.d { "Analytics: track(${event.name}) → forwarded direct" }
-            return
+        scope.launch(sendDispatcher) {
+            if (sentryReady.value && tryDirect { downstream.track(event) }) {
+                log.d { "Analytics: track(${event.name}) → forwarded direct" }
+            } else {
+                // Not ready, or direct push threw: buffer at TAIL (FIFO ordering).
+                log.d { "Analytics: track(${event.name}) → buffered (Sentry not ready)" }
+                enqueueAtTail(BufferedItem.Track(event))
+            }
         }
-        // Not ready, or direct push threw: buffer at TAIL (FIFO ordering).
-        log.d { "Analytics: track(${event.name}) → buffered (Sentry not ready)" }
-        scope.launch { enqueueAtTail(BufferedItem.Track(event)) }
     }
 
     override fun trackImmediate(event: AnalyticsEvent) {
-        if (sentryReady.value && tryDirect { downstream.trackImmediate(event) }) {
-            log.d { "Analytics: trackImmediate(${event.name}) → forwarded direct" }
-            return
+        scope.launch(sendDispatcher) {
+            if (sentryReady.value && tryDirect { downstream.trackImmediate(event) }) {
+                log.d { "Analytics: trackImmediate(${event.name}) → forwarded direct" }
+            } else {
+                // Not ready, or direct push threw: buffer at HEAD so this jumps any
+                // lower-priority events still queued behind it.
+                log.d { "Analytics: trackImmediate(${event.name}) → buffered at HEAD (Sentry not ready)" }
+                enqueueAtHead(BufferedItem.Track(event))
+            }
         }
-        // Not ready, or direct push threw: buffer at HEAD so this jumps any
-        // lower-priority events still queued behind it.
-        log.d { "Analytics: trackImmediate(${event.name}) → buffered at HEAD (Sentry not ready)" }
-        scope.launch { enqueueAtHead(BufferedItem.Track(event)) }
     }
 
     override fun captureException(throwable: Throwable) {
-        if (sentryReady.value && tryDirect { downstream.captureException(throwable) }) {
-            log.d { "Analytics: captureException(${throwable::class.simpleName}) → forwarded direct" }
-            return
+        scope.launch(sendDispatcher) {
+            if (sentryReady.value && tryDirect { downstream.captureException(throwable) }) {
+                log.d { "Analytics: captureException(${throwable::class.simpleName}) → forwarded direct" }
+            } else {
+                log.d { "Analytics: captureException(${throwable::class.simpleName}) → buffered (Sentry not ready)" }
+                enqueueAtTail(BufferedItem.Exception(throwable))
+            }
         }
-        log.d { "Analytics: captureException(${throwable::class.simpleName}) → buffered (Sentry not ready)" }
-        scope.launch { enqueueAtTail(BufferedItem.Exception(throwable)) }
     }
 
     override fun captureExceptionImmediate(throwable: Throwable) {
-        if (sentryReady.value && tryDirect { downstream.captureExceptionImmediate(throwable) }) {
-            log.d { "Analytics: captureExceptionImmediate(${throwable::class.simpleName}) → forwarded direct" }
-            return
+        scope.launch(sendDispatcher) {
+            if (sentryReady.value && tryDirect { downstream.captureExceptionImmediate(throwable) }) {
+                log.d { "Analytics: captureExceptionImmediate(${throwable::class.simpleName}) → forwarded direct" }
+            } else {
+                log.d { "Analytics: captureExceptionImmediate(${throwable::class.simpleName}) → buffered at HEAD (Sentry not ready)" }
+                enqueueAtHead(BufferedItem.Exception(throwable))
+            }
         }
-        log.d { "Analytics: captureExceptionImmediate(${throwable::class.simpleName}) → buffered at HEAD (Sentry not ready)" }
-        scope.launch { enqueueAtHead(BufferedItem.Exception(throwable)) }
     }
 
     /**
@@ -174,7 +208,7 @@ class BufferedAnalyticsService(
     fun onSentryReady() {
         if (!sentryReady.compareAndSet(expect = false, update = true)) return
         log.d { "Sentry ready — flushing buffered analytics events" }
-        scope.launch { flush() }
+        scope.launch(sendDispatcher) { flush() }
     }
 
     /**

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactory.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceFactory.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.domain.analytics
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -19,6 +20,8 @@ fun createBufferedAnalyticsService(
     settingsRepository: SettingsRepository,
     nativeInitializer: NativeSentryInitializer,
     analyticsDevEnabled: Boolean,
+    // Tests inject an eager dispatcher; production uses the service's single send lane (null).
+    sendDispatcher: CoroutineDispatcher? = null,
 ): BufferedAnalyticsService {
     // Independent scope so the buffer's periodic flusher survives any
     // individual feature-scope cancellation. SupervisorJob so a single
@@ -39,5 +42,6 @@ fun createBufferedAnalyticsService(
                 },
             ),
         scope = analyticsScope,
+        sendDispatcher = sendDispatcher,
     )
 }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
@@ -99,7 +99,7 @@ class BufferedAnalyticsServiceTest {
     fun `init forwards dsn environment release and isDebug to the downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.init(dsn = "http://abc@onion/3", environment = "production", release = "0.5.0", isDebug = false)
 
@@ -114,7 +114,7 @@ class BufferedAnalyticsServiceTest {
     fun `init does not flip readiness on its own`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.init("http://abc@onion/3", "production", "0.5.0", false)
 
@@ -127,7 +127,7 @@ class BufferedAnalyticsServiceTest {
     fun `track before ready goes to the buffer not the downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.track(AnalyticsEvent.ScreenOpened.Dashboard)
             advanceUntilIdle() // drain the fire-and-forget enqueue coroutine
@@ -140,7 +140,7 @@ class BufferedAnalyticsServiceTest {
     fun `captureException before ready goes to the buffer`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.captureException(RuntimeException("boom"))
             advanceUntilIdle()
@@ -153,7 +153,7 @@ class BufferedAnalyticsServiceTest {
     fun `trackImmediate before ready jumps the line ahead of pending normal events`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             // The AnalyticsEvent sealed type has only one concrete subclass right
             // now (Dashboard), so we use exception messages as the distinguishable
@@ -197,7 +197,7 @@ class BufferedAnalyticsServiceTest {
             // ensures `trackImmediate` itself is exercised so a future
             // refactor that breaks it loudly fails.
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.track(AnalyticsEvent.ScreenOpened.Dashboard)
             service.trackImmediate(AnalyticsEvent.ScreenOpened.Dashboard)
@@ -220,7 +220,7 @@ class BufferedAnalyticsServiceTest {
             // verifies the synchronous fast-path is wired so subsequent
             // refactors can't accidentally route all calls through the buffer.
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -237,7 +237,7 @@ class BufferedAnalyticsServiceTest {
     fun `onSentryReady flips the flag`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             assertFalse(service.isReady)
             service.onSentryReady()
@@ -248,7 +248,7 @@ class BufferedAnalyticsServiceTest {
     fun `onSentryReady drains the buffer to the downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             // Pile up multiple buffered events
             service.track(AnalyticsEvent.ScreenOpened.Dashboard)
@@ -269,7 +269,7 @@ class BufferedAnalyticsServiceTest {
     fun `onSentryReady is idempotent - second call does not double-flush`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             service.track(AnalyticsEvent.ScreenOpened.Dashboard)
             advanceUntilIdle()
@@ -290,7 +290,7 @@ class BufferedAnalyticsServiceTest {
     fun `track after ready goes directly to downstream not the buffer`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -304,7 +304,7 @@ class BufferedAnalyticsServiceTest {
     fun `trackImmediate after ready goes directly to downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -318,7 +318,7 @@ class BufferedAnalyticsServiceTest {
     fun `captureException after ready goes directly to downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -334,7 +334,7 @@ class BufferedAnalyticsServiceTest {
     fun `captureExceptionImmediate after ready goes directly to downstream`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -365,6 +365,7 @@ class BufferedAnalyticsServiceTest {
                     scope = unconfinedScope(),
                     maxBuffer = 3,
                     flushIntervalMs = 0L,
+                    sendDispatcher = Dispatchers.Unconfined,
                 )
 
             // Use exceptions for distinguishable identity — see the buffer-
@@ -404,6 +405,7 @@ class BufferedAnalyticsServiceTest {
                     scope = unconfinedScope(),
                     maxBuffer = 3,
                     flushIntervalMs = 0L,
+                    sendDispatcher = Dispatchers.Unconfined,
                 )
 
             // Three normal-priority items fill the buffer. Then a critical
@@ -440,7 +442,7 @@ class BufferedAnalyticsServiceTest {
     fun `track falls back to buffer when downstream throws after ready`() =
         runTest {
             val downstream = RecordingAnalyticsService(throwOnTrack = true)
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -456,7 +458,7 @@ class BufferedAnalyticsServiceTest {
     fun `captureException falls back to buffer when downstream throws after ready`() =
         runTest {
             val downstream = RecordingAnalyticsService(throwOnCaptureException = true)
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -473,7 +475,7 @@ class BufferedAnalyticsServiceTest {
     fun `isReady reflects the readiness flag`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             assertFalse(service.isReady)
             service.onSentryReady()
@@ -484,7 +486,7 @@ class BufferedAnalyticsServiceTest {
     fun `bufferedCount tracks enqueue and drain`() =
         runTest {
             val downstream = RecordingAnalyticsService()
-            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             assertEquals(0, service.bufferedCount())
 

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
@@ -1,11 +1,15 @@
 package network.bisq.mobile.domain.analytics
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -53,6 +57,7 @@ class BufferedAnalyticsServiceTest {
     private class RecordingAnalyticsService(
         private val throwOnTrack: Boolean = false,
         var throwOnInit: Boolean = false,
+        var throwCancellationOnInit: Boolean = false,
         private val throwOnCaptureException: Boolean = false,
     ) : AnalyticsService {
         val initCalls = mutableListOf<InitArgs>()
@@ -77,6 +82,7 @@ class BufferedAnalyticsServiceTest {
             socksProxyPort: Int?,
         ) {
             initCalls += InitArgs(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
+            if (throwCancellationOnInit) throw CancellationException("simulated cancellation")
             if (throwOnInit) error("simulated init failure")
         }
 
@@ -553,5 +559,38 @@ class BufferedAnalyticsServiceTest {
             assertTrue(service.isReady, "readiness must be attainable once a later init succeeds")
             assertEquals(listOf<AnalyticsEvent>(AnalyticsEvent.ScreenOpened.Dashboard), downstream.tracked)
             assertEquals(0, service.bufferedCount())
+        }
+
+    @Test
+    fun `cancellation thrown by downstream init propagates and never marks init succeeded`() =
+        runTest {
+            val downstream = RecordingAnalyticsService(throwCancellationOnInit = true)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.track(AnalyticsEvent.ScreenOpened.Dashboard)
+
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
+            service.onSentryReady()
+
+            assertFalse(service.isReady, "a cancelled init must never flip readiness")
+            assertEquals(1, service.bufferedCount(), "events must stay buffered after a cancelled init")
+        }
+
+    // ============ DEFAULT SEND LANE ============
+
+    @Test
+    fun `default send lane processes operations when no dispatcher is injected`() =
+        runTest {
+            val downstream = RecordingAnalyticsService()
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L)
+
+            service.track(AnalyticsEvent.ScreenOpened.Dashboard)
+
+            // The production lane (Dispatchers.Default, parallelism 1) is asynchronous —
+            // poll in real time from outside the test scheduler's virtual clock.
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000) {
+                    while (service.bufferedCount() != 1) delay(10)
+                }
+            }
         }
 }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/BufferedAnalyticsServiceTest.kt
@@ -52,6 +52,7 @@ class BufferedAnalyticsServiceTest {
      */
     private class RecordingAnalyticsService(
         private val throwOnTrack: Boolean = false,
+        var throwOnInit: Boolean = false,
         private val throwOnCaptureException: Boolean = false,
     ) : AnalyticsService {
         val initCalls = mutableListOf<InitArgs>()
@@ -76,6 +77,7 @@ class BufferedAnalyticsServiceTest {
             socksProxyPort: Int?,
         ) {
             initCalls += InitArgs(dsn, environment, release, isDebug, socksProxyHost, socksProxyPort)
+            if (throwOnInit) error("simulated init failure")
         }
 
         override fun track(event: AnalyticsEvent) {
@@ -172,6 +174,7 @@ class BufferedAnalyticsServiceTest {
 
             assertEquals(3, service.bufferedCount())
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -206,6 +209,7 @@ class BufferedAnalyticsServiceTest {
             assertEquals(2, service.bufferedCount(), "both tracks must be in the buffer pre-ready")
             assertTrue(downstream.tracked.isEmpty(), "nothing reaches downstream pre-ready")
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -221,6 +225,7 @@ class BufferedAnalyticsServiceTest {
             // refactors can't accidentally route all calls through the buffer.
             val downstream = RecordingAnalyticsService()
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -240,6 +245,7 @@ class BufferedAnalyticsServiceTest {
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             assertFalse(service.isReady)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             assertTrue(service.isReady)
         }
@@ -257,6 +263,7 @@ class BufferedAnalyticsServiceTest {
             advanceUntilIdle()
             assertEquals(3, service.bufferedCount())
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -274,11 +281,13 @@ class BufferedAnalyticsServiceTest {
             service.track(AnalyticsEvent.ScreenOpened.Dashboard)
             advanceUntilIdle()
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
             assertEquals(1, downstream.tracked.size)
 
             // Second ready call must not re-flush already-drained events.
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
             assertEquals(1, downstream.tracked.size, "second ready signal must be a no-op")
@@ -291,6 +300,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService()
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -305,6 +315,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService()
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -319,6 +330,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService()
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -335,6 +347,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService()
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -385,6 +398,7 @@ class BufferedAnalyticsServiceTest {
 
             assertEquals(3, service.bufferedCount(), "buffer must stay bounded")
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -426,6 +440,7 @@ class BufferedAnalyticsServiceTest {
 
             assertEquals(3, service.bufferedCount())
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -443,6 +458,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService(throwOnTrack = true)
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -459,6 +475,7 @@ class BufferedAnalyticsServiceTest {
         runTest {
             val downstream = RecordingAnalyticsService(throwOnCaptureException = true)
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
 
@@ -478,6 +495,7 @@ class BufferedAnalyticsServiceTest {
             val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
 
             assertFalse(service.isReady)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             assertTrue(service.isReady)
         }
@@ -495,8 +513,45 @@ class BufferedAnalyticsServiceTest {
             advanceUntilIdle()
             assertEquals(2, service.bufferedCount())
 
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
             service.onSentryReady()
             advanceUntilIdle()
+            assertEquals(0, service.bufferedCount())
+        }
+
+    // ============ INIT FAILURE GATING ============
+
+    @Test
+    fun `failed init keeps events buffered and onSentryReady does not flip readiness`() =
+        runTest {
+            val downstream = RecordingAnalyticsService(throwOnInit = true)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.track(AnalyticsEvent.ScreenOpened.Dashboard)
+
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
+            service.onSentryReady()
+
+            assertFalse(service.isReady, "failed init must never flip readiness")
+            assertTrue(downstream.tracked.isEmpty(), "no event may reach an uninitialised SDK")
+            assertEquals(1, service.bufferedCount(), "events must stay buffered after failed init")
+        }
+
+    @Test
+    fun `successful re-init after a failed one allows readiness and flushes the buffer`() =
+        runTest {
+            val downstream = RecordingAnalyticsService(throwOnInit = true)
+            val service = BufferedAnalyticsService(downstream, unconfinedScope(), flushIntervalMs = 0L, sendDispatcher = Dispatchers.Unconfined)
+            service.track(AnalyticsEvent.ScreenOpened.Dashboard)
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
+            service.onSentryReady()
+            assertFalse(service.isReady)
+
+            downstream.throwOnInit = false
+            service.init("http://abc@onion/3", "production", "0.5.0", false)
+            service.onSentryReady()
+
+            assertTrue(service.isReady, "readiness must be attainable once a later init succeeds")
+            assertEquals(listOf<AnalyticsEvent>(AnalyticsEvent.ScreenOpened.Dashboard), downstream.tracked)
             assertEquals(0, service.bufferedCount())
         }
 }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnostics.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnostics.kt
@@ -1,0 +1,103 @@
+package network.bisq.mobile.presentation.common.utils
+
+import android.os.Handler
+import android.os.Looper
+import android.os.StrictMode
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+
+/**
+ * Debug-only instrumentation. Three complementary detectors, all logging to logcat:
+ *
+ * 1. StrictMode thread policy — names disk/network calls made on the main thread (`StrictMode` tag).
+ * 2. Looper slow-dispatch log — names the exact Handler/message whose dispatch exceeded a frame
+ *    budget (tag [TAG], "Slow main dispatch").
+ * 3. Pulse watchdog — a background thread that expects a 50ms heartbeat from the main looper and,
+ *    when the heartbeat goes silent, samples the main thread's live stack *mid-stall* (tag [TAG],
+ *    "Main thread stalled"). This catches blockage from lock contention/computation that neither
+ *    StrictMode nor the dispatch log attributes.
+ *
+ * Correlate findings by timestamp: a dropped frame shows up as a stalled pulse with the culprit
+ * stack, usually accompanied by either a StrictMode violation or a slow-dispatch line naming the
+ * message. Watchdog self-disables after [WATCHDOG_LIFETIME_MS] — bootstrap is the window of
+ * interest and the sampler should not spam logs for a whole session.
+ */
+object MainThreadDiagnostics {
+    private const val TAG = "MainThreadPulse"
+    private const val HEARTBEAT_INTERVAL_MS = 50L
+    private const val STALL_THRESHOLD_MS = 100L
+    private const val SLOW_DISPATCH_THRESHOLD_MS = 32L
+    private const val WATCHDOG_LIFETIME_MS = 5 * 60 * 1000L
+
+    @Volatile
+    private var installed = false
+
+    /** Must be called from the main thread (Application.onCreate). No-op unless [isDebug]. */
+    fun install(isDebug: Boolean) {
+        if (!isDebug || installed) return
+        installed = true
+        installStrictMode()
+        installSlowDispatchLog()
+        startPulseWatchdog()
+        Log.i(TAG, "Main-thread diagnostics installed")
+    }
+
+    private fun installStrictMode() {
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy
+                .Builder()
+                .detectAll()
+                .penaltyLog()
+                .build(),
+        )
+    }
+
+    private fun installSlowDispatchLog() {
+        var dispatchStartMs = 0L
+        var currentMessage: String? = null
+        Looper.getMainLooper().setMessageLogging { line ->
+            if (line.startsWith(">>>>> Dispatching")) {
+                dispatchStartMs = SystemClock.uptimeMillis()
+                currentMessage = line
+            } else if (line.startsWith("<<<<< Finished")) {
+                val tookMs = SystemClock.uptimeMillis() - dispatchStartMs
+                if (tookMs >= SLOW_DISPATCH_THRESHOLD_MS) {
+                    Log.w(TAG, "Slow main dispatch ${tookMs}ms: ${currentMessage?.removePrefix(">>>>> Dispatching to ")}")
+                }
+            }
+        }
+    }
+
+    private fun startPulseWatchdog() {
+        val lastBeatMs = AtomicLong(SystemClock.uptimeMillis())
+        val mainHandler = Handler(Looper.getMainLooper())
+        val heartbeat =
+            object : Runnable {
+                override fun run() {
+                    lastBeatMs.set(SystemClock.uptimeMillis())
+                    mainHandler.postDelayed(this, HEARTBEAT_INTERVAL_MS)
+                }
+            }
+        mainHandler.post(heartbeat)
+
+        val mainThread = Looper.getMainLooper().thread
+        val deadline = SystemClock.uptimeMillis() + WATCHDOG_LIFETIME_MS
+        thread(name = "MainThreadPulseWatchdog", isDaemon = true) {
+            while (SystemClock.uptimeMillis() < deadline) {
+                Thread.sleep(HEARTBEAT_INTERVAL_MS)
+                val silentForMs = SystemClock.uptimeMillis() - lastBeatMs.get()
+                if (silentForMs >= STALL_THRESHOLD_MS) {
+                    // Sample while the stall is ongoing — this stack IS the culprit (or its tail).
+                    val stack = mainThread.stackTrace.joinToString(separator = "\n    ") { it.toString() }
+                    Log.w(TAG, "Main thread stalled ~${silentForMs}ms; main stack:\n    $stack")
+                    // Back off so a single long stall produces a few samples, not hundreds.
+                    Thread.sleep(200)
+                }
+            }
+            mainHandler.removeCallbacks(heartbeat)
+            Log.i(TAG, "Pulse watchdog finished its ${WATCHDOG_LIFETIME_MS / 60000}min window")
+        }
+    }
+}

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnostics.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnostics.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import android.os.StrictMode
 import android.os.SystemClock
 import android.util.Log
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 
@@ -23,13 +24,18 @@ import kotlin.concurrent.thread
  * stack, usually accompanied by either a StrictMode violation or a slow-dispatch line naming the
  * message. Watchdog self-disables after [WATCHDOG_LIFETIME_MS] — bootstrap is the window of
  * interest and the sampler should not spam logs for a whole session.
+ *
+ * Coverage-excluded: debug-only instrumentation wired to Looper/StrictMode is not unit-testable.
+ * The pure sanitizer logic IS covered via MainThreadDiagnosticsSanitizerTest.
  */
+@ExcludeFromCoverage
 object MainThreadDiagnostics {
     private const val TAG = "MainThreadPulse"
     private const val HEARTBEAT_INTERVAL_MS = 50L
     private const val STALL_THRESHOLD_MS = 100L
     private const val SLOW_DISPATCH_THRESHOLD_MS = 32L
     private const val WATCHDOG_LIFETIME_MS = 5 * 60 * 1000L
+    private const val MAX_SAMPLES_PER_STALL = 5
 
     @Volatile
     private var installed = false
@@ -54,6 +60,41 @@ object MainThreadDiagnostics {
         )
     }
 
+    // The raw Looper dispatch line embeds the callback's toString(), which for a custom
+    // Runnable could carry arbitrary (sensitive) state — and a dotted token in it can be a
+    // hostname or address just as easily as a class name, so free-form token harvesting is
+    // out. Looper builds the line as ">>>>> Dispatching to <Handler.toString()> <callback>:
+    // <what>", and Handler.toString() is framework-generated ("Handler (<class>) {<hex>}"),
+    // so an anchored structural match yields the handler class and `what` from trusted
+    // metadata only. From the callback segment we keep just two framework-generated shapes:
+    // a default Object.toString() (Class@hex) and kotlinx.coroutines' "Continuation at
+    // <fqcn>" (sourced from a StackTraceElement) — anything else collapses to a placeholder.
+    private val DISPATCH_LINE = Regex("""^>>>>> Dispatching to Handler \(([\w.$]+)\) \{[0-9a-f]+\} (.*): (-?\d+)$""")
+    private val DEFAULT_TO_STRING = Regex("""^([\w.$]+)@[0-9a-f]+$""")
+    private val CONTINUATION_AT = Regex("""Continuation at ([\w.$]+)""")
+
+    internal fun sanitizeDispatchTarget(line: String?): String {
+        val match = line?.let { DISPATCH_LINE.find(it) } ?: return "unknown"
+        val (handlerClass, callback, what) = match.destructured
+        val callbackPart =
+            when {
+                callback == "null" -> null
+                else ->
+                    DEFAULT_TO_STRING.find(callback)?.groupValues?.get(1)
+                        ?: CONTINUATION_AT
+                            .findAll(callback)
+                            .map { it.groupValues[1] }
+                            .distinct()
+                            .joinToString(" ")
+                            .ifEmpty { "custom-callback" }
+            }
+        return buildString {
+            append(handlerClass)
+            if (callbackPart != null) append(' ').append(callbackPart)
+            append(" what=").append(what)
+        }
+    }
+
     private fun installSlowDispatchLog() {
         var dispatchStartMs = 0L
         var currentMessage: String? = null
@@ -64,7 +105,7 @@ object MainThreadDiagnostics {
             } else if (line.startsWith("<<<<< Finished")) {
                 val tookMs = SystemClock.uptimeMillis() - dispatchStartMs
                 if (tookMs >= SLOW_DISPATCH_THRESHOLD_MS) {
-                    Log.w(TAG, "Slow main dispatch ${tookMs}ms: ${currentMessage?.removePrefix(">>>>> Dispatching to ")}")
+                    Log.w(TAG, "Slow main dispatch ${tookMs}ms: ${sanitizeDispatchTarget(currentMessage)}")
                 }
             }
         }
@@ -85,18 +126,28 @@ object MainThreadDiagnostics {
         val mainThread = Looper.getMainLooper().thread
         val deadline = SystemClock.uptimeMillis() + WATCHDOG_LIFETIME_MS
         thread(name = "MainThreadPulseWatchdog", isDaemon = true) {
+            var samplesThisStall = 0
             while (SystemClock.uptimeMillis() < deadline) {
                 Thread.sleep(HEARTBEAT_INTERVAL_MS)
                 val silentForMs = SystemClock.uptimeMillis() - lastBeatMs.get()
                 if (silentForMs >= STALL_THRESHOLD_MS) {
-                    // Sample while the stall is ongoing — this stack IS the culprit (or its tail).
-                    val stack = mainThread.stackTrace.joinToString(separator = "\n    ") { it.toString() }
-                    Log.w(TAG, "Main thread stalled ~${silentForMs}ms; main stack:\n    $stack")
+                    if (samplesThisStall < MAX_SAMPLES_PER_STALL) {
+                        samplesThisStall++
+                        // Sample while the stall is ongoing — this stack IS the culprit (or its tail).
+                        val stack = mainThread.stackTrace.joinToString(separator = "\n    ") { it.toString() }
+                        Log.w(TAG, "Main thread stalled ~${silentForMs}ms; main stack:\n    $stack")
+                    }
                     // Back off so a single long stall produces a few samples, not hundreds.
                     Thread.sleep(200)
+                } else {
+                    samplesThisStall = 0
                 }
             }
-            mainHandler.removeCallbacks(heartbeat)
+            // Removal must run on the main looper: the heartbeat always re-posts itself before
+            // returning, so by the time this queued task executes the next beat is in the queue
+            // and gets removed. Removing directly from this thread could interleave between
+            // lastBeatMs.set(...) and postDelayed(...), leaving a beat re-queued forever.
+            mainHandler.post { mainHandler.removeCallbacks(heartbeat) }
             Log.i(TAG, "Pulse watchdog finished its ${WATCHDOG_LIFETIME_MS / 60000}min window")
         }
     }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainApplication.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainApplication.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.domain.utils.SystemOutFilter
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.notification.NotificationChannels
+import network.bisq.mobile.presentation.common.utils.MainThreadDiagnostics
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -33,6 +34,11 @@ abstract class MainApplication :
 
     override fun onCreate() {
         super.onCreate()
+
+        // Debug-only main-thread stall detectors (StrictMode + slow-dispatch log + pulse
+        // watchdog). First, so DI setup and the whole bootstrap window are covered. No-op
+        // in release builds.
+        MainThreadDiagnostics.install(isDebug())
 
         // Initialize ApplicationContextProvider for code that needs context without Koin
         ApplicationContextProvider.initialize(this)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceBootstrapTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/ApplicationLifecycleServiceBootstrapTest.kt
@@ -300,6 +300,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                 downstream = analytics,
                 scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob()),
                 flushIntervalMs = 0L,
+                sendDispatcher = Dispatchers.Unconfined,
             )
         val provider = FakeSocksPortProvider(CompletableDeferred(9050))
         val settingsRepo = SettingsRepositoryMock(Settings(analyticsEnabled = true))
@@ -340,6 +341,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                 downstream = analytics,
                 scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob()),
                 flushIntervalMs = 0L,
+                sendDispatcher = Dispatchers.Unconfined,
             )
         val provider = FakeSocksPortProvider(CompletableDeferred()) // never completes
         val settingsRepo = SettingsRepositoryMock(Settings(analyticsEnabled = true))
@@ -477,6 +479,7 @@ class ApplicationLifecycleServiceBootstrapTest {
                 downstream = analytics,
                 scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob()),
                 flushIntervalMs = 0L,
+                sendDispatcher = Dispatchers.Unconfined,
             )
         val provider = FakeSocksPortProvider(CompletableDeferred(9050))
         val settingsRepo = SettingsRepositoryMock(Settings(analyticsEnabled = true))

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnosticsSanitizerTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/utils/MainThreadDiagnosticsSanitizerTest.kt
@@ -1,0 +1,76 @@
+package network.bisq.mobile.presentation.common.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the privacy property of the slow-dispatch log: the raw Looper dispatch line embeds the
+ * callback's toString(), which a custom Runnable could load with sensitive state — the sanitized
+ * form must carry only trusted framework metadata (handler class, `what`, and callback class
+ * names from framework-generated shapes), never free-form toString() content.
+ */
+class MainThreadDiagnosticsSanitizerTest {
+    @Test
+    fun `keeps class tokens and the message what code`() {
+        val line =
+            ">>>>> Dispatching to Handler (android.view.Choreographer\$FrameHandler) {fdd6b28} " +
+                "android.view.Choreographer\$FrameDisplayEventReceiver@abc123: 0"
+
+        val sanitized = MainThreadDiagnostics.sanitizeDispatchTarget(line)
+
+        assertTrue(sanitized.contains("android.view.Choreographer"), sanitized)
+        assertTrue(sanitized.endsWith("what=0"), sanitized)
+        assertFalse(sanitized.contains("{fdd6b28}"), "instance hashes must not survive: $sanitized")
+    }
+
+    @Test
+    fun `drops arbitrary callback toString content`() {
+        val secret = "seed words horse battery staple"
+        val line = ">>>>> Dispatching to Handler (android.os.Handler) {1a2b3c} MyRunnable[$secret]: 7"
+
+        val sanitized = MainThreadDiagnostics.sanitizeDispatchTarget(line)
+
+        assertFalse(sanitized.contains("seed words"), "payload content must never survive: $sanitized")
+        assertFalse(sanitized.contains("battery"), sanitized)
+        assertTrue(sanitized.contains("android.os.Handler"), sanitized)
+    }
+
+    @Test
+    fun `keeps continuation class names that identify the culprit`() {
+        val line =
+            ">>>>> Dispatching to Handler (android.os.Handler) {f3211d4} " +
+                "DispatchedContinuation[Dispatchers.Main.immediate, Continuation at " +
+                "androidx.datastore.core.DataStoreImpl\$data\$1.invokeSuspend(DataStoreImpl.kt)]: 0"
+
+        val sanitized = MainThreadDiagnostics.sanitizeDispatchTarget(line)
+
+        assertTrue(sanitized.contains("androidx.datastore.core.DataStoreImpl"), sanitized)
+    }
+
+    @Test
+    fun `dotted non-class tokens in callback toString do not survive`() {
+        val line =
+            ">>>>> Dispatching to Handler (android.os.Handler) {1a2b3c} " +
+                "UploadTask[target=api.example.onion user=alice@proton.me]: 2"
+
+        val sanitized = MainThreadDiagnostics.sanitizeDispatchTarget(line)
+
+        assertFalse(sanitized.contains("api.example.onion"), "hostnames must not survive: $sanitized")
+        assertFalse(sanitized.contains("proton.me"), "addresses must not survive: $sanitized")
+        assertEquals("android.os.Handler custom-callback what=2", sanitized)
+    }
+
+    @Test
+    fun `line not matching the framework dispatch shape renders as unknown`() {
+        val spoofed = "Handler (leaked.secret.Token) {1a2b3c} whatever: 1 trailing junk"
+
+        assertEquals("unknown", MainThreadDiagnostics.sanitizeDispatchTarget(spoofed))
+    }
+
+    @Test
+    fun `null line renders as unknown`() {
+        assertEquals("unknown", MainThreadDiagnostics.sanitizeDispatchTarget(null))
+    }
+}


### PR DESCRIPTION
 - contribs to #1683 (PR 1/2)
 - added MainThreadDiagnostics object helper installable for all android apps (noop when build is not debug)
 - ensured sentry analytics wrapper operations run off main thread including init
 - moved bootrap tor control port verification off main thread
 - updated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network connectivity checks by moving socket operations off the main thread and preserving cancellation behavior.
  * Analytics events now maintain submission order, remain buffered when initialization fails, and flush after successful initialization.
  * Analytics SDK operations run asynchronously without blocking callers.

* **Diagnostics**
  * Added debug-only main-thread diagnostics for policy violations, slow dispatches, and stalled-thread detection.
  * Diagnostic output is sanitized to avoid exposing sensitive details.
  * Diagnostics are automatically disabled in release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->