### PR TITLE
chore/improve_trade_funnel_analytics_based_on_first_full_report

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -141,14 +141,16 @@ class ClientTradesServiceFacade(
         _selectedTrade.value = findOpenTradeItemModel(tradeId)
     }
 
-    override suspend fun rejectTrade(): Result<Unit> {
+    override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> {
         if (globalUiManager.notifyIfDemoModeRestricted()) return Result.success(Unit)
-        return apiGateway.rejectTrade(requireNotNull(tradeId)).onSuccess { trackTrade(AnalyticsEvent.Trade.Rejected) }
+        return apiGateway.rejectTrade(requireNotNull(tradeId)).onSuccess { trackTrade(AnalyticsEvent.Trade.Rejected(reason)) }
     }
 
-    override suspend fun cancelTrade(): Result<Unit> {
+    override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> {
         if (globalUiManager.notifyIfDemoModeRestricted()) return Result.success(Unit)
-        return apiGateway.cancelTrade(requireNotNull(tradeId)).onSuccess { trackTrade(AnalyticsEvent.Trade.Cancelled) }
+        // Before the request: the cancel transition itself would reset the stall clock to ~zero.
+        val stall = selectedTradeStallBucket()
+        return apiGateway.cancelTrade(requireNotNull(tradeId)).onSuccess { trackTrade(AnalyticsEvent.Trade.Cancelled(reason, stall)) }
     }
 
     override suspend fun closeTrade(): Result<Unit> {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -245,7 +245,7 @@ class NodeTradesServiceFacade(
                 .firstOrNull { it.tradeId == tradeId }
     }
 
-    override suspend fun rejectTrade(): Result<Unit> =
+    override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> =
         withContext(Dispatchers.Default) {
             try {
                 val (channel, trade, userName) = getTradeChannelUserNameTriple()
@@ -257,10 +257,12 @@ class NodeTradesServiceFacade(
             } catch (e: Exception) {
                 Result.failure(e)
             }
-        }.onSuccess { trackTrade(AnalyticsEvent.Trade.Rejected) }
+        }.onSuccess { trackTrade(AnalyticsEvent.Trade.Rejected(reason)) }
 
-    override suspend fun cancelTrade(): Result<Unit> =
-        withContext(Dispatchers.Default) {
+    override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> {
+        // Before the request: the cancel transition itself would reset the stall clock to ~zero.
+        val stall = selectedTradeStallBucket()
+        return withContext(Dispatchers.Default) {
             try {
                 val (channel, trade, userName) = getTradeChannelUserNameTriple()
                 val encoded: String = Res.encode("bisqEasy.openTrades.tradeLogMessage.cancelled", userName)
@@ -270,7 +272,8 @@ class NodeTradesServiceFacade(
             } catch (e: Exception) {
                 Result.failure(e)
             }
-        }.onSuccess { trackTrade(AnalyticsEvent.Trade.Cancelled) }
+        }.onSuccess { trackTrade(AnalyticsEvent.Trade.Cancelled(reason, stall)) }
+    }
 
     override suspend fun closeTrade(): Result<Unit> =
         withContext(Dispatchers.Default) {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTrad
 import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -141,6 +142,66 @@ class TradeAnalyticsTrackerTest {
 
             verify(exactly = 1) { analytics.track(Trade.Errored) }
             verify { analytics.captureException(any<TradeProtocolException>()) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `stall bucket is UNKNOWN with no witnessed transition`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics)
+            val openTrades = MutableStateFlow(listOf(fakeTrade()))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+
+            // The initial state replay is a first sighting, not a transition — its age is unknowable.
+            assertEquals(Trade.StallBucket.UNKNOWN, tracker.stallBucketFor("t1"))
+            assertEquals(Trade.StallBucket.UNKNOWN, tracker.stallBucketFor("never-seen"))
+            assertEquals(Trade.StallBucket.UNKNOWN, tracker.stallBucketFor(null))
+            scope.cancel()
+        }
+
+    @Test
+    fun `stall bucket measures time since the last witnessed transition`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            var nowMs = 0L
+            val tracker = TradeAnalyticsTracker(analytics, clock = { nowMs })
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+            val openTrades = MutableStateFlow(listOf(fakeTrade(tradeState = state)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION // witnessed at nowMs = 0
+
+            nowMs = 30L * 60 * 1000
+            assertEquals(Trade.StallBucket.UNDER_1H, tracker.stallBucketFor("t1"))
+            nowMs = 2L * 60 * 60 * 1000
+            assertEquals(Trade.StallBucket.H1_TO_24H, tracker.stallBucketFor("t1"))
+            nowMs = 2L * 24 * 60 * 60 * 1000
+            assertEquals(Trade.StallBucket.D1_TO_3D, tracker.stallBucketFor("t1"))
+            nowMs = 4L * 24 * 60 * 60 * 1000
+            assertEquals(Trade.StallBucket.OVER_3D, tracker.stallBucketFor("t1"))
+            scope.cancel()
+        }
+
+    @Test
+    fun `stall entries are evicted when a trade leaves the open list`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, clock = { 0L })
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+            val openTrades = MutableStateFlow(listOf(fakeTrade(tradeState = state)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            assertEquals(Trade.StallBucket.UNDER_1H, tracker.stallBucketFor("t1"))
+
+            openTrades.value = emptyList()
+
+            assertEquals(Trade.StallBucket.UNKNOWN, tracker.stallBucketFor("t1"))
             scope.cancel()
         }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
@@ -28,6 +28,12 @@ abstract class BaseTradesServiceFacade(
     protected fun trackTrade(event: AnalyticsEvent.Trade) = tradeAnalyticsTracker.track(event)
 
     /**
+     * Stall bucket for the currently selected trade. Capture BEFORE issuing the cancel request —
+     * the cancellation itself transitions the trade state and would reset the clock to ~zero.
+     */
+    protected fun selectedTradeStallBucket(): AnalyticsEvent.Trade.StallBucket = tradeAnalyticsTracker.stallBucketFor(selectedTrade.value?.tradeId)
+
+    /**
      * Wraps a user-driven confirm [action] with step-outcome analytics (CONFIRMED/FAILED/STALLED),
      * timing the currently selected trade's own state transition. With no selected trade it just runs
      * the action untracked. `serviceScope` is read fresh so the stall watch launches on the live scope.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.service.LifeCycleAware
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.core.pagination.PaginatedResponse
 import network.bisq.mobile.domain.core.pagination.PaginationParams
 import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
@@ -36,9 +37,15 @@ interface TradesServiceFacade : LifeCycleAware {
 
     fun selectOpenTrade(tradeId: String)
 
-    suspend fun rejectTrade(): Result<Unit>
+    /** [reason] comes from the optional chips on the interrupt dialog — analytics only (#1711). */
+    suspend fun rejectTrade(
+        reason: AnalyticsEvent.Trade.InterruptReason = AnalyticsEvent.Trade.InterruptReason.UNSPECIFIED,
+    ): Result<Unit>
 
-    suspend fun cancelTrade(): Result<Unit>
+    /** [reason] comes from the optional chips on the interrupt dialog — analytics only (#1711). */
+    suspend fun cancelTrade(
+        reason: AnalyticsEvent.Trade.InterruptReason = AnalyticsEvent.Trade.InterruptReason.UNSPECIFIED,
+    ): Result<Unit>
 
     suspend fun closeTrade(): Result<Unit>
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
@@ -91,6 +91,66 @@ sealed class AnalyticsEvent(
             STALLED("stalled"),
         }
 
+        /**
+         * Why the user interrupted (cancelled/rejected) a trade — from the optional single-tap
+         * chips on the interrupt confirmation dialog. Fixed enum, never free text.
+         * [UNSPECIFIED] means the chips were skipped.
+         *
+         * The point of the taxonomy: separate liquidity/human interrupts (price moved, changed
+         * mind) from app-caused ones ([NO_PROGRESS] — the desync/stuck-trade symptom), so the
+         * monthly funnel can attribute non-completion.
+         */
+        enum class InterruptReason(
+            val slug: String,
+        ) {
+            PEER_UNRESPONSIVE("peer_unresponsive"),
+            PRICE_MOVED("price_moved"),
+            PAYMENT_METHOD_ISSUE("payment_method_issue"),
+
+            /** The user-visible trade state stopped advancing — the stuck-trade symptom. */
+            NO_PROGRESS("no_progress"),
+            CHANGED_MIND("changed_mind"),
+            OTHER("other"),
+
+            /** The optional reason chips were skipped. */
+            UNSPECIFIED("unspecified"),
+        }
+
+        /**
+         * Time since the trade's last WITNESSED state transition when the user cancelled, bucketed
+         * (never raw durations — bounded names only). A cancel after days without a transition is
+         * a desync fingerprint; minutes is a human decision.
+         *
+         * [UNKNOWN] keeps the data honest: transition times live in memory only (the trade DTO
+         * carries no per-state timestamps), so a state change the app never saw this session — e.g.
+         * it happened before an app restart — has an unknowable age and MUST NOT masquerade as a
+         * short stall.
+         */
+        enum class StallBucket(
+            val slug: String,
+        ) {
+            /** No transition witnessed this session — age unknowable, not "recent". */
+            UNKNOWN("unknown"),
+            UNDER_1H("lt_1h"),
+            H1_TO_24H("1h_24h"),
+            D1_TO_3D("1d_3d"),
+            OVER_3D("gt_3d"),
+            ;
+
+            companion object {
+                private const val HOUR_MS = 60 * 60 * 1000L
+                private const val DAY_MS = 24 * HOUR_MS
+
+                fun fromMillis(millis: Long): StallBucket =
+                    when {
+                        millis < HOUR_MS -> UNDER_1H
+                        millis < DAY_MS -> H1_TO_24H
+                        millis < 3 * DAY_MS -> D1_TO_3D
+                        else -> OVER_3D
+                    }
+            }
+        }
+
         /** The user VIEWED this phase's screen (view-based; emitted from the trade-detail presenter). */
         data class PhaseOpened(
             val phase: Phase,
@@ -114,9 +174,27 @@ sealed class AnalyticsEvent(
 
         data object Completed : Trade("trade.completed")
 
-        data object Cancelled : Trade("trade.cancelled")
+        /**
+         * Reason and stall bucket are baked into the wire name (the [Settings.LanguageChanged]
+         * pattern): GlitchTip groups by title and events carry no identity to join on, so one name
+         * holding both is the only way to correlate the user's claim against the objective stall —
+         * e.g. `changed_mind` with `gt_3d` is a mislabelled stuck trade. `report.py` counts the
+         * funnel by `trade.cancelled` PREFIX, so the variants keep aggregating into the existing
+         * month-over-month numbers (old app versions' plain `trade.cancelled` included).
+         */
+        data class Cancelled(
+            val reason: InterruptReason,
+            val stall: StallBucket,
+        ) : Trade("trade.cancelled_${reason.slug}_${stall.slug}")
 
-        data object Rejected : Trade("trade.rejected")
+        /**
+         * Reason only — no stall bucket. Rejection happens right after take (phase 1), so
+         * time-since-last-transition is nearly always minutes: a bucket would add 28 wire names
+         * without signal.
+         */
+        data class Rejected(
+            val reason: InterruptReason,
+        ) : Trade("trade.rejected_${reason.slug}")
 
         /** A protocol/peer error surfaced on the trade (from the trade model's error flows). */
         data object Errored : Trade("trade.errored")
@@ -127,7 +205,9 @@ sealed class AnalyticsEvent(
                 Phase.entries.map { PhaseOpened(it) } +
                     Phase.entries.map { PhaseReached(it) } +
                     Step.entries.flatMap { step -> Outcome.entries.map { outcome -> Action(step, outcome) } } +
-                    listOf(Taken, Completed, Cancelled, Rejected, Errored)
+                    InterruptReason.entries.flatMap { reason -> StallBucket.entries.map { Cancelled(reason, it) } } +
+                    InterruptReason.entries.map { Rejected(it) } +
+                    listOf(Taken, Completed, Errored)
             }
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPre
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.domain.utils.Logging
 
 /**
@@ -35,11 +36,49 @@ import network.bisq.mobile.domain.utils.Logging
 class TradeAnalyticsTracker(
     private val analyticsService: AnalyticsService,
     private val stallTimeoutMs: Long = DEFAULT_STALL_TIMEOUT_MS,
+    private val clock: () -> Long = { DateUtils.now() },
 ) : Logging {
     companion object {
         // Generous for Tor round-trips. Only the user's OWN local state transition is timed (fast), so
         // this never trips on a legitimate counterparty wait, which can span hours/days.
         const val DEFAULT_STALL_TIMEOUT_MS = 45_000L
+    }
+
+    // In-memory only, by design: the trade DTO carries no per-state timestamps, so a
+    // transition the app never saw this session has an unknowable age — stallBucketFor reports it
+    // as UNKNOWN rather than fabricating a short stall. Entries are evicted as trades leave the
+    // open list. If UNKNOWN dominates cancel events in the monthly report, the follow-up is
+    // persisting this map, not widening the buckets.
+    private val lastKnownStateByTradeId = mutableMapOf<String, BisqEasyTradeStateEnum>()
+    private val lastTransitionAtMsByTradeId = mutableMapOf<String, Long>()
+
+    /**
+     * Bucketed time since [tradeId]'s last witnessed state transition — for stamping onto
+     * [AnalyticsEvent.Trade.Cancelled]. Callers MUST capture this BEFORE issuing the cancel
+     * request: the cancellation itself transitions the trade state, which resets the clock to
+     * ~zero.
+     */
+    fun stallBucketFor(tradeId: String?): AnalyticsEvent.Trade.StallBucket {
+        val lastTransitionAtMs =
+            tradeId?.let { lastTransitionAtMsByTradeId[it] }
+                ?: return AnalyticsEvent.Trade.StallBucket.UNKNOWN
+        return AnalyticsEvent.Trade.StallBucket.fromMillis(clock() - lastTransitionAtMs)
+    }
+
+    /**
+     * A first sighting (no previous state) is NOT a transition — it is either a freshly taken trade
+     * or a pre-existing one loaded on startup, and only the former's age would be ~zero. StateFlows
+     * also replay their current value on every re-subscription (the observers re-subscribe whenever
+     * the open-trades list changes), which the same-state check discards.
+     */
+    private fun recordTransition(
+        id: String,
+        state: BisqEasyTradeStateEnum,
+    ) {
+        val previous = lastKnownStateByTradeId.put(id, state)
+        if (previous != null && previous != state) {
+            lastTransitionAtMsByTradeId[id] = clock()
+        }
     }
 
     /**
@@ -112,12 +151,18 @@ class TradeAnalyticsTracker(
         }
 
         // Completion: BTC_CONFIRMED. flatMapLatest re-subscribes to the current trades' state flows
-        // whenever the open-trade list changes.
+        // whenever the open-trade list changes. The same stream feeds the stall clock — every state
+        // change is a witnessed transition.
         scope.launch {
             openTradeItems
                 .flatMapLatest { trades ->
+                    // Evict stall entries for trades no longer open, so the maps stay bounded.
+                    val openIds = trades.mapTo(mutableSetOf()) { tradeId(it) }
+                    lastKnownStateByTradeId.keys.retainAll(openIds)
+                    lastTransitionAtMsByTradeId.keys.retainAll(openIds)
                     merge(*trades.map { item -> item.bisqEasyTradeModel.tradeState.map { state -> tradeId(item) to state } }.toTypedArray())
                 }.collect { (id, state) ->
+                    recordTransition(id, state)
                     if (state == BisqEasyTradeStateEnum.BTC_CONFIRMED && completed.add(id)) {
                         analyticsService.track(AnalyticsEvent.Trade.Completed)
                     }

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -928,3 +928,12 @@ mobile.peerProfile.ownProfileGuard=This is your own profile.
 mobile.peerProfile.notFound=This profile could not be found.
 mobile.peerProfile.loadFailed=Could not load this profile. Check your connection and try again.
 mobile.peerProfile.ignoreConfirm.headline=Ignore this user?
+
+# Trade interrupt reason chips — optional single-tap survey on the cancel/reject dialog
+mobile.tradeInterrupt.reasonPrompt=Reason? Optional — helps improve Bisq
+mobile.tradeInterrupt.reason.peerUnresponsive=No response
+mobile.tradeInterrupt.reason.priceMoved=Price moved
+mobile.tradeInterrupt.reason.paymentMethodIssue=Payment issue
+mobile.tradeInterrupt.reason.noProgress=Trade stalled
+mobile.tradeInterrupt.reason.changedMind=Changed my mind
+mobile.tradeInterrupt.reason.other=Other

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEventContractTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEventContractTest.kt
@@ -185,6 +185,44 @@ class AnalyticsEventContractTest {
     }
 
     @Test
+    fun `Trade Cancelled and Rejected bake reason and stall into the wire name`() {
+        // Pins the wire format: report.py aggregates the funnel by `trade.cancelled` /
+        // `trade.rejected` PREFIX, so every variant must keep that prefix intact.
+        assertEquals(
+            "trade.cancelled_no_progress_gt_3d",
+            AnalyticsEvent.Trade
+                .Cancelled(
+                    AnalyticsEvent.Trade.InterruptReason.NO_PROGRESS,
+                    AnalyticsEvent.Trade.StallBucket.OVER_3D,
+                ).name,
+        )
+        assertEquals(
+            "trade.cancelled_unspecified_unknown",
+            AnalyticsEvent.Trade
+                .Cancelled(
+                    AnalyticsEvent.Trade.InterruptReason.UNSPECIFIED,
+                    AnalyticsEvent.Trade.StallBucket.UNKNOWN,
+                ).name,
+        )
+        assertEquals(
+            "trade.rejected_changed_mind",
+            AnalyticsEvent.Trade.Rejected(AnalyticsEvent.Trade.InterruptReason.CHANGED_MIND).name,
+        )
+    }
+
+    @Test
+    fun `StallBucket fromMillis maps durations onto the declared buckets`() {
+        val hourMs = 60 * 60 * 1000L
+        assertEquals(AnalyticsEvent.Trade.StallBucket.UNDER_1H, AnalyticsEvent.Trade.StallBucket.fromMillis(0))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.UNDER_1H, AnalyticsEvent.Trade.StallBucket.fromMillis(hourMs - 1))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.H1_TO_24H, AnalyticsEvent.Trade.StallBucket.fromMillis(hourMs))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.H1_TO_24H, AnalyticsEvent.Trade.StallBucket.fromMillis(24 * hourMs - 1))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.D1_TO_3D, AnalyticsEvent.Trade.StallBucket.fromMillis(24 * hourMs))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.D1_TO_3D, AnalyticsEvent.Trade.StallBucket.fromMillis(3 * 24 * hourMs - 1))
+        assertEquals(AnalyticsEvent.Trade.StallBucket.OVER_3D, AnalyticsEvent.Trade.StallBucket.fromMillis(3 * 24 * hourMs))
+    }
+
+    @Test
     fun `all event objects are singletons not data classes with payload`() {
         // Privacy contract: events MUST NOT carry free-form payload. Sealed
         // class structure makes this hard to violate, but a future contributor

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/ChipUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/ChipUiTest.kt
@@ -1,0 +1,84 @@
+package network.bisq.mobile.presentation.common.ui.components.atoms
+
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+
+/**
+ * UI tests for [BisqChip], focused on the survey-chip additions: the selected state, the
+ * Compact size, and the removable trailing icon being truly absent (not a dead slot) when
+ * `showRemove` is off.
+ */
+class ChipUiTest : BisqComposeUiTestBase() {
+    private val label = "Price moved"
+
+    @Test
+    fun `when chip tapped then invokes onClick with label`() {
+        val onClick = mockk<(String) -> Unit>(relaxed = true)
+
+        setTestContent {
+            // No remove icon: with it shown, a center tap can land on the trailing IconButton
+            // instead of the chip surface — the survey chips render exactly this shape.
+            BisqChip(label = label, showRemove = false, onClick = onClick)
+        }
+
+        composeTestRule.onNodeWithText(label).performClick()
+
+        verify(exactly = 1) { onClick(label) }
+    }
+
+    @Test
+    fun `when remove shown and tapped then invokes onRemove with label`() {
+        val onRemove = mockk<(String) -> Unit>(relaxed = true)
+
+        setTestContent {
+            BisqChip(label = label, showRemove = true, onRemove = onRemove)
+        }
+
+        composeTestRule.onNodeWithContentDescription("close").performClick()
+
+        verify(exactly = 1) { onRemove(label) }
+    }
+
+    @Test
+    fun `when remove hidden then close icon is absent`() {
+        setTestContent {
+            BisqChip(label = label, showRemove = false)
+        }
+
+        composeTestRule.onNodeWithText(label).assertExists()
+        composeTestRule.onNodeWithContentDescription("close").assertDoesNotExist()
+    }
+
+    @Test
+    fun `when compact selected default chip then renders label`() {
+        setTestContent {
+            BisqChip(
+                label = label,
+                showRemove = false,
+                selected = true,
+                size = BisqChipSize.Compact,
+            )
+        }
+
+        composeTestRule.onNodeWithText(label).assertExists()
+    }
+
+    @Test
+    fun `when outline selected chip then renders label`() {
+        setTestContent {
+            BisqChip(
+                label = label,
+                showRemove = false,
+                selected = true,
+                type = BisqChipType.Outline,
+            )
+        }
+
+        composeTestRule.onNodeWithText(label).assertExists()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialogUiTest.kt
@@ -1,0 +1,41 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules.dialog
+
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+import kotlin.test.assertNotEquals
+
+/** UI test for [ConfirmationDialog]'s vertical button placement with both buttons present. */
+class ConfirmationDialogUiTest : BisqComposeUiTestBase() {
+    @Test
+    fun `when vertical placement with both buttons then both render and confirm fires`() {
+        val onConfirm = mockk<() -> Unit>(relaxed = true)
+        val onDismiss = mockk<(Boolean) -> Unit>(relaxed = true)
+
+        setTestContent {
+            ConfirmationDialog(
+                headline = "Vertical",
+                message = "Stacked buttons",
+                confirmButtonText = "Yes",
+                dismissButtonText = "No",
+                verticalButtonPlacement = true,
+                onConfirm = onConfirm,
+                onDismiss = onDismiss,
+            )
+        }
+
+        // Actually stacked, not side by side: in the horizontal Row both buttons share a top edge.
+        val yesTop = composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").getUnclippedBoundsInRoot().top
+        val noTop = composeTestRule.onNodeWithContentDescription("dialog_confirm_no").getUnclippedBoundsInRoot().top
+        assertNotEquals(yesTop, noTop)
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+
+        verify(exactly = 1) { onConfirm() }
+        verify(exactly = 0) { onDismiss(any()) }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/trades/CancelTradeDialogUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/trades/CancelTradeDialogUiTest.kt
@@ -1,0 +1,175 @@
+package network.bisq.mobile.presentation.common.ui.components.organisms.trades
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade.InterruptReason
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+
+/**
+ * UI tests for [CancelTradeDialog]: warning copy per rejection/buyer/seller variant, the
+ * analytics-gated reason chips (hidden unless opted in), and that the confirm callback
+ * forwards the selected [InterruptReason] — falling back to UNSPECIFIED when none is picked.
+ */
+class CancelTradeDialogUiTest : BisqComposeUiTestBase() {
+    private val reasonPrompt get() = "mobile.tradeInterrupt.reasonPrompt".i18n()
+    private val priceMovedLabel get() = "mobile.tradeInterrupt.reason.priceMoved".i18n()
+
+    @Test
+    fun `when rejection then shows reject warning and hides reason prompt by default`() {
+        val onConfirm = mockk<(InterruptReason) -> Unit>(relaxed = true)
+
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = onConfirm,
+                onDismiss = {},
+                isRejection = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText("bisqEasy.openTrades.rejectTrade.warning".i18n()).assertExists()
+        composeTestRule.onNodeWithText(reasonPrompt).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when buyer cancels then shows buyer warning`() {
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = {},
+                onDismiss = {},
+                isRejection = false,
+                isBuyer = true,
+            )
+        }
+
+        val part2 = "bisqEasy.openTrades.cancelTrade.warning.part2".i18n()
+        composeTestRule
+            .onNodeWithText("bisqEasy.openTrades.cancelTrade.warning.buyer".i18n(part2))
+            .assertExists()
+    }
+
+    @Test
+    fun `when seller cancels then shows seller warning`() {
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = {},
+                onDismiss = {},
+                isRejection = false,
+                isBuyer = false,
+            )
+        }
+
+        val part2 = "bisqEasy.openTrades.cancelTrade.warning.part2".i18n()
+        composeTestRule
+            .onNodeWithText("bisqEasy.openTrades.cancelTrade.warning.seller".i18n(part2))
+            .assertExists()
+    }
+
+    @Test
+    fun `when reason chips shown then lists every reason except unspecified`() {
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = {},
+                onDismiss = {},
+                isRejection = false,
+                showReasonChips = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText(reasonPrompt).assertExists()
+        composeTestRule.onNodeWithText("mobile.tradeInterrupt.reason.peerUnresponsive".i18n()).assertExists()
+        composeTestRule.onNodeWithText(priceMovedLabel).assertExists()
+        composeTestRule.onNodeWithText("mobile.tradeInterrupt.reason.paymentMethodIssue".i18n()).assertExists()
+        composeTestRule.onNodeWithText("mobile.tradeInterrupt.reason.noProgress".i18n()).assertExists()
+        composeTestRule.onNodeWithText("mobile.tradeInterrupt.reason.changedMind".i18n()).assertExists()
+        composeTestRule.onNodeWithText("mobile.tradeInterrupt.reason.other".i18n()).assertExists()
+        // Chips are the dialog's only selectable nodes: exactly six guards against an
+        // empty-labeled UNSPECIFIED chip sneaking past the per-label asserts above.
+        composeTestRule.onAllNodes(isSelectable()).assertCountEquals(6)
+    }
+
+    @Test
+    fun `when no reason selected and confirmed then forwards unspecified`() {
+        val onConfirm = mockk<(InterruptReason) -> Unit>(relaxed = true)
+
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = onConfirm,
+                onDismiss = {},
+                isRejection = false,
+                showReasonChips = true,
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+
+        verify(exactly = 1) { onConfirm(InterruptReason.UNSPECIFIED) }
+    }
+
+    @Test
+    fun `when reason selected and confirmed then forwards that reason`() {
+        val onConfirm = mockk<(InterruptReason) -> Unit>(relaxed = true)
+
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = onConfirm,
+                onDismiss = {},
+                isRejection = false,
+                showReasonChips = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText(priceMovedLabel).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+
+        verify(exactly = 1) { onConfirm(InterruptReason.PRICE_MOVED) }
+    }
+
+    @Test
+    fun `when selected reason tapped again then deselects and confirm falls back to unspecified`() {
+        val onConfirm = mockk<(InterruptReason) -> Unit>(relaxed = true)
+
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = onConfirm,
+                onDismiss = {},
+                isRejection = false,
+                showReasonChips = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText(priceMovedLabel).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(priceMovedLabel).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+
+        verify(exactly = 1) { onConfirm(InterruptReason.UNSPECIFIED) }
+    }
+
+    @Test
+    fun `when dismiss tapped then calls onDismiss and never confirms`() {
+        val onConfirm = mockk<(InterruptReason) -> Unit>(relaxed = true)
+        val onDismiss = mockk<() -> Unit>(relaxed = true)
+
+        setTestContent {
+            CancelTradeDialog(
+                onCancelConfirm = onConfirm,
+                onDismiss = onDismiss,
+                isRejection = false,
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_no").performClick()
+
+        verify(exactly = 1) { onDismiss() }
+        verify(exactly = 0) { onConfirm(any()) }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -29,6 +29,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.core.pagination.PaginatedResponse
 import network.bisq.mobile.domain.core.pagination.PaginationParams
 import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
@@ -122,9 +123,9 @@ class CreateOfferPricePresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun selectOpenTrade(tradeId: String) {}
 
-        override suspend fun rejectTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
-        override suspend fun cancelTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
         override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -37,6 +37,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.core.pagination.PaginatedResponse
 import network.bisq.mobile.domain.core.pagination.PaginationParams
 import network.bisq.mobile.domain.formatters.PriceQuoteFormatter
@@ -135,9 +136,9 @@ class CreateOfferReviewPresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun selectOpenTrade(tradeId: String) {}
 
-        override suspend fun rejectTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
-        override suspend fun cancelTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
         override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -34,6 +34,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.core.pagination.PaginatedResponse
 import network.bisq.mobile.domain.core.pagination.PaginationParams
 import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
@@ -87,9 +88,9 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun selectOpenTrade(tradeId: String) {}
 
-        override suspend fun rejectTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
-        override suspend fun cancelTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
         override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -31,6 +31,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.UrlLauncher
 import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.core.pagination.PaginatedResponse
 import network.bisq.mobile.domain.core.pagination.PaginationParams
 import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
@@ -115,9 +116,9 @@ class TakeOfferCoordinatorTest {
 
         override fun selectOpenTrade(tradeId: String) {}
 
-        override suspend fun rejectTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
-        override suspend fun cancelTrade(): Result<Unit> = Result.success(Unit)
+        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
 
         override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTest.kt
@@ -14,6 +14,7 @@ import network.bisq.mobile.data.service.mediation.MediationServiceFacade
 import network.bisq.mobile.data.service.offers.MediatorNotAvailableException
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
@@ -214,6 +215,45 @@ class TradeDetailsHeaderPresenterTest : PresentationKoinTestBase() {
             advanceUntilIdle()
 
             coVerify { tradesServiceFacade.cancelTrade() }
+        }
+
+    @Test
+    fun `when interrupt trade in reject state then forwards selected reason to reject trade`() =
+        runTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = true)
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            coEvery { tradesServiceFacade.rejectTrade(any()) } returns Result.success(Unit)
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onInterruptTrade(AnalyticsEvent.Trade.InterruptReason.PRICE_MOVED)
+            advanceUntilIdle()
+
+            coVerify { tradesServiceFacade.rejectTrade(AnalyticsEvent.Trade.InterruptReason.PRICE_MOVED) }
+            coVerify(exactly = 0) { tradesServiceFacade.cancelTrade(any()) }
+        }
+
+    @Test
+    fun `when interrupt trade in cancel state then forwards selected reason to cancel trade`() =
+        runTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = true)
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            coEvery { tradesServiceFacade.cancelTrade(any()) } returns Result.success(Unit)
+
+            val presenter = createPresenter()
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            harness.tradeStateFlow.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            advanceUntilIdle()
+
+            presenter.onInterruptTrade(AnalyticsEvent.Trade.InterruptReason.PRICE_MOVED)
+            advanceUntilIdle()
+
+            coVerify { tradesServiceFacade.cancelTrade(AnalyticsEvent.Trade.InterruptReason.PRICE_MOVED) }
+            coVerify(exactly = 0) { tradesServiceFacade.rejectTrade(any()) }
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTest.kt
@@ -19,6 +19,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import java.util.Locale
 import kotlin.test.Test
@@ -60,12 +61,13 @@ class TradeDetailsHeaderPresenterTest : PresentationKoinTestBase() {
         }
     }
 
-    private fun createPresenter(): TradeDetailsHeaderPresenter =
+    private fun createPresenter(settingsRepository: SettingsRepositoryMock = SettingsRepositoryMock()): TradeDetailsHeaderPresenter =
         TradeDetailsHeaderPresenter(
             mainPresenter,
             tradesServiceFacade,
             mediationServiceFacade,
             userProfileServiceFacade,
+            settingsRepository,
         )
 
     @Test
@@ -79,6 +81,29 @@ class TradeDetailsHeaderPresenterTest : PresentationKoinTestBase() {
             advanceUntilIdle()
 
             assertEquals(DirectionEnum.SELL, presenter.directionEnum)
+        }
+
+    @Test
+    fun `isAnalyticsEnabled mirrors the persisted opt-in and gates the interrupt-reason chips`() =
+        runTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            val settingsRepository = SettingsRepositoryMock()
+
+            val presenter = createPresenter(settingsRepository)
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Default is opted-out — the chips must never show unless proven otherwise.
+            assertEquals(false, presenter.isAnalyticsEnabled.value)
+
+            settingsRepository.setAnalyticsEnabled(true)
+            advanceUntilIdle()
+            assertEquals(true, presenter.isAnalyticsEnabled.value)
+
+            settingsRepository.setAnalyticsEnabled(false)
+            advanceUntilIdle()
+            assertEquals(false, presenter.isAnalyticsEnabled.value)
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTradeStateParameterizedTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenterTradeStateParameterizedTest.kt
@@ -14,6 +14,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -75,6 +76,7 @@ class TradeDetailsHeaderPresenterTradeStateParameterizedTest(
             tradesServiceFacade,
             mediationServiceFacade,
             userProfileServiceFacade,
+            SettingsRepositoryMock(),
         )
 
     @Test

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -207,7 +207,7 @@ val presentationModule =
         // Trade history dependencies
         factory { GetPaginatedClosedTradesUseCase(get()) }
         factory { ClosedTradeListPresenter(get(), get(), get(), get()) }
-        factory { TradeDetailsHeaderPresenter(get(), get(), get(), get()) }
+        factory { TradeDetailsHeaderPresenter(get(), get(), get(), get(), get()) }
         factory { InterruptedTradePresenter(get(), get(), get(), get()) }
         factory { TradeFlowPresenter(get(), get(), get()) }
         factory { OpenTradePresenter(get(), get(), get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Chip.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/Chip.kt
@@ -19,14 +19,21 @@ enum class BisqChipType {
     Outline,
 }
 
+enum class BisqChipSize {
+    Default,
+    Compact,
+}
+
 @Composable
 fun BisqChip(
     modifier: Modifier = Modifier,
     label: String = "",
     showRemove: Boolean = true,
+    selected: Boolean = false,
     onClick: ((String) -> Unit)? = null,
     onRemove: ((String) -> Unit)? = null,
     type: BisqChipType = BisqChipType.Default,
+    size: BisqChipSize = BisqChipSize.Default,
 ) {
     val chipColors =
         if (type == BisqChipType.Outline) {
@@ -51,10 +58,12 @@ fun BisqChip(
                 labelColor = BisqTheme.colors.light_grey10,
                 leadingIconColor = BisqTheme.colors.light_grey10,
                 trailingIconColor = BisqTheme.colors.light_grey10,
-                selectedLabelColor = BisqTheme.colors.light_grey10,
+                // Selected must be unmistakable: `secondary` (#2C2C2C) vs the unselected
+                // `dark_grey40` (#2B2B2B) is imperceptible — use the green-tinted pair instead.
+                selectedLabelColor = BisqTheme.colors.primary,
                 selectedLeadingIconColor = BisqTheme.colors.primary,
                 selectedTrailingIconColor = BisqTheme.colors.primary,
-                selectedContainerColor = BisqTheme.colors.secondary,
+                selectedContainerColor = BisqTheme.colors.primary2,
                 disabledContainerColor = BisqTheme.colors.secondary,
                 disabledLabelColor = BisqTheme.colors.light_grey10.copy(alpha = 0.4f),
                 disabledLeadingIconColor = BisqTheme.colors.primary.copy(alpha = 0.4f),
@@ -67,17 +76,28 @@ fun BisqChip(
         onClick = {
             onClick?.invoke(label)
         },
-        label = { BisqText.BaseLight(label, modifier = Modifier.padding(vertical = BisqUIConstants.ScreenPadding)) },
-        selected = false,
-        trailingIcon = {
-            if (showRemove) {
-                IconButton(
-                    onClick = { onRemove?.invoke(label) },
-                ) {
-                    CloseIcon(modifier = Modifier.size(InputChipDefaults.AvatarSize))
-                }
+        label = {
+            when (size) {
+                BisqChipSize.Default ->
+                    BisqText.BaseLight(label, modifier = Modifier.padding(vertical = BisqUIConstants.ScreenPadding))
+                BisqChipSize.Compact -> BisqText.SmallLight(label)
             }
         },
+        selected = selected,
+        // null, not a no-op lambda: InputChip reserves the trailing-icon slot width whenever the
+        // param is non-null, so a conditional no-op still costs every chip dead trailing space.
+        trailingIcon =
+            if (showRemove) {
+                {
+                    IconButton(
+                        onClick = { onRemove?.invoke(label) },
+                    ) {
+                        CloseIcon(modifier = Modifier.size(InputChipDefaults.AvatarSize))
+                    }
+                }
+            } else {
+                null
+            },
         modifier = modifier,
         colors = chipColors,
         border =
@@ -86,10 +106,16 @@ fun BisqChip(
                     borderColor = BisqTheme.colors.primary,
                     selectedBorderColor = BisqTheme.colors.primary,
                     enabled = true,
-                    selected = false,
+                    selected = selected,
                 )
             } else {
-                null
+                // Transparent when unselected (not null) so selecting never changes the chip's size.
+                InputChipDefaults.inputChipBorder(
+                    borderColor = Color.Transparent,
+                    selectedBorderColor = BisqTheme.colors.primary,
+                    enabled = true,
+                    selected = selected,
+                )
             },
         shape = RoundedCornerShape(BisqUIConstants.BorderRadius),
     )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/BisqDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/BisqDialog.kt
@@ -26,6 +26,9 @@ fun BisqDialog(
     padding: Dp = BisqUIConstants.ScreenPadding2X,
     marginTop: Dp = BisqUIConstants.ScreenPadding8X,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    // Pinned below the scrollable [content] — action buttons go here so long copy scrolls
+    // behind them instead of pushing them off-screen.
+    stickyBottomContent: (@Composable ColumnScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     Dialog(
@@ -44,13 +47,21 @@ fun BisqDialog(
             shape = RoundedCornerShape(BisqUIConstants.BorderRadius),
         ) {
             Column(
-                modifier =
-                    Modifier
-                        .padding(padding)
-                        .verticalScroll(rememberScrollState()),
+                modifier = Modifier.padding(padding),
                 horizontalAlignment = horizontalAlignment,
             ) {
-                content()
+                Column(
+                    // fill = false keeps short dialogs wrapped; on overflow only this part scrolls,
+                    // so the sticky content below always stays on screen.
+                    modifier =
+                        Modifier
+                            .weight(1f, fill = false)
+                            .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = horizontalAlignment,
+                ) {
+                    content()
+                }
+                stickyBottomContent?.invoke(this)
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/ConfirmationDialog.kt
@@ -51,6 +51,19 @@ fun ConfirmationDialog(
         horizontalAlignment = horizontalAlignment,
         marginTop = marginTop,
         onDismissRequest = { onDismiss(false) },
+        // Buttons are pinned below the scrollable copy — on long dialogs the text scrolls
+        // behind them instead of pushing OK/Cancel off-screen.
+        stickyBottomContent = {
+            ConfirmationDialogButtons(
+                confirmButtonText = confirmButtonText,
+                dismissButtonText = dismissButtonText,
+                confirmButtonLoading = confirmButtonLoading,
+                dismissButtonLoading = dismissButtonLoading,
+                verticalButtonPlacement = verticalButtonPlacement,
+                onConfirm = onConfirm,
+                onDismiss = onDismiss,
+            )
+        },
     ) {
         if (headline.isNotEmpty()) {
             if (headlineLeftIcon == null && !closeButton) {
@@ -79,65 +92,77 @@ fun ConfirmationDialog(
         if (extraContent != null) {
             BisqGap.V1()
         }
-        if (verticalButtonPlacement) {
-            Column {
-                if (confirmButtonText.isNotBlank()) {
-                    BisqButton(
-                        text = confirmButtonText,
-                        onClick = onConfirm,
-                        fullWidth = true,
-                        isLoading = confirmButtonLoading,
-                        disabled = dismissButtonLoading,
-                        modifier = Modifier.semantics { contentDescription = "dialog_confirm_yes" },
-                    )
-                }
-                if (confirmButtonText.isNotBlank() && dismissButtonText.isNotBlank()) {
-                    BisqGap.VHalf()
-                }
-                if (dismissButtonText.isNotBlank()) {
-                    BisqButton(
-                        text = dismissButtonText,
-                        type = BisqButtonType.Grey,
-                        onClick = { onDismiss(true) },
-                        fullWidth = true,
-                        isLoading = dismissButtonLoading,
-                        disabled = confirmButtonLoading,
-                        modifier = Modifier.semantics { contentDescription = "dialog_confirm_no" },
-                    )
-                }
+    }
+}
+
+@Composable
+private fun ConfirmationDialogButtons(
+    confirmButtonText: String,
+    dismissButtonText: String,
+    confirmButtonLoading: Boolean,
+    dismissButtonLoading: Boolean,
+    verticalButtonPlacement: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: (Boolean) -> Unit,
+) {
+    if (verticalButtonPlacement) {
+        Column {
+            if (confirmButtonText.isNotBlank()) {
+                BisqButton(
+                    text = confirmButtonText,
+                    onClick = onConfirm,
+                    fullWidth = true,
+                    isLoading = confirmButtonLoading,
+                    disabled = dismissButtonLoading,
+                    modifier = Modifier.semantics { contentDescription = "dialog_confirm_yes" },
+                )
             }
-        } else {
-            Row(
-                modifier = Modifier.height(IntrinsicSize.Max),
-                horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
-            ) {
-                if (confirmButtonText.isNotBlank()) {
-                    BisqButton(
-                        modifier =
-                            Modifier
-                                .weight(1.0F)
-                                .fillMaxHeight()
-                                .semantics { contentDescription = "dialog_confirm_yes" },
-                        text = confirmButtonText,
-                        isLoading = confirmButtonLoading,
-                        disabled = dismissButtonLoading,
-                        onClick = onConfirm,
-                    )
-                }
-                if (dismissButtonText.isNotBlank()) {
-                    BisqButton(
-                        modifier =
-                            Modifier
-                                .weight(1.0F)
-                                .fillMaxHeight()
-                                .semantics { contentDescription = "dialog_confirm_no" },
-                        text = dismissButtonText,
-                        type = BisqButtonType.Grey,
-                        isLoading = dismissButtonLoading,
-                        disabled = confirmButtonLoading,
-                        onClick = { onDismiss(true) },
-                    )
-                }
+            if (confirmButtonText.isNotBlank() && dismissButtonText.isNotBlank()) {
+                BisqGap.VHalf()
+            }
+            if (dismissButtonText.isNotBlank()) {
+                BisqButton(
+                    text = dismissButtonText,
+                    type = BisqButtonType.Grey,
+                    onClick = { onDismiss(true) },
+                    fullWidth = true,
+                    isLoading = dismissButtonLoading,
+                    disabled = confirmButtonLoading,
+                    modifier = Modifier.semantics { contentDescription = "dialog_confirm_no" },
+                )
+            }
+        }
+    } else {
+        Row(
+            modifier = Modifier.height(IntrinsicSize.Max),
+            horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+        ) {
+            if (confirmButtonText.isNotBlank()) {
+                BisqButton(
+                    modifier =
+                        Modifier
+                            .weight(1.0F)
+                            .fillMaxHeight()
+                            .semantics { contentDescription = "dialog_confirm_yes" },
+                    text = confirmButtonText,
+                    isLoading = confirmButtonLoading,
+                    disabled = dismissButtonLoading,
+                    onClick = onConfirm,
+                )
+            }
+            if (dismissButtonText.isNotBlank()) {
+                BisqButton(
+                    modifier =
+                        Modifier
+                            .weight(1.0F)
+                            .fillMaxHeight()
+                            .semantics { contentDescription = "dialog_confirm_no" },
+                    text = dismissButtonText,
+                    type = BisqButtonType.Grey,
+                    isLoading = dismissButtonLoading,
+                    disabled = confirmButtonLoading,
+                    onClick = { onDismiss(true) },
+                )
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WarningConfirmationDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/dialog/WarningConfirmationDialog.kt
@@ -20,6 +20,7 @@ fun WarningConfirmationDialog(
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalButtonPlacement: Boolean = false,
     dismissOnClickOutside: Boolean = true,
+    extraContent: (@Composable () -> Unit)? = null,
 ) {
     ConfirmationDialog(
         headline = headline,
@@ -34,5 +35,6 @@ fun WarningConfirmationDialog(
         horizontalAlignment = horizontalAlignment,
         verticalButtonPlacement = verticalButtonPlacement,
         dismissOnClickOutside = dismissOnClickOutside,
+        extraContent = extraContent,
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/trades/CancelTradeDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/trades/CancelTradeDialog.kt
@@ -1,17 +1,36 @@
 package network.bisq.mobile.presentation.common.ui.components.organisms.trades
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade.InterruptReason
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqChip
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqChipSize
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.WarningConfirmationDialog
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
 @Composable
 fun CancelTradeDialog(
-    onCancelConfirm: () -> Unit,
+    onCancelConfirm: (InterruptReason) -> Unit,
     onDismiss: () -> Unit,
     isRejection: Boolean,
     isBuyer: Boolean = true,
+    // Chips feed the opt-in analytics, so they only show for opted-in users — asking "why?"
+    // when the answer goes nowhere would be dishonest. Default false: never show unless proven.
+    showReasonChips: Boolean = false,
 ) {
     val part2: String = "bisqEasy.openTrades.cancelTrade.warning.part2".i18n()
     val warningText1 =
@@ -25,6 +44,9 @@ fun CancelTradeDialog(
             }
         }
 
+    // Optional, single-tap, skippable — feeds the opt-in trade-funnel analytics only (#1711).
+    var selectedReason by remember { mutableStateOf<InterruptReason?>(null) }
+
     WarningConfirmationDialog(
         message = warningText1,
         horizontalAlignment = Alignment.Start,
@@ -35,6 +57,64 @@ fun CancelTradeDialog(
                 BisqUIConstants.ScreenPaddingHalf
             },
         onDismiss = onDismiss,
-        onConfirm = onCancelConfirm,
+        onConfirm = { onCancelConfirm(selectedReason ?: InterruptReason.UNSPECIFIED) },
+        extraContent =
+            if (showReasonChips) {
+                {
+                    InterruptReasonChips(
+                        selectedReason = selectedReason,
+                        onReasonClick = { reason ->
+                            selectedReason = if (selectedReason == reason) null else reason
+                        },
+                    )
+                }
+            } else {
+                null
+            },
     )
 }
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun InterruptReasonChips(
+    selectedReason: InterruptReason?,
+    onReasonClick: (InterruptReason) -> Unit,
+) {
+    Column {
+        // Divider marks the survey as a separate, optional section — not part of the warning copy.
+        BisqHDivider(verticalPadding = 0.dp)
+        BisqGap.VHalf()
+        BisqText.SmallLight(
+            "mobile.tradeInterrupt.reasonPrompt".i18n(),
+            color = BisqTheme.colors.mid_grey20,
+        )
+        BisqGap.VHalf()
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+        ) {
+            InterruptReason.entries
+                .filterNot { it == InterruptReason.UNSPECIFIED }
+                .forEach { reason ->
+                    BisqChip(
+                        label = reason.label(),
+                        selected = reason == selectedReason,
+                        showRemove = false,
+                        size = BisqChipSize.Compact,
+                        onClick = { onReasonClick(reason) },
+                    )
+                }
+        }
+    }
+}
+
+private fun InterruptReason.label(): String =
+    when (this) {
+        InterruptReason.PEER_UNRESPONSIVE -> "mobile.tradeInterrupt.reason.peerUnresponsive".i18n()
+        InterruptReason.PRICE_MOVED -> "mobile.tradeInterrupt.reason.priceMoved".i18n()
+        InterruptReason.PAYMENT_METHOD_ISSUE -> "mobile.tradeInterrupt.reason.paymentMethodIssue".i18n()
+        InterruptReason.NO_PROGRESS -> "mobile.tradeInterrupt.reason.noProgress".i18n()
+        InterruptReason.CHANGED_MIND -> "mobile.tradeInterrupt.reason.changedMind".i18n()
+        InterruptReason.OTHER -> "mobile.tradeInterrupt.reason.other".i18n()
+        InterruptReason.UNSPECIFIED -> ""
+    }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
@@ -71,6 +71,7 @@ fun OpenTradeScreen(tradeId: String) {
     val isInMediation by presenter.isInMediation.collectAsState()
     val tradeCloseType by headerPresenter.tradeCloseType.collectAsState()
     val showInterruptionConfirmationDialog by headerPresenter.showInterruptionConfirmationDialog.collectAsState()
+    val isAnalyticsEnabled by headerPresenter.isAnalyticsEnabled.collectAsState()
     val showMediationConfirmationDialog by headerPresenter.showMediationConfirmationDialog.collectAsState()
     val showTradeNotFoundDialog by presenter.showTradeNotFoundDialog.collectAsState()
     val mediationError by headerPresenter.mediationError.collectAsState()
@@ -220,10 +221,11 @@ fun OpenTradeScreen(tradeId: String) {
 
     if (showInterruptionConfirmationDialog) {
         CancelTradeDialog(
-            onCancelConfirm = { headerPresenter.onInterruptTrade() },
+            onCancelConfirm = { reason -> headerPresenter.onInterruptTrade(reason) },
             onDismiss = { headerPresenter.onCloseInterruptionConfirmationDialog() },
             isBuyer = headerPresenter.directionEnum.isBuy,
             isRejection = tradeCloseType == TradeDetailsHeaderPresenter.TradeCloseType.REJECT,
+            showReasonChips = isAnalyticsEnabled,
         )
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeDetailsHeaderPresenter.kt
@@ -20,7 +20,9 @@ import network.bisq.mobile.data.service.offers.MediatorNotAvailableException
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.formatters.TradeDurationFormatter
+import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
@@ -33,6 +35,7 @@ class TradeDetailsHeaderPresenter(
     var tradesServiceFacade: TradesServiceFacade,
     var mediationServiceFacade: MediationServiceFacade,
     val userProfileServiceFacade: UserProfileServiceFacade,
+    private val settingsRepository: SettingsRepository,
 ) : BasePresenter(mainPresenter) {
     enum class TradeCloseType {
         REJECT,
@@ -74,6 +77,11 @@ class TradeDetailsHeaderPresenter(
     private val _isInterruptTradeEnabled = MutableStateFlow(true)
     val isInterruptTradeEnabled: StateFlow<Boolean> = _isInterruptTradeEnabled.asStateFlow()
 
+    // Gates the interrupt-reason chips: asking "why?" when the answer feeds analytics the user
+    // declined would be dishonest. Defaults to false — never show until proven opted-in.
+    private val _isAnalyticsEnabled = MutableStateFlow(false)
+    val isAnalyticsEnabled: StateFlow<Boolean> = _isAnalyticsEnabled.asStateFlow()
+
     private val _isOpenMediationEnabled = MutableStateFlow(true)
     val isOpenMediationEnabled: StateFlow<Boolean> = _isOpenMediationEnabled.asStateFlow()
 
@@ -81,6 +89,12 @@ class TradeDetailsHeaderPresenter(
 
     override fun onViewAttached() {
         super.onViewAttached()
+
+        presenterScope.launch {
+            settingsRepository.data.collect { settings ->
+                _isAnalyticsEnabled.value = settings.analyticsEnabled
+            }
+        }
 
         presenterScope.launch {
             combine(
@@ -320,7 +334,7 @@ class TradeDetailsHeaderPresenter(
         _showInterruptionConfirmationDialog.value = false
     }
 
-    fun onInterruptTrade() {
+    fun onInterruptTrade(reason: AnalyticsEvent.Trade.InterruptReason = AnalyticsEvent.Trade.InterruptReason.UNSPECIFIED) {
         _showInterruptionConfirmationDialog.value = false
         if (selectedTrade.value == null) {
             return
@@ -329,7 +343,7 @@ class TradeDetailsHeaderPresenter(
             when (tradeCloseType.value) {
                 TradeCloseType.REJECT -> {
                     tradesServiceFacade
-                        .rejectTrade()
+                        .rejectTrade(reason)
                         .onFailure { exception ->
                             handleError(exception)
                         }
@@ -337,7 +351,7 @@ class TradeDetailsHeaderPresenter(
 
                 TradeCloseType.CANCEL -> {
                     tradesServiceFacade
-                        .cancelTrade()
+                        .cancelTrade(reason)
                         .onFailure { exception ->
                             handleError(exception)
                         }


### PR DESCRIPTION
 - resolves #1711 
 - added new reasons for interruption of trade analytics
 - bind analytics calls into trade funnel
 - added ui reason prompt to share when cancel/reject trade only visible if the user is opted in to analytics
 - stalled metrics are in-memory only for now. A persisted version follow up will be done if this is proven to be not enough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade cancellation and rejection dialogs can offer selectable reasons, including payment issues, stalled trades, price changes, and changed plans.
  * Trade interruption analytics now record the selected reason and cancellation delay category when analytics is enabled.
  * Dialog actions remain visible while longer content scrolls.
  * Added compact and selected states for chips, with improved visual feedback.

* **Bug Fixes**
  * Trade interruption behavior now respects the user’s analytics preference.
  * Cancellation timing is captured before trade state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->