### PR TITLE
bugfix/terminal_compilation_ios_error

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -82,12 +82,34 @@ kotlin {
             baseName = clientFrameworkBaseName
             configureSharedExports()
 
-            // Link Swift bridge object files (only from domain module to avoid duplicates)
-            val swiftBridgeModules = listOf("LocalEncryptionBridge")
+            // The Sentry cinterop manifest contributes `-framework Sentry`,
+            // but the standalone Kotlin/Native framework linker does not
+            // inherit CocoaPods' FRAMEWORK_SEARCH_PATHS from the synthetic
+            // Pods xcconfig. Xcode supplies that path itself, which is why
+            // the IDE build can succeed while `:clientApp:build` fails with
+            // `ld: framework 'Sentry' not found`.
+            val appleSdkName =
+                if (iosTarget.name == "iosArm64") {
+                    "iphoneos"
+                } else {
+                    "iphonesimulator"
+                }
+            val configuration = buildType.name.lowercase().replaceFirstChar { it.uppercase() }
+            val sentryFrameworkSearchPath =
+                layout.buildDirectory
+                    .dir("cocoapods/synthetic/ios/build/$configuration-$appleSdkName/Sentry")
+                    .get()
+                    .asFile
+                    .absolutePath
+            linkerOpts("-F$sentryFrameworkSearchPath")
+
+            // Link Swift bridge object files (only from domain module to avoid duplicates).
+            // Per-SDK dir: device and simulator objects are not interchangeable.
+            val swiftBridgeModules = listOf("LocalEncryptionBridge", "PushNotificationKeyStore")
             val domainSwiftBridgeDir =
                 project(":shared:domain")
                     .layout.buildDirectory
-                    .dir("swift-bridge")
+                    .dir("swift-bridge/$appleSdkName")
                     .get()
                     .asFile
 
@@ -99,7 +121,7 @@ kotlin {
             val isMac = System.getProperty("os.name").lowercase().contains("mac")
             if (isMac) {
                 try {
-                    val swiftLibPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator"
+                    val swiftLibPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$appleSdkName"
                     linkerOpts(
                         *objectFiles.toTypedArray(),
                         "-L$swiftLibPath",

--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -124,7 +124,11 @@ kotlin {
             val isMac = System.getProperty("os.name").lowercase().contains("mac")
             if (isMac) {
                 try {
-                    val swiftLibPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$appleSdkName"
+                    // Same DEVELOPER_DIR resolution as the shared modules' getSwiftLibPath.
+                    val developerPath =
+                        System.getenv("DEVELOPER_DIR")
+                            ?: "/Applications/Xcode.app/Contents/Developer"
+                    val swiftLibPath = "$developerPath/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$appleSdkName"
                     linkerOpts(
                         *objectFiles.toTypedArray(),
                         "-L$swiftLibPath",
@@ -490,15 +494,20 @@ tasks.matching { it.name == "podInstall" }.configureEach {
 fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String = "${appName.replace(" ", "")}-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 
 // -------------------- Swift Bridge Configuration --------------------
-// Ensure Swift bridge objects are built before linking iOS frameworks
+// Ensure Swift bridge objects are built before linking iOS frameworks. SDK-specific aggregates
+// so a simulator link doesn't also compile device bridge objects (and vice versa);
+// `compileSwiftBridge` stays available as the both-SDKs convenience umbrella.
 tasks
-    .matching {
-        it.name.startsWith("link") &&
-            (it.name.contains("IosSimulatorArm64") || it.name.contains("IosArm64")) &&
-            !it.name.contains("Test")
-    }.configureEach {
-        dependsOn(":shared:domain:compileSwiftBridge")
-        dependsOn(":shared:presentation:compileSwiftBridge")
+    .matching { it.name.startsWith("link") && it.name.contains("IosSimulatorArm64") && !it.name.contains("Test") }
+    .configureEach {
+        dependsOn(":shared:domain:compileSwiftBridgeIphonesimulator")
+        dependsOn(":shared:presentation:compileSwiftBridgeIphonesimulator")
+    }
+tasks
+    .matching { it.name.startsWith("link") && it.name.contains("IosArm64") && !it.name.contains("Test") }
+    .configureEach {
+        dependsOn(":shared:domain:compileSwiftBridgeIphoneos")
+        dependsOn(":shared:presentation:compileSwiftBridgeIphoneos")
     }
 
 // -------------------- ProGuard Mapping Configuration --------------------

--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -94,10 +94,13 @@ kotlin {
                 } else {
                     "iphonesimulator"
                 }
-            val configuration = buildType.name.lowercase().replaceFirstChar { it.uppercase() }
+            // Always Debug-<sdk>: the cocoapods plugin builds each pod once per SDK, in Debug
+            // configuration only — there is no Release-<sdk> pod output, and the Debug-built
+            // Sentry is fine for RELEASE framework links too (the -F path only serves symbol
+            // resolution; the framework actually embedded into the app is Xcode's own build).
             val sentryFrameworkSearchPath =
                 layout.buildDirectory
-                    .dir("cocoapods/synthetic/ios/build/$configuration-$appleSdkName/Sentry")
+                    .dir("cocoapods/synthetic/ios/build/Debug-$appleSdkName/Sentry")
                     .get()
                     .asFile
                     .absolutePath

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeTest.kt
@@ -244,13 +244,13 @@ class ClientPushNotificationServiceFacadeTest {
     // decrypt, leaving pushes silently broken.
 
     @Test
-    fun `validateSymmetricKey returns null when key is present (iOS)`() {
+    fun `validateSymmetricKey returns null when key is present for iOS`() {
         val result = validateSymmetricKey(PlatformType.IOS, "some-base64")
         assertEquals(null, result)
     }
 
     @Test
-    fun `validateSymmetricKey returns null when key is present (Android)`() {
+    fun `validateSymmetricKey returns null when key is present for Android`() {
         val result = validateSymmetricKey(PlatformType.ANDROID, "some-base64")
         assertEquals(null, result)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,18 @@
+// R8 pinned ahead of the AGP-bundled one: AGP 8.13.x ships an R8 whose kotlin-metadata parser
+// predates Kotlin 2.4, so every minified build warns "error occurred when parsing kotlin
+// metadata" and Kotlin-aware shrinking silently degrades to plain-Java treatment. Drop this
+// pin when AGP is upgraded to a version whose bundled R8 understands the project's Kotlin.
+// Compatibility table: https://developer.android.com/studio/build/kotlin-d8-r8-versions
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools:r8:9.4.12")
+    }
+}
+
 // ktlint version constant
 val ktlintVersion = "1.7.1"
 
@@ -94,6 +109,18 @@ dependencies {
 
 // Configure all subprojects to run generateResourceBundles before compilation
 subprojects {
+    // KGP's cinterop commonizer invokes `Task.project` at execution time — a configuration-cache
+    // violation inside the Kotlin plugin (surfaces as "compileIosMainKotlinMetadata caused
+    // invocation of 'Task.project' by commonizeCInterop") that FAILS the build at the very end.
+    // Marking the offenders incompatible downgrades that to discarding the cache entry: iOS task
+    // graphs can't cache anyway (Swift-bridge Exec tasks), Android-only builds keep caching.
+    // Re-check when upgrading Kotlin — if KGP fixes it, this block can go.
+    tasks.configureEach {
+        if (name == "commonizeCInterop" || name == "compileIosMainKotlinMetadata") {
+            notCompatibleWithConfigurationCache("KGP commonizeCInterop accesses Task.project at execution time")
+        }
+    }
+
     // Apply ktlint to all subprojects with KMP plugin
     plugins.withId("org.jetbrains.kotlin.multiplatform") {
         apply(

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -678,6 +678,10 @@ class SwiftBridgeConfiguration {
                         val objectFile = getSwiftBridgeOutputDir(sdkName).file("$bridgeModuleName.o").asFile
 
                         inputs.files(swiftFile, headerFile)
+                        // Exec does not track commandLine: declare these so an SDK/triple change
+                        // invalidates the task instead of leaving a stale object file.
+                        inputs.property("sdkName", sdkName)
+                        inputs.property("targetTriple", targetTriple)
                         outputs.file(objectFile)
 
                         // Only run on macOS

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -551,15 +551,19 @@ class SwiftBridgeConfiguration {
     /**
      * Get Swift library path without spawning external processes (config cache friendly).
      */
-    private fun getSwiftLibPath(): String {
+    private fun getSwiftLibPath(sdkName: String): String {
         val developerPath =
             System.getenv("DEVELOPER_DIR")
                 ?: "/Applications/Xcode.app/Contents/Developer"
         // Swift libraries are in the toolchain, not the SDK
-        return "$developerPath/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator"
+        return "$developerPath/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$sdkName"
     }
 
-    private fun getSwiftBridgeOutputDir(): Directory = layout.buildDirectory.dir("swift-bridge").get()
+    // Namespaced per SDK: device and simulator objects are not interchangeable, and a shared
+    // output path lets a stale artifact from one SDK get linked into the other's binary.
+    private fun getSwiftBridgeOutputDir(sdkName: String): Directory = layout.buildDirectory.dir("swift-bridge/$sdkName").get()
+
+    private fun sdkNameFor(target: KotlinNativeTarget): String = if (target.name == "iosArm64") "iphoneos" else "iphonesimulator"
 
     /**
      * Configure cinterops for all discovered bridge modules. this is required for discovering the bridge in both test and main.
@@ -603,17 +607,18 @@ class SwiftBridgeConfiguration {
         bridgeModules: List<String>,
     ) {
         targets.forEach { target ->
+            val sdkName = sdkNameFor(target)
             target.binaries.all {
                 val objectFiles =
                     bridgeModules.map {
-                        getSwiftBridgeOutputDir().file("$it.o").asFile.absolutePath
+                        getSwiftBridgeOutputDir(sdkName).file("$it.o").asFile.absolutePath
                     }
 
                 val isMac = System.getProperty("os.name").lowercase().contains("mac")
 
                 if (isMac) {
                     try {
-                        val swiftLibPath = getSwiftLibPath()
+                        val swiftLibPath = getSwiftLibPath(sdkName)
                         linkerOpts(
                             *objectFiles.toTypedArray(),
                             "-L$swiftLibPath",
@@ -637,7 +642,6 @@ class SwiftBridgeConfiguration {
      */
     fun configureSwiftBridge() {
         val interopDir = file("${rootDir.absolutePath}/iosClient/iosClient/interop")
-        val swiftOutputDir = getSwiftBridgeOutputDir()
 
         val bridgeModules = discoverBridgeModules(interopDir)
 
@@ -651,82 +655,104 @@ class SwiftBridgeConfiguration {
                 }
             }
 
-        // Create a compile task for each Swift bridge module
-        val compileSwiftBridgeTasks =
-            bridgeModules.map { bridgeModuleName ->
-                tasks.register<Exec>("compileSwiftBridge_$bridgeModuleName") {
-                    group = "build"
-                    description = "Compile Swift bridge module: $bridgeModuleName for iOS tests"
-                    notCompatibleWithConfigurationCache("Swift bridge compile Exec is not configuration cache friendly")
+        // Device objects are always arm64; the simulator arch follows the host.
+        val targetTripleBySdk =
+            mapOf(
+                "iphonesimulator" to "$simulatorArch-apple-ios16.0-simulator",
+                "iphoneos" to "arm64-apple-ios16.0",
+            )
 
-                    val swiftFile = file("$interopDir/$bridgeModuleName.swift")
-                    val headerFile = file("$interopDir/$bridgeModuleName.h")
-                    val objectFile = swiftOutputDir.file("$bridgeModuleName.o").asFile
+        // Create a compile task per Swift bridge module PER SDK: device and simulator objects are
+        // not interchangeable (`ld: building for 'iOS', but linking in object file built for
+        // 'iOS-simulator'`), so each variant gets its own task and output dir.
+        val compileTasksBySdk =
+            targetTripleBySdk.mapValues { (sdkName, targetTriple) ->
+                bridgeModules.map { bridgeModuleName ->
+                    tasks.register<Exec>("compileSwiftBridge_${bridgeModuleName}_$sdkName") {
+                        group = "build"
+                        description = "Compile Swift bridge module $bridgeModuleName for $sdkName"
+                        notCompatibleWithConfigurationCache("Swift bridge compile Exec is not configuration cache friendly")
 
-                    inputs.files(swiftFile, headerFile)
-                    outputs.file(objectFile)
+                        val swiftFile = file("$interopDir/$bridgeModuleName.swift")
+                        val headerFile = file("$interopDir/$bridgeModuleName.h")
+                        val objectFile = getSwiftBridgeOutputDir(sdkName).file("$bridgeModuleName.o").asFile
 
-                    // Only run on macOS
-                    onlyIf {
-                        val isMac = System.getProperty("os.name").lowercase().contains("mac")
-                        if (!isMac) {
-                            logger.info("Skipping Swift bridge compilation on non-macOS platform")
+                        inputs.files(swiftFile, headerFile)
+                        outputs.file(objectFile)
+
+                        // Only run on macOS
+                        onlyIf {
+                            val isMac = System.getProperty("os.name").lowercase().contains("mac")
+                            if (!isMac) {
+                                logger.info("Skipping Swift bridge compilation on non-macOS platform")
+                            }
+                            isMac
                         }
-                        isMac
-                    }
 
-                    doFirst {
-                        swiftOutputDir.asFile.mkdirs()
-                        logger.info("Compiling Swift bridge for architecture: $simulatorArch")
-                    }
+                        doFirst {
+                            objectFile.parentFile.mkdirs()
+                            logger.info("Compiling Swift bridge $bridgeModuleName for $targetTriple")
+                        }
 
-                    // Compile Swift to object file for simulator with dynamic SDK path
-                    commandLine(
-                        "xcrun",
-                        "-sdk",
-                        "iphonesimulator",
-                        "swiftc",
-                        "-emit-object",
-                        "-parse-as-library",
-                        "-o",
-                        objectFile.absolutePath,
-                        "-module-name",
-                        bridgeModuleName,
-                        "-import-objc-header",
-                        headerFile.absolutePath,
-                        "-target",
-                        "$simulatorArch-apple-ios16.0-simulator",
-                        swiftFile.absolutePath,
-                    )
+                        commandLine(
+                            "xcrun",
+                            "-sdk",
+                            sdkName,
+                            "swiftc",
+                            "-emit-object",
+                            "-parse-as-library",
+                            "-o",
+                            objectFile.absolutePath,
+                            "-module-name",
+                            bridgeModuleName,
+                            "-import-objc-header",
+                            headerFile.absolutePath,
+                            "-target",
+                            targetTriple,
+                            swiftFile.absolutePath,
+                        )
 
-                    doLast {
-                        logger.info("Successfully compiled $bridgeModuleName Swift bridge for $simulatorArch")
+                        doLast {
+                            logger.info("Successfully compiled $bridgeModuleName Swift bridge for $targetTriple")
+                        }
                     }
                 }
             }
 
-        // Create an aggregate task that compiles all Swift bridges
+        val compileSwiftBridgeSimulator =
+            tasks.register("compileSwiftBridgeIphonesimulator") {
+                group = "build"
+                description = "Compile all Swift bridge modules for the iOS simulator"
+                dependsOn(compileTasksBySdk.getValue("iphonesimulator"))
+            }
+        val compileSwiftBridgeDevice =
+            tasks.register("compileSwiftBridgeIphoneos") {
+                group = "build"
+                description = "Compile all Swift bridge modules for iOS devices"
+                dependsOn(compileTasksBySdk.getValue("iphoneos"))
+            }
+        // Umbrella kept for external dependents (e.g. clientApp's link tasks depend on it by name).
         val compileSwiftBridge =
             tasks.register("compileSwiftBridge") {
                 group = "build"
-                description = "Compile all Swift bridge modules for iOS tests"
-                dependsOn(compileSwiftBridgeTasks)
+                description = "Compile all Swift bridge modules for all iOS SDKs"
+                dependsOn(compileSwiftBridgeSimulator, compileSwiftBridgeDevice)
             }
 
         // Ensure Swift bridge objects are built before linking iOS test binaries
         tasks.matching { it.name.startsWith("link") && it.name.contains("TestIosSimulatorArm64") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
         // Also ensure Swift bridge objects are built before linking iOS main binaries (for frameworks)
         tasks.matching { it.name.startsWith("link") && it.name.contains("IosSimulatorArm64") && !it.name.contains("Test") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
         tasks.matching { it.name.startsWith("link") && it.name.contains("IosArm64") && !it.name.contains("Test") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeDevice)
         }
         // Also tie to test Kotlin compilation as a safety net (ensures object files exist by link time)
         tasks.matching { it.name == "compileTestKotlinIosSimulatorArm64" }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
 
         kotlin {

--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -223,15 +223,19 @@ class SwiftBridgeConfiguration {
     /**
      * Get Swift library path without spawning external processes (config cache friendly).
      */
-    private fun getSwiftLibPath(): String {
+    private fun getSwiftLibPath(sdkName: String): String {
         val developerPath =
             System.getenv("DEVELOPER_DIR")
                 ?: "/Applications/Xcode.app/Contents/Developer"
         // Swift libraries are in the toolchain, not the SDK
-        return "$developerPath/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator"
+        return "$developerPath/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$sdkName"
     }
 
-    private fun getSwiftBridgeOutputDir(): Directory = layout.buildDirectory.dir("swift-bridge").get()
+    // Namespaced per SDK: device and simulator objects are not interchangeable, and a shared
+    // output path lets a stale artifact from one SDK get linked into the other's binary.
+    private fun getSwiftBridgeOutputDir(sdkName: String): Directory = layout.buildDirectory.dir("swift-bridge/$sdkName").get()
+
+    private fun sdkNameFor(target: KotlinNativeTarget): String = if (target.name == "iosArm64") "iphoneos" else "iphonesimulator"
 
     /**
      * Configure cinterops for all discovered bridge modules. this is required for discovering the bridge in both test and main.
@@ -275,17 +279,18 @@ class SwiftBridgeConfiguration {
         bridgeModules: List<String>,
     ) {
         targets.forEach { target ->
+            val sdkName = sdkNameFor(target)
             target.binaries.all {
                 val objectFiles =
                     bridgeModules.map {
-                        getSwiftBridgeOutputDir().file("$it.o").asFile.absolutePath
+                        getSwiftBridgeOutputDir(sdkName).file("$it.o").asFile.absolutePath
                     }
 
                 val isMac = System.getProperty("os.name").lowercase().contains("mac")
 
                 if (isMac) {
                     try {
-                        val swiftLibPath = getSwiftLibPath()
+                        val swiftLibPath = getSwiftLibPath(sdkName)
                         linkerOpts(
                             *objectFiles.toTypedArray(),
                             "-L$swiftLibPath",
@@ -309,7 +314,6 @@ class SwiftBridgeConfiguration {
      */
     fun configureSwiftBridge() {
         val interopDir = file("${rootDir.absolutePath}/iosClient/iosClient/interop")
-        val swiftOutputDir = getSwiftBridgeOutputDir()
 
         val bridgeModules = discoverBridgeModules(interopDir)
 
@@ -323,82 +327,104 @@ class SwiftBridgeConfiguration {
                 }
             }
 
-        // Create a compile task for each Swift bridge module
-        val compileSwiftBridgeTasks =
-            bridgeModules.map { bridgeModuleName ->
-                tasks.register<Exec>("compileSwiftBridge_$bridgeModuleName") {
-                    group = "build"
-                    description = "Compile Swift bridge module: $bridgeModuleName for iOS tests"
-                    notCompatibleWithConfigurationCache("Swift bridge compile Exec is not configuration cache friendly")
+        // Device objects are always arm64; the simulator arch follows the host.
+        val targetTripleBySdk =
+            mapOf(
+                "iphonesimulator" to "$simulatorArch-apple-ios16.0-simulator",
+                "iphoneos" to "arm64-apple-ios16.0",
+            )
 
-                    val swiftFile = file("$interopDir/$bridgeModuleName.swift")
-                    val headerFile = file("$interopDir/$bridgeModuleName.h")
-                    val objectFile = swiftOutputDir.file("$bridgeModuleName.o").asFile
+        // Create a compile task per Swift bridge module PER SDK: device and simulator objects are
+        // not interchangeable (`ld: building for 'iOS', but linking in object file built for
+        // 'iOS-simulator'`), so each variant gets its own task and output dir.
+        val compileTasksBySdk =
+            targetTripleBySdk.mapValues { (sdkName, targetTriple) ->
+                bridgeModules.map { bridgeModuleName ->
+                    tasks.register<Exec>("compileSwiftBridge_${bridgeModuleName}_$sdkName") {
+                        group = "build"
+                        description = "Compile Swift bridge module $bridgeModuleName for $sdkName"
+                        notCompatibleWithConfigurationCache("Swift bridge compile Exec is not configuration cache friendly")
 
-                    inputs.files(swiftFile, headerFile)
-                    outputs.file(objectFile)
+                        val swiftFile = file("$interopDir/$bridgeModuleName.swift")
+                        val headerFile = file("$interopDir/$bridgeModuleName.h")
+                        val objectFile = getSwiftBridgeOutputDir(sdkName).file("$bridgeModuleName.o").asFile
 
-                    // Only run on macOS
-                    onlyIf {
-                        val isMac = System.getProperty("os.name").lowercase().contains("mac")
-                        if (!isMac) {
-                            logger.info("Skipping Swift bridge compilation on non-macOS platform")
+                        inputs.files(swiftFile, headerFile)
+                        outputs.file(objectFile)
+
+                        // Only run on macOS
+                        onlyIf {
+                            val isMac = System.getProperty("os.name").lowercase().contains("mac")
+                            if (!isMac) {
+                                logger.info("Skipping Swift bridge compilation on non-macOS platform")
+                            }
+                            isMac
                         }
-                        isMac
-                    }
 
-                    doFirst {
-                        swiftOutputDir.asFile.mkdirs()
-                        logger.info("Compiling Swift bridge for architecture: $simulatorArch")
-                    }
+                        doFirst {
+                            objectFile.parentFile.mkdirs()
+                            logger.info("Compiling Swift bridge $bridgeModuleName for $targetTriple")
+                        }
 
-                    // Compile Swift to object file for simulator with dynamic SDK path
-                    commandLine(
-                        "xcrun",
-                        "-sdk",
-                        "iphonesimulator",
-                        "swiftc",
-                        "-emit-object",
-                        "-parse-as-library",
-                        "-o",
-                        objectFile.absolutePath,
-                        "-module-name",
-                        bridgeModuleName,
-                        "-import-objc-header",
-                        headerFile.absolutePath,
-                        "-target",
-                        "$simulatorArch-apple-ios16.0-simulator",
-                        swiftFile.absolutePath,
-                    )
+                        commandLine(
+                            "xcrun",
+                            "-sdk",
+                            sdkName,
+                            "swiftc",
+                            "-emit-object",
+                            "-parse-as-library",
+                            "-o",
+                            objectFile.absolutePath,
+                            "-module-name",
+                            bridgeModuleName,
+                            "-import-objc-header",
+                            headerFile.absolutePath,
+                            "-target",
+                            targetTriple,
+                            swiftFile.absolutePath,
+                        )
 
-                    doLast {
-                        logger.info("Successfully compiled $bridgeModuleName Swift bridge for $simulatorArch")
+                        doLast {
+                            logger.info("Successfully compiled $bridgeModuleName Swift bridge for $targetTriple")
+                        }
                     }
                 }
             }
 
-        // Create an aggregate task that compiles all Swift bridges
+        val compileSwiftBridgeSimulator =
+            tasks.register("compileSwiftBridgeIphonesimulator") {
+                group = "build"
+                description = "Compile all Swift bridge modules for the iOS simulator"
+                dependsOn(compileTasksBySdk.getValue("iphonesimulator"))
+            }
+        val compileSwiftBridgeDevice =
+            tasks.register("compileSwiftBridgeIphoneos") {
+                group = "build"
+                description = "Compile all Swift bridge modules for iOS devices"
+                dependsOn(compileTasksBySdk.getValue("iphoneos"))
+            }
+        // Umbrella kept for external dependents (e.g. clientApp's link tasks depend on it by name).
         val compileSwiftBridge =
             tasks.register("compileSwiftBridge") {
                 group = "build"
-                description = "Compile all Swift bridge modules for iOS tests"
-                dependsOn(compileSwiftBridgeTasks)
+                description = "Compile all Swift bridge modules for all iOS SDKs"
+                dependsOn(compileSwiftBridgeSimulator, compileSwiftBridgeDevice)
             }
 
         // Ensure Swift bridge objects are built before linking iOS test binaries
         tasks.matching { it.name.startsWith("link") && it.name.contains("TestIosSimulatorArm64") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
         // Also ensure Swift bridge objects are built before linking iOS main binaries (for frameworks)
         tasks.matching { it.name.startsWith("link") && it.name.contains("IosSimulatorArm64") && !it.name.contains("Test") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
         tasks.matching { it.name.startsWith("link") && it.name.contains("IosArm64") && !it.name.contains("Test") }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeDevice)
         }
         // Also tie to test Kotlin compilation as a safety net (ensures object files exist by link time)
         tasks.matching { it.name == "compileTestKotlinIosSimulatorArm64" }.configureEach {
-            dependsOn(compileSwiftBridge)
+            dependsOn(compileSwiftBridgeSimulator)
         }
 
         kotlin {

--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -350,6 +350,10 @@ class SwiftBridgeConfiguration {
                         val objectFile = getSwiftBridgeOutputDir(sdkName).file("$bridgeModuleName.o").asFile
 
                         inputs.files(swiftFile, headerFile)
+                        // Exec does not track commandLine: declare these so an SDK/triple change
+                        // invalidates the task instead of leaving a stale object file.
+                        inputs.property("sdkName", sdkName)
+                        inputs.property("targetTriple", targetTriple)
                         outputs.file(objectFile)
 
                         // Only run on macOS


### PR DESCRIPTION
 - fixed tests names causing Kotlin/Native compilation in iOS fail build (compilation error)
 - fixed swift bridge not applied for every variant (build plain command has been broken for months now and nobody exercises it)
 - took the opporutnity to upgrade R8 following android official chained upgrades guidelines (fixes release warnings for android)