### PR TITLE
fix: un-ignore AndroidMemoryReportServiceTest

### DIFF
--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/AndroidMemoryReportServiceTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/AndroidMemoryReportServiceTest.kt
@@ -4,55 +4,66 @@ import android.app.ActivityManager
 import android.os.Debug
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import network.bisq.mobile.node.common.test_utils.TestApplication
+import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@Ignore("JDK mismatch compilation issues to be addressed")
+@Config(application = TestApplication::class)
+@RunWith(RobolectricTestRunner::class)
 class AndroidMemoryReportServiceTest {
     private lateinit var memoryReportService: AndroidMemoryReportService
     private val activityManager = mockk<ActivityManager>(relaxed = true)
+    private val deviceMemInfo = ActivityManager.MemoryInfo()
+    private val appMemInfo = mockk<Debug.MemoryInfo>(relaxed = true)
 
     @Before
     fun setUp() {
-        val deviceMemInfo = ActivityManager.MemoryInfo()
-        val appMemInfo = Debug.MemoryInfo()
-        val runtime = mockk<Runtime>(relaxed = true)
-        every { runtime.totalMemory() } returns 256L * 1024L * 1024L
-        every { runtime.freeMemory() } returns 128L * 1024L * 1024L
-        every { runtime.maxMemory() } returns 512L * 1024L * 1024L
-        memoryReportService = AndroidMemoryReportService(activityManager, deviceMemInfo, appMemInfo, runtime, true)
+        mockkStatic(Debug::class)
+        every { Debug.getMemoryInfo(any()) } returns Unit
+        every { appMemInfo.totalPss } returns 512 * 1024 // 512 MB in KB
+        every { Debug.getNativeHeapAllocatedSize() } returns 64L * 1024L * 1024L
+        every { Debug.getNativeHeapFreeSize() } returns 32L * 1024L * 1024L
+        every { activityManager.getMemoryInfo(any()) } answers {
+            firstArg<ActivityManager.MemoryInfo>().apply {
+                totalMem = 1024L * 1024L * 1024L // 1 GB
+                availMem = 512L * 1024L * 1024L // 512 MB free
+            }
+        }
+        memoryReportService =
+            AndroidMemoryReportService(
+                activityManager,
+                deviceMemInfo,
+                appMemInfo,
+                Runtime.getRuntime(),
+                true,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Debug::class)
     }
 
     @Test
     fun `logReport should log memory usage without crashing`() {
-        val memoryInfo = mockk<ActivityManager.MemoryInfo>()
-        every { activityManager.getMemoryInfo(any()) } answers {
-            firstArg<ActivityManager.MemoryInfo>().apply {
-                totalMem = 1024L * 1024L * 1024L // 1 GB
-                availMem = 512L * 1024L * 1024L // 512 MB free
-            }
-        }
-
         memoryReportService.logReport()
 
         verify { activityManager.getMemoryInfo(any()) }
+        verify { Debug.getMemoryInfo(any()) }
     }
 
     @Test
     fun `getUsedMemoryInBytes should return correct used memory`() {
-        val memoryInfo = mockk<ActivityManager.MemoryInfo>()
-        every { activityManager.getMemoryInfo(any()) } answers {
-            firstArg<ActivityManager.MemoryInfo>().apply {
-                totalMem = 1024L * 1024L * 1024L // 1 GB
-                availMem = 512L * 1024L * 1024L // 512 MB free
-            }
-        }
-
         val usedMemory = memoryReportService.getUsedMemoryInBytes()
 
         assertEquals(512L * 1024L * 1024L, usedMemory) // 512 MB used in bytes
@@ -60,13 +71,6 @@ class AndroidMemoryReportServiceTest {
 
     @Test
     fun `getUsedMemoryInMB should return correct used memory in MB`() {
-        every { activityManager.getMemoryInfo(any()) } answers {
-            firstArg<ActivityManager.MemoryInfo>().apply {
-                totalMem = 1024L * 1024L * 1024L // 1 GB
-                availMem = 512L * 1024L * 1024L // 512 MB free
-            }
-        }
-
         val usedMemoryMB = memoryReportService.getUsedMemoryInMB()
 
         assertEquals(512L, usedMemoryMB) // 512 MB used
@@ -74,12 +78,6 @@ class AndroidMemoryReportServiceTest {
 
     @Test
     fun `getFreeMemoryInMB should return correct free memory in MB`() {
-        every { activityManager.getMemoryInfo(any()) } answers {
-            firstArg<ActivityManager.MemoryInfo>().apply {
-                availMem = 512L * 1024L * 1024L // 512 MB free
-            }
-        }
-
         val freeMemoryMB = memoryReportService.getFreeMemoryInMB()
 
         assertEquals(512L, freeMemoryMB) // 512 MB free
@@ -87,12 +85,6 @@ class AndroidMemoryReportServiceTest {
 
     @Test
     fun `getTotalMemoryInMB should return correct total memory in MB`() {
-        every { activityManager.getMemoryInfo(any()) } answers {
-            firstArg<ActivityManager.MemoryInfo>().apply {
-                totalMem = 1024L * 1024L * 1024L // 1 GB
-            }
-        }
-
         val totalMemoryMB = memoryReportService.getTotalMemoryInMB()
 
         assertEquals(1024L, totalMemoryMB) // 1024 MB total

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/AndroidMemoryReportServiceTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/utils/AndroidMemoryReportServiceTest.kt
@@ -51,6 +51,7 @@ class AndroidMemoryReportServiceTest {
 
     @After
     fun tearDown() {
+        memoryReportService.shutdown()
         unmockkStatic(Debug::class)
     }
 


### PR DESCRIPTION
 - Removes the `@Ignore` on AndroidMemoryReportServiceTest - the failure was mocking of `java.lang.Runtime` on JDK 21.
 - Using Robolectric + TestApplication + real Runtime.getRuntime() and stubbing only specific functions fixes the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled Android memory reporting tests to run reliably in the test environment.
  * Added coverage for native heap, application memory usage, total device memory, and available memory values.
  * Improved verification of memory-related system calls and test cleanup.
  * Strengthened test isolation and consistency by standardizing shared fixtures and restoring mocked system behavior after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->