### PR TITLE
Release/anode 0.11.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.10.1
+node.android.version=0.11.0
 
 client.name=Bisq Connect
 client.android.version=0.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.11.0
+node.android.version=0.11.1
 
 client.name=Bisq Connect
 client.android.version=0.8.1
@@ -44,7 +44,7 @@ client.ios.version=0.8.1
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=48
 client.android.version.code=30
-node.android.version.code=48
+node.android.version.code=49
 
 # Logging
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # -------------------- Project Specific --------------------
 bisq-core = "2.1.11"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "dc1431e4d8063b23f1c3371388ca32577954735f"
+bisq-core-commit = "7c981af404b783488fa01d23a51d78b72ca1cb94"
 
 
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing


### PR DESCRIPTION
 - contribs to #1709 
 - updated metadata and bump versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android node to version 0.11.1.
  * Incremented the Android node version code.
  * Updated the bundled Bisq Core revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->