### PR TITLE
chore/include_start9_in_automated_release_action

### DIFF
--- a/.github/workflows/release-umbrel-images.yml
+++ b/.github/workflows/release-umbrel-images.yml
@@ -77,10 +77,21 @@ on:
 permissions:
   contents: read
 
+# One release run per ref, SERIALIZED (cancel-in-progress deliberately false): cancelling could
+# kill a run after its external writes began (images pushed, fork fast-forwarded, store PR not yet
+# opened) — and the cancelling run is no guaranteed redo, since an unrelated libs.versions.toml
+# push resolves should_build=false and exits without doing anything, leaving the release half-done.
+# Queued runs wait instead; GitHub keeps the newest pending run per group, so the latest version
+# still lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Decide whether to build, and resolve the version + bisq2 commit from the version catalog.
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       should_build: ${{ steps.r.outputs.should_build }}
       version: ${{ steps.r.outputs.version }}
@@ -140,6 +151,8 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.should_build == 'true'
     runs-on: ubuntu-latest
+    # Generous: the arm64 half runs under QEMU emulation (see SPEED note at the bottom).
+    timeout-minutes: 240
     # packages:write scoped to only the job that publishes images (resolve/update-store stay read-only).
     permissions:
       contents: read
@@ -149,8 +162,10 @@ jobs:
       web_digest: ${{ steps.web.outputs.digest }}
     steps:
       - name: Validate config
+        env:
+          NS: ${{ vars.GHCR_NAMESPACE }}
         run: |
-          [ -n "${{ vars.GHCR_NAMESPACE }}" ] \
+          [ -n "$NS" ] \
             || { echo "::error::repo variable GHCR_NAMESPACE not set"; exit 1; }
 
       - name: Checkout bisq2 @ pinned commit
@@ -232,6 +247,7 @@ jobs:
     needs: [resolve, build-and-push]
     if: github.event_name == 'push' || inputs.update_store
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false # a community failure must not cancel the official PR, and vice versa
       matrix:
@@ -292,6 +308,14 @@ jobs:
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
+          # Digests must be present and well-formed BEFORE any rewrite: with an empty digest the
+          # sed below writes `...:VERSION@` and the post-pin grep guards still match (empty suffix),
+          # silently shipping a store PR with a malformed image ref.
+          for name in NODE_DIGEST WEB_DIGEST; do
+            eval "value=\${$name:-}"
+            printf '%s' "$value" | grep -qE '^sha256:[0-9a-f]{64}$' \
+              || { echo "::error::$name is missing or malformed ('$value') — did the image build/push produce a digest?"; exit 1; }
+          done
           cd store
           git config user.name "bisq-mobile-ci"
           git config user.email "ci@bisq.network"

--- a/release-umbrel-images.yml
+++ b/release-umbrel-images.yml
@@ -1,0 +1,592 @@
+name: Release Umbrel images
+
+# Builds + pushes the dockerised Bisq 2 trusted-node images for the Umbrel app, then opens a PR to
+# each configured Umbrel store repo pinning the new image digests:
+#   - bisq2-api          (the headless node)
+#   - bisq2-api-web-ui   (the QR/status web sidecar)
+#
+# DECOUPLED FROM bisq2's RELEASE CADENCE: the node image only needs bisq2 SOURCE at a specific
+# commit. This workflow lives in THIS repo (which we maintain), reads the commit + version we pin
+# in gradle/libs.versions.toml, and builds from there. bisq2 is touched only for rare Dockerfile
+# changes, never for a release.
+#
+# VERSIONING — single source of truth = gradle/libs.versions.toml. The Umbrel image is the bisq2
+# api-app (the trusted node), so it tracks the API pin, NOT bisq-core (which the mobile nodeApp
+# embeds — a separate deployment that can pin a different commit):
+#   bisq-api             -> "2.1.11"          (the bisq2 api version; changes when bisq2 releases)
+#   bisq-api-commit      -> "<hash>"          (the bisq2 source built into the image)
+#   umbrel-image-version -> "2.1.11.1-rc3"    (scheme <bisq2-api>.<umbrel-build>[-rcN])
+# To cut a release: edit `umbrel-image-version`, PR to main, merge -> this fires, builds, and opens
+# a store PR (per channel) you merge to publish.
+#
+# TWO STORE CHANNELS (fanned out by the update-store matrix, each independent + optional):
+#   community  our own store (default branch `main`) — the fast-lane fork main gives an INSTANT test/RC
+#              store users can add manually; good for smoke-testing a build before it hits everyone.
+#   official   getumbrel/umbrel-apps (default branch `master`) — the DEFAULT Umbrel App Store, reviewed
+#              by Umbrel maintainers. No fast-lane (users get it via the store once the PR merges).
+# A channel SKIPS ITSELF if its repo/fork Variables are unset, so `official` stays dormant until you
+# configure UMBREL_OFFICIAL_REPO/FORK — no failed runs in the meantime.
+#
+# CONFIG (repo Variables + Secrets):
+#   Variable  GHCR_NAMESPACE        images are pushed here, e.g. ghcr.io/bisq-network
+#   Variable  UMBREL_STORE_REPO     COMMUNITY store = PR TARGET, e.g. bisq-network/bisq2-umbrel (pull-only)
+#   Variable  UMBREL_STORE_FORK     our community fork = PUSH HEAD, e.g. rodvar/bisq2-umbrel-fork (we own it)
+#   Variable  UMBREL_OFFICIAL_REPO  OFFICIAL store = PR TARGET, e.g. getumbrel/umbrel-apps (optional; pull-only)
+#   Variable  UMBREL_OFFICIAL_FORK  our official fork = PUSH HEAD, e.g. rodvar/umbrel-apps (optional; we own it)
+#   Secret    GHCR_USERNAME         GHCR user (also the fork owner for the store push/PR)
+#   Secret    GHCR_TOKEN            ONE classic PAT used by all jobs — needs scopes:
+#                                     * write:packages  -> push images to GHCR_NAMESPACE
+#                                     * public_repo     -> push branch(+main) to the fork(s) and open the
+#                                                          cross-repo PR to each store (all public; else `repo`)
+#                                   The PAT owner must own BOTH forks (community + official).
+#
+# STORE ACCESS MODEL: we have pull-only on both stores, so per channel update-store bases a release branch
+# on the store's CURRENT default branch (so any manifest fields the maintainers curated are preserved —
+# we only rewrite version, releaseNotes, and the two image digests), pushes it to OUR fork, and opens a
+# cross-repo PR a maintainer merges to publish. For community it ALSO fast-forwards the fork's default
+# branch so the fork doubles as an instant community store for local testing. Retarget/handoff is entirely
+# via the Variables above — no code change.
+#
+# STARTOS CHANNEL (update-startos job): the same node image also ships to StartOS. The 0.4-SDK package
+# (community-maintained at Start9-Community/bisq2-startos, mirrored at bisq-network/bisq2-startos)
+# consumes ghcr.io/bisq-network/bisq2-api UNMODIFIED via a dockerTag pin, so a release is a two-file
+# TS edit: `dockerTag` in startos/manifest/index.ts + `version`/`releaseNotes` in
+# startos/versions/current.ts (StartOS version scheme = `<image tag>:0`; the `:N` packaging revision
+# is only ever bumped by hand in the package repo). Same fork-PR model, fanned out to both repos:
+#   Variable  STARTOS_REPO         Start9 community package repo = PR TARGET, e.g. Start9-Community/bisq2-startos
+#   Variable  STARTOS_MIRROR_REPO  our org mirror = PR TARGET, e.g. bisq-network/bisq2-startos
+#   Variable  STARTOS_FORK         PUSH HEAD for both (same fork network), e.g. rodvar/bisq2-startos-fork
+# Each target skips itself while its Variable is unset. Merging the Start9-Community PR is the publish
+# gate: their CI tags + builds + signs the s9pk and pushes it to their registry on merge — nothing else
+# to trigger. Generated releaseNotes are fixed translated boilerplate (5 locales); edit the PR by hand
+# when a release deserves richer notes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Override version (blank = use umbrel-image-version from libs.versions.toml)"
+        required: false
+        default: ""
+        type: string
+      platforms:
+        description: "Target platforms"
+        required: true
+        default: "linux/amd64,linux/arm64"
+        type: string
+      update_store:
+        description: "Also open store PRs pinning the new images (push events always do this)"
+        required: false
+        default: false
+        type: boolean
+      release_notes:
+        description: "Release notes for the store manifest (blank = generated default)"
+        required: false
+        default: ""
+        type: string
+  push:
+    branches: [main]
+    paths: [gradle/libs.versions.toml]
+
+permissions:
+  contents: read
+
+jobs:
+  # Decide whether to build, and resolve the version + bisq2 commit from the version catalog.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.r.outputs.should_build }}
+      version: ${{ steps.r.outputs.version }}
+      bisq2_ref: ${{ steps.r.outputs.bisq2_ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so github.event.before is reachable for the version-change check
+          persist-credentials: false # read-only checkout; don't leave the token in .git/config
+
+      - id: r
+        env:
+          OVERRIDE: ${{ inputs.version }}
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          read_v() { grep -E "^$1 " gradle/libs.versions.toml | sed -E 's/.*"([^"]+)".*/\1/'; }
+
+          version="${OVERRIDE:-}"
+          [ -n "$version" ] || version="$(read_v umbrel-image-version)"
+          bisq_api="$(read_v bisq-api)"
+          bisq2_ref="$(read_v bisq-api-commit)"
+          [ -n "$version" ]   || { echo "::error::umbrel-image-version not found in libs.versions.toml"; exit 1; }
+          [ -n "$bisq2_ref" ] || { echo "::error::bisq-api-commit not found in libs.versions.toml"; exit 1; }
+
+          # Drift guard: the version's api part must match bisq-api.
+          api_part="$(echo "$version" | cut -d. -f1-3)"
+          if [ "$api_part" != "$bisq_api" ]; then
+            echo "::error::version '$version' api part ($api_part) != bisq-api ($bisq_api) — keep them in sync"
+            exit 1
+          fi
+
+          # Build on manual dispatch always; on push only if the version line actually changed
+          # (libs.versions.toml also changes for unrelated dependency bumps).
+          should_build=true
+          if [ "$EVENT" = "push" ]; then
+            # Compare against the state BEFORE the whole push (github.event.before), not HEAD^ — a
+            # multi-commit / rebase push could carry the version bump in an earlier commit. An empty
+            # or unreachable BEFORE (new branch / zeros) yields "" and falls through to a build.
+            before="$(git show "${BEFORE}:gradle/libs.versions.toml" 2>/dev/null | grep -E '^umbrel-image-version ' || true)"
+            after="$(grep -E '^umbrel-image-version ' gradle/libs.versions.toml || true)"
+            if [ "$before" = "$after" ]; then
+              should_build=false
+              echo "::notice::umbrel-image-version unchanged in this push — skipping build"
+            fi
+          fi
+
+          {
+            echo "version=$version"
+            echo "bisq2_ref=$bisq2_ref"
+            echo "should_build=$should_build"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::version=$version bisq2_ref=$bisq2_ref should_build=$should_build"
+
+  build-and-push:
+    needs: resolve
+    if: needs.resolve.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    # packages:write scoped to only the job that publishes images (resolve/update-store stay read-only).
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      node_digest: ${{ steps.node.outputs.digest }}
+      web_digest: ${{ steps.web.outputs.digest }}
+    steps:
+      - name: Validate config
+        run: |
+          [ -n "${{ vars.GHCR_NAMESPACE }}" ] \
+            || { echo "::error::repo variable GHCR_NAMESPACE not set"; exit 1; }
+
+      - name: Checkout bisq2 @ pinned commit
+        uses: actions/checkout@v4
+        with:
+          repository: bisq-network/bisq2
+          ref: ${{ needs.resolve.outputs.bisq2_ref }}
+          path: bisq2
+          fetch-depth: 1
+          persist-credentials: false # read-only source checkout used as a docker context; no token in .git
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      # The node Dockerfile builds the api-app from source (./gradlew installDist, ~<1min) and
+      # its build context MUST be the bisq2 repo root (it does `COPY . .`).
+      - name: Build & push node image
+        id: node
+        uses: docker/build-push-action@v6
+        with:
+          context: bisq2
+          file: bisq2/apps/api-app/docker/Dockerfile
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: true
+          tags: ${{ vars.GHCR_NAMESPACE }}/bisq2-api:${{ needs.resolve.outputs.version }}
+          provenance: false
+
+      - name: Build & push web-UI sidecar image
+        id: web
+        uses: docker/build-push-action@v6
+        with:
+          context: bisq2/apps/api-app/docker/qr-ui
+          file: bisq2/apps/api-app/docker/qr-ui/Dockerfile
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: true
+          build-args: |
+            APP_VERSION=${{ needs.resolve.outputs.version }}
+          tags: ${{ vars.GHCR_NAMESPACE }}/bisq2-api-web-ui:${{ needs.resolve.outputs.version }}
+          provenance: false
+
+      - name: Summary — pushed images
+        # Values come in via env (not ${{ }} interpolation into the script): version derives from
+        # libs.versions.toml / a dispatch input, and this workflow fires on pushes touching that
+        # file — raw interpolation into a run script is a script-injection surface on a runner
+        # that holds the GHCR PAT in its docker login state. Matches the env style of every other
+        # step in this file.
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          BISQ2_REF: ${{ needs.resolve.outputs.bisq2_ref }}
+          PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          NS: ${{ vars.GHCR_NAMESPACE }}
+          NODE_DIGEST: ${{ steps.node.outputs.digest }}
+          WEB_DIGEST: ${{ steps.web.outputs.digest }}
+        run: |
+          {
+            echo "## Bisq 2 Umbrel images — \`${VERSION}\`"
+            echo "Built bisq2 @ \`${BISQ2_REF}\` for \`${PLATFORMS}\`."
+            echo "- ${NS}/bisq2-api:${VERSION}@${NODE_DIGEST}"
+            echo "- ${NS}/bisq2-api-web-ui:${VERSION}@${WEB_DIGEST}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Digest-pin the freshly-built images into each configured store + bump the manifest version & notes.
+  # Fans out over both channels (community + official); each is independent (fail-fast: false) and skips
+  # itself if its repo/fork Variables are unset. We have pull-only access, so per channel we base a
+  # release branch on the store's CURRENT default branch (preserving maintainer-curated fields), push it
+  # to OUR fork, and open a cross-repo PR a maintainer merges to publish. Community also fast-lanes the
+  # fork's default branch (= instant test store). Runs on a real version bump (push); manual if opted in.
+  update-store:
+    needs: [resolve, build-and-push]
+    if: github.event_name == 'push' || inputs.update_store
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # a community failure must not cancel the official PR, and vice versa
+      matrix:
+        channel: [community, official]
+    steps:
+      - name: Resolve channel target (repo / fork / base branch / fast-lane)
+        id: target
+        env:
+          CHANNEL: ${{ matrix.channel }}
+          COMMUNITY_REPO: ${{ vars.UMBREL_STORE_REPO }}
+          COMMUNITY_FORK: ${{ vars.UMBREL_STORE_FORK }}
+          OFFICIAL_REPO: ${{ vars.UMBREL_OFFICIAL_REPO }}
+          OFFICIAL_FORK: ${{ vars.UMBREL_OFFICIAL_FORK }}
+        run: |
+          set -euo pipefail
+          case "$CHANNEL" in
+            community) REPO="$COMMUNITY_REPO"; FORK="$COMMUNITY_FORK"; BASE="main";   FAST=true  ;;
+            official)  REPO="$OFFICIAL_REPO";  FORK="$OFFICIAL_FORK";  BASE="master"; FAST=false ;;
+            *) echo "::error::unknown channel '$CHANNEL'"; exit 1 ;;
+          esac
+          # A channel with unset repo/fork Variables is simply not configured yet — skip it (not a failure)
+          # so `official` stays dormant until UMBREL_OFFICIAL_REPO/FORK are added.
+          if [ -z "$REPO" ] || [ -z "$FORK" ]; then
+            echo "::notice::channel '$CHANNEL' not configured (repo/fork Variables unset) — skipping"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "enabled=true"
+            echo "repo=$REPO"
+            echo "fork=$FORK"
+            echo "base=$BASE"
+            echo "fast=$FAST"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::channel=$CHANNEL repo=$REPO fork=$FORK base=$BASE fast=$FAST"
+
+      - name: Checkout our fork
+        if: steps.target.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.target.outputs.fork }}
+          token: ${{ secrets.GHCR_TOKEN }} # classic PAT: public_repo covers fork push + cross-repo PR
+          persist-credentials: true # keep the token in store/.git/config for the later `git push` to origin
+          path: store
+          fetch-depth: 0 # need real history to branch off the store's default branch and push non-shallow
+
+      - name: Pin digests + bump version & release notes on a branch off the store's default branch
+        id: pin
+        if: steps.target.outputs.enabled == 'true'
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          BISQ2_REF: ${{ needs.resolve.outputs.bisq2_ref }}
+          NS: ${{ vars.GHCR_NAMESPACE }}
+          NODE_DIGEST: ${{ needs.build-and-push.outputs.node_digest }}
+          WEB_DIGEST: ${{ needs.build-and-push.outputs.web_digest }}
+          UPSTREAM: ${{ steps.target.outputs.repo }}
+          BASE: ${{ steps.target.outputs.base }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          cd store
+          git config user.name "bisq-mobile-ci"
+          git config user.email "ci@bisq.network"
+          # Base on the store's CURRENT default branch (not the fork's, which may be stale) so the PR
+          # always diffs cleanly against upstream and preserves any fields the maintainers curated.
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch upstream "$BASE"
+          branch="release/bisq2-node-${VERSION}"
+          git checkout -B "$branch" "upstream/${BASE}"
+          cd bisq2-node
+
+          # Release notes: workflow_dispatch override if given, else generated from the ACTUAL source
+          # delta. The previous release's bisq2 commit is recovered from the store's CURRENT manifest
+          # (we embed "bisq2 @ <hash>" in every generated note precisely so the next run can diff
+          # against it) — must be read BEFORE the python block below rewrites the file. Fallbacks:
+          # no prior hash recorded -> compare against the released api tag; same source -> say so
+          # instead of linking an empty compare.
+          API_PART="$(echo "$VERSION" | cut -d. -f1-3)"
+          SHORT="$(echo "$BISQ2_REF" | cut -c1-7)"
+          NOTES="${RELEASE_NOTES:-}"
+          if [ -z "$NOTES" ]; then
+            PREV_REF="$(grep -oE 'bisq2 @ [0-9a-f]{7,40}' umbrel-app.yml | head -1 | awk '{print $3}' || true)"
+            if [ -n "$PREV_REF" ] && [ "${BISQ2_REF#"$PREV_REF"}" = "$BISQ2_REF" ]; then
+              NOTES="Maintenance update with the latest Bisq 2 upstream fixes and improvements (Bisq 2 API ${API_PART}, bisq2 @ ${SHORT}). Full changes: https://github.com/bisq-network/bisq2/compare/${PREV_REF}...${SHORT}"
+            elif [ -n "$PREV_REF" ]; then
+              NOTES="Packaging update — no Bisq 2 source changes (Bisq 2 API ${API_PART}, bisq2 @ ${SHORT})."
+            else
+              NOTES="Update to Bisq 2 API ${API_PART} (bisq2 @ ${SHORT}). Full changes: https://github.com/bisq-network/bisq2/compare/v${API_PART}...${SHORT}"
+            fi
+          fi
+
+          # Set version + releaseNotes in umbrel-app.yml via Python (not sed) so it handles BOTH the
+          # official store's single-line `releaseNotes: ""` and our community store's `releaseNotes: >-`
+          # folded block, and so arbitrary note text needs no shell/sed escaping (passed via env). Only
+          # these two keys are rewritten; every other line (and the digest lines below) is left untouched.
+          NOTES="$NOTES" VERSION="$VERSION" python3 - <<'PY'
+          import os, json, re
+          version = os.environ["VERSION"]
+          notes = " ".join(os.environ["NOTES"].split())  # collapse any newlines -> single line
+          path = "umbrel-app.yml"
+          src = open(path).read().split("\n")
+          out, i = [], 0
+          def indent(s): return len(s) - len(s.lstrip(" "))
+          while i < len(src):
+              line = src[i]
+              if re.match(r'^version:\s', line):
+                  out.append('version: ' + json.dumps(version, ensure_ascii=False)); i += 1; continue
+              m = re.match(r'^(\s*)releaseNotes:\s*(.*)$', line)
+              if m:
+                  key_indent, val = len(m.group(1)), m.group(2).strip()
+                  out.append(m.group(1) + 'releaseNotes: ' + json.dumps(notes, ensure_ascii=False)); i += 1
+                  if val[:1] in ('|', '>'):  # folded/literal block -> drop its continuation lines
+                      while i < len(src) and (src[i].strip() == '' or indent(src[i]) > key_indent):
+                          i += 1
+                  continue
+              out.append(line); i += 1
+          open(path, "w").write("\n".join(out))
+          print("umbrel-app.yml: version=%s notes=%r" % (version, notes))
+          PY
+
+          # Namespace-AGNOSTIC pin rewritten to ${NS}:<version>@<digest> — Umbrel's lint-apps.mjs
+          # REQUIRES both a tag and a digest on every image ref (a digest-only pin fails their CI),
+          # and the tag also keeps the ref human-readable. The first bisq-network release also
+          # migrates the namespace (e.g. rodvar -> bisq-network).
+          # web-ui first (more specific); the node regex requires /bisq2-api immediately followed by :/@,
+          # so it never matches the longer -web-ui line.
+          sed -i -E "s#(image: )[^[:space:]]+/bisq2-api-web-ui[:@][^[:space:]]*#\1${NS}/bisq2-api-web-ui:${VERSION}@${WEB_DIGEST}#" docker-compose.yml
+          sed -i -E "s#(image: )[^[:space:]]+/bisq2-api[:@][^[:space:]]*#\1${NS}/bisq2-api:${VERSION}@${NODE_DIGEST}#" docker-compose.yml
+          # Fail loudly if a pin didn't take (compose format drift / renamed image): sed -i exits 0 even
+          # on no match, which would silently ship a store PR that doesn't actually pin the new images.
+          grep -qF "/bisq2-api-web-ui:${VERSION}@${WEB_DIGEST}" docker-compose.yml \
+            || { echo "::error::web-ui image not pinned to ${VERSION}@${WEB_DIGEST} — no matching image line?"; exit 1; }
+          grep -qF "/bisq2-api:${VERSION}@${NODE_DIGEST}" docker-compose.yml \
+            || { echo "::error::node image not pinned to ${VERSION}@${NODE_DIGEST} — no matching image line?"; exit 1; }
+          echo "resulting refs:"; grep -E '^\s*image:' docker-compose.yml
+          cd ..
+          # Idempotent: a re-run of an already-published version yields no diff — skip the commit (and,
+          # via the step output, the push/PR below) instead of failing on "nothing to commit".
+          if git diff --quiet; then
+            echo "::notice::store already at ${VERSION} with these digests — nothing to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -am "Release Bisq 2 Node ${VERSION} (pin images, bump version + notes)"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push to fork (branch + optional fast-lane) and open cross-repo PR
+        if: steps.target.outputs.enabled == 'true' && steps.pin.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          UPSTREAM: ${{ steps.target.outputs.repo }}
+          FORK: ${{ steps.target.outputs.fork }}
+          BASE: ${{ steps.target.outputs.base }}
+          FAST: ${{ steps.target.outputs.fast }}
+          CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -euo pipefail
+          cd store
+          branch="release/bisq2-node-${VERSION}"
+          fork_owner="${FORK%%/*}"
+          git push -f -u origin "$branch"
+          # Fast-lane (community only): fork's default branch := store default + this release, so the fork
+          # URL is an instant community store for testing on Umbrel without waiting on a maintainer merge.
+          # Guarded off when the channel disables it (official) or if FORK==UPSTREAM (would bypass review).
+          if [ "$FAST" = "true" ] && [ "$FORK" != "$UPSTREAM" ]; then
+            git push -f origin "$branch":"$BASE"
+          else
+            echo "::notice::fast-lane off for channel '$CHANNEL' (or FORK==UPSTREAM) — skipping default-branch push"
+          fi
+          # Open the cross-repo PR; treat ONLY the duplicate-PR case as a notice and fail on real
+          # errors (auth/permission/API) instead of masking them as success.
+          if out="$(gh pr create --repo "$UPSTREAM" --base "$BASE" --head "${fork_owner}:${branch}" \
+              --title "Release Bisq 2 Node ${VERSION}" \
+              --body "Automated by the Release Umbrel images workflow (channel: ${CHANNEL}), opened from fork \`${FORK}\` (we have pull-only access to \`${UPSTREAM}\`). Digest-pins the freshly-built images and bumps the manifest version to \`${VERSION}\`. Merge to publish." 2>&1)"; then
+            echo "$out"
+          elif printf '%s' "$out" | grep -qi "already exists"; then
+            echo "::notice::PR already exists for ${fork_owner}:${branch}"
+          else
+            echo "::error::gh pr create failed: $out"; exit 1
+          fi
+
+  # Bump the StartOS package to the freshly-pushed node image in each configured package repo.
+  # Same fork-PR model as update-store, but the "pin" is a two-file TypeScript edit (dockerTag +
+  # version/releaseNotes) instead of compose digests — the package consumes the GHCR image unmodified.
+  # Fans out over the Start9 community package repo and our org mirror; each target skips itself while
+  # its repo Variable is unset. Merging the Start9-Community PR IS the publish step: their CI tags,
+  # builds, signs and ships the s9pk to their registry on push to main.
+  update-startos:
+    needs: [resolve, build-and-push]
+    if: github.event_name == 'push' || inputs.update_store
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # the mirror lagging (or unset) must not cancel the Start9 PR, and vice versa
+      matrix:
+        target: [startos, startos-mirror]
+    steps:
+      - name: Resolve target (repo / fork / branch name)
+        id: target
+        env:
+          TARGET: ${{ matrix.target }}
+          STARTOS_REPO: ${{ vars.STARTOS_REPO }}
+          STARTOS_MIRROR_REPO: ${{ vars.STARTOS_MIRROR_REPO }}
+          FORK: ${{ vars.STARTOS_FORK }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          case "$TARGET" in
+            startos)        REPO="$STARTOS_REPO" ;;
+            startos-mirror) REPO="$STARTOS_MIRROR_REPO" ;;
+            *) echo "::error::unknown target '$TARGET'"; exit 1 ;;
+          esac
+          # An unset target is simply not configured yet — skip it (not a failure), same pattern as
+          # the umbrel channels above.
+          if [ -z "$REPO" ] || [ -z "$FORK" ]; then
+            echo "::notice::target '$TARGET' not configured (repo/fork Variables unset) — skipping"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "enabled=true"
+            echo "repo=$REPO"
+            echo "fork=$FORK"
+            # Both targets push to the SAME fork, so the branch name carries the target.
+            echo "branch=release/${TARGET}-${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::target=$TARGET repo=$REPO fork=$FORK"
+
+      - name: Checkout our fork
+        if: steps.target.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.target.outputs.fork }}
+          token: ${{ secrets.GHCR_TOKEN }} # classic PAT: public_repo covers fork push + cross-repo PR
+          persist-credentials: true # keep the token in pkg/.git/config for the later `git push` to origin
+          path: pkg
+          fetch-depth: 0 # need real history to branch off the target's default branch and push non-shallow
+
+      - name: Pin image tag + bump version & releaseNotes on a branch off the target's default branch
+        id: pin
+        if: steps.target.outputs.enabled == 'true'
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          NS: ${{ vars.GHCR_NAMESPACE }}
+          UPSTREAM: ${{ steps.target.outputs.repo }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          set -euo pipefail
+          cd pkg
+          git config user.name "bisq-mobile-ci"
+          git config user.email "ci@bisq.network"
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch upstream main
+          git checkout -B "$BRANCH" upstream/main
+
+          # Hard requirement: the 0.4-SDK layout. The mirror keeps its Variable unset until the 0.4
+          # sync has merged, so hitting this means format drift, not a half-migrated mirror.
+          [ -f startos/manifest/index.ts ] && [ -f startos/versions/current.ts ] \
+            || { echo "::error::${UPSTREAM} lacks the startos/ 0.4 layout — cannot pin"; exit 1; }
+
+          sed -i -E "s#(dockerTag: ')[^']+(')#\1${NS}/bisq2-api:${VERSION}\2#" startos/manifest/index.ts
+          grep -qF "dockerTag: '${NS}/bisq2-api:${VERSION}'" startos/manifest/index.ts \
+            || { echo "::error::dockerTag not pinned to ${VERSION} — manifest format drift?"; exit 1; }
+
+          # StartOS version = '<image tag>:0' (the :N packaging revision restarts at 0 on every image
+          # bump; mid-cycle :N bumps are hand-made in the package repo and never produced here).
+          # releaseNotes are regenerated as fixed translated boilerplate in the package's five locales —
+          # arbitrary text can't be machine-translated in CI, so richer notes are edited into the PR by
+          # hand before merge.
+          VERSION="$VERSION" python3 - <<'PY'
+          import json, os, re
+          version = os.environ["VERSION"]
+          url = "https://github.com/bisq-network/bisq2/releases"
+          notes = {
+              "en_US": f"Updates the node to Bisq 2 API {version} with the latest upstream fixes and improvements. Full changes: {url}",
+              "es_ES": f"Actualiza el nodo a la API {version} de Bisq 2 con las últimas correcciones y mejoras. Cambios completos: {url}",
+              "de_DE": f"Aktualisiert den Knoten auf die Bisq-2-API {version} mit den neuesten Fehlerbehebungen und Verbesserungen. Alle Änderungen: {url}",
+              "pl_PL": f"Aktualizuje węzeł do API Bisq 2 {version} z najnowszymi poprawkami i ulepszeniami. Pełna lista zmian: {url}",
+              "fr_FR": f"Met à jour le nœud vers l'API Bisq 2 {version} avec les derniers correctifs et améliorations. Liste complète des changements : {url}",
+          }
+          path = "startos/versions/current.ts"
+          src = open(path).read()
+          src, n = re.subn(r"(\n  version: ')[^']+(',)", lambda m: m.group(1) + version + ":0" + m.group(2), src, count=1)
+          assert n == 1, "version line not found in current.ts"
+          # json.dumps yields a double-quoted TS-valid string literal, so apostrophes need no escaping.
+          block = "  releaseNotes: {\n" + "".join(
+              f"    {loc}:\n      {json.dumps(text, ensure_ascii=False)},\n" for loc, text in notes.items()
+          ) + "  },"
+          src, n = re.subn(r"  releaseNotes: \{.*?\n  \},", lambda m: block, src, count=1, flags=re.S)
+          assert n == 1, "releaseNotes block not found in current.ts"
+          open(path, "w").write(src)
+          print(f"current.ts: version={version}:0, releaseNotes regenerated ({len(notes)} locales)")
+          PY
+
+          # Idempotent: re-running an already-pinned version yields no diff — skip commit/push/PR.
+          if git diff --quiet; then
+            echo "::notice::${UPSTREAM} already at ${VERSION} — nothing to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -am "Update Bisq 2 Node to bisq2-api ${VERSION}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push to fork and open cross-repo PR
+        if: steps.target.outputs.enabled == 'true' && steps.pin.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          UPSTREAM: ${{ steps.target.outputs.repo }}
+          FORK: ${{ steps.target.outputs.fork }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          cd pkg
+          fork_owner="${FORK%%/*}"
+          git push -f -u origin "$BRANCH"
+          publish_note="Merging publishes: this repo's CI tags, builds, signs and ships the s9pk to the registry."
+          [ "$TARGET" = "startos-mirror" ] && publish_note="Mirror sync only — the registry release is driven by the Start9-Community repo."
+          if out="$(gh pr create --repo "$UPSTREAM" --base main --head "${fork_owner}:${BRANCH}" \
+              --title "Update Bisq 2 Node to bisq2-api ${VERSION}" \
+              --body "Automated by the bisq-mobile release workflow, opened from fork \`${FORK}\` (we have pull-only access to \`${UPSTREAM}\`). Pins \`dockerTag\` to the freshly-built multi-arch \`bisq2-api:${VERSION}\` image and bumps the package version to \`${VERSION}:0\` per UPDATING.md. Release notes are generated boilerplate — edit before merge if this release deserves specifics. ${publish_note}" 2>&1)"; then
+            echo "$out"
+          elif printf '%s' "$out" | grep -qi "already exists"; then
+            echo "::notice::PR already exists for ${fork_owner}:${BRANCH}"
+          else
+            echo "::error::gh pr create failed: $out"; exit 1
+          fi
+
+# ── Notes ─────────────────────────────────────────────────────────────────────────────────────
+# - Retarget/handoff is entirely via Variables (no code change): GHCR_NAMESPACE (image registry ns),
+#   UMBREL_STORE_REPO/FORK (community channel), UMBREL_OFFICIAL_REPO/FORK (official channel),
+#   STARTOS_REPO / STARTOS_MIRROR_REPO / STARTOS_FORK (StartOS package repos).
+# - Each channel is optional + independent (matrix, fail-fast: false): an unset channel is skipped with a
+#   notice, and one channel failing does not cancel the other.
+# - If we ever get write on a store: point that channel's *_FORK at its *_REPO — the branch push +
+#   (same-repo) PR still work; the fast-lane push is GUARDED off (FORK==UPSTREAM) so review isn't bypassed.
+# - The community fork's default branch is force-updated each release (it is a throwaway contribution fork,
+#   not a source of truth); its only jobs are being the PR head and an instant test store. The official
+#   fork is NOT fast-laned, so its default branch is left alone.
+# - Release notes: pass `release_notes` on a manual run to set the store manifest note; otherwise a default
+#   is generated from the version + bisq2 commit. Edit the opened PR if you want richer notes before merge.
+# - SPEED: if emulated arm64 gets slow, split into a matrix of native runners (ubuntu-latest +
+#   ubuntu-24.04-arm), build per-arch by digest, then merge with `docker buildx imagetools create`.


### PR DESCRIPTION
 - contribs to #1639 
 - added on release umbrel also the release update for startos to make its updates automatable as well
 - used the same kind of workflow, with precise notes on how it works and what is needed for it to succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated multi-platform image builds and publishing for Umbrel node and web interface images.
  * Added automatic version, image digest, and release note updates across configured Umbrel and StartOS package repositories.
  * Added automated pull request creation for distributing releases.
* **Reliability**
  * Added validation, drift detection, digest verification, duplicate handling, execution time limits, and failure reporting for safer, more consistent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->