### PR TITLE
chore/automated_script_for_monthly_mobile_reports

### DIFF
--- a/scripts/monthly-report/.env.example
+++ b/scripts/monthly-report/.env.example
@@ -6,7 +6,7 @@ BISQ_REPORT_SSH_HOST=your-host-alias
 
 # Play Console statistics bucket for live audience + installs (Download reports -> Statistics ->
 # "Copy Cloud Storage URI"). Read via gcloud with your own creds; leave unset to keep those manual.
-BISQ_REPORT_PLAY_STATS_BUCKET=pubsite_prod_XXXXXXXXXXXX
+# BISQ_REPORT_PLAY_STATS_BUCKET=pubsite_prod_XXXXXXXXXXXX
 
 # Optional overrides:
 # BISQ_REPORT_PG_CONTAINER=glitchtip-postgres-1

--- a/scripts/monthly-report/.env.example
+++ b/scripts/monthly-report/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env (gitignored) so `python3 report.py` picks these up automatically — no exports needed.
+# Shell-exported values take precedence over anything here.
+
+# GlitchTip host (SSH alias) — required for the engagement/analytics half.
+BISQ_REPORT_SSH_HOST=your-host-alias
+
+# Play Console statistics bucket for live audience + installs (Download reports -> Statistics ->
+# "Copy Cloud Storage URI"). Read via gcloud with your own creds; leave unset to keep those manual.
+BISQ_REPORT_PLAY_STATS_BUCKET=pubsite_prod_XXXXXXXXXXXX
+
+# Optional overrides:
+# BISQ_REPORT_PG_CONTAINER=glitchtip-postgres-1
+# BISQ_REPORT_PLAY_KEY=../../credentials/bisq-mobile-reporting.json

--- a/scripts/monthly-report/.gitignore
+++ b/scripts/monthly-report/.gitignore
@@ -1,0 +1,10 @@
+# Real manual numbers and generated reports — never commit
+inputs.json
+report-*.md
+*.json.key
+__pycache__/
+.venv/
+# Local host/bucket config (deployment-specific) — never commit
+.env
+# Month-over-month snapshots hold real aggregate metrics — keep out of public git history
+history/

--- a/scripts/monthly-report/README.md
+++ b/scripts/monthly-report/README.md
@@ -1,0 +1,72 @@
+# Monthly KPI report generator
+
+Produces a Markdown monthly report for the 3 Bisq mobile apps (Connect Android, Connect iOS,
+Easy Node Android) to review and paste into the GH wiki. Replaces the ad-hoc Matrix status updates
+(issue #1359).
+
+## The honesty model (read this first)
+
+Three provenance tiers are kept **separate on purpose** — they are not the same kind of number and
+the channels are not deduplicable (a person can be on Play *and* sideload):
+
+| Tier | Source | What it is |
+|---|---|---|
+| Real user counts | **Play Console / App Store Connect** | DAU/MAU/installs — the only true headcounts |
+| Sideload floor | **GitHub download stats** | active updating base, estimated; bots inflate absolutes |
+| Engagement floor | **GlitchTip** | event volume + behavior for the **opted-in** subset — NO user identity, by privacy design |
+
+There is deliberately **no single "total users"** number. GlitchTip cannot count users (the opt-in
+contract nulls `event.user` and disables sessions) — that is a feature of the privacy posture, not a
+gap to paper over.
+
+## Run
+
+```bash
+cd scripts/monthly-report
+cp .env.example .env                         # set BISQ_REPORT_SSH_HOST (+ optional bucket); gitignored
+cp inputs.example.json inputs.json           # fill store/operator numbers you have; leave unknowns null
+python3 report.py --window 30 --inputs inputs.json --out report-$(date +%Y-%m).md
+```
+
+`report.py` auto-loads `.env` (shell exports still win), so no per-run exports are needed. The host is
+never hardcoded — it lives only in your gitignored `.env`.
+
+Requirements: SSH access to the GlitchTip host (read-only Postgres) and the `gh` CLI (GitHub).
+
+**Optional — live Play data.** Two independent halves, each degrades to `inputs.json` if unavailable:
+
+- **Vitals (crash-free % + ANR)** via `play.py` → Play Developer Reporting API. Needs a service-account
+  key granted read-only in Play Console (`BISQ_REPORT_PLAY_KEY`, default `../../credentials/…`,
+  gitignored) and the `google-auth`/`requests` packages (hence the venv). Apps below Play's
+  minimum-user threshold have Vitals suppressed and show `—`.
+- **Audience (active devices) + new installs** via `play_installs.py` → Play Console statistics
+  bucket. These `pubsite_prod_*` buckets are ACL-based and can't be shared with a service account, so
+  it reads through the `gcloud` CLI with your own creds: install `gcloud`, `gcloud auth login` as the
+  Play owner, and set `BISQ_REPORT_PLAY_STATS_BUCKET` (from Play Console → Download reports →
+  Statistics → "Copy Cloud Storage URI"). MAU/DAU, total installs and rating stay manual — Play
+  exposes no API for those.
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+export BISQ_REPORT_PLAY_STATS_BUCKET=pubsite_prod_XXXXXXXXXXXX
+.venv/bin/python3 report.py --window 30 --inputs inputs.json --out report-$(date +%Y-%m).md
+```
+
+## Modules
+
+- `glitchtip.py` — engagement & health over SSH+SQL (event volume, opt-in, trade funnel `trade.*`,
+  errors). Runnable standalone for a quick readout.
+- `github_downloads.py` — sideload active-base estimate from release `download_count`
+  (methodology from the manual `github-download-stats` report). Runnable standalone.
+- `play.py` — live Play Vitals (crash-free % + ANR) via the Play Developer Reporting API; optional,
+  degrades to `inputs.json` when the key/venv/access is absent. Runnable standalone.
+- `play_installs.py` — live audience (active devices) + new installs from the Play statistics bucket
+  via `gcloud`; optional, degrades to `inputs.json`. Runnable standalone (`python3 play_installs.py 2026-07`).
+- `report.py` — orchestrates all of the above + `inputs.json`, renders the md.
+- `inputs.example.json` — remaining manual store numbers (MAU/DAU, total installs, rating, iOS).
+
+
+## Tuning
+
+`github_downloads.BOT_DISCOUNT` (default 0.20) and the active-base low-bound factor (0.75) can be
+tuned against the manual `github-download-stats` estimates.

--- a/scripts/monthly-report/github_downloads.py
+++ b/scripts/monthly-report/github_downloads.py
@@ -1,0 +1,119 @@
+"""GitHub Releases download stats -> active sideload-base estimate.
+
+Automates the methodology from docs/analysis (github-download-stats-2026-08.md):
+the per-release APK download_count *while that release is the latest one* is the best proxy for
+the updating (i.e. active) sideload user base — mostly the same people re-downloading each release.
+We take the current-latest release's per-week rate and discount for bots/scanners/re-fetches.
+
+CAVEATS baked into the output so the report stays honest:
+  - GitHub counts every asset GET (bots, scanners, CDN) -> absolutes are an upper bound.
+  - Cumulative != unique users; it's the same base re-downloading.
+  - iOS .ipa is meaningless here: AltStore PAL mirrors the binary (only a handful of ingestion
+    fetches show on GH). iOS adoption is not measurable from GitHub.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import date, datetime
+
+REPO = "bisq-network/bisq-mobile"
+# Bot/re-fetch discount applied to raw download_count for the active-base estimate.
+BOT_DISCOUNT = 0.20
+
+# Match a release tag to an app + asset kind. Tags look like `connect_0.8.0`, `anode_0.10.0`, etc.
+APPS = {
+    "Bisq Easy Node (Android)": {"tag_prefix": ("anode_", "node_", "bisq_easy"), "asset": ".apk"},
+    "Bisq Connect (Android)": {"tag_prefix": ("connect_",), "asset": ".apk"},
+}
+
+
+@dataclass
+class ReleaseDl:
+    tag: str
+    published: date
+    apk_downloads: int
+    days_as_latest: int
+
+    @property
+    def per_week(self) -> int:
+        d = max(self.days_as_latest, 1)
+        return round(self.apk_downloads / d * 7)
+
+
+@dataclass
+class AppSideload:
+    app: str
+    latest: ReleaseDl | None
+    recent: list[ReleaseDl]
+    total_all_time: int
+
+    @property
+    def active_base_estimate(self) -> tuple[int, int] | None:
+        """Low-high active sideload base from the latest release's weekly pull, bot-discounted."""
+        if not self.latest:
+            return None
+        base = self.latest.per_week * (1 - BOT_DISCOUNT)
+        return (round(base * 0.75), round(base))  # widen to a range
+
+
+def _gh_releases() -> list[dict]:
+    cmd = ["gh", "api", f"repos/{REPO}/releases", "--paginate", "--jq",
+           ".[] | {tag: .tag_name, published: .published_at, "
+           "assets: [.assets[] | {name: .name, dl: .download_count}]}"]
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if out.returncode != 0:
+        raise RuntimeError(f"gh api failed: {out.stderr.strip()}")
+    return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+
+
+def _app_for_tag(tag: str) -> str | None:
+    for app, cfg in APPS.items():
+        if tag.startswith(cfg["tag_prefix"]):
+            return app
+    return None
+
+
+def collect() -> list[AppSideload]:
+    raw = _gh_releases()
+    # Bucket releases per app, newest first, computing each one's "days as latest" window.
+    by_app: dict[str, list[dict]] = {app: [] for app in APPS}
+    for rel in raw:
+        app = _app_for_tag(rel["tag"])
+        if app:
+            by_app[app].append(rel)
+
+    result: list[AppSideload] = []
+    today = date.today()
+    for app, rels in by_app.items():
+        rels.sort(key=lambda r: r["published"], reverse=True)
+        parsed: list[ReleaseDl] = []
+        total = 0
+        for idx, rel in enumerate(rels):
+            pub = datetime.fromisoformat(rel["published"].replace("Z", "+00:00")).date()
+            apk_dl = sum(a["dl"] for a in rel["assets"] if a["name"].lower().endswith(".apk"))
+            total += apk_dl
+            # Window = until the next (newer) release, or today for the latest.
+            next_date = (
+                datetime.fromisoformat(rels[idx - 1]["published"].replace("Z", "+00:00")).date()
+                if idx > 0 else today
+            )
+            days = max((next_date - pub).days, 1)
+            parsed.append(ReleaseDl(rel["tag"], pub, apk_dl, days))
+        result.append(AppSideload(
+            app=app,
+            latest=parsed[0] if parsed else None,
+            recent=parsed[:6],
+            total_all_time=total,
+        ))
+    return result
+
+
+if __name__ == "__main__":
+    for a in collect():
+        est = a.active_base_estimate
+        est_s = f"~{est[0]}-{est[1]}" if est else "n/a"
+        print(f"{a.app}: latest {a.latest.tag if a.latest else '-'} "
+              f"({a.latest.per_week if a.latest else 0}/wk), active sideload base {est_s}, "
+              f"all-time APK dl {a.total_all_time}")

--- a/scripts/monthly-report/github_downloads.py
+++ b/scripts/monthly-report/github_downloads.py
@@ -38,7 +38,9 @@ class ReleaseDl:
 
     @property
     def per_week(self) -> int:
-        d = max(self.days_as_latest, 1)
+        # Floor at a full week: a release only days old would extrapolate its launch spike
+        # (everyone updates in the first days) into a wildly inflated weekly rate.
+        d = max(self.days_as_latest, 7)
         return round(self.apk_downloads / d * 7)
 
 

--- a/scripts/monthly-report/glitchtip.py
+++ b/scripts/monthly-report/glitchtip.py
@@ -1,0 +1,139 @@
+"""GlitchTip (self-hosted, Tor-only) data source for the monthly report.
+
+Reads the analytics Postgres over SSH — the same read-only path used for manual readouts:
+    ssh $BISQ_REPORT_SSH_HOST -> docker exec $BISQ_REPORT_PG_CONTAINER psql
+
+HARD PRIVACY LIMIT (by design, not a bug): the opt-in analytics contract nulls event.user and
+disables session tracking, so GlitchTip has NO per-device identity. Everything here is EVENT
+VOLUME and a version FLOOR for the opted-in subset — never a user headcount. User counts come
+from the stores (Play/ASC), never from here. See docs and the project memory for context.
+
+Connection is configured via environment (this is a PUBLIC repo — no infra names are hardcoded):
+    BISQ_REPORT_SSH_HOST      SSH host/alias for the GlitchTip host (required)
+    BISQ_REPORT_PG_CONTAINER  Postgres container name (default: glitchtip's stock compose name)
+
+Projects: 2=Bisq Easy Node (Android), 3=Bisq Connect (Android), 4=Bisq Connect (iOS).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+
+
+def _psql(sql: str) -> list[dict]:
+    """Run a query over SSH and return rows as dicts (JSON via psql's row_to_json).
+
+    Host/container are read from env at call time (so report.py's .env loader applies regardless of
+    import order); no deployment-specific host lives in this public repo."""
+    ssh_host = os.environ.get("BISQ_REPORT_SSH_HOST", "")
+    pg_container = os.environ.get("BISQ_REPORT_PG_CONTAINER", "glitchtip-postgres-1")
+    if not ssh_host:
+        raise RuntimeError(
+            "BISQ_REPORT_SSH_HOST is not set — export it (or add it to .env) as your GlitchTip "
+            "host/alias, e.g.\n    export BISQ_REPORT_SSH_HOST=your-host-alias")
+    wrapped = f"SELECT coalesce(json_agg(t), '[]') FROM ({sql}) t;"
+    cmd = [
+        "ssh", "-o", "ConnectTimeout=15", "-o", "BatchMode=yes", ssh_host,
+        f"docker exec -i {pg_container} psql -U postgres -d postgres -t -A -c \"{wrapped}\"",
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+    if out.returncode != 0:
+        raise RuntimeError(f"psql failed: {out.stderr.strip() or out.stdout.strip()}")
+    return json.loads(out.stdout.strip() or "[]")
+
+
+@dataclass
+class ProjectEngagement:
+    project: str
+    events: int
+    errors: int
+    opt_in: int
+    opt_out: int
+    os_versions: int
+    trade_taken: int
+    trade_completed: int
+    dashboard_opens: int
+
+    @property
+    def trade_success_pct(self) -> float | None:
+        return round(100 * self.trade_completed / self.trade_taken, 1) if self.trade_taken else None
+
+
+@dataclass
+class GlitchTipSnapshot:
+    window_days: int
+    projects: list[ProjectEngagement] = field(default_factory=list)
+    top_errors: list[dict] = field(default_factory=list)
+    trade_funnel: list[dict] = field(default_factory=list)
+
+    @property
+    def total_events(self) -> int:
+        return sum(p.events for p in self.projects)
+
+
+def collect(window_days: int = 30) -> GlitchTipSnapshot:
+    win = f"e.timestamp >= now() - interval '{window_days} days'"
+
+    engagement = _psql(f"""
+        SELECT p.name AS project,
+               count(*) AS events,
+               count(*) FILTER (WHERE e.type = 1) AS errors,
+               count(*) FILTER (WHERE e.title = 'settings.analytics_enabled') AS opt_in,
+               count(*) FILTER (WHERE e.title = 'settings.analytics_disabled') AS opt_out,
+               count(DISTINCT e.data #>> '{{contexts,os,version}}') AS os_versions,
+               count(*) FILTER (WHERE e.title LIKE 'trade.taken%') AS trade_taken,
+               count(*) FILTER (WHERE e.title LIKE 'trade.completed%') AS trade_completed,
+               count(*) FILTER (WHERE e.title LIKE 'screen.dashboard_opened%') AS dashboard_opens
+        FROM issue_events_issueevent e
+        JOIN issue_events_issue i ON i.id = e.issue_id
+        JOIN projects_project p ON p.id = i.project_id
+        WHERE {win}
+        GROUP BY p.name
+        ORDER BY events DESC
+    """)
+
+    # Real errors/crashes only (type=1), most frequent first.
+    top_errors = _psql(f"""
+        SELECT p.name AS project,
+               CASE e.level WHEN 5 THEN 'fatal' WHEN 4 THEN 'error' ELSE e.level::text END AS level,
+               left(e.title, 80) AS title,
+               count(*) AS n
+        FROM issue_events_issueevent e
+        JOIN issue_events_issue i ON i.id = e.issue_id
+        JOIN projects_project p ON p.id = i.project_id
+        WHERE {win} AND e.type = 1
+        GROUP BY p.name, e.level, e.title
+        ORDER BY n DESC
+        LIMIT 15
+    """)
+
+    # Trade-funnel step outcomes (the trade.* sealed events added for #1622).
+    trade_funnel = _psql(f"""
+        SELECT left(e.title, 60) AS step, count(*) AS n
+        FROM issue_events_issueevent e
+        WHERE {win} AND e.title LIKE 'trade.%'
+        GROUP BY step
+        ORDER BY n DESC
+    """)
+
+    projects = [
+        ProjectEngagement(
+            project=r["project"], events=r["events"], errors=r["errors"],
+            opt_in=r["opt_in"], opt_out=r["opt_out"], os_versions=r["os_versions"],
+            trade_taken=r["trade_taken"], trade_completed=r["trade_completed"],
+            dashboard_opens=r["dashboard_opens"],
+        )
+        for r in engagement
+    ]
+    return GlitchTipSnapshot(window_days, projects, top_errors, trade_funnel)
+
+
+if __name__ == "__main__":
+    snap = collect()
+    print(f"GlitchTip {snap.window_days}d — total events (opted-in floor): {snap.total_events}")
+    for p in snap.projects:
+        print(f"  {p.project}: {p.events} events, {p.errors} errors, "
+              f"opt-in {p.opt_in}/opt-out {p.opt_out}, trade {p.trade_completed}/{p.trade_taken} "
+              f"({p.trade_success_pct}% success)")

--- a/scripts/monthly-report/glitchtip.py
+++ b/scripts/monthly-report/glitchtip.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 
@@ -34,9 +35,11 @@ def _psql(sql: str) -> list[dict]:
             "BISQ_REPORT_SSH_HOST is not set — export it (or add it to .env) as your GlitchTip "
             "host/alias, e.g.\n    export BISQ_REPORT_SSH_HOST=your-host-alias")
     wrapped = f"SELECT coalesce(json_agg(t), '[]') FROM ({sql}) t;"
+    # shlex.quote so the remote shell treats container name and SQL as literals.
     cmd = [
         "ssh", "-o", "ConnectTimeout=15", "-o", "BatchMode=yes", ssh_host,
-        f"docker exec -i {pg_container} psql -U postgres -d postgres -t -A -c \"{wrapped}\"",
+        f"docker exec -i {shlex.quote(pg_container)} psql -U postgres -d postgres -t -A "
+        f"-c {shlex.quote(wrapped)}",
     ]
     out = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
     if out.returncode != 0:

--- a/scripts/monthly-report/inputs.example.json
+++ b/scripts/monthly-report/inputs.example.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Manual numbers that have no API yet (or until the Play/ASC service accounts land). Copy to inputs.json, fill what you have, leave unknowns null -> they render as 'pending'. Phase 2 replaces the 'stores' block with automated Play/ASC modules.",
+  "month": "2026-08",
+  "stores": {
+    "Bisq Connect (Android)": {"play_mau": null, "play_dau": null, "play_total_installs": null, "play_new_installs_30d": null, "play_rating": null},
+    "Bisq Easy Node (Android)": {"play_mau": null, "play_dau": null, "play_total_installs": null, "play_new_installs_30d": null, "play_rating": null},
+    "Bisq Connect (iOS)": {"testflight_testers": null, "testflight_sessions_30d": null, "altstore_pal_installs": null}
+  },
+  "backend_nodes": {"_comment": "Trusted-node backends — later. Operator-supplied.", "umbrel_installs": null, "start9_installs": null}
+}

--- a/scripts/monthly-report/play.py
+++ b/scripts/monthly-report/play.py
@@ -1,0 +1,140 @@
+"""Google Play Developer Reporting API — live app Vitals (crash + ANR) for the monthly report.
+
+Pulls the rolling 28-day user-weighted crash rate and ANR rate for each Android app, i.e. the same
+core-vitals figures shown in the Play Console. This is the ONLY store metric a Google API exposes:
+audience / installs / DAU / MAU are NOT available here (they live in the Play Console statistics
+GCS bucket) and stay manual in inputs.json.
+
+Auth: a service-account key granted read-only access in Play Console (Users & permissions). Path is
+read from BISQ_REPORT_PLAY_KEY, else ../../credentials/bisq-mobile-reporting.json (gitignored). If the
+key is missing or access is denied, collect() returns {} so the report cleanly falls back to manual
+inputs — this module augments the report, it must never break it.
+
+Requires the google-auth + requests packages (see requirements.txt); run report.py under a venv that
+has them to activate live Vitals. Plain stdlib python3 still runs the report, just without this half.
+"""
+from __future__ import annotations
+
+import os
+import time
+from datetime import date, timedelta
+
+from google.oauth2 import service_account
+from google.auth.transport.requests import AuthorizedSession
+
+# Google occasionally returns transient 5xx/429 on these endpoints — retry with backoff.
+_TRANSIENT = {429, 500, 502, 503, 504}
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+KEY_PATH = os.environ.get(
+    "BISQ_REPORT_PLAY_KEY",
+    os.path.join(SCRIPT_DIR, "..", "..", "credentials", "bisq-mobile-reporting.json"),
+)
+SCOPE = "https://www.googleapis.com/auth/playdeveloperreporting"
+BASE = "https://playdeveloperreporting.googleapis.com/v1beta1"
+
+# Play applicationId per app (must match the store listing).
+APPS = {
+    "Bisq Connect (Android)": "network.bisq.mobile.client",
+    "Bisq Easy Node (Android)": "network.bisq.mobile.node",
+}
+
+# metric_set -> the rolling-28d user-weighted rate metric (value is a [0,1] fraction).
+METRICS = {
+    "crash_rate_pct": ("crashRateMetricSet", "crashRate28dUserWeighted"),
+    "anr_rate_pct": ("anrRateMetricSet", "anrRate28dUserWeighted"),
+}
+
+
+def _session() -> AuthorizedSession:
+    creds = service_account.Credentials.from_service_account_file(KEY_PATH, scopes=[SCOPE])
+    return AuthorizedSession(creds)
+
+
+def _request(sess: AuthorizedSession, method: str, url: str, *, attempts: int = 4, **kw):
+    """GET/POST with backoff on transient 5xx/429; raises on the last failure or a non-transient one."""
+    for i in range(attempts):
+        r = sess.request(method, url, timeout=45, **kw)
+        if r.status_code in _TRANSIENT and i < attempts - 1:
+            time.sleep(2 ** i)  # 1s, 2s, 4s
+            continue
+        r.raise_for_status()
+        return r
+    raise RuntimeError("unreachable")
+
+
+def _latest_daily_end(sess: AuthorizedSession, pkg: str, metric_set: str) -> dict | None:
+    """The most recent DAILY end date the API has data for, as a google.type.DateTime dict."""
+    r = _request(sess, "GET", f"{BASE}/apps/{pkg}/{metric_set}")
+    for f in r.json().get("freshnessInfo", {}).get("freshnesses", []):
+        if f.get("aggregationPeriod") == "DAILY":
+            return f.get("latestEndTime")
+    return None
+
+
+def _latest_rate(sess: AuthorizedSession, pkg: str, metric_set: str, metric: str):
+    """Return (value_fraction, day) for the most recent available row, or (None, None)."""
+    end = _latest_daily_end(sess, pkg, metric_set)
+    if not end:
+        return None, None
+    tz = end.get("timeZone", {"id": "America/Los_Angeles"})
+    end_d = date(end["year"], end.get("month", 1), end.get("day", 1))
+    start_d = end_d - timedelta(days=5)
+    body = {
+        "timelineSpec": {
+            "aggregationPeriod": "DAILY",
+            "startTime": {"year": start_d.year, "month": start_d.month, "day": start_d.day, "timeZone": tz},
+            "endTime": {"year": end_d.year, "month": end_d.month, "day": end_d.day, "timeZone": tz},
+        },
+        "metrics": [metric],
+        "pageSize": 100,
+    }
+    r = _request(sess, "POST", f"{BASE}/apps/{pkg}/{metric_set}:query", json=body)
+    best_val, best_day = None, None
+    for row in r.json().get("rows", []):
+        st = row.get("startTime", {})
+        d = date(st.get("year", 1), st.get("month", 1), st.get("day", 1))
+        for m in row.get("metrics", []):
+            if m.get("metric") == metric and "decimalValue" in m:
+                if best_day is None or d > best_day:
+                    best_val, best_day = float(m["decimalValue"]["value"]), d
+    return best_val, best_day
+
+
+def _safe(sess, pkg, metric_set, metric):
+    try:
+        return _latest_rate(sess, pkg, metric_set, metric)
+    except Exception:
+        return None, None
+
+
+def collect() -> dict:
+    """{app_label: {"crash_rate_pct", "anr_rate_pct", "as_of"}} for readable apps; {} on any failure."""
+    if not os.path.exists(KEY_PATH):
+        return {}
+    try:
+        sess = _session()
+    except Exception:
+        return {}
+
+    out: dict[str, dict] = {}
+    for label, pkg in APPS.items():
+        vals, days = {}, []
+        for field, (metric_set, metric) in METRICS.items():
+            v, d = _safe(sess, pkg, metric_set, metric)
+            vals[field] = round(v * 100, 3) if v is not None else None
+            if d:
+                days.append(d)
+        if any(v is not None for v in vals.values()):
+            vals["as_of"] = max(days).isoformat() if days else None
+            out[label] = vals
+    return out
+
+
+if __name__ == "__main__":
+    data = collect()
+    if not data:
+        print("Play Vitals: no data (key missing, access denied, or API unreachable).")
+    for label, v in data.items():
+        print(f"{label}: crash {v.get('crash_rate_pct')}% · ANR {v.get('anr_rate_pct')}% "
+              f"(28d user-weighted, as of {v.get('as_of')})")

--- a/scripts/monthly-report/play_installs.py
+++ b/scripts/monthly-report/play_installs.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import gzip
 import os
 import subprocess
+import sys
 
 APPS = {
     "Bisq Connect (Android)": "network.bisq.mobile.client",
@@ -68,7 +69,9 @@ def collect(month: str) -> dict:
         try:
             idx, rows = _overview(pkg, yyyymm)
             ad_i, ni_i = idx["Active Device Installs"], idx["Daily User Installs"]
-        except Exception:
+        except Exception as e:
+            # Diagnostics to stderr only — stdout is the report's Markdown.
+            print(f"play_installs: skipping {label} ({yyyymm}): {e}", file=sys.stderr)
             continue
         active = [v for v in (_int(r[ad_i]) for r in rows) if v is not None]
         installs = [v for v in (_int(r[ni_i]) for r in rows) if v is not None]

--- a/scripts/monthly-report/play_installs.py
+++ b/scripts/monthly-report/play_installs.py
@@ -1,0 +1,94 @@
+"""Play Console statistics bucket — live audience (active devices) + new installs per Android app.
+
+Reads the monthly install "overview" CSVs Play exports to its Cloud Storage bucket:
+    gs://<bucket>/stats/installs/installs_<package>_<YYYYMM>_overview.csv   (UTF-16, one row per day)
+
+We take, over the report month:
+    Active Device Installs -> audience / active devices (averaged across the month's days)
+    Daily User Installs    -> new installs (summed)
+
+NOT available from the bucket (stay manual in inputs.json): DAU/MAU (dashboard-only, never exported),
+lifetime "Total installs", and rating (a separate ratings report).
+
+AUTH: these pubsite_prod_* buckets are ACL-based and can't be shared with a service account, so this
+reads via the `gcloud` CLI using your own credentials (the Play account Google authorized). Requires
+`gcloud` installed and authed as the Play owner, plus BISQ_REPORT_PLAY_STATS_BUCKET set. If any of
+that is missing, collect() returns {} and the report falls back to manual inputs — it never breaks.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+import subprocess
+
+APPS = {
+    "Bisq Connect (Android)": "network.bisq.mobile.client",
+    "Bisq Easy Node (Android)": "network.bisq.mobile.node",
+}
+
+
+def _bucket() -> str:
+    # Read at call time so report.py's .env loader applies regardless of import order.
+    return os.environ.get("BISQ_REPORT_PLAY_STATS_BUCKET", "").replace("gs://", "").strip("/")
+
+
+def _int(s: str):
+    try:
+        return int(s.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _overview(pkg: str, yyyymm: str):
+    """(column-index map, list-of-cell-rows) for one app-month, or raises if unreadable."""
+    obj = f"gs://{_bucket()}/stats/installs/installs_{pkg}_{yyyymm}_overview.csv"
+    r = subprocess.run(["gcloud", "storage", "cat", obj], capture_output=True, timeout=120)
+    if r.returncode != 0:
+        raise RuntimeError(r.stderr.decode("utf-8", "replace")[:200])
+    raw = r.stdout
+    if raw[:2] == b"\x1f\x8b":  # `gcloud storage cat` returns these objects gzip-compressed
+        raw = gzip.decompress(raw)
+    lines = [ln for ln in raw.decode("utf-16").splitlines() if ln.strip()]
+    header = [h.strip() for h in lines[0].split(",")]
+    idx = {name: i for i, name in enumerate(header)}
+    rows = [ln.split(",") for ln in lines[1:] if len(ln.split(",")) >= len(header)]
+    return idx, rows
+
+
+def collect(month: str) -> dict:
+    """{app_label: {play_active_devices_avg, play_new_installs_30d}} for readable apps; {} on failure.
+
+    `month` is the report label 'YYYY-MM'; we read that calendar month's install overview.
+    """
+    if not _bucket():
+        return {}
+    yyyymm = month.replace("-", "")
+    out: dict[str, dict] = {}
+    for label, pkg in APPS.items():
+        try:
+            idx, rows = _overview(pkg, yyyymm)
+            ad_i, ni_i = idx["Active Device Installs"], idx["Daily User Installs"]
+        except Exception:
+            continue
+        active = [v for v in (_int(r[ad_i]) for r in rows) if v is not None]
+        installs = [v for v in (_int(r[ni_i]) for r in rows) if v is not None]
+        if not active and not installs:
+            continue
+        vals: dict = {}
+        if active:
+            vals["play_active_devices_avg"] = round(sum(active) / len(active))
+        if installs:
+            vals["play_new_installs_30d"] = sum(installs)
+        out[label] = vals
+    return out
+
+
+if __name__ == "__main__":
+    import sys
+    m = sys.argv[1] if len(sys.argv) > 1 else "2026-07"
+    data = collect(m)
+    if not data:
+        print(f"Play stats: no data for {m} (bucket unset, gcloud not authed, or month missing).")
+    for label, v in data.items():
+        print(f"{label} [{m}]: active devices avg {v.get('play_active_devices_avg')}, "
+              f"new installs {v.get('play_new_installs_30d')}")

--- a/scripts/monthly-report/report.py
+++ b/scripts/monthly-report/report.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from datetime import date
 
 import glitchtip
@@ -27,6 +28,7 @@ import github_downloads
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 HISTORY_DIR = os.path.join(SCRIPT_DIR, "history")
+MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
 
 
 def _load_env() -> None:
@@ -56,7 +58,7 @@ def _bar_chart(title: str, items: list[tuple[str, int]], width: int = 34) -> lis
     GitHub, wikis) with no image hosting, unlike Mermaid which needs a Mermaid-aware renderer."""
     total = sum(v for _, v in items) or 1
     mx = max((v for _, v in items), default=1) or 1
-    lblw = max((len(l) for l, _ in items), default=0)
+    lblw = max((len(lbl) for lbl, _ in items), default=0)
     out = ["```", title, ""]
     for label, v in items:
         bar = "█" * max(1, round(v / mx * width))
@@ -66,6 +68,15 @@ def _bar_chart(title: str, items: list[tuple[str, int]], width: int = 34) -> lis
 
 
 # --- Month-over-month history (self-contained JSON snapshots, error-safe) -----
+
+def _load_snapshot(month: str) -> dict | None:
+    """Saved snapshot for `month`, or None. Never raises."""
+    try:
+        with open(os.path.join(HISTORY_DIR, month + ".json")) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return None
+
 
 def _load_prev_snapshot(month: str) -> tuple[str | None, dict | None]:
     """Most recent saved snapshot strictly older than `month`. Never raises — a missing/unreadable
@@ -77,11 +88,8 @@ def _load_prev_snapshot(month: str) -> tuple[str | None, dict | None]:
         return None, None
     if not keys:
         return None, None
-    try:
-        with open(os.path.join(HISTORY_DIR, keys[-1] + ".json")) as fh:
-            return keys[-1], json.load(fh)
-    except (OSError, ValueError):
-        return None, None
+    snap = _load_snapshot(keys[-1])
+    return (keys[-1], snap) if snap else (None, None)
 
 
 def _save_snapshot(month: str, snap: dict) -> None:
@@ -153,8 +161,39 @@ def _mom_section(snap: dict, prev_month: str | None, prev: dict | None) -> list[
     return L
 
 
-def render(window_days: int, inputs: dict, label: str | None = None) -> str:
-    month = label or inputs.get("month", date.today().strftime("%Y-%m"))
+def _wikiify(md: str, month: str, heading: str) -> str:
+    """Wiki-page variant: reports stack newest-first on one year page, so the H1 title becomes an
+    H2 month section ('## July 2026') and every other heading demotes one level — no stacked H1s.
+    Fenced code blocks (the bar charts) are left untouched."""
+    try:
+        y, m = (int(x) for x in month.split("-"))
+        title = date(y, m, 1).strftime("%B %Y")
+    except ValueError:
+        title = heading
+    out: list[str] = []
+    fenced = replaced_title = False
+    for ln in md.split("\n"):
+        if ln.startswith("```"):
+            fenced = not fenced
+        elif not fenced and ln.startswith("#"):
+            if not replaced_title:
+                replaced_title = True
+                out.append(f"## {title}")
+                continue
+            ln = "#" + ln
+        out.append(ln)
+    return "\n".join(out)
+
+
+def render(window_days: int, inputs: dict, label: str | None = None, wiki: bool = False) -> str:
+    # `month` keys the history snapshots and the Play bucket lookup, so it must stay YYYY-MM.
+    # A YYYY-MM label sets it (the usual way to report on a past month); any other label
+    # ('Aug 1–14') is display-only and falls back to inputs/today for the key.
+    if label and MONTH_RE.match(label):
+        month = label
+    else:
+        month = inputs.get("month", date.today().strftime("%Y-%m"))
+    heading = label or month
     gt = glitchtip.collect(window_days)
     sideload = github_downloads.collect()
     stores = inputs.get("stores", {})
@@ -193,7 +232,7 @@ def render(window_days: int, inputs: dict, label: str | None = None) -> str:
     ios = stores.get("Bisq Connect (iOS)", {})
     L: list[str] = []
 
-    L.append(f"# Bisq Mobile — KPI Report — {month}")
+    L.append(f"# Bisq Mobile — KPI Report — {heading}")
     L.append("")
     L.append(f"_Generated {date.today().isoformat()} · window: last {window_days} days "
              "(Play metrics are a 28-day average). Sources: **Play / TestFlight** (real audience), "
@@ -237,6 +276,11 @@ def render(window_days: int, inputs: dict, label: str | None = None) -> str:
         "trades_started": taken,
         "trades_completed": completed,
     }
+    # Re-running a month must never degrade its snapshot: keep previously saved values wherever
+    # this run came back empty (e.g. Play overlay unreachable), overlay everything non-null.
+    existing = _load_snapshot(month)
+    if existing:
+        snap = {**existing, **{k: v for k, v in snap.items() if v is not None}}
     _save_snapshot(month, snap)
 
     L.append("## Audience at a glance")
@@ -297,7 +341,9 @@ def render(window_days: int, inputs: dict, label: str | None = None) -> str:
     L.append("")
 
     # ---- Stability (Play-measured) -----------------------------------------
-    if any(node.get(k) is not None for k in ("play_crash_rate_pct", "play_anr_rate_pct")):
+    if any(stores.get(app, {}).get(k) is not None
+           for app in ("Bisq Connect (Android)", "Bisq Easy Node (Android)")
+           for k in ("play_crash_rate_pct", "play_anr_rate_pct")):
         L.append("### Stability (Play-measured, all installs)")
         L.append("")
         L.append("| App | Crash-free | ANR rate | Rating |")
@@ -357,7 +403,8 @@ def render(window_days: int, inputs: dict, label: str | None = None) -> str:
     L.append("### Trade activity")
     L.append("")
     if taken:
-        pct = lambda n: f"{round(100 * n / taken)}%"
+        def pct(n: int) -> str:
+            return f"{round(100 * n / taken)}%"
         people = cancelled + rejected
         L.append(f"- **{taken:,} trades started** in the window; **{completed:,} completed** "
                  f"({pct(completed)}).")
@@ -411,7 +458,8 @@ def render(window_days: int, inputs: dict, label: str | None = None) -> str:
     L.append("_Caveats: GlitchTip is opt-in (default off) with no per-device identity — a floor, "
              "not a total. GitHub counts every asset GET (bots inflate absolutes). Store numbers are "
              "the authoritative user counts and land here once the Play/ASC APIs are wired._")
-    return "\n".join(L)
+    md = "\n".join(L)
+    return _wikiify(md, month, heading) if wiki else md
 
 
 def main() -> None:
@@ -422,6 +470,9 @@ def main() -> None:
     ap.add_argument("--label", help="period label for the header, e.g. '2026-08' or 'Aug 1–14'")
     ap.add_argument("--inputs", default="inputs.json", help="manual store/operator numbers (JSON)")
     ap.add_argument("--out", help="write markdown here instead of stdout")
+    ap.add_argument("--wiki", action="store_true",
+                    help="wiki-page variant: '## <Month> <Year>' section with demoted headings, "
+                         "ready to paste at the top of the year page")
     args = ap.parse_args()
 
     try:
@@ -430,7 +481,7 @@ def main() -> None:
     except FileNotFoundError:
         inputs = {}
 
-    md = render(args.window, inputs, args.label)
+    md = render(args.window, inputs, args.label, args.wiki)
     if args.out:
         with open(args.out, "w") as f:
             f.write(md + "\n")

--- a/scripts/monthly-report/report.py
+++ b/scripts/monthly-report/report.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Bisq Mobile monthly KPI report generator.
+
+Phase 1 (this file): automates the two halves that need only access we already have —
+  - Engagement & health from GlitchTip (opted-in floor; NEVER a user headcount, by privacy design)
+  - Sideload base from GitHub download stats
+plus a manual-inputs seam (inputs.json) for store/operator numbers until the Play/ASC APIs land.
+
+Output is Markdown to stdout (or --out FILE) for you to review/tweak and paste into the GH wiki.
+
+    python3 report.py --window 30 --inputs inputs.json --out report-2026-08.md
+
+Design note on honesty: the report deliberately keeps three provenance tiers separate — real store
+user counts (Play/ASC), sideload floors (GitHub), and engagement floors (GlitchTip). It never blends
+them into a single "users" number, because the channels are not deduplicable (a person can be on
+Play AND sideload). See README.md.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import date
+
+import glitchtip
+import github_downloads
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HISTORY_DIR = os.path.join(SCRIPT_DIR, "history")
+
+
+def _load_env() -> None:
+    """Populate os.environ from a gitignored `.env` next to this script (KEY=VALUE lines), without
+    overriding anything already set in the shell. Lets `python3 report.py` just work — no exports."""
+    try:
+        with open(os.path.join(SCRIPT_DIR, ".env")) as f:
+            for raw in f:
+                line = raw.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    except FileNotFoundError:
+        pass
+
+
+def _fmt(v) -> str:
+    return "—" if v is None else (f"{v:,}" if isinstance(v, int) else str(v))
+
+
+def _funnel_count(funnel: list[dict], *prefixes: str) -> int:
+    return sum(r["n"] for r in funnel if any(r["step"].startswith(p) for p in prefixes))
+
+
+def _bar_chart(title: str, items: list[tuple[str, int]], width: int = 34) -> list[str]:
+    """Horizontal bar chart as a monospace code block — renders in ANY markdown tool (MacDown,
+    GitHub, wikis) with no image hosting, unlike Mermaid which needs a Mermaid-aware renderer."""
+    total = sum(v for _, v in items) or 1
+    mx = max((v for _, v in items), default=1) or 1
+    lblw = max((len(l) for l, _ in items), default=0)
+    out = ["```", title, ""]
+    for label, v in items:
+        bar = "█" * max(1, round(v / mx * width))
+        out.append(f"{label.ljust(lblw)}  {bar}  {v:,} ({round(100 * v / total)}%)")
+    out.append("```")
+    return out
+
+
+# --- Month-over-month history (self-contained JSON snapshots, error-safe) -----
+
+def _load_prev_snapshot(month: str) -> tuple[str | None, dict | None]:
+    """Most recent saved snapshot strictly older than `month`. Never raises — a missing/unreadable
+    history dir just means 'no comparison yet' (e.g. the very first report)."""
+    try:
+        keys = sorted(f[:-5] for f in os.listdir(HISTORY_DIR)
+                      if f.endswith(".json") and f[:-5] < month)
+    except OSError:
+        return None, None
+    if not keys:
+        return None, None
+    try:
+        with open(os.path.join(HISTORY_DIR, keys[-1] + ".json")) as fh:
+            return keys[-1], json.load(fh)
+    except (OSError, ValueError):
+        return None, None
+
+
+def _save_snapshot(month: str, snap: dict) -> None:
+    """Best-effort persist; a failure here must never break report generation."""
+    try:
+        os.makedirs(HISTORY_DIR, exist_ok=True)
+        with open(os.path.join(HISTORY_DIR, month + ".json"), "w") as fh:
+            json.dump(snap, fh, indent=2, sort_keys=True)
+    except OSError:
+        pass
+
+
+def _num(v) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:,.2f}".rstrip("0").rstrip(".")
+    return f"{v:,}"
+
+
+def _delta(cur, prev) -> str:
+    if cur is None or prev is None:
+        return "—"
+    d = cur - prev
+    if abs(d) < 1e-9:
+        return "±0"
+    mag = _num(round(abs(d), 2) if isinstance(d, float) else abs(d))
+    return f"{'▲ +' if d > 0 else '▼ −'}{mag}"
+
+
+def _sideload_mid(sideload, needle: str):
+    for a in sideload:
+        if needle.lower() in a.app.lower() and a.active_base_estimate:
+            lo, hi = a.active_base_estimate
+            return (lo + hi) // 2
+    return None
+
+
+def _mom_section(snap: dict, prev_month: str | None, prev: dict | None) -> list[str]:
+    L = ["## Month over month", ""]
+    if not prev:
+        L.append("_First report — no prior month to compare yet. Next month's report will show "
+                 "deltas here automatically._")
+        L.append("")
+        return L
+    L.append(f"_Change vs **{prev_month}**._")
+    L.append("")
+    rows = [
+        ("Bisq Easy — active devices", "node_active_devices"),
+        ("Bisq Easy — MAU", "node_mau"),
+        ("Bisq Easy — DAU", "node_dau"),
+        ("Bisq Easy — rating", "node_rating"),
+        ("Bisq Connect — audience (all platforms)", "connect_audience_total"),
+        ("Bisq Connect — iOS testers", "connect_ios_testers"),
+        ("Bisq Connect — MAU", "connect_mau"),
+        ("Bisq Connect — rating", "connect_rating"),
+        ("Sideload base — Easy (mid)", "sideload_easy_mid"),
+        ("Sideload base — Connect (mid)", "sideload_connect_mid"),
+        ("Analytics events (opted-in)", "analytics_events_total"),
+        ("New opt-ins", "new_optins_total"),
+        ("Trades started", "trades_started"),
+        ("Trades completed", "trades_completed"),
+    ]
+    L.append("| Metric | This month | vs last month |")
+    L.append("|---|---|---|")
+    for lbl, key in rows:
+        L.append(f"| {lbl} | {_num(snap.get(key))} | {_delta(snap.get(key), prev.get(key))} |")
+    L.append("")
+    return L
+
+
+def render(window_days: int, inputs: dict, label: str | None = None) -> str:
+    month = label or inputs.get("month", date.today().strftime("%Y-%m"))
+    gt = glitchtip.collect(window_days)
+    sideload = github_downloads.collect()
+    stores = inputs.get("stores", {})
+
+    # Overlay live Play Vitals (crash/ANR) when reachable; silently fall back to manual inputs
+    # otherwise (missing key, no venv/google-auth, denied access, or app below Play's data floor).
+    vitals_as_of = None
+    try:
+        import play
+        for app_label, v in play.collect().items():
+            s = stores.setdefault(app_label, {})
+            if v.get("crash_rate_pct") is not None:
+                s["play_crash_rate_pct"] = v["crash_rate_pct"]
+            if v.get("anr_rate_pct") is not None:
+                s["play_anr_rate_pct"] = v["anr_rate_pct"]
+            vitals_as_of = v.get("as_of") or vitals_as_of
+    except Exception:
+        pass
+
+    # Overlay live audience + new installs from the Play statistics bucket (via gcloud); falls back
+    # to manual inputs when the bucket env / gcloud auth / month file is absent.
+    installs_live = False
+    try:
+        import play_installs
+        for app_label, v in play_installs.collect(month).items():
+            s = stores.setdefault(app_label, {})
+            for k, val in v.items():
+                if val is not None:
+                    s[k] = val
+                    installs_live = True
+    except Exception:
+        pass
+
+    connect = stores.get("Bisq Connect (Android)", {})
+    node = stores.get("Bisq Easy Node (Android)", {})
+    ios = stores.get("Bisq Connect (iOS)", {})
+    L: list[str] = []
+
+    L.append(f"# Bisq Mobile — KPI Report — {month}")
+    L.append("")
+    L.append(f"_Generated {date.today().isoformat()} · window: last {window_days} days "
+             "(Play metrics are a 28-day average). Sources: **Play / TestFlight** (real audience), "
+             "**GitHub** (sideload), **self-hosted analytics** (engagement, opt-in only)._")
+    L.append("")
+
+    # ---- Audience overview (the honest combined picture) --------------------
+    connect_android_audience = connect.get("play_active_devices_avg") or 0
+    connect_ios_audience = ios.get("testflight_testers") or 0
+    node_audience = node.get("play_active_devices_avg") or 0
+    connect_total = connect_android_audience + connect_ios_audience
+
+    # Trade funnel — computed once here, reused in the Trade activity section + the snapshot.
+    fn = gt.trade_funnel
+    taken = _funnel_count(fn, "trade.taken")
+    completed = _funnel_count(fn, "trade.completed")
+    cancelled = _funnel_count(fn, "trade.cancelled")
+    rejected = _funnel_count(fn, "trade.rejected")
+    errored = _funnel_count(fn, "trade.errored")
+    step_failures = sum(r["n"] for r in fn if r["step"].endswith("_failed"))
+    in_flight = max(taken - completed - cancelled - rejected - errored, 0)
+
+    # Month-over-month: load the PREVIOUS month before writing this one, then persist this snapshot.
+    prev_month, prev_snap = _load_prev_snapshot(month)
+    snap = {
+        "month": month,
+        "node_active_devices": node_audience or None,
+        "node_mau": node.get("play_mau"),
+        "node_dau": node.get("play_dau"),
+        "node_rating": node.get("play_rating"),
+        "connect_audience_total": connect_total or None,
+        "connect_android_devices": connect_android_audience or None,
+        "connect_ios_testers": connect_ios_audience or None,
+        "connect_mau": connect.get("play_mau"),
+        "connect_dau": connect.get("play_dau"),
+        "connect_rating": connect.get("play_rating"),
+        "sideload_easy_mid": _sideload_mid(sideload, "node"),
+        "sideload_connect_mid": _sideload_mid(sideload, "connect"),
+        "analytics_events_total": gt.total_events,
+        "new_optins_total": sum(p.opt_in for p in gt.projects),
+        "trades_started": taken,
+        "trades_completed": completed,
+    }
+    _save_snapshot(month, snap)
+
+    L.append("## Audience at a glance")
+    L.append("")
+    L.append(f"- **Bisq Easy (node app):** ~{node_audience:,} active devices (Android only), "
+             f"the larger audience — plus an estimated sideload base on top (see below).")
+    L.append(f"- **Bisq Connect:** ~{connect_total:,} across platforms "
+             f"(~{connect_android_audience:,} Android active devices + ~{connect_ios_audience:,} iOS "
+             "TestFlight testers), plus Android sideload.")
+    L.append("- Channels are not deduplicable, so these are per-app pictures, not one global total. "
+             "Store numbers are real device counts; sideload and analytics are floors.")
+    if connect_total and connect_ios_audience and connect_ios_audience / connect_total >= 0.35:
+        L.append(f"- **iOS is ~{round(100 * connect_ios_audience / connect_total)}% of the Connect "
+                 "audience despite no App Store presence** (TestFlight + AltStore only) — validation "
+                 "of the sideload-first iOS strategy.")
+    L.append("")
+
+    # Monospace bar charts render in ANY markdown tool (MacDown, GitHub, wikis) with no image
+    # hosting — unlike Mermaid, which only renders in Mermaid-aware viewers (GitHub, not MacDown).
+    if node_audience and connect_total:
+        L += _bar_chart("Audience by app (active devices / TestFlight testers)",
+                        [("Bisq Easy (node)", node_audience), ("Bisq Connect", connect_total)])
+        L.append("")
+    if connect_android_audience and connect_ios_audience:
+        L += _bar_chart("Bisq Connect by platform",
+                        [("Android (Play active devices)", connect_android_audience),
+                         ("iOS (TestFlight testers)", connect_ios_audience)])
+        L.append("")
+
+    L += _mom_section(snap, prev_month, prev_snap)
+
+    # ---- A. Reach & audience ------------------------------------------------
+    L.append("## Reach & audience")
+    L.append("")
+    L.append("### App stores")
+    L.append("")
+    L.append("| App | Audience (active devices) | MAU | DAU | Total installs | New installs (28d) | Rating |")
+    L.append("|---|---|---|---|---|---|---|")
+    for app in ("Bisq Connect (Android)", "Bisq Easy Node (Android)"):
+        s = stores.get(app, {})
+        L.append(f"| {app} | {_fmt(s.get('play_active_devices_avg'))} | {_fmt(s.get('play_mau'))} | "
+                 f"{_fmt(s.get('play_dau'))} | {_fmt(s.get('play_total_installs'))} | "
+                 f"{_fmt(s.get('play_new_installs_30d'))} | {_fmt(s.get('play_rating'))} |")
+    L.append("")
+    L.append("_**Audience** = active devices (28-day average): devices with the app installed and "
+             "used in the period — the truest 'how many people use it' number. "
+             "**MAU** = monthly active users (unique users active in the last 28 days). "
+             "**DAU** = daily active users (average per day over the period)._")
+    L.append("")
+    if installs_live:
+        L.append(f"_Audience (active devices) & new installs are pulled live from the Play Console "
+                 f"statistics export ({month} monthly average). MAU/DAU, total installs and rating "
+                 "stay manual — Play exposes no API for those._")
+        L.append("")
+    L.append(f"**Bisq Connect (iOS):** TestFlight testers {_fmt(ios.get('testflight_testers'))}, "
+             f"AltStore PAL installs {_fmt(ios.get('altstore_pal_installs'))} "
+             "_(iOS active-user metrics aren't exposed like Play's; testers is the closest proxy)._")
+    L.append("")
+
+    # ---- Stability (Play-measured) -----------------------------------------
+    if any(node.get(k) is not None for k in ("play_crash_rate_pct", "play_anr_rate_pct")):
+        L.append("### Stability (Play-measured, all installs)")
+        L.append("")
+        L.append("| App | Crash-free | ANR rate | Rating |")
+        L.append("|---|---|---|---|")
+        for app in ("Bisq Connect (Android)", "Bisq Easy Node (Android)"):
+            s = stores.get(app, {})
+            crash = s.get("play_crash_rate_pct")
+            cf = f"{100 - crash:.2f}%" if crash is not None else "—"
+            anr = f"{s.get('play_anr_rate_pct')}%" if s.get("play_anr_rate_pct") is not None else "—"
+            L.append(f"| {app} | {cf} | {anr} | {_fmt(s.get('play_rating'))} |")
+        L.append("")
+        if vitals_as_of:
+            L.append(f"_Crash-free & ANR are pulled live from the Play Developer Reporting API "
+                     f"(28-day user-weighted, as of {vitals_as_of}). Apps below Play's minimum-user "
+                     "threshold show — (Vitals suppressed)._")
+            L.append("")
+        nr, cr, ncrash = node.get("play_rating"), connect.get("play_rating"), node.get("play_crash_rate_pct")
+        if nr is not None and cr is not None and ncrash is not None and (cr - nr) >= 0.5:
+            L.append(f"_The node app's lower rating ({nr}) despite {100 - ncrash:.2f}% crash-free "
+                     "isn't a stability story — it points to UX/expectations rather than defects, "
+                     "and is the clearest KPI to watch._")
+            L.append("")
+
+    L.append("### Sideload (GitHub download stats)")
+    L.append("")
+    L.append("_Active base ≈ the latest release's per-week APK pull, bot-discounted. Same base "
+             "re-downloads each release; cumulative ≠ unique. iOS not measurable (AltStore mirrors "
+             "the IPA)._")
+    L.append("")
+    L.append("| App | Latest | Latest /week | Active sideload base | All-time APK dl |")
+    L.append("|---|---|---|---|---|")
+    for a in sideload:
+        est = a.active_base_estimate
+        est_s = f"~{est[0]:,}–{est[1]:,}" if est else "—"
+        latest = a.latest.tag if a.latest else "—"
+        wk = f"{a.latest.per_week:,}" if a.latest else "—"
+        L.append(f"| {a.app} | {latest} | {wk} | {est_s} | {a.total_all_time:,} |")
+    L.append("")
+
+    # ---- B. Engagement & health --------------------------------------------
+    L.append("## Engagement & product health")
+    L.append("")
+    L.append("_From the app's own privacy-preserving analytics — **opt-in only** (off by default) "
+             "and with no per-device identity, so these are engagement floors, not user counts._")
+    L.append("")
+    L.append(f"Total analytics events ({window_days}d): **{gt.total_events:,}** across opted-in "
+             "installs.")
+    L.append("")
+    L.append("| App | Events | Errors | New opt-ins | Opt-outs | Dashboard opens |")
+    L.append("|---|---|---|---|---|---|")
+    for p in gt.projects:
+        L.append(f"| {p.project} | {p.events:,} | {p.errors} | {p.opt_in} | {p.opt_out} | "
+                 f"{p.dashboard_opens:,} |")
+    L.append("")
+
+    # ---- Trade funnel insights (funnel already computed near the top) -------
+    L.append("### Trade activity")
+    L.append("")
+    if taken:
+        pct = lambda n: f"{round(100 * n / taken)}%"
+        people = cancelled + rejected
+        L.append(f"- **{taken:,} trades started** in the window; **{completed:,} completed** "
+                 f"({pct(completed)}).")
+        L.append(f"- Of the rest: {cancelled:,} cancelled ({pct(cancelled)}), "
+                 f"{rejected:,} rejected by the counterparty ({pct(rejected)}), "
+                 f"{in_flight:,} still in progress ({pct(in_flight)}), {errored:,} errored.")
+        L.append(f"- Non-completion is **people, not the app**: {people:,} of {taken:,} "
+                 f"({pct(people)}) were user cancellations or counterparty rejections. Read the "
+                 "completion rate as a matching/liquidity signal, not an app-quality one.")
+        L.append(f"- **App mechanics are healthy: only {step_failures} step action(s) failed.** "
+                 "(Completion % also understates the true rate: trades started late in the window "
+                 "haven't finished yet.)")
+    else:
+        L.append("_No trades started in the window._")
+    L.append("")
+    L.append("<details><summary>Full step breakdown</summary>")
+    L.append("")
+    L.append("| Step | Count |")
+    L.append("|---|---|")
+    for r in fn[:24]:
+        L.append(f"| {r['step']} | {r['n']:,} |")
+    L.append("")
+    L.append("</details>")
+    L.append("")
+
+    L.append("### Errors & crashes (from analytics)")
+    L.append("")
+    if gt.top_errors:
+        fatals = sum(r["n"] for r in gt.top_errors if str(r["level"]).lower() == "fatal")
+        ios_sigpipe = sum(r["n"] for r in gt.top_errors
+                          if "iOS" in r["project"] and "SIGPIPE" in r["title"])
+        summary = f"{fatals} fatal event(s) across opted-in installs this month"
+        if ios_sigpipe:
+            summary += (f"; iOS **SIGPIPE** crashes are the dominant class ({ios_sigpipe}) and the "
+                        "top engineering-triage target")
+        L.append(summary + ".")
+        L.append("")
+        L.append("<details><summary>Full error/crash breakdown</summary>")
+        L.append("")
+        L.append("| App | Level | Title | Count |")
+        L.append("|---|---|---|---|")
+        for r in gt.top_errors:
+            L.append(f"| {r['project']} | {r['level']} | {r['title']} | {r['n']} |")
+        L.append("")
+        L.append("</details>")
+    else:
+        L.append("_No error/crash issues in window._")
+    L.append("")
+
+    L.append("---")
+    L.append("_Caveats: GlitchTip is opt-in (default off) with no per-device identity — a floor, "
+             "not a total. GitHub counts every asset GET (bots inflate absolutes). Store numbers are "
+             "the authoritative user counts and land here once the Play/ASC APIs are wired._")
+    return "\n".join(L)
+
+
+def main() -> None:
+    _load_env()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--window", type=int, default=30,
+                    help="reporting window in days (30 = monthly, 14 = fortnightly)")
+    ap.add_argument("--label", help="period label for the header, e.g. '2026-08' or 'Aug 1–14'")
+    ap.add_argument("--inputs", default="inputs.json", help="manual store/operator numbers (JSON)")
+    ap.add_argument("--out", help="write markdown here instead of stdout")
+    args = ap.parse_args()
+
+    try:
+        with open(args.inputs) as f:
+            inputs = json.load(f)
+    except FileNotFoundError:
+        inputs = {}
+
+    md = render(args.window, inputs, args.label)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(md + "\n")
+        print(f"wrote {args.out}")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/monthly-report/requirements.txt
+++ b/scripts/monthly-report/requirements.txt
@@ -2,4 +2,4 @@
 #   python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
 #   .venv/bin/python3 report.py ...
 google-auth>=2.0
-requests>=2.0
+requests>=2.33.0

--- a/scripts/monthly-report/requirements.txt
+++ b/scripts/monthly-report/requirements.txt
@@ -1,0 +1,5 @@
+# Optional — only needed for live Play Vitals (play.py). The rest of the report runs on stdlib.
+#   python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+#   .venv/bin/python3 report.py ...
+google-auth>=2.0
+requests>=2.0


### PR DESCRIPTION
 - resolves #1359
 - added python "sub-project" under scripts to generate monthly project reports automatically
 - sourced data from Google Play, Gitub, Glitchtip and possibility for manual (used for now for iOS data)
 - implemented report outcome in md format to easily add to github/wiki

First report generated for July (its actually mid-july mid august) generated [here](https://github.com/bisq-network/bisq-mobile/wiki/2026-Monthly-Reports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a monthly KPI report generator covering audience, engagement, stability, installs, sideloads, trade activity, and errors.
  * Added optional live integrations for GitHub release downloads, GlitchTip analytics, Google Play stability metrics, and Play Console installs.
  * Added configurable manual inputs, reporting windows, labels, and output files.
* **Documentation**
  * Added setup instructions, configuration examples, usage guidance, and module documentation.
  * Added sample inputs for manually supplied mobile and backend metrics.
* **Chores**
  * Added safeguards to exclude generated reports, credentials, local environments, and historical snapshots from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->