### PR TITLE
test: migrate client/node tests to leaf bases

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/test_utils/ClientKoinIntegrationTestBase.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/test_utils/ClientKoinIntegrationTestBase.kt
@@ -4,23 +4,7 @@ import network.bisq.mobile.client.common.di.clientTestModule
 import network.bisq.mobile.test.koin.KoinIntegrationTestBase
 import org.koin.core.module.Module
 
-/**
- * Leaf base for client-app tests that require the full [clientTestModule] Koin graph.
- *
- * Use for client facades, services, and presenters — not for `:shared:presentation`
- * presenter tests (use `PresentationKoinTestBase` there).
- *
- * ```kotlin
- * class MyIntegrationTest : ClientKoinIntegrationTestBase() {
- *     override fun additionalModules(): List<Module> = listOf(
- *         module { single<MyDependency> { mockk(relaxed = true) } }
- *     )
- *
- *     @Test
- *     fun `my test`() = runTest { /* ... */ }
- * }
- * ```
- */
+/** Leaf base for client facades, services, and presenters ([clientTestModule] floor). */
 abstract class ClientKoinIntegrationTestBase : KoinIntegrationTestBase() {
     override fun baseModules(): List<Module> = listOf(clientTestModule)
 }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/main/ClientMainPresenterTest.kt
@@ -7,17 +7,12 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import network.bisq.mobile.client.common.di.clientTestModule
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.model.TradeReadStateMap
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
@@ -35,11 +30,8 @@ import network.bisq.mobile.domain.repository.TradeReadStateRepository
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
-import network.bisq.mobile.presentation.common.ui.platform.getScreenWidthDp
-import org.junit.After
-import org.junit.Before
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import network.bisq.mobile.test.presentation.coroutines.PlatformStaticMocks
+import org.koin.core.module.Module
 import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -47,39 +39,42 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ClientMainPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ClientMainPresenterTest : ClientKoinIntegrationTestBase() {
+    private val connectivityService: ClientConnectivityService = mockk(relaxed = true)
+    private val networkServiceFacade: NetworkServiceFacade = mockk(relaxed = true)
+    private val settingsServiceFacade: SettingsServiceFacade = mockk(relaxed = true)
+    private val tradesServiceFacade: TradesServiceFacade = mockk(relaxed = true)
+    private val userProfileServiceFacade: UserProfileServiceFacade = mockk(relaxed = true)
+    private val openTradesNotificationService: OpenTradesNotificationService = mockk(relaxed = true)
+    private val tradeReadStateRepository: TradeReadStateRepository = mockk(relaxed = true)
+    private val applicationLifecycleService: ApplicationLifecycleService = mockk(relaxed = true)
+    private val urlLauncher: UrlLauncher = mockk(relaxed = true)
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
 
-    private lateinit var connectivityService: ClientConnectivityService
-    private lateinit var networkServiceFacade: NetworkServiceFacade
-    private lateinit var settingsServiceFacade: SettingsServiceFacade
-    private lateinit var tradesServiceFacade: TradesServiceFacade
-    private lateinit var userProfileServiceFacade: UserProfileServiceFacade
-    private lateinit var openTradesNotificationService: OpenTradesNotificationService
-    private lateinit var tradeReadStateRepository: TradeReadStateRepository
-    private lateinit var applicationLifecycleService: ApplicationLifecycleService
-    private lateinit var urlLauncher: UrlLauncher
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<ClientConnectivityService> { connectivityService }
+                single<NetworkServiceFacade> { networkServiceFacade }
+                single<SettingsServiceFacade> { settingsServiceFacade }
+                single<TradesServiceFacade> { tradesServiceFacade }
+                single<UserProfileServiceFacade> { userProfileServiceFacade }
+                single<OpenTradesNotificationService> { openTradesNotificationService }
+                single<TradeReadStateRepository> { tradeReadStateRepository }
+                single<ApplicationLifecycleService> { applicationLifecycleService }
+                single<UrlLauncher> { urlLauncher }
+                single<NavigationManager> { navigationManager }
+            },
+        )
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun beforeStartKoin() {
+        super.beforeStartKoin()
+        PlatformStaticMocks.mockScreenWidth(480)
+    }
 
-        // Mock the Android-specific static function called from MainPresenter.init
-        mockkStatic("network.bisq.mobile.presentation.common.ui.platform.PlatformPresentationAbstractions_androidKt")
-        every { getScreenWidthDp() } returns 480
-
-        connectivityService = mockk(relaxed = true)
-        networkServiceFacade = mockk(relaxed = true)
+    override fun onSetup() {
         every { connectivityService.clientRevoked } returns MutableStateFlow(false)
         every { connectivityService.status } returns MutableStateFlow(ConnectivityService.ConnectivityStatus.BOOTSTRAPPING)
-        settingsServiceFacade = mockk(relaxed = true)
-        tradesServiceFacade = mockk(relaxed = true)
-        userProfileServiceFacade = mockk(relaxed = true)
-        openTradesNotificationService = mockk(relaxed = true)
-        tradeReadStateRepository = mockk(relaxed = true)
-        applicationLifecycleService = mockk(relaxed = true)
-        urlLauncher = mockk(relaxed = true)
-
         every { tradesServiceFacade.openTradeItems } returns
             MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
         every { userProfileServiceFacade.selectedUserProfile } returns MutableStateFlow<UserProfileVO?>(null)
@@ -87,29 +82,14 @@ class ClientMainPresenterTest {
         every { settingsServiceFacade.useAnimations } returns MutableStateFlow(true)
         every { settingsServiceFacade.languageCode } returns MutableStateFlow("en")
         every { tradeReadStateRepository.data } returns flowOf(TradeReadStateMap())
-
-        startKoin {
-            modules(
-                clientTestModule,
-                module {
-                    single<ClientConnectivityService> { connectivityService }
-                    single<NetworkServiceFacade> { networkServiceFacade }
-                    single<SettingsServiceFacade> { settingsServiceFacade }
-                    single<TradesServiceFacade> { tradesServiceFacade }
-                    single<UserProfileServiceFacade> { userProfileServiceFacade }
-                    single<OpenTradesNotificationService> { openTradesNotificationService }
-                    single<TradeReadStateRepository> { tradeReadStateRepository }
-                    single<ApplicationLifecycleService> { applicationLifecycleService }
-                    single<UrlLauncher> { urlLauncher }
-                },
-            )
-        }
     }
 
-    @After
-    fun tearDown() {
-        stopKoin()
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            PlatformStaticMocks.unmockScreenWidth()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     private fun createPresenter(): ClientMainPresenter =
@@ -127,7 +107,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `onResume calls ensureTorRunning and starts connectivity monitoring`() =
-        runTest(testDispatcher) {
+        runTest {
             val presenter = createPresenter()
             presenter.onResume()
             advanceUntilIdle()
@@ -138,7 +118,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `onResume handles ensureTorRunning failure gracefully`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { networkServiceFacade.ensureTorRunning() } throws RuntimeException("Tor failure")
 
             val presenter = createPresenter()
@@ -152,7 +132,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `onPause stops connectivity monitoring`() =
-        runTest(testDispatcher) {
+        runTest {
             val presenter = createPresenter()
             presenter.onPause()
 
@@ -161,7 +141,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `when reconnecting and main content visible then shows reconnect overlay`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED)
             every { connectivityService.status } returns statusFlow
 
@@ -179,7 +159,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `when reconnecting before main content visible then hides reconnect overlay`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             every { connectivityService.status } returns statusFlow
 
@@ -192,7 +172,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `when reconnection succeeds then hides reconnect overlay`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             every { connectivityService.status } returns statusFlow
 
@@ -211,7 +191,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `when disconnected without prior reconnecting then hides connection lost dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED)
             every { connectivityService.status } returns statusFlow
 
@@ -229,7 +209,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `when disconnected after prolonged reconnecting then shows connection lost dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             every { connectivityService.status } returns statusFlow
 
@@ -254,7 +234,7 @@ class ClientMainPresenterTest {
      */
     @Test
     fun `disconnected after intermediate connected state does not show lost dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             every { connectivityService.status } returns statusFlow
 
@@ -288,7 +268,7 @@ class ClientMainPresenterTest {
      */
     @Test
     fun `mainVisible toggling during reconnecting keeps overlay in sync with status`() =
-        runTest(testDispatcher) {
+        runTest {
             val statusFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             every { connectivityService.status } returns statusFlow
 
@@ -344,7 +324,7 @@ class ClientMainPresenterTest {
 
     @Test
     fun `onConnectivityRecoveryAction on iOS restarts services and navigates to splash`() =
-        runTest(testDispatcher) {
+        runTest {
             mockkStatic("network.bisq.mobile.data.utils.PlatformDomainAbstractions_androidKt")
             try {
                 every { getPlatformInfo() } returns
@@ -353,27 +333,7 @@ class ClientMainPresenterTest {
                         override val type = PlatformType.IOS
                     }
 
-                val navigationManager = mockk<NavigationManager>(relaxed = true)
                 coEvery { applicationLifecycleService.restartAllServices() } returns true
-
-                stopKoin()
-                startKoin {
-                    modules(
-                        clientTestModule,
-                        module {
-                            single<ClientConnectivityService> { connectivityService }
-                            single<NetworkServiceFacade> { networkServiceFacade }
-                            single<SettingsServiceFacade> { settingsServiceFacade }
-                            single<TradesServiceFacade> { tradesServiceFacade }
-                            single<UserProfileServiceFacade> { userProfileServiceFacade }
-                            single<OpenTradesNotificationService> { openTradesNotificationService }
-                            single<TradeReadStateRepository> { tradeReadStateRepository }
-                            single<ApplicationLifecycleService> { applicationLifecycleService }
-                            single<UrlLauncher> { urlLauncher }
-                            single<NavigationManager> { navigationManager }
-                        },
-                    )
-                }
 
                 val presenter = createPresenter()
                 presenter.onViewAttached()

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/cash_deposit/CashDepositAccountDetailPresenterTest.kt
@@ -2,13 +2,9 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail.cas
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.cash_deposit.CashDepositAccount
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.cash_deposit.CashDepositAccountPayload
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountCountryDetails
@@ -16,55 +12,33 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.coun
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.client.payment_accounts.presentation.common.ui.account_detail.cash_deposit.CashDepositAccountDetailPresenter
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CashDepositAccountDetailPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
+class CashDepositAccountDetailPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: CashDepositAccountDetailPresenter
 
-    @Before
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        runCatching { stopKoin() }
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-        presenter =
-            CashDepositAccountDetailPresenter(paymentAccountsServiceFacade, mockk<MainPresenter>(relaxed = true))
+    override fun onSetup() {
+        presenter = CashDepositAccountDetailPresenter(paymentAccountsServiceFacade, mainPresenter)
     }
 
-    @After
-    fun tearDown() {
-        presenter.onDestroy()
-        runCatching { stopKoin() }
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            if (::presenter.isInitialized) presenter.onDestroy()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     @Test
     fun `initialize loads country details for account country`() =
-        runTest(testDispatcher) {
+        runTest {
             val details = sampleCountryDetails()
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(details)
 
@@ -78,7 +52,7 @@ class CashDepositAccountDetailPresenterTest {
 
     @Test
     fun `initialize clears loading and shows error when country details fail`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.failure(RuntimeException("boom"))
 
             presenter.initialize(sampleAccount())

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/common/ui/account_detail/same_bank/SameBankAccountDetailPresenterTest.kt
@@ -2,13 +2,9 @@ package network.bisq.mobile.client.payment_accounts.common.ui.account_detail.sam
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountCountryDetails
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
@@ -16,55 +12,33 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.same_bank.S
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.same_bank.SameBankAccountPayload
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.client.payment_accounts.presentation.common.ui.account_detail.bank.BankAccountDetailPresenter
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SameBankAccountDetailPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
+class SameBankAccountDetailPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: BankAccountDetailPresenter
 
-    @Before
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        runCatching { stopKoin() }
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-        presenter =
-            BankAccountDetailPresenter(paymentAccountsServiceFacade, mockk<MainPresenter>(relaxed = true))
+    override fun onSetup() {
+        presenter = BankAccountDetailPresenter(paymentAccountsServiceFacade, mainPresenter)
     }
 
-    @After
-    fun tearDown() {
-        presenter.onDestroy()
-        runCatching { stopKoin() }
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            if (::presenter.isInitialized) presenter.onDestroy()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     @Test
     fun `initialize loads country details for account country`() =
-        runTest(testDispatcher) {
+        runTest {
             val details = sampleCountryDetails()
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(details)
 
@@ -78,7 +52,7 @@ class SameBankAccountDetailPresenterTest {
 
     @Test
     fun `initialize clears loading and shows error when country details fail`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.failure(RuntimeException("boom"))
 
             presenter.initialize(sampleAccount())

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/CreatePaymentAccountPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/CreatePaymentAccountPresenterTest.kt
@@ -1,15 +1,11 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
@@ -17,26 +13,15 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.zelle.Creat
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.zelle.CreateZelleAccountPayload
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CreatePaymentAccountPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class CreatePaymentAccountPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: CreatePaymentAccountPresenter
 
     val mockFiatPaymentMethod: FiatPaymentMethod =
@@ -60,32 +45,6 @@ class CreatePaymentAccountPresenterTest {
                 ),
         )
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
-    }
-
     private fun createPresenter(): CreatePaymentAccountPresenter =
         CreatePaymentAccountPresenter(
             mainPresenter = mainPresenter,
@@ -93,7 +52,7 @@ class CreatePaymentAccountPresenterTest {
 
     @Test
     fun `when initial state then payment method and create account are null`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -107,7 +66,7 @@ class CreatePaymentAccountPresenterTest {
 
     @Test
     fun `when navigate from select payment method then updates method and emits form navigation effect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             val paymentMethod = mockFiatPaymentMethod
@@ -128,7 +87,7 @@ class CreatePaymentAccountPresenterTest {
 
     @Test
     fun `when navigate from payment account form then updates create account and emits review navigation effect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             val createAccount = mockCreateAccount
@@ -149,7 +108,7 @@ class CreatePaymentAccountPresenterTest {
 
     @Test
     fun `when select method then form submitted then state retains both values and effects are emitted in order`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             val paymentMethod = mockFiatPaymentMethod

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/crypto/SelectCryptoPaymentMethodPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/crypto/SelectCryptoPaymentMethodPresenterTest.kt
@@ -3,28 +3,15 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.crypto.CryptoPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -32,40 +19,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SelectCryptoPaymentMethodPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
-    private lateinit var mainPresenter: MainPresenter
+class SelectCryptoPaymentMethodPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
 
     private lateinit var presenter: SelectCryptoPaymentMethodPresenter
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
-    }
 
     private fun createPresenter(): SelectCryptoPaymentMethodPresenter =
         SelectCryptoPaymentMethodPresenter(
@@ -75,7 +33,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when initial state then has expected defaults`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -92,7 +50,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when view is attached then crypto methods are loaded`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -116,7 +74,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when crypto methods load fails then error state is set`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { paymentAccountsServiceFacade.getCryptoPaymentMethods() } returns
                 Result.failure(
@@ -138,7 +96,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when retry is clicked after failure then methods are requested again and error clears on success`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods = listOf(sampleCryptoMethod(code = "XMR", name = "Monero"))
             coEvery { paymentAccountsServiceFacade.getCryptoPaymentMethods() } returnsMany
@@ -164,7 +122,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when search query changes then list is filtered by name or code`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -188,7 +146,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when search query has surrounding whitespace then query is trimmed before filtering`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -212,7 +170,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when selected method is filtered out by search then selected method is cleared`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -241,7 +199,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when method is selected then selected payment method is updated`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods = listOf(sampleCryptoMethod(code = "XMR", name = "Monero"))
             coEvery { paymentAccountsServiceFacade.getCryptoPaymentMethods() } returns Result.success(methods)
@@ -262,7 +220,7 @@ class SelectCryptoPaymentMethodPresenterTest {
 
     @Test
     fun `when next is clicked with a selected method then navigation effect is emitted`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods = listOf(sampleCryptoMethod(code = "XMR", name = "Monero"))
             coEvery { paymentAccountsServiceFacade.getCryptoPaymentMethods() } returns Result.success(methods)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/fiat/SelectFiatPaymentMethodPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step1_select_payment_method/fiat/SelectFiatPaymentMethodPresenterTest.kt
@@ -3,34 +3,21 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.presentation.model.account.FiatPaymentMethodChargebackRiskVO
 import network.bisq.mobile.client.common.presentation.model.account.toVO
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.EMPTY_STRING
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,40 +25,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SelectFiatPaymentMethodPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
-    private lateinit var mainPresenter: MainPresenter
+class SelectFiatPaymentMethodPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
 
     private lateinit var presenter: SelectFiatPaymentMethodPresenter
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
-    }
 
     private fun createPresenter(): SelectFiatPaymentMethodPresenter =
         SelectFiatPaymentMethodPresenter(
@@ -81,7 +39,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when initial state then has expected defaults`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -99,7 +57,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when view is attached then fiat methods are loaded`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -129,7 +87,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when fiat methods load fails then error state is set`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { paymentAccountsServiceFacade.getFiatPaymentMethods() } returns
                 Result.failure(
@@ -151,7 +109,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when retry is clicked after failure then methods are requested again and error clears on success`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -184,7 +142,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when search query changes then list is filtered by method name`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -216,7 +174,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when risk filter changes then list is filtered by chargeback risk`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -248,7 +206,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when both query and risk filter are applied then fiat results satisfy both predicates`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -285,7 +243,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when selected fiat method is filtered out by search then selected method is cleared`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -322,7 +280,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when selected fiat method is filtered out by risk filter then selected method is cleared`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -360,7 +318,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when fiat method is selected then selected payment method is updated`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -388,7 +346,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when search query has surrounding whitespace then query is trimmed before filtering`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(
@@ -420,7 +378,7 @@ class SelectFiatPaymentMethodPresenterTest {
 
     @Test
     fun `when next is clicked with a selected method then navigation effect is emitted`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val methods =
                 listOf(

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/ach_transfer/AchTransferFormPresenterTest.kt
@@ -1,27 +1,14 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.ach_transfer
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountType
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -30,77 +17,60 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AchTransferFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class AchTransferFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: AchTransferFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        runCatching { stopKoin() }
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter = AchTransferFormPresenter(mainPresenter = mainPresenter)
     }
 
-    @AfterTest
-    fun tearDown() {
-        presenter.onDestroy()
-        runCatching { stopKoin() }
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            if (::presenter.isInitialized) presenter.onDestroy()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     @Test
     fun `when holder name changes then updates holderNameEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(AchTransferFormUiAction.OnHolderNameChange("John Doe"))
             assertEquals("John Doe", presenter.uiState.value.holderNameEntry.value)
         }
 
     @Test
     fun `when holder address changes then updates holderAddressEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(AchTransferFormUiAction.OnHolderAddressChange("123 Main St"))
             assertEquals("123 Main St", presenter.uiState.value.holderAddressEntry.value)
         }
 
     @Test
     fun `when bank name changes then updates bankNameEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(AchTransferFormUiAction.OnBankNameChange("Bisq Bank"))
             assertEquals("Bisq Bank", presenter.uiState.value.bankNameEntry.value)
         }
 
     @Test
     fun `when routing number changes then updates routingNrEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(AchTransferFormUiAction.OnRoutingNrChange("021000021"))
             assertEquals("021000021", presenter.uiState.value.routingNrEntry.value)
         }
 
     @Test
     fun `when account number changes then updates accountNrEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(AchTransferFormUiAction.OnAccountNrChange("123456789"))
             assertEquals("123456789", presenter.uiState.value.accountNrEntry.value)
         }
 
     @Test
     fun `when bank account type selected then updates selection and clears error`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnNextClick)
             assertNotNull(presenter.uiState.value.bankAccountTypeErrorMessage)
 
@@ -112,7 +82,7 @@ class AchTransferFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid fields then no effect and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
             presenter.onAction(AchTransferFormUiAction.OnHolderNameChange("a"))
             presenter.onAction(AchTransferFormUiAction.OnHolderAddressChange("a"))
@@ -137,7 +107,7 @@ class AchTransferFormPresenterTest {
 
     @Test
     fun `when next clicked with valid fields then emits ACH transfer account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("ACH Main"))
             presenter.onAction(AchTransferFormUiAction.OnHolderNameChange(" John Doe "))
             presenter.onAction(AchTransferFormUiAction.OnHolderAddressChange(" 123 Main St "))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/bank/BankAccountFormPresenterTest.kt
@@ -2,15 +2,11 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountCountryDetails
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountType
@@ -22,16 +18,7 @@ import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRai
 import network.bisq.mobile.domain.model.account.create.CreatePaymentAccount
 import network.bisq.mobile.domain.model.account.create.CreatePaymentAccountPayload
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.junit.After
-import org.junit.Before
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -40,33 +27,21 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class BankAccountFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
+class BankAccountFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: TestBankAccountFormPresenter
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        runCatching { stopKoin() }
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-        presenter = TestBankAccountFormPresenter(paymentAccountsServiceFacade, mockk<MainPresenter>(relaxed = true))
+    override fun onSetup() {
+        presenter = TestBankAccountFormPresenter(paymentAccountsServiceFacade, mainPresenter)
     }
 
-    @After
-    fun tearDown() {
-        presenter.onDestroy()
-        runCatching { stopKoin() }
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            if (::presenter.isInitialized) presenter.onDestroy()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     @Test
@@ -87,7 +62,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when country selected then resets dependent state and loads country details`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("DE") } returns Result.success(sampleCountryDetails(country = Country("DE", "Germany")))
             presenter.initialize(samplePaymentMethod())
             seedCountryDependentState()
@@ -115,7 +90,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when country details fail then error state is set`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.failure(RuntimeException("boom"))
             presenter.initialize(samplePaymentMethod())
 
@@ -129,7 +104,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when invalid country index selected then state is unchanged`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.initialize(samplePaymentMethod())
             val initialState = presenter.uiState.value
 
@@ -141,7 +116,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when currency selected then updates selection and clears error`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.initialize(samplePaymentMethod())
             presenter.onCommonAction(AccountFormUiAction.OnNextClick)
             assertNotNull(presenter.uiState.value.currencyErrorMessage)
@@ -155,7 +130,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `field actions update entries and bank account type selection clears error`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails())
             presenter.initialize(samplePaymentMethod())
             presenter.onAction(BankAccountFormUiAction.OnCountrySelect(2))
@@ -186,7 +161,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid fields then no effect and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.initialize(samplePaymentMethod())
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
             presenter.onAction(BankAccountFormUiAction.OnAccountNrChange(""))
@@ -205,7 +180,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when bank validation supported then required bank fields block next`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails(bankAccountValidationSupported = true))
             presenter.initialize(samplePaymentMethod())
             presenter.onAction(BankAccountFormUiAction.OnCountrySelect(2))
@@ -231,7 +206,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when bank validation unsupported then bank specific fields do not block next`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails(bankAccountValidationSupported = false))
             presenter.initialize(samplePaymentMethod())
             presenter.onAction(BankAccountFormUiAction.OnCountrySelect(2))
@@ -257,7 +232,7 @@ class BankAccountFormPresenterTest {
 
     @Test
     fun `when next clicked with valid fields then emits account with trimmed payload`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns Result.success(sampleCountryDetails(bankAccountValidationSupported = true))
             presenter.initialize(samplePaymentMethod())
             presenter.onAction(BankAccountFormUiAction.OnCountrySelect(2))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/cash_deposit/CashDepositFormPresenterTest.kt
@@ -2,15 +2,11 @@ package network.bisq.mobile.client.payment_accounts.presentation.create_payment_
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank.BankAccountCountryDetails
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
@@ -19,54 +15,33 @@ import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccount
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.junit.After
-import org.junit.Before
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CashDepositFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
+class CashDepositFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: CashDepositFormPresenter
 
-    @Before
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        runCatching { stopKoin() }
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-        presenter = CashDepositFormPresenter(paymentAccountsServiceFacade, mockk<MainPresenter>(relaxed = true))
+    override fun onSetup() {
+        presenter = CashDepositFormPresenter(paymentAccountsServiceFacade, mainPresenter)
     }
 
-    @After
-    fun tearDown() {
-        presenter.onDestroy()
-        runCatching { stopKoin() }
-        Dispatchers.resetMain()
+    override fun onTearDown() {
+        try {
+            if (::presenter.isInitialized) presenter.onDestroy()
+        } finally {
+            super.onTearDown()
+        }
     }
 
     @Test
     fun `when bank account validation supported then bank specific required fields block next`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns
                 Result.success(sampleCountryDetails(bankAccountValidationSupported = true))
             presenter.initialize(samplePaymentMethod())
@@ -89,7 +64,7 @@ class CashDepositFormPresenterTest {
 
     @Test
     fun `when bank account validation unsupported then bank specific required fields do not block next`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { paymentAccountsServiceFacade.getBankAccountCountryDetails("US") } returns
                 Result.success(sampleCountryDetails(bankAccountValidationSupported = false))
             presenter.initialize(samplePaymentMethod())

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/monero/MoneroFormPresenterTest.kt
@@ -1,27 +1,14 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.monero
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.crypto.CryptoAccountFormUiAction
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -30,46 +17,20 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MoneroFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class MoneroFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: MoneroFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter =
             MoneroFormPresenter(
                 mainPresenter = mainPresenter,
             )
     }
 
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
-    }
-
     @Test
     fun `when use sub addresses is enabled then flag is updated and placeholder is set`() =
-        runTest(testDispatcher) {
+        runTest {
             // When
             presenter.onAction(
                 MoneroFormUiAction.OnUseSubAddressesChange(
@@ -85,7 +46,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when monero custom fields change and use sub addresses enabled then values update and placeholder stays synced`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onAction(
                 MoneroFormUiAction.OnUseSubAddressesChange(
@@ -126,7 +87,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when monero custom fields change and use sub addresses disabled then keeps existing sub address entry`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onAction(
                 MoneroFormUiAction.OnUseSubAddressesChange(
@@ -170,7 +131,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid entries then no navigation effect is emitted`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(
                 AccountFormUiAction.OnUniqueAccountNameChange(
@@ -222,7 +183,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when next clicked with valid non subaddress form then emits account with trimmed direct address`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(
                 AccountFormUiAction.OnUniqueAccountNameChange(
@@ -273,7 +234,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when next clicked with auto conf enabled then emits parsed auto conf payload fields`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Monero AutoConf"))
             presenter.onAction(MoneroFormUiAction.OnUseSubAddressesChange(false))
@@ -303,7 +264,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when next clicked with valid subaddress form then emits account using main address and parsed indexes`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Monero Subaddresses"))
             presenter.onAction(MoneroFormUiAction.OnUseSubAddressesChange(true))
@@ -334,7 +295,7 @@ class MoneroFormPresenterTest {
 
     @Test
     fun `when toggling from subaddress mode to direct mode then stale subaddress mode fields are not included in payload`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Monero Toggle"))
             presenter.onAction(MoneroFormUiAction.OnUseSubAddressesChange(true))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/other_crypto/OtherCryptoFormPresenterTest.kt
@@ -1,28 +1,15 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.other_crypto
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.crypto.CryptoPaymentMethod
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.crypto.CryptoAccountFormUiAction
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -30,43 +17,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class OtherCryptoFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class OtherCryptoFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: OtherCryptoFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter = OtherCryptoFormPresenter(mainPresenter = mainPresenter)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     @Test
     fun `when crypto actions are dispatched then crypto ui state updates`() =
-        runTest(testDispatcher) {
+        runTest {
             // When
             presenter.onCryptoCommonAction(CryptoAccountFormUiAction.OnAddressChange("0xABCDEF"))
             presenter.onCryptoCommonAction(CryptoAccountFormUiAction.OnIsInstantChange(true))
@@ -87,7 +48,7 @@ class OtherCryptoFormPresenterTest {
 
     @Test
     fun `when next clicked before initialize then no effect is emitted`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("ETH Account"))
             presenter.onCryptoCommonAction(CryptoAccountFormUiAction.OnAddressChange("0x123456"))
@@ -104,7 +65,7 @@ class OtherCryptoFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid entries then no navigation effect is emitted and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.initialize(samplePaymentMethod())
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
@@ -133,7 +94,7 @@ class OtherCryptoFormPresenterTest {
 
     @Test
     fun `when next clicked with valid auto conf enabled entries then emits account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.initialize(samplePaymentMethod())
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("  ETH Account  "))
@@ -167,7 +128,7 @@ class OtherCryptoFormPresenterTest {
 
     @Test
     fun `when next clicked with auto conf disabled then auto conf payload fields are null`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.initialize(samplePaymentMethod())
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("ETH No AutoConf"))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/revolut/RevolutFormPresenterTest.kt
@@ -1,31 +1,18 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.revolut
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -33,39 +20,13 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class RevolutFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class RevolutFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: RevolutFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter = RevolutFormPresenter(mainPresenter = mainPresenter)
         presenter.initialize(samplePaymentMethod())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     @Test
@@ -77,14 +38,14 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when username changes then updates userNameEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(RevolutFormUiAction.OnUserNameChange("satoshi"))
             assertEquals("satoshi", presenter.uiState.value.userNameEntry.value)
         }
 
     @Test
     fun `when currency picker opens and closes then state updates and search clears`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(RevolutFormUiAction.OnOpenCurrencyPicker)
             presenter.onAction(RevolutFormUiAction.OnCurrencySearchChange("eur"))
             assertTrue(presenter.uiState.value.isCurrencyPickerOpen)
@@ -97,14 +58,14 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when toggle currency then updates selected set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(RevolutFormUiAction.OnCurrencyToggle("EUR"))
             assertEquals(setOf("USD", "GBP"), presenter.uiState.value.selectedCurrencyCodes)
         }
 
     @Test
     fun `when clear all then selected currencies become empty`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(RevolutFormUiAction.OnClearAllCurrencies)
             assertTrue(
                 presenter.uiState.value.selectedCurrencyCodes
@@ -114,7 +75,7 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when select all then selected currencies include all available`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(RevolutFormUiAction.OnClearAllCurrencies)
             presenter.onAction(RevolutFormUiAction.OnSelectAllCurrencies)
             assertEquals(setOf("USD", "EUR", "GBP"), presenter.uiState.value.selectedCurrencyCodes)
@@ -122,7 +83,7 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid fields then no effect and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
             presenter.onAction(RevolutFormUiAction.OnUserNameChange("a"))
             presenter.onAction(RevolutFormUiAction.OnClearAllCurrencies)
@@ -140,7 +101,7 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when next clicked with only unsupported selected currency codes then no effect and currency error is set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Revolut Personal"))
             presenter.onAction(RevolutFormUiAction.OnUserNameChange("satoshi"))
             presenter.onAction(RevolutFormUiAction.OnClearAllCurrencies)
@@ -157,7 +118,7 @@ class RevolutFormPresenterTest {
 
     @Test
     fun `when next clicked with valid fields then emits Revolut account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Revolut Personal"))
             presenter.onAction(RevolutFormUiAction.OnUserNameChange("  satoshi  "))
             presenter.onAction(RevolutFormUiAction.OnClearAllCurrencies)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/wise/WiseFormPresenterTest.kt
@@ -1,31 +1,18 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.wise
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -33,39 +20,13 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class WiseFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class WiseFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: WiseFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter = WiseFormPresenter(mainPresenter = mainPresenter)
         presenter.initialize(samplePaymentMethod())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     @Test
@@ -77,28 +38,28 @@ class WiseFormPresenterTest {
 
     @Test
     fun `when holder name changes then updates holderNameEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(WiseFormUiAction.OnHolderNameChange("John Doe"))
             assertEquals("John Doe", presenter.uiState.value.holderNameEntry.value)
         }
 
     @Test
     fun `when email changes then updates emailEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(WiseFormUiAction.OnEmailChange("john@example.com"))
             assertEquals("john@example.com", presenter.uiState.value.emailEntry.value)
         }
 
     @Test
     fun `when toggle currency then updates selected set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(WiseFormUiAction.OnCurrencyToggle("EUR"))
             assertEquals(setOf("USD", "GBP"), presenter.uiState.value.selectedCurrencyCodes)
         }
 
     @Test
     fun `when clear all then selected currencies become empty`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(WiseFormUiAction.OnClearAllCurrencies)
             assertTrue(
                 presenter.uiState.value.selectedCurrencyCodes
@@ -108,7 +69,7 @@ class WiseFormPresenterTest {
 
     @Test
     fun `when select all then selected currencies include all available`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onAction(WiseFormUiAction.OnClearAllCurrencies)
             presenter.onAction(WiseFormUiAction.OnSelectAllCurrencies)
             assertEquals(setOf("USD", "EUR", "GBP"), presenter.uiState.value.selectedCurrencyCodes)
@@ -116,7 +77,7 @@ class WiseFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid fields then no effect and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
             presenter.onAction(WiseFormUiAction.OnHolderNameChange("a"))
             presenter.onAction(WiseFormUiAction.OnEmailChange("invalid"))
@@ -136,7 +97,7 @@ class WiseFormPresenterTest {
 
     @Test
     fun `when next clicked with only unsupported selected currency codes then no effect and currency error is set`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Wise Personal"))
             presenter.onAction(WiseFormUiAction.OnHolderNameChange("John Doe"))
             presenter.onAction(WiseFormUiAction.OnEmailChange("john@example.com"))
@@ -154,7 +115,7 @@ class WiseFormPresenterTest {
 
     @Test
     fun `when next clicked with valid fields then emits Wise account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Wise Personal"))
             presenter.onAction(WiseFormUiAction.OnHolderNameChange("John Doe"))
             presenter.onAction(WiseFormUiAction.OnEmailChange("john@example.com"))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step2_payment_account_form/form/zelle/ZelleFormPresenterTest.kt
@@ -1,26 +1,13 @@
 package network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.zelle
 
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.presentation.create_payment_account.step2_payment_account_form.form.AccountFormUiAction
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -28,43 +15,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ZelleFormPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var mainPresenter: MainPresenter
+class ZelleFormPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
     private lateinit var presenter: ZelleFormPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        mainPresenter = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                },
-            )
-        }
-
+    override fun onSetup() {
         presenter = ZelleFormPresenter(mainPresenter = mainPresenter)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     @Test
     fun `when holder name changes then updates holderNameEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             // When
             presenter.onAction(ZelleFormUiAction.OnHolderNameChange("John Doe"))
 
@@ -74,7 +35,7 @@ class ZelleFormPresenterTest {
 
     @Test
     fun `when email or mobile changes then updates emailOrMobileNrEntry`() =
-        runTest(testDispatcher) {
+        runTest {
             // When
             presenter.onAction(ZelleFormUiAction.OnEmailOrMobileNrChange("user@example.com"))
 
@@ -84,7 +45,7 @@ class ZelleFormPresenterTest {
 
     @Test
     fun `when next clicked with invalid entries then no navigation effect is emitted and errors are set`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("a"))
             presenter.onAction(ZelleFormUiAction.OnHolderNameChange("a"))
@@ -107,7 +68,7 @@ class ZelleFormPresenterTest {
 
     @Test
     fun `when next clicked with valid email flow then emits account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Zelle Personal"))
             presenter.onAction(ZelleFormUiAction.OnHolderNameChange("John Doe"))
@@ -129,7 +90,7 @@ class ZelleFormPresenterTest {
 
     @Test
     fun `when next clicked with valid us mobile flow then emits account payload`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter.onCommonAction(AccountFormUiAction.OnUniqueAccountNameChange("Zelle Mobile"))
             presenter.onAction(ZelleFormUiAction.OnHolderNameChange("Jane Doe"))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/create_payment_account/step3_account_review/PaymentAccountReviewPresenterTest.kt
@@ -5,15 +5,11 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.FiatPaymentMethod
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
@@ -24,17 +20,11 @@ import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccount
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.data.replicated.account.payment_method.FiatPaymentRail
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
 import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -43,43 +33,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class PaymentAccountReviewPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var globalUiManager: GlobalUiManager
+class PaymentAccountReviewPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+    private val globalUiManager: GlobalUiManager = mockk(relaxed = true)
     private lateinit var presenter: PaymentAccountReviewPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun additionalModules(): List<Module> = listOf(module { single<GlobalUiManager> { globalUiManager } })
 
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        globalUiManager = mockk(relaxed = true)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { mockk(relaxed = true) }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { globalUiManager }
-                },
-            )
-        }
-
+    override fun onSetup() {
         every { globalUiManager.scheduleShowLoading() } returns Unit
         every { globalUiManager.scheduleHideLoading() } returns Unit
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): PaymentAccountReviewPresenter =
@@ -90,7 +54,7 @@ class PaymentAccountReviewPresenterTest {
 
     @Test
     fun `when initial state then loading is true and payment account is null`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -104,7 +68,7 @@ class PaymentAccountReviewPresenterTest {
 
     @Test
     fun `when initialized then clears loading and derives review payment account state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleCreateZelleAccount()
             presenter = createPresenter()
@@ -122,7 +86,7 @@ class PaymentAccountReviewPresenterTest {
 
     @Test
     fun `when create account action succeeds then adds account and emits close flow effect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleCreateZelleAccount()
             coEvery { paymentAccountsServiceFacade.addAccount(account) } returns Result.success(Unit)
@@ -142,7 +106,7 @@ class PaymentAccountReviewPresenterTest {
 
     @Test
     fun `when create account action conflicts then shows duplicate account snackbar and does not emit close flow effect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleCreateZelleAccount()
             coEvery { paymentAccountsServiceFacade.addAccount(account) } returns
@@ -172,7 +136,7 @@ class PaymentAccountReviewPresenterTest {
 
     @Test
     fun `when create account action fails then shows error snackbar and does not emit close flow effect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleCreateZelleAccount()
             coEvery { paymentAccountsServiceFacade.addAccount(account) } returns Result.failure(IllegalStateException("create failed"))

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_account_detail/PaymentAccountMusigDetailPresenterTest.kt
@@ -5,14 +5,10 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.currency.FiatCurrency
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.zelle.ZelleAccount
@@ -20,67 +16,40 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.zelle.Zelle
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.components.organisms.SnackbarType
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import network.bisq.mobile.test.coroutines.TestCoroutineJobsManager
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
 import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class PaymentAccountMusigDetailPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var globalUiManager: GlobalUiManager
-    private lateinit var navigationManager: NavigationManager
-    private lateinit var accountsByNameFlow: MutableStateFlow<Map<String, PaymentAccount>>
+class PaymentAccountMusigDetailPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+    private val globalUiManager: GlobalUiManager = mockk(relaxed = true)
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
+    private val accountsByNameFlow = MutableStateFlow<Map<String, PaymentAccount>>(emptyMap())
 
     private lateinit var presenter: PaymentAccountMusigDetailPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<NavigationManager> { navigationManager }
+                single<GlobalUiManager> { globalUiManager }
+            },
+        )
 
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        globalUiManager = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
-        accountsByNameFlow = MutableStateFlow(emptyMap())
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { navigationManager }
-                    factory<CoroutineJobsManager> { TestCoroutineJobsManager(testDispatcher) }
-                    single<GlobalUiManager> { globalUiManager }
-                },
-            )
-        }
-
+    override fun onSetup() {
         every { paymentAccountsServiceFacade.accountsByName } returns accountsByNameFlow
         every { globalUiManager.scheduleShowLoading() } returns Unit
         every { globalUiManager.scheduleHideLoading() } returns Unit
         every { navigationManager.navigateBack(any()) } returns Unit
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): PaymentAccountMusigDetailPresenter =
@@ -91,7 +60,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when initialize with matching account then sets payment account and clears missing flag`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleZelleAccount()
             accountsByNameFlow.value = mapOf(account.accountName to account)
@@ -109,7 +78,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when initialize with unknown account then marks account as missing`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val existingAccount = sampleZelleAccount()
             accountsByNameFlow.value = mapOf(existingAccount.accountName to existingAccount)
@@ -127,7 +96,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when delete action triggered then shows delete confirmation dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -141,7 +110,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when cancel delete action triggered then hides delete confirmation dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             presenter.onAction(PaymentAccountMusigDetailUiAction.OnDeleteAccountClick)
@@ -157,7 +126,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when confirm delete without selected account then does not call delete or navigation`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -174,7 +143,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when confirm delete succeeds then hides dialog shows loading lifecycle and navigates back`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleZelleAccount()
             accountsByNameFlow.value = mapOf(account.accountName to account)
@@ -198,7 +167,7 @@ class PaymentAccountMusigDetailPresenterTest {
 
     @Test
     fun `when confirm delete fails then hides dialog loading and shows error snackbar without navigation`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val account = sampleZelleAccount()
             accountsByNameFlow.value = mapOf(account.accountName to account)

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/PaymentAccountsMusigPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/payment_accounts/presentation/payment_accounts_list/PaymentAccountsMusigPresenterTest.kt
@@ -5,15 +5,11 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.payment_accounts.domain.model.crypto.monero.MoneroAccount
 import network.bisq.mobile.client.payment_accounts.domain.model.crypto.monero.MoneroAccountPayload
 import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.country.Country
@@ -25,65 +21,30 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.zelle.Zelle
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.fiat.FiatPaymentMethodChargebackRisk
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.common.ui.navigation.types.PaymentAccountType
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
 import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class PaymentAccountsMusigPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var paymentAccountsServiceFacade: PaymentAccountsServiceFacade
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var globalUiManager: GlobalUiManager
-    private lateinit var navigationManager: NavigationManager
-    private lateinit var accountsFlow: MutableStateFlow<List<PaymentAccount>>
+class PaymentAccountsMusigPresenterTest : ClientKoinIntegrationTestBase() {
+    private val paymentAccountsServiceFacade: PaymentAccountsServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
+    private val accountsFlow = MutableStateFlow<List<PaymentAccount>>(emptyList())
 
     private lateinit var presenter: PaymentAccountsMusigPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun additionalModules(): List<Module> = listOf(module { single<NavigationManager> { navigationManager } })
 
-        paymentAccountsServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        globalUiManager = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
-        accountsFlow = MutableStateFlow(emptyList())
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { navigationManager }
-                    single<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
-                    single<GlobalUiManager> { globalUiManager }
-                },
-            )
-        }
-
+    override fun onSetup() {
         every { paymentAccountsServiceFacade.accountsFlow } returns accountsFlow
         coEvery { paymentAccountsServiceFacade.getAccounts() } returns Result.success(Unit)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): PaymentAccountsMusigPresenter =
@@ -94,7 +55,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when initial state then has expected defaults`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -112,7 +73,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when view attached and get accounts succeeds then loading is cleared without error`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { paymentAccountsServiceFacade.getAccounts() } returns Result.success(Unit)
             presenter = createPresenter()
@@ -130,7 +91,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when view attached and get accounts fails then error state is shown`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { paymentAccountsServiceFacade.getAccounts() } returns Result.failure(IllegalStateException("load failed"))
             presenter = createPresenter()
@@ -148,7 +109,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when retry clicked after failure then get accounts is requested again and error clears`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { paymentAccountsServiceFacade.getAccounts() } returnsMany
                 listOf(
@@ -172,7 +133,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when fiat and crypto accounts emitted then ui state maps each account type correctly`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             presenter.onViewAttached()
@@ -198,7 +159,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when only fiat accounts emitted then crypto list remains empty`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
             presenter.onViewAttached()
@@ -216,7 +177,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when tab selected then selected tab state is updated`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -230,7 +191,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when add fiat action triggered then navigates to create payment account fiat route`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 
@@ -250,7 +211,7 @@ class PaymentAccountsMusigPresenterTest {
 
     @Test
     fun `when add crypto action triggered then navigates to create payment account crypto route`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             presenter = createPresenter()
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/splash/ClientSplashPresenterNavigationTest.kt
@@ -4,15 +4,10 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettings
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsSerializer
@@ -20,6 +15,7 @@ import network.bisq.mobile.client.common.domain.service.bootstrap.ClientApplicat
 import network.bisq.mobile.client.common.domain.service.bootstrap.ClientApplicationBootstrapFacade.ConnectBootstrapPhase
 import network.bisq.mobile.client.common.domain.service.network.ClientConnectivityService
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.data.replicated.settings.SettingsVO
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
@@ -27,22 +23,13 @@ import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.network.ConnectivityService.ConnectivityStatus
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
-import network.bisq.mobile.domain.analytics.AnalyticsService
-import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
-import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.domain.utils.VersionProvider
 import network.bisq.mobile.i18n.UiString
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.junit.After
-import org.junit.Before
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
 import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,18 +38,16 @@ import kotlin.test.assertEquals
  * Tests ClientSplashPresenter's connectivity checks and navigation logic.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ClientSplashPresenterNavigationTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    private lateinit var navigationManager: NavigationManager
-    private lateinit var settingsServiceFacade: SettingsServiceFacade
-    private lateinit var userProfileService: UserProfileServiceFacade
-    private lateinit var settingsRepository: SettingsRepository
-    private lateinit var applicationBootstrapFacade: ClientApplicationBootstrapFacade
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var versionProvider: VersionProvider
-    private lateinit var connectivityService: ConnectivityService
-    private lateinit var sensitiveSettingsRepository: SensitiveSettingsRepository
+class ClientSplashPresenterNavigationTest : ClientKoinIntegrationTestBase() {
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
+    private val settingsServiceFacade: SettingsServiceFacade = mockk(relaxed = true)
+    private val userProfileService: UserProfileServiceFacade = mockk(relaxed = true)
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true)
+    private val applicationBootstrapFacade: ClientApplicationBootstrapFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+    private val versionProvider: VersionProvider = mockk(relaxed = true)
+    private val connectivityService: ConnectivityService = mockk(relaxed = true)
+    private val sensitiveSettingsRepository: SensitiveSettingsRepository = mockk(relaxed = true)
 
     private val progressFlow = MutableStateFlow(0f)
     private val connectivityStatusFlow = MutableStateFlow(ConnectivityStatus.BOOTSTRAPPING)
@@ -70,19 +55,14 @@ class ClientSplashPresenterNavigationTest {
     private val bootstrapFailedFlow = MutableStateFlow(false)
     private val bootstrapPhaseFlow = MutableStateFlow(ConnectBootstrapPhase.CONNECTING)
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun additionalModules(): List<Module> = listOf(module { single<NavigationManager> { navigationManager } })
 
-        settingsServiceFacade = mockk(relaxed = true)
-        userProfileService = mockk(relaxed = true)
-        settingsRepository = mockk(relaxed = true)
-        applicationBootstrapFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        versionProvider = mockk(relaxed = true)
-        connectivityService = mockk(relaxed = true)
-        sensitiveSettingsRepository = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
+    override fun onSetup() {
+        progressFlow.value = 0f
+        connectivityStatusFlow.value = ConnectivityStatus.BOOTSTRAPPING
+        torBootstrapFailedFlow.value = false
+        bootstrapFailedFlow.value = false
+        bootstrapPhaseFlow.value = ConnectBootstrapPhase.CONNECTING
 
         // Default: have valid sensitive settings so tests don't auto-redirect to pairing
         coEvery { sensitiveSettingsRepository.fetch() } returns
@@ -107,36 +87,17 @@ class ClientSplashPresenterNavigationTest {
         every { connectivityService.status } returns connectivityStatusFlow
 
         ApplicationBootstrapFacade.isDemo = false
+    }
 
-        startKoin {
-            modules(
-                module {
-                    single { CoroutineExceptionHandlerSetup() }
-                    factory<CoroutineJobsManager> {
-                        DefaultCoroutineJobsManager().apply {
-                            get<CoroutineExceptionHandlerSetup>().setupExceptionHandler(this)
-                        }
-                    }
-                    single<GlobalUiManager> { GlobalUiManager(testDispatcher) }
-                    single<NavigationManager> { navigationManager }
-                    single<AnalyticsService> { NoOpAnalyticsService }
-                },
-            )
+    override fun onTearDown() {
+        try {
+            ApplicationBootstrapFacade.isDemo = false
+            torBootstrapFailedFlow.value = false
+            bootstrapFailedFlow.value = false
+            SensitiveSettingsSerializer.resetKeystoreInvalidatedForTest()
+        } finally {
+            super.onTearDown()
         }
-    }
-
-    @After
-    fun tearDown() {
-        ApplicationBootstrapFacade.isDemo = false
-        torBootstrapFailedFlow.value = false
-        bootstrapFailedFlow.value = false
-        resetKeystoreInvalidatedFlag()
-        stopKoin()
-        Dispatchers.resetMain()
-    }
-
-    private fun resetKeystoreInvalidatedFlag() {
-        SensitiveSettingsSerializer.resetKeystoreInvalidatedForTest()
     }
 
     private fun createPresenter(): ClientSplashPresenter =
@@ -153,7 +114,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup with connection failed flag when not connected`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService stays in BOOTSTRAPPING (never reaches CONNECTED)
             coEvery { settingsServiceFacade.getSettings() } returns
                 Result.success(SettingsVO(isTacAccepted = true))
@@ -183,7 +144,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup immediately when Tor bootstrap fails`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService stays in BOOTSTRAPPING
             val presenter = createPresenter()
             presenter.onViewAttached()
@@ -207,7 +168,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup immediately when bootstrap fails`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService stays in BOOTSTRAPPING
             val presenter = createPresenter()
             presenter.onViewAttached()
@@ -231,7 +192,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `waits for Tor connectivity timeout before failing`() =
-        runTest(testDispatcher) {
+        runTest {
             val torWaitTimeoutMs =
                 ClientConnectivityService.START_DELAY_TOR +
                     ClientConnectivityService.PERIOD +
@@ -276,7 +237,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to home when connected`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService reports connected with data
             connectivityStatusFlow.value = ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED
 
@@ -299,7 +260,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup when profile data fetch fails after connecting`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: connectivity is established, but the profile/settings fetch fails (e.g. the user
             // enabled Airplane mode right after connecting). An already-configured user must NOT be
             // sent to onboarding.
@@ -331,7 +292,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `demo mode skips connectivity check`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: Demo mode is enabled and connectivity is bootstrapping
             ApplicationBootstrapFacade.isDemo = true
 
@@ -354,7 +315,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `safety net triggers after timeout when not connected`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService stays in BOOTSTRAPPING, progress never reaches 1.0
             val presenter = createPresenter()
             presenter.onViewAttached()
@@ -378,7 +339,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `safety net proceeds to home when websocket already connected`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: WS connected (LOADING_DATA) but connectivity confirmation is slow — status stays
             // BOOTSTRAPPING so progress never reaches 1.0 on its own.
             bootstrapPhaseFlow.value = ConnectBootstrapPhase.LOADING_DATA
@@ -407,7 +368,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `safety net does not trigger in demo mode`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: Demo mode is enabled, connectivity is bootstrapping
             ApplicationBootstrapFacade.isDemo = true
 
@@ -432,7 +393,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup WITHOUT connection failed when no saved configuration`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: No saved trusted node configuration (first-time user)
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings()
 
@@ -454,7 +415,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup with keystore error when keystore is invalidated`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: No saved configuration (defaults returned after corruption handler)
             // and keystoreInvalidated flag is set
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings()
@@ -482,7 +443,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to home when connectivity reaches REQUESTING_INVENTORY`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: ConnectivityService reports requesting inventory
             connectivityStatusFlow.value = ConnectivityStatus.REQUESTING_INVENTORY
 
@@ -505,7 +466,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to trusted node setup when connected with limitations and override is disabled`() =
-        runTest(testDispatcher) {
+        runTest {
             connectivityStatusFlow.value = ConnectivityStatus.CONNECTED_WITH_LIMITATIONS
 
             val presenter = createPresenter()
@@ -529,7 +490,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `navigates to home when connected with limitations and route override is enabled`() =
-        runTest(testDispatcher) {
+        runTest {
             connectivityStatusFlow.value = ConnectivityStatus.CONNECTED_WITH_LIMITATIONS
             coEvery { settingsServiceFacade.getSettings() } returns
                 Result.success(SettingsVO(isTacAccepted = true))
@@ -549,7 +510,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `clientUiState connecting phase shows connecting detail`() =
-        runTest(testDispatcher) {
+        runTest {
             val presenter = createPresenter()
             presenter.onViewAttached()
             testScheduler.runCurrent()
@@ -561,7 +522,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `clientUiState loading data phase marks connecting done and loading active`() =
-        runTest(testDispatcher) {
+        runTest {
             val presenter = createPresenter()
             presenter.onViewAttached()
             testScheduler.runCurrent()
@@ -578,7 +539,7 @@ class ClientSplashPresenterNavigationTest {
 
     @Test
     fun `clientUiState connected phase marks loading done`() =
-        runTest(testDispatcher) {
+        runTest {
             val presenter = createPresenter()
             presenter.onViewAttached()
             testScheduler.runCurrent()

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/trusted_node_setup/TrustedNodeSetupPresenterTest.kt
@@ -6,17 +6,12 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.client.common.domain.access.ApiAccessService
 import network.bisq.mobile.client.common.domain.access.pairing.PairingCode
 import network.bisq.mobile.client.common.domain.access.pairing.Permission
@@ -27,6 +22,7 @@ import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.client.trusted_node_setup.components.SubscriptionsFailedDialogUiAction
 import network.bisq.mobile.client.trusted_node_setup.use_case.TrustedNodeConnectionStatus
 import network.bisq.mobile.client.trusted_node_setup.use_case.TrustedNodeSetupUseCase
@@ -34,17 +30,11 @@ import network.bisq.mobile.client.trusted_node_setup.use_case.TrustedNodeSetupUs
 import network.bisq.mobile.data.service.bootstrap.ApplicationLifecycleService
 import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.network.KmpTorService
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.i18n.I18nSupport
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.junit.After
-import org.junit.Before
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
 import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,21 +49,20 @@ import kotlin.time.Clock
  * including pairing code validation, connection management, and user actions.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class TrustedNodeSetupPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
+class TrustedNodeSetupPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+    private val kmpTorService: KmpTorService = mockk(relaxed = true)
+    private val trustedNodeSetupUseCase: TrustedNodeSetupUseCase = mockk(relaxed = true)
+    private val apiAccessService: ApiAccessService = mockk(relaxed = true)
+    private val sensitiveSettingsRepository: SensitiveSettingsRepository = mockk(relaxed = true)
+    private val applicationLifecycleService: ApplicationLifecycleService = mockk(relaxed = true)
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val connectivityService: ConnectivityService = mockk(relaxed = true)
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
+    private val failedSubscriptionTopicsFlow = MutableStateFlow<Set<Topic>>(emptySet())
+    private val connectionStateFlow = MutableStateFlow<ConnectionState>(ConnectionState.Connected)
 
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var kmpTorService: KmpTorService
-    private lateinit var trustedNodeSetupUseCase: TrustedNodeSetupUseCase
-    private lateinit var apiAccessService: ApiAccessService
-    private lateinit var sensitiveSettingsRepository: SensitiveSettingsRepository
-    private lateinit var applicationLifecycleService: ApplicationLifecycleService
-    private lateinit var webSocketClientService: WebSocketClientService
-    private lateinit var connectivityService: ConnectivityService
-    private lateinit var navigationManager: NavigationManager
     private lateinit var presenter: TrustedNodeSetupPresenter
-    private lateinit var failedSubscriptionTopicsFlow: MutableStateFlow<Set<Topic>>
-    private lateinit var connectionStateFlow: MutableStateFlow<ConnectionState>
 
     // Test data
     private val validPairingCode = "12345-ABCDE"
@@ -94,36 +83,13 @@ class TrustedNodeSetupPresenterTest {
             torClientAuthSecret = null,
         )
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+    override fun additionalModules(): List<Module> = listOf(module { single<NavigationManager> { navigationManager } })
 
-        // Setup i18n
+    override fun onSetup() {
         I18nSupport.setLanguage()
 
-        // Setup mocks
-        mainPresenter = mockk(relaxed = true)
-        kmpTorService = mockk(relaxed = true)
-        trustedNodeSetupUseCase = mockk(relaxed = true)
-        apiAccessService = mockk(relaxed = true)
-        sensitiveSettingsRepository = mockk(relaxed = true)
-        applicationLifecycleService = mockk(relaxed = true)
-        webSocketClientService = mockk(relaxed = true)
-        connectivityService = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
-        failedSubscriptionTopicsFlow = MutableStateFlow(emptySet())
-        connectionStateFlow = MutableStateFlow(ConnectionState.Connected)
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { navigationManager }
-                    single<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
-                    single<GlobalUiManager> { mockk(relaxed = true) }
-                    single<SensitiveSettingsRepository> { sensitiveSettingsRepository }
-                },
-            )
-        }
+        failedSubscriptionTopicsFlow.value = emptySet()
+        connectionStateFlow.value = ConnectionState.Connected
 
         // Default mock behaviors
         every { trustedNodeSetupUseCase.state } returns MutableStateFlow(TrustedNodeSetupUseCaseState())
@@ -132,15 +98,6 @@ class TrustedNodeSetupPresenterTest {
         every { webSocketClientService.failedSubscriptionTopics } returns failedSubscriptionTopicsFlow
         every { webSocketClientService.connectionState } returns connectionStateFlow
         every { connectivityService.status } returns MutableStateFlow(ConnectivityService.ConnectivityStatus.CONNECTED_AND_DATA_RECEIVED)
-    }
-
-    @After
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): TrustedNodeSetupPresenter =
@@ -165,7 +122,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when initial state then has correct default values`() =
-        runTest(testDispatcher) {
+        runTest {
             // When
             setupPresenter()
 
@@ -182,7 +139,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when initialize with workflow false and connectivity connected then shows connected status`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings(bisqApiUrl = validRestApiUrl)
             every { connectivityService.status } returns
@@ -201,7 +158,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when initialize with workflow false and connectivity reconnecting then shows reconnecting status`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings(bisqApiUrl = validRestApiUrl)
             every { connectivityService.status } returns
@@ -220,7 +177,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when initialize with workflow false and connectivity not connected then shows unable to connect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings(bisqApiUrl = validRestApiUrl)
             every { connectivityService.status } returns MutableStateFlow(ConnectivityService.ConnectivityStatus.DISCONNECTED)
@@ -241,7 +198,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when connectivity changes in setup phase then status updates live`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val connectivityFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.DISCONNECTED)
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings(bisqApiUrl = validRestApiUrl)
@@ -261,7 +218,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when connectivity changes from reconnecting to disconnected in setup phase then shows unable to connect`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given: matches transition after max reconnecting duration (e.g. DISCONNECTED from base timeout)
             val connectivityFlow = MutableStateFlow(ConnectivityService.ConnectivityStatus.RECONNECTING)
             coEvery { sensitiveSettingsRepository.fetch() } returns SensitiveSettings(bisqApiUrl = validRestApiUrl)
@@ -285,7 +242,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when initialize with workflow true then does not change status`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -302,7 +259,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when valid pairing code entered then updates api url`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             presenter = createPresenter()
@@ -323,7 +280,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when invalid pairing code entered then shows error`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val errorMessage = "Invalid pairing code"
             val invalidParingCode = "invalid-code"
@@ -343,7 +300,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when blank pairing code entered then clears state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             setupPresenter()
@@ -365,7 +322,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when pairing code with whitespace entered then trims correctly`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val codeWithWhitespace = "  $validPairingCode  "
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
@@ -385,7 +342,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when show qr code view action then sets flag to true`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -399,7 +356,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when qr code view dismissed then sets flag to false`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.onAction(TrustedNodeSetupUiAction.OnShowQrCodeView)
@@ -415,7 +372,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when qr code view failed to open then shows error and closes view`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.onAction(TrustedNodeSetupUiAction.OnShowQrCodeView)
@@ -433,7 +390,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when qr code error closed then clears error flag`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.onAction(TrustedNodeSetupUiAction.OnQrCodeFail)
@@ -449,7 +406,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when qr code result received then processes as pairing code`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             setupPresenter()
@@ -468,7 +425,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when test and save pressed then starts use case`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } returns true
@@ -489,7 +446,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when test and save pressed then starts countdown timer`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } coAnswers {
@@ -512,7 +469,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when connection setup succeeds then navigates to splash`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } returns true
@@ -534,7 +491,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when connection setup fails then does not navigate`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } returns false
@@ -556,7 +513,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when test and save pressed without pairing code then does nothing`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -570,7 +527,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when test and save pressed during ongoing connection then ignores request`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } coAnswers {
@@ -598,7 +555,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when cancel pressed then cancels jobs and resets state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { trustedNodeSetupUseCase(any()) } coAnswers {
@@ -626,7 +583,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when cancel pressed with internal tor starting then stops tor`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             val torStartingState = MutableStateFlow(KmpTorService.TorState.Starting)
@@ -655,7 +612,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when cancel pressed without connection then resets state safely`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -673,7 +630,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when use case emits connection status then updates ui state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val stateFlow = MutableStateFlow(TrustedNodeSetupUseCaseState())
             every { trustedNodeSetupUseCase.state } returns stateFlow
@@ -691,7 +648,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when use case emits incompatible api version then updates with server version`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val stateFlow = MutableStateFlow(TrustedNodeSetupUseCaseState())
             every { trustedNodeSetupUseCase.state } returns stateFlow
@@ -713,7 +670,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when tor state changes then updates ui state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val torStateFlow: MutableStateFlow<KmpTorService.TorState> =
                 MutableStateFlow(KmpTorService.TorState.Stopped())
@@ -730,7 +687,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when tor bootstrap progress changes then updates ui state`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val torProgressFlow = MutableStateFlow(0)
             every { kmpTorService.bootstrapProgress } returns torProgressFlow
@@ -748,7 +705,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when status is connecting then isConnectionInProgress returns true`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val stateFlow = MutableStateFlow(TrustedNodeSetupUseCaseState())
             every { trustedNodeSetupUseCase.state } returns stateFlow
@@ -764,7 +721,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when status is idle then isConnectionInProgress returns false`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -774,7 +731,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when not connected and workflow then canScanQrCode returns true`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -784,7 +741,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when not connected and not workflow then canScanQrCode returns false`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -794,7 +751,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when connected then canScanQrCode returns false`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             val stateFlow = MutableStateFlow(TrustedNodeSetupUseCaseState())
             every { trustedNodeSetupUseCase.state } returns stateFlow
@@ -811,7 +768,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnPairWithNewNodePress action then shows change node warning dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -825,7 +782,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnChangeNodeWarningCancel action then hides change node warning dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.onAction(TrustedNodeSetupUiAction.OnPairWithNewNodePress)
@@ -841,7 +798,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnChangeNodeWarningConfirm action then hides main content before clearing settings`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { sensitiveSettingsRepository.clear() } returns Unit
             setupPresenter()
             presenter.onAction(TrustedNodeSetupUiAction.OnPairWithNewNodePress)
@@ -858,7 +815,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnChangeNodeWarningConfirm action then clears settings and navigates to TrustedNodeSetup`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { sensitiveSettingsRepository.clear() } returns Unit
             setupPresenter()
@@ -882,7 +839,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnChangeNodeWarningConfirm action then hides dialog`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { sensitiveSettingsRepository.clear() } returns Unit
             setupPresenter()
@@ -901,7 +858,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `shows connection failed warning when initialized with showConnectionFailed true`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -915,7 +872,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `does NOT show connection failed warning when initialized without flag`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -929,7 +886,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `hides connection failed warning on retry press`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
@@ -948,7 +905,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `continue from failed subscriptions dialog navigates to splash with override`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.initialize(isWorkflow = true, showSubscriptionsFailed = true)
@@ -974,7 +931,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `failed topics update even after subscriptions warning opens`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             failedSubscriptionTopicsFlow.value = setOf(Topic.TRADES, Topic.OFFERS)
             setupPresenter()
@@ -993,7 +950,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `shows connection failed warning instead when websocket is already disconnected`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             failedSubscriptionTopicsFlow.value = setOf(Topic.TRADES)
             connectionStateFlow.value = ConnectionState.Disconnected()
@@ -1011,7 +968,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `switches subscriptions warning to connection failed warning when websocket disconnects`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             failedSubscriptionTopicsFlow.value = setOf(Topic.TRADES)
             setupPresenter()
@@ -1031,7 +988,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `re-enables retry guard when connection failed warning is shown again after successful retry`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
             presenter.initialize(isWorkflow = true, showConnectionFailed = true)
@@ -1051,7 +1008,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `re-enables retry guard when subscriptions failed warning is shown again after successful retry`() =
-        runTest(testDispatcher) {
+        runTest {
             coEvery { applicationLifecycleService.restartAllServices() } returns true
             setupPresenter()
             presenter.initialize(isWorkflow = true, showSubscriptionsFailed = true)
@@ -1075,7 +1032,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `re-shows connection failed warning when lifecycle restart fails`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             coEvery { applicationLifecycleService.restartAllServices() } returns false
             setupPresenter()
@@ -1093,7 +1050,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `hides connection failed warning on pair with new node press`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.initialize(isWorkflow = true, showConnectionFailed = true)
@@ -1111,7 +1068,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `shows keystore error dialog when initialized with showKeystoreError true`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -1125,7 +1082,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `does NOT show keystore error dialog when initialized without flag`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -1139,7 +1096,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `hides keystore error dialog on dismiss action`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
             presenter.initialize(isWorkflow = true, showKeystoreError = true)
@@ -1156,7 +1113,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `keystore error takes priority over connection failed`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             setupPresenter()
 
@@ -1171,7 +1128,7 @@ class TrustedNodeSetupPresenterTest {
 
     @Test
     fun `when OnChangeNodeWarningConfirm action then resets state to idle`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             every { apiAccessService.getPairingCodeQr(validPairingCode) } returns Result.success(validPairingQrCode)
             coEvery { sensitiveSettingsRepository.clear() } returns Unit

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/test_utils/NodeKoinIntegrationTestBase.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/test_utils/NodeKoinIntegrationTestBase.kt
@@ -4,11 +4,7 @@ import network.bisq.mobile.node.common.di.testModule
 import network.bisq.mobile.test.koin.KoinIntegrationTestBase
 import org.koin.core.module.Module
 
-/**
- * Leaf test base for node presenter tests. Provides the Koin floor (NavigationManager,
- * CoroutineJobsManager, GlobalUiManager) via [testModule] and the coroutine/dispatcher lifecycle
- * from [KoinIntegrationTestBase]. Mirrors `ClientKoinIntegrationTestBase`.
- */
+/** Leaf base for node presenters/facades ([testModule] floor). */
 abstract class NodeKoinIntegrationTestBase : KoinIntegrationTestBase() {
     override fun baseModules(): List<Module> = listOf(testModule)
 }

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/connections/NodeNetworkConnectionsPresenterTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/connections/NodeNetworkConnectionsPresenterTest.kt
@@ -2,77 +2,30 @@ package network.bisq.mobile.node.network.presentation.connections
 
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.node.common.domain.service.network.NodeInfo
 import network.bisq.mobile.node.common.domain.service.network.NodeNetworkServiceFacade
 import network.bisq.mobile.node.common.domain.service.network.NodePeerInfo
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.node.common.test_utils.NodeKoinIntegrationTestBase
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class NodeNetworkConnectionsPresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
+class NodeNetworkConnectionsPresenterTest : NodeKoinIntegrationTestBase() {
+    private val networkServiceFacade: NodeNetworkServiceFacade = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
 
-    private lateinit var networkServiceFacade: NodeNetworkServiceFacade
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var globalUiManager: GlobalUiManager
-    private lateinit var navigationManager: NavigationManager
-
-    private lateinit var connectedPeers: MutableStateFlow<List<NodePeerInfo>>
-    private lateinit var myNodeInfo: MutableStateFlow<NodeInfo>
+    private val connectedPeers = MutableStateFlow<List<NodePeerInfo>>(emptyList())
+    private val myNodeInfo = MutableStateFlow(NodeInfo())
 
     private lateinit var presenter: NodeNetworkConnectionsPresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        networkServiceFacade = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        globalUiManager = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
-
-        connectedPeers = MutableStateFlow(emptyList())
+    override fun onSetup() {
         every { networkServiceFacade.connectedPeers } returns connectedPeers
-
-        myNodeInfo = MutableStateFlow(NodeInfo())
         every { networkServiceFacade.myNodeInfo } returns myNodeInfo
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { navigationManager }
-                    single<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
-                    single<GlobalUiManager> { globalUiManager }
-                },
-            )
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): NodeNetworkConnectionsPresenter =
@@ -83,7 +36,7 @@ class NodeNetworkConnectionsPresenterTest {
 
     @Test
     fun `when peers are present then uiState exposes count and peers`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             connectedPeers.value =
                 listOf(
@@ -104,7 +57,7 @@ class NodeNetworkConnectionsPresenterTest {
 
     @Test
     fun `when peers are empty then uiState is empty`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given no peers
 
             // When
@@ -120,7 +73,7 @@ class NodeNetworkConnectionsPresenterTest {
 
     @Test
     fun `when peers arrive unordered then newest established peers come first`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given peers in mixed establishment order
             connectedPeers.value =
                 listOf(
@@ -144,7 +97,7 @@ class NodeNetworkConnectionsPresenterTest {
 
     @Test
     fun `when the peer list changes then uiState updates reactively`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given an attached presenter with no peers
             presenter = createPresenter()
             presenter.onViewAttached()
@@ -161,7 +114,7 @@ class NodeNetworkConnectionsPresenterTest {
 
     @Test
     fun `when node identity resolves then uiState exposes keyId and nodeTag`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             myNodeInfo.value = NodeInfo(keyId = "key-123", nodeTag = "default")
 

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/my_node/NetworkMyNodePresenterTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/network/presentation/my_node/NetworkMyNodePresenterTest.kt
@@ -2,82 +2,34 @@ package network.bisq.mobile.node.network.presentation.my_node
 
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import network.bisq.mobile.android.node.BuildNodeConfig
 import network.bisq.mobile.data.service.network.KmpTorService
-import network.bisq.mobile.domain.utils.CoroutineJobsManager
-import network.bisq.mobile.domain.utils.DefaultCoroutineJobsManager
 import network.bisq.mobile.node.common.domain.service.network.NodeInfo
 import network.bisq.mobile.node.common.domain.service.network.NodeNetworkServiceFacade
-import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
-import network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManager
+import network.bisq.mobile.node.common.test_utils.NodeKoinIntegrationTestBase
 import network.bisq.mobile.presentation.main.MainPresenter
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class NetworkMyNodePresenterTest {
-    private val testDispatcher = StandardTestDispatcher()
+class NetworkMyNodePresenterTest : NodeKoinIntegrationTestBase() {
+    private val networkServiceFacade: NodeNetworkServiceFacade = mockk(relaxed = true)
+    private val kmpTorService: KmpTorService = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
 
-    private lateinit var networkServiceFacade: NodeNetworkServiceFacade
-    private lateinit var kmpTorService: KmpTorService
-    private lateinit var mainPresenter: MainPresenter
-    private lateinit var globalUiManager: GlobalUiManager
-    private lateinit var navigationManager: NavigationManager
-
-    private lateinit var myNodeInfo: MutableStateFlow<NodeInfo>
-    private lateinit var torState: MutableStateFlow<KmpTorService.TorState>
+    private val myNodeInfo = MutableStateFlow(NodeInfo())
+    private val torState = MutableStateFlow<KmpTorService.TorState>(KmpTorService.TorState.Stopped())
 
     private lateinit var presenter: NetworkMyNodePresenter
 
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-
-        networkServiceFacade = mockk(relaxed = true)
-        kmpTorService = mockk(relaxed = true)
-        mainPresenter = mockk(relaxed = true)
-        globalUiManager = mockk(relaxed = true)
-        navigationManager = mockk(relaxed = true)
-
-        myNodeInfo = MutableStateFlow(NodeInfo())
-        torState = MutableStateFlow(KmpTorService.TorState.Stopped())
-
+    override fun onSetup() {
         every { networkServiceFacade.myNodeInfo } returns myNodeInfo
         every { kmpTorService.state } returns torState
-
-        startKoin {
-            modules(
-                module {
-                    single<NavigationManager> { navigationManager }
-                    single<CoroutineJobsManager> { DefaultCoroutineJobsManager() }
-                    single<GlobalUiManager> { globalUiManager }
-                },
-            )
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        try {
-            stopKoin()
-        } finally {
-            Dispatchers.resetMain()
-        }
     }
 
     private fun createPresenter(): NetworkMyNodePresenter =
@@ -89,7 +41,7 @@ class NetworkMyNodePresenterTest {
 
     @Test
     fun `when node info is resolved then uiState exposes address and keyId`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             myNodeInfo.value = NodeInfo(onionAddress = "abcd.onion:1234", keyId = "135e9801")
             torState.value = KmpTorService.TorState.Started
@@ -109,7 +61,7 @@ class NetworkMyNodePresenterTest {
 
     @Test
     fun `when node info is not yet resolved then address and keyId are null`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given no node info
 
             // When
@@ -125,7 +77,7 @@ class NetworkMyNodePresenterTest {
 
     @Test
     fun `when tor is not started then isTorRunning is false`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given
             torState.value = KmpTorService.TorState.Stopped()
 
@@ -140,7 +92,7 @@ class NetworkMyNodePresenterTest {
 
     @Test
     fun `when node info arrives then uiState updates reactively`() =
-        runTest(testDispatcher) {
+        runTest {
             // Given an attached presenter with no node info
             presenter = createPresenter()
             presenter.onViewAttached()

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,6 +36,7 @@ Changed file layer?
 ├── Presenter (:shared:presentation) → *PresenterTest.kt, PresentationKoinTestBase / PlatformPresentationKoinTestBase → recipes.md#presenter
 ├── Composable (:shared:presentation) → *UiTest.kt, BisqComposeUiTestBase or PresentationKoinComposeTestBase → recipes.md#compose
 ├── Screen (:shared:presentation) resolved via RememberPresenterLifecycleBackStackAware → PresentationInjectComposeUiTestBase → recipes.md#compose
+├── Client/Node app presenter → ClientKoinIntegrationTestBase / NodeKoinIntegrationTestBase → recipes.md#client
 ├── Client facade/service → ClientKoinIntegrationTestBase → recipes.md#client
 ├── Client Compose + TestApplication → BisqComposeUiTestBase + @Config(TestApplication); no startKoin → recipes.md#compose
 ├── Client Compose + inject overrides → ClientInjectComposeUiTestBase (not TestApplication) → recipes.md#compose

--- a/docs/testing/catalog.md
+++ b/docs/testing/catalog.md
@@ -12,7 +12,7 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | --- | --- | --- |
 | `PresentationKoinTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/coroutines/PresentationKoinTestBase.kt` | `:shared:presentation` presenter tests |
 | `PlatformPresentationKoinTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/coroutines/PlatformPresentationKoinTestBase.kt` | + static platform mocks (`getScreenWidthDp`) |
-| `ClientKoinIntegrationTestBase` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/ClientKoinIntegrationTestBase.kt` | Client facades/services |
+| `ClientKoinIntegrationTestBase` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/ClientKoinIntegrationTestBase.kt` | Client facades/services/presenters |
 | `ClientInjectComposeUiTestBase` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/ClientInjectComposeUiTestBase.kt` | Client Compose + inject overrides (not `TestApplication`) |
 | `NodeKoinIntegrationTestBase` | `apps/nodeApp/src/androidUnitTest/kotlin/.../test_utils/NodeKoinIntegrationTestBase.kt` | Node presenters/facades |
 | `BisqComposeUiTestBase` | `shared/test-utils/src/androidMain/kotlin/.../test/presentation/compose/BisqComposeUiTestBase.kt` | Compose UI, no Koin |
@@ -29,8 +29,10 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `analyticsTestModule` | `shared/test-utils/src/androidMain/kotlin/.../test/koin/AnalyticsTestModule.kt` |
 | `clientTestModule` | `apps/clientApp/src/androidUnitTest/kotlin/.../client/common/di/TestModule.kt` |
 | `commonTestModule` | `apps/clientApp/src/commonTest/kotlin/.../client/common/di/CommonTestModule.kt` |
-| `testModule` | `shared/domain/src/commonTest/kotlin/.../data/di/TestModule.kt` |
-| `TestApplication` | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/TestApplication.kt` |
+| `testModule` (node) | `apps/nodeApp/src/androidUnitTest/kotlin/.../node/common/di/TestModule.kt` |
+| `testModule` (domain) | `shared/domain/src/commonTest/kotlin/.../data/di/TestModule.kt` |
+| `TestApplication` (client) | `apps/clientApp/src/androidUnitTest/kotlin/.../test_utils/TestApplication.kt` |
+| `TestApplication` (node) | `apps/nodeApp/src/androidUnitTest/kotlin/.../test_utils/TestApplication.kt` |
 | `TestDoubles` | `apps/clientApp/src/androidUnitTest/kotlin/.../client/test_utils/TestDoubles.kt` |
 | `MainPresenterTestFactory` | `.../test_utils/MainPresenterTestFactory.kt` |
 | `FakeAppUpdateLinker` | `.../test_utils/FakeAppUpdateLinker.kt` |

--- a/docs/testing/recipes.md
+++ b/docs/testing/recipes.md
@@ -173,9 +173,11 @@ Pitfalls: mocks assigned in `onKoinReady()` are fine — module definitions reso
 
 ---
 
-## Client facade {#client}
+## Client / Node app {#client}
 
-Base: `ClientKoinIntegrationTestBase`. Proof: `ClientSettingsServiceFacadeTest`.
+Bases: `ClientKoinIntegrationTestBase` (client) / `NodeKoinIntegrationTestBase` (node). Proofs: `ClientSettingsServiceFacadeTest`, `ClientSplashPresenterTest`, `NodeNetworkOverviewPresenterTest`.
+
+### Facade
 
 ```kotlin
 class MyClientFacadeTest : ClientKoinIntegrationTestBase() {
@@ -200,7 +202,34 @@ class MyClientFacadeTest : ClientKoinIntegrationTestBase() {
 }
 ```
 
-Pitfalls: construct facade manually in `onSetup()`; mock at gateway/repository boundary; call `activate()` before flow asserts; no `TestApplication` in same class.
+### Presenter
+
+Stubbing goes in `onSetup()`. Floor modules bind a no-op/relaxed `NavigationManager` and a real `GlobalUiManager` — override via `additionalModules()` only when the test verifies on those managers. Mocks referenced by `additionalModules()` must be property initializers (evaluated during `startKoin`, before `onSetup()`).
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyClientPresenterTest : ClientKoinIntegrationTestBase() {
+    private val mainPresenter: MainPresenter = mockk(relaxed = true) // VERIFY
+    private val navigationManager: NavigationManager = mockk(relaxed = true)
+
+    override fun additionalModules(): List<Module> =
+        listOf(module { single<NavigationManager> { navigationManager } })
+
+    override fun onSetup() {
+        // stubbing only — VERIFY
+    }
+
+    @Test
+    fun `when action then navigates`() = runTest {
+        val presenter = MyPresenter(mainPresenter = mainPresenter) // VERIFY
+        presenter.onAction(MyUiAction.SomeClick)
+        advanceUntilIdle()
+        verify { navigationManager.navigate(any(), any(), any()) }
+    }
+}
+```
+
+Pitfalls: construct facade/presenter manually in `onSetup()` or per-test; mock at gateway/repository boundary for facades; call `activate()` before facade flow asserts; no `TestApplication` in same class; no inline `startKoin` / `Dispatchers.setMain`; if overriding `beforeStartKoin` / `onTearDown`, always call `super` (`try/finally` for tear-down).
 
 ---
 

--- a/docs/testing/recipes.md
+++ b/docs/testing/recipes.md
@@ -224,7 +224,7 @@ class MyClientPresenterTest : ClientKoinIntegrationTestBase() {
         val presenter = MyPresenter(mainPresenter = mainPresenter) // VERIFY
         presenter.onAction(MyUiAction.SomeClick)
         advanceUntilIdle()
-        verify { navigationManager.navigate(any(), any(), any()) }
+        verify { navigationManager.navigate(MyNavRoute.SomeDestination, any(), any()) } // VERIFY: destination for SomeClick
     }
 }
 ```


### PR DESCRIPTION
Follow up on https://github.com/bisq-network/bisq-mobile/pull/1703

 - Migrate remaining presenters in clientApp and nodeApp onto cataloged leaf bases ClientKoinIntegrationTestBase and NodeKoinIntegrationTestBase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized client and node presenter tests on shared integration-test setup.
  * Simplified test lifecycle, mocking, and coroutine execution while preserving existing scenarios and assertions.
  * Improved consistency across payment account, navigation, network, splash, and main presenter tests.

* **Documentation**
  * Expanded testing guidance and catalog entries for client and node presenter tests.
  * Added recipes covering setup, module overrides, mocks, navigation verification, and common pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->