### PR TITLE
Show a loading state while Connect apps load ignored peers

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -92,7 +92,7 @@ val clientPresentationModule =
             )
         } bind ITopBarPresenter::class
 
-        factory<MiscItemsPresenter> { ClientMiscItemsPresenter(get(), get(), get()) }
+        factory<MiscItemsPresenter> { ClientMiscItemsPresenter(get(), get()) }
 
         factory { ClientNetworkOverviewPresenter(get(), get(), get(), get()) }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/tabs/more/ClientMiscItemsPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/tabs/more/ClientMiscItemsPresenter.kt
@@ -4,7 +4,6 @@ import bisqapps.apps.clientapp.generated.resources.Res
 import bisqapps.apps.clientapp.generated.resources.nav_trusted_node
 import network.bisq.mobile.client.common.presentation.navigation.ClientNavRoute
 import network.bisq.mobile.client.shared.BuildConfig
-import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -13,10 +12,9 @@ import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 class ClientMiscItemsPresenter(
-    userProfileService: UserProfileServiceFacade,
     backendCapabilitiesService: BackendCapabilitiesService,
     mainPresenter: MainPresenter,
-) : MiscItemsPresenter(userProfileService, backendCapabilitiesService, mainPresenter) {
+) : MiscItemsPresenter(backendCapabilitiesService, mainPresenter) {
     override fun getPaymentAccountNavRoute(): NavRoute = if (BuildConfig.MU_SIG_ENABLED) ClientNavRoute.PaymentAccountsMusig else NavRoute.PaymentAccounts
 
     override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -66,7 +66,7 @@ val androidNodePresentationModule =
 
         factory<TopBarPresenter> { TopBarPresenter(get(), get(), get(), get(), get()) } bind ITopBarPresenter::class
 
-        factory<MiscItemsPresenter> { NodeMiscItemsPresenter(get(), get(), get()) }
+        factory<MiscItemsPresenter> { NodeMiscItemsPresenter(get(), get()) }
 
         factory<FaqPresenter> { FaqNodePresenter(get()) }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/tabs/more/NodeMiscItemsPresenter.kt
@@ -2,7 +2,6 @@ package network.bisq.mobile.node.tabs.more
 
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.backup
-import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -11,10 +10,9 @@ import network.bisq.mobile.presentation.tabs.more.MenuItem
 import network.bisq.mobile.presentation.tabs.more.MiscItemsPresenter
 
 class NodeMiscItemsPresenter(
-    userProfileService: UserProfileServiceFacade,
     backendCapabilitiesService: BackendCapabilitiesService,
     mainPresenter: MainPresenter,
-) : MiscItemsPresenter(userProfileService, backendCapabilitiesService, mainPresenter) {
+) : MiscItemsPresenter(backendCapabilitiesService, mainPresenter) {
     override fun getPaymentAccountNavRoute(): NavRoute = NavRoute.PaymentAccounts
 
     override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -402,6 +402,7 @@ mobile.settings.ignoredUsers=Ignored peers
 mobile.settings.ignoredUsers.empty=No ignored profiles
 mobile.settings.ignoredUsers.unblock=Undo ignore
 mobile.settings.ignoredUsers.loadFailed=Could not load ignored peers. Please try again.
+mobile.settings.ignoredUsers.unblockFailed=Could not undo the ignore. Please try again.
 ################################################################################
 # Resources
 ################################################################################

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -401,7 +401,7 @@ mobile.settings.userProfile.labels.save=Save
 mobile.settings.ignoredUsers=Ignored peers
 mobile.settings.ignoredUsers.empty=No ignored profiles
 mobile.settings.ignoredUsers.unblock=Undo ignore
-mobile.settings.ignoredUsers.loadFailed=Could not load ignored peers. Check your connection and try again.
+mobile.settings.ignoredUsers.loadFailed=Could not load ignored peers. Please try again.
 ################################################################################
 # Resources
 ################################################################################

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -401,6 +401,7 @@ mobile.settings.userProfile.labels.save=Save
 mobile.settings.ignoredUsers=Ignored peers
 mobile.settings.ignoredUsers.empty=No ignored profiles
 mobile.settings.ignoredUsers.unblock=Undo ignore
+mobile.settings.ignoredUsers.loadFailed=Could not load ignored peers. Check your connection and try again.
 ################################################################################
 # Resources
 ################################################################################

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersContentUiTest.kt
@@ -1,0 +1,108 @@
+package network.bisq.mobile.presentation.settings.ignored_users
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class IgnoredUsersContentUiTest : BisqComposeUiTestBase() {
+    private val peer = createMockUserProfile("SatoshiFan")
+
+    private val iconProvider: suspend (UserProfileVO) -> PlatformImage = { createEmptyImage() }
+
+    private fun setTestContent(
+        uiState: IgnoredUsersUiState,
+        onAction: (IgnoredUsersUiAction) -> Unit = {},
+    ) {
+        setTestContent {
+            IgnoredUsersContent(
+                uiState = uiState,
+                userProfileIconProvider = iconProvider,
+                onAction = onAction,
+            )
+        }
+    }
+
+    @Test
+    fun `while loading then shows the loading indicator`() {
+        setTestContent(uiState = IgnoredUsersUiState(isLoading = true))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("loading_indicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun `when the load failed then shows the error and retry dispatches OnRetryLoadClick`() {
+        var capturedAction: IgnoredUsersUiAction? = null
+        setTestContent(
+            uiState = IgnoredUsersUiState(isLoading = false, isLoadFailed = true),
+            onAction = { capturedAction = it },
+        )
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers.loadFailed".i18n())
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("mobile.action.retry".i18n()).performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(IgnoredUsersUiAction.OnRetryLoadClick, capturedAction)
+    }
+
+    @Test
+    fun `when no ignored users then shows the empty message`() {
+        setTestContent(uiState = IgnoredUsersUiState(isLoading = false))
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers.empty".i18n())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when unblock clicked then dispatches OnUnblockClick for that peer`() {
+        var capturedAction: IgnoredUsersUiAction? = null
+        setTestContent(
+            uiState = IgnoredUsersUiState(ignoredUsers = listOf(peer), isLoading = false),
+            onAction = { capturedAction = it },
+        )
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers.unblock".i18n())
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(IgnoredUsersUiAction.OnUnblockClick(peer.networkId.pubKey.id), capturedAction)
+    }
+
+    @Test
+    fun `when the confirmation is open then confirming dispatches OnConfirmUnblock`() {
+        var capturedAction: IgnoredUsersUiAction? = null
+        setTestContent(
+            uiState =
+                IgnoredUsersUiState(
+                    ignoredUsers = listOf(peer),
+                    isLoading = false,
+                    unblockUserId = peer.networkId.pubKey.id,
+                ),
+            onAction = { capturedAction = it },
+        )
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(IgnoredUsersUiAction.OnConfirmUnblock, capturedAction)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
@@ -3,18 +3,23 @@ package network.bisq.mobile.presentation.settings.ignored_users
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -42,12 +47,12 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
             coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
 
             presenter.onViewAttached()
-            assertTrue(presenter.isLoading.value)
+            assertTrue(presenter.uiState.value.isLoading)
 
             advanceUntilIdle()
 
-            assertFalse(presenter.isLoading.value)
-            assertEquals(listOf(user), presenter.ignoredUsers.value)
+            assertFalse(presenter.uiState.value.isLoading)
+            assertEquals(listOf(user), presenter.uiState.value.ignoredUsers)
         }
 
     @Test
@@ -58,9 +63,12 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
             presenter.onViewAttached()
             advanceUntilIdle()
 
-            assertFalse(presenter.isLoading.value)
-            assertTrue(presenter.isLoadFailed.value)
-            assertTrue(presenter.ignoredUsers.value.isEmpty())
+            assertFalse(presenter.uiState.value.isLoading)
+            assertTrue(presenter.uiState.value.isLoadFailed)
+            assertTrue(
+                presenter.uiState.value.ignoredUsers
+                    .isEmpty(),
+            )
         }
 
     @Test
@@ -72,15 +80,95 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
 
             presenter.onViewAttached()
             advanceUntilIdle()
-            assertTrue(presenter.isLoadFailed.value)
+            assertTrue(presenter.uiState.value.isLoadFailed)
 
             coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
-            presenter.onRetryLoad()
+            presenter.onAction(IgnoredUsersUiAction.OnRetryLoadClick)
             advanceUntilIdle()
 
-            assertFalse(presenter.isLoadFailed.value)
-            assertFalse(presenter.isLoading.value)
-            assertEquals(listOf(user), presenter.ignoredUsers.value)
+            assertFalse(presenter.uiState.value.isLoadFailed)
+            assertFalse(presenter.uiState.value.isLoading)
+            assertEquals(listOf(user), presenter.uiState.value.ignoredUsers)
+        }
+
+    @Test
+    fun `unblock click opens the confirmation for that peer and dismiss closes it`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
+            assertEquals(user.networkId.pubKey.id, presenter.uiState.value.unblockUserId)
+
+            presenter.onAction(IgnoredUsersUiAction.OnDismissUnblockDialog)
+            assertNull(presenter.uiState.value.unblockUserId)
+        }
+
+    @Test
+    fun `confirm without an open dialog does nothing`() =
+        runTest {
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { userProfileServiceFacade.undoIgnoreUserProfile(any()) }
+        }
+
+    @Test
+    fun `peer profile click navigates to that peer`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(IgnoredUsersUiAction.OnPeerProfileClick(user.networkId.pubKey.id))
+            advanceUntilIdle()
+
+            verify { navigationManager.navigate(NavRoute.PeerProfile(user.networkId.pubKey.id), any(), any()) }
+        }
+
+    @Test
+    fun `a successful unblock closes the dialog and reloads the remaining peers`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns emptySet()
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns emptyList()
+
+            presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { userProfileServiceFacade.undoIgnoreUserProfile(user.networkId.pubKey.id) }
+            assertNull(presenter.uiState.value.unblockUserId)
+            assertTrue(
+                presenter.uiState.value.ignoredUsers
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `the icon provider delegates to the facade`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            val icon: PlatformImage = mockk()
+            coEvery { userProfileServiceFacade.getUserProfileIcon(user) } returns icon
+
+            assertSame(icon, presenter.userProfileIconProvider(user))
         }
 
     @Test
@@ -96,12 +184,13 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
             presenter.onViewAttached()
             advanceUntilIdle()
 
-            presenter.unblockUserConfirm(user.networkId.pubKey.id)
-            presenter.unblockUserConfirm(user.networkId.pubKey.id)
+            presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
             advanceUntilIdle()
 
             coVerify(exactly = 1) { userProfileServiceFacade.undoIgnoreUserProfile(user.networkId.pubKey.id) }
-            assertFalse(presenter.isUnblockUserConfirmEnabled.value)
+            assertFalse(presenter.uiState.value.isUnblockConfirmEnabled)
         }
 
     @Test
@@ -115,9 +204,10 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
             presenter.onViewAttached()
             advanceUntilIdle()
 
-            presenter.unblockUserConfirm(user.networkId.pubKey.id)
+            presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
             advanceUntilIdle()
 
-            assertTrue(presenter.isUnblockUserConfirmEnabled.value)
+            assertTrue(presenter.uiState.value.isUnblockConfirmEnabled)
         }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecyc
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -29,6 +30,58 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
             )
         presenter = IgnoredUsersPresenter(userProfileServiceFacade, mainPresenter)
     }
+
+    @Test
+    fun `while ignored users are loading isLoading stays true and clears once loaded`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } coAnswers {
+                delay(1000)
+                setOf(user.networkId.pubKey.id)
+            }
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+
+            presenter.onViewAttached()
+            assertTrue(presenter.isLoading.value)
+
+            advanceUntilIdle()
+
+            assertFalse(presenter.isLoading.value)
+            assertEquals(listOf(user), presenter.ignoredUsers.value)
+        }
+
+    @Test
+    fun `when loading ignored users fails then load failed is exposed and loading clears`() =
+        runTest {
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } throws RuntimeException("no connection")
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            assertFalse(presenter.isLoading.value)
+            assertTrue(presenter.isLoadFailed.value)
+            assertTrue(presenter.ignoredUsers.value.isEmpty())
+        }
+
+    @Test
+    fun `retry after a failed load clears the error and shows the ignored users`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } throws RuntimeException("no connection")
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+            assertTrue(presenter.isLoadFailed.value)
+
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
+            presenter.onRetryLoad()
+            advanceUntilIdle()
+
+            assertFalse(presenter.isLoadFailed.value)
+            assertFalse(presenter.isLoading.value)
+            assertEquals(listOf(user), presenter.ignoredUsers.value)
+        }
 
     @Test
     fun `rapid double-tap on unblock confirm calls undoIgnoreUserProfile only once`() =

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenterTest.kt
@@ -137,17 +137,16 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
         }
 
     @Test
-    fun `a successful unblock closes the dialog and reloads the remaining peers`() =
+    fun `a successful unblock closes the dialog and drops the peer without reloading`() =
         runTest {
             val user = createMockUserProfile("blocked-user")
-            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
-            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+            val other = createMockUserProfile("other-blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns
+                setOf(user.networkId.pubKey.id, other.networkId.pubKey.id)
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user, other)
 
             presenter.onViewAttached()
             advanceUntilIdle()
-
-            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns emptySet()
-            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns emptyList()
 
             presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
             presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
@@ -155,10 +154,31 @@ class IgnoredUsersPresenterTest : PlatformPresentationKoinTestBase() {
 
             coVerify(exactly = 1) { userProfileServiceFacade.undoIgnoreUserProfile(user.networkId.pubKey.id) }
             assertNull(presenter.uiState.value.unblockUserId)
-            assertTrue(
-                presenter.uiState.value.ignoredUsers
-                    .isEmpty(),
-            )
+            assertEquals(listOf(other), presenter.uiState.value.ignoredUsers)
+            // The remaining peers stay on screen: no second fetch, so no spinner over the list.
+            coVerify(exactly = 1) { userProfileServiceFacade.findUserProfiles(any()) }
+            assertFalse(presenter.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `a failed unblock closes the dialog, keeps the peer and reports the error`() =
+        runTest {
+            val user = createMockUserProfile("blocked-user")
+            coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(user.networkId.pubKey.id)
+            coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(user)
+            coEvery { userProfileServiceFacade.undoIgnoreUserProfile(any()) } throws RuntimeException("fail")
+
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            presenter.onAction(IgnoredUsersUiAction.OnUnblockClick(user.networkId.pubKey.id))
+            presenter.onAction(IgnoredUsersUiAction.OnConfirmUnblock)
+            advanceUntilIdle()
+
+            assertNull(presenter.uiState.value.unblockUserId)
+            assertEquals(listOf(user), presenter.uiState.value.ignoredUsers)
+            assertTrue(presenter.uiState.value.isUnblockConfirmEnabled)
+            verify { globalUiManager.showSnackbar(any(), any(), any(), any()) }
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreenUiTest.kt
@@ -1,0 +1,94 @@
+package network.bisq.mobile.presentation.settings.ignored_users
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.PreviewTopBarPresenter
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import org.junit.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Covers the stateful [IgnoredUsersScreen] — the seam [IgnoredUsersContentUiTest] cannot reach:
+ * the presenter resolved from Koin, its load firing from the lifecycle, and actions round-tripping
+ * back into the facade.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class IgnoredUsersScreenUiTest : PresentationKoinComposeTestBase() {
+    private lateinit var userProfileServiceFacade: UserProfileServiceFacade
+    private lateinit var mainPresenter: MainPresenter
+
+    private val peer = createMockUserProfile(PEER_ID)
+
+    private companion object {
+        /** [createMockUserProfile] sets `networkId.pubKey.id` to the name, so the id is the name. */
+        const val PEER_ID = "SatoshiFan"
+    }
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<ITopBarPresenter> { PreviewTopBarPresenter() }
+                factory { IgnoredUsersPresenter(userProfileServiceFacade, mainPresenter) }
+            },
+        )
+
+    override fun onKoinReady() {
+        super.onKoinReady()
+        userProfileServiceFacade = mockk(relaxed = true)
+        mainPresenter = mockk(relaxed = true)
+
+        coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(PEER_ID)
+        coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(peer)
+    }
+
+    @Test
+    fun `when attached then renders the ignored peers loaded from the facade`() {
+        setTestContent { IgnoredUsersScreen() }
+
+        composeTestRule.onNodeWithText(peer.userName).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when the load fails then shows the error and retry reloads`() {
+        coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } throws RuntimeException("no connection")
+
+        setTestContent { IgnoredUsersScreen() }
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers.loadFailed".i18n())
+            .assertIsDisplayed()
+
+        coEvery { userProfileServiceFacade.getIgnoredUserProfileIds() } returns setOf(PEER_ID)
+        composeTestRule.onNodeWithText("mobile.action.retry".i18n()).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(peer.userName).assertIsDisplayed()
+    }
+
+    @Test
+    fun `unblocking a peer confirms through the facade`() {
+        setTestContent { IgnoredUsersScreen() }
+
+        composeTestRule
+            .onNodeWithText("mobile.settings.ignoredUsers.unblock".i18n())
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("dialog_confirm_yes").performClick()
+        composeTestRule.waitForIdle()
+
+        coVerify(exactly = 1) { userProfileServiceFacade.undoIgnoreUserProfile(PEER_ID) }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsContentUiTest.kt
@@ -1,7 +1,6 @@
 package network.bisq.mobile.presentation.tabs.more
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -15,7 +14,6 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class MiscItemsContentUiTest : BisqComposeUiTestBase() {
     private fun setTestContent(
@@ -52,7 +50,7 @@ class MiscItemsContentUiTest : BisqComposeUiTestBase() {
     }
 
     @Test
-    fun `when enabled item clicked then dispatches OnMenuItemClick with its route`() {
+    fun `when item clicked then dispatches OnMenuItemClick with its route`() {
         var capturedAction: MiscItemsUiAction? = null
         setTestContent(uiState = sampleUiState(), onAction = { capturedAction = it })
         composeTestRule.waitForIdle()
@@ -66,19 +64,9 @@ class MiscItemsContentUiTest : BisqComposeUiTestBase() {
     }
 
     @Test
-    fun `when item is disabled then it is not enabled`() {
-        setTestContent(uiState = sampleUiState(ignoredEnabled = false))
-        composeTestRule.waitForIdle()
-
-        composeTestRule
-            .onNodeWithText("mobile.settings.ignoredUsers".i18n())
-            .assertIsNotEnabled()
-    }
-
-    @Test
-    fun `when disabled item tapped then no action is dispatched`() {
+    fun `when ignored users item clicked then dispatches its route`() {
         var capturedAction: MiscItemsUiAction? = null
-        setTestContent(uiState = sampleUiState(ignoredEnabled = false), onAction = { capturedAction = it })
+        setTestContent(uiState = sampleUiState(), onAction = { capturedAction = it })
         composeTestRule.waitForIdle()
 
         composeTestRule
@@ -86,10 +74,10 @@ class MiscItemsContentUiTest : BisqComposeUiTestBase() {
             .performClick()
         composeTestRule.waitForIdle()
 
-        assertNull(capturedAction)
+        assertEquals(MiscItemsUiAction.OnMenuItemClick(NavRoute.IgnoredUsers), capturedAction)
     }
 
-    private fun sampleUiState(ignoredEnabled: Boolean = false) =
+    private fun sampleUiState() =
         MiscItemsUiState(
             sections =
                 listOf(
@@ -106,7 +94,6 @@ class MiscItemsContentUiTest : BisqComposeUiTestBase() {
                                     label = UiString("mobile.settings.ignoredUsers"),
                                     icon = Res.drawable.nav_ignored_users,
                                     route = NavRoute.IgnoredUsers,
-                                    isEnabled = ignoredEnabled,
                                 ),
                             ),
                     ),

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
@@ -2,14 +2,12 @@ package network.bisq.mobile.presentation.tabs.more
 
 import bisqapps.shared.presentation.generated.resources.Res
 import bisqapps.shared.presentation.generated.resources.nav_settings
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
-import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
@@ -24,7 +22,6 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MiscItemsPresenterTest : PresentationKoinTestBase() {
-    private lateinit var userProfileService: UserProfileServiceFacade
     private lateinit var mainPresenter: MainPresenter
     private lateinit var backendCapabilitiesService: BackendCapabilitiesService
 
@@ -33,17 +30,15 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
     private lateinit var presenter: MiscItemsPresenter
 
     override fun onKoinReady() {
-        userProfileService = mockk(relaxed = true)
         mainPresenter = mockk(relaxed = true)
         capabilitiesFlow.value = BackendCapabilities.UNAVAILABLE
         backendCapabilitiesService =
             mockk<BackendCapabilitiesService>(relaxed = true).also {
                 every { it.capabilities } returns capabilitiesFlow
             }
-        coEvery { userProfileService.getIgnoredUserProfileIds() } returns emptySet()
     }
 
-    private fun createPresenter(): MiscItemsPresenter = TestMiscItemsPresenter(userProfileService, backendCapabilitiesService, mainPresenter)
+    private fun createPresenter(): MiscItemsPresenter = TestMiscItemsPresenter(backendCapabilitiesService, mainPresenter)
 
     private fun ignoredUsersItem(): MenuItem =
         presenter.uiState.value.sections
@@ -81,10 +76,9 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
         }
 
     @Test
-    fun `when no ignored users then ignored users item is disabled`() =
+    fun `when attached then ignored users item is present`() =
         runTest {
             // Given
-            coEvery { userProfileService.getIgnoredUserProfileIds() } returns emptySet()
             presenter = createPresenter()
 
             // When
@@ -92,22 +86,7 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
             advanceUntilIdle()
 
             // Then
-            assertFalse(ignoredUsersItem().isEnabled)
-        }
-
-    @Test
-    fun `when ignored users exist then ignored users item is enabled`() =
-        runTest {
-            // Given
-            coEvery { userProfileService.getIgnoredUserProfileIds() } returns setOf("ignored-user-id")
-            presenter = createPresenter()
-
-            // When
-            presenter.onViewAttached()
-            advanceUntilIdle()
-
-            // Then
-            assertTrue(ignoredUsersItem().isEnabled)
+            assertEquals("mobile.settings.ignoredUsers", ignoredUsersItem().label.key)
         }
 
     @Test
@@ -217,10 +196,9 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
      * without pulling in per-app resource/BuildConfig dependencies.
      */
     private class TestMiscItemsPresenter(
-        userProfileService: UserProfileServiceFacade,
         backendCapabilitiesService: BackendCapabilitiesService,
         mainPresenter: MainPresenter,
-    ) : MiscItemsPresenter(userProfileService, backendCapabilitiesService, mainPresenter) {
+    ) : MiscItemsPresenter(backendCapabilitiesService, mainPresenter) {
         override fun getPaymentAccountNavRoute(): NavRoute = NavRoute.PaymentAccounts
 
         override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -31,7 +31,6 @@ import network.bisq.mobile.presentation.offer.take_offer.payment_method.TakeOffe
 import network.bisq.mobile.presentation.offer.take_offer.review.TakeOfferReviewPresenter
 import network.bisq.mobile.presentation.peer_profile.PeerProfilePresenter
 import network.bisq.mobile.presentation.report_user.ReportUserPresenter
-import network.bisq.mobile.presentation.settings.ignored_users.IIgnoredUsersPresenter
 import network.bisq.mobile.presentation.settings.ignored_users.IgnoredUsersPresenter
 import network.bisq.mobile.presentation.settings.payment_accounts.PaymentAccountsPresenter
 import network.bisq.mobile.presentation.settings.reputation.ReputationPresenter
@@ -139,7 +138,7 @@ val presentationModule =
 
         factory { SettingsPresenter(get(), get(), get(), get(), get(), get()) }
 
-        factory { IgnoredUsersPresenter(get(), get()) } bind IIgnoredUsersPresenter::class
+        factory { IgnoredUsersPresenter(get(), get()) }
 
         factory { PaymentAccountsPresenter(get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
@@ -10,8 +10,10 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -95,10 +97,21 @@ class IgnoredUsersPresenter(
         guardedSuspendAction(_isUnblockConfirmEnabled, "unblockUserConfirm") {
             try {
                 userProfileServiceFacade.undoIgnoreUserProfile(userId)
-                _uiState.update { it.copy(unblockUserId = null) }
-                loadIgnoredUsers()
+                // Dropping the row locally rather than reloading: a reload would blank the list
+                // behind a spinner, and a reload that then failed would read as "the unblock
+                // failed" right after one that succeeded.
+                _uiState.update { state ->
+                    state.copy(
+                        ignoredUsers = state.ignoredUsers.filterNot { it.id == userId },
+                        unblockUserId = null,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                log.e(e) { "Failed to unblock user: $userId" }
+                // The dialog is closed first: a snackbar would render behind it otherwise.
+                _uiState.update { it.copy(unblockUserId = null) }
+                handleError(e, "mobile.settings.ignoredUsers.unblockFailed".i18n())
             }
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.presentation.settings.ignored_users
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,11 +21,21 @@ class IgnoredUsersPresenter(
     private val _ignoredUsers = MutableStateFlow<List<UserProfileVO>>(emptyList())
     override val ignoredUsers: StateFlow<List<UserProfileVO>> = _ignoredUsers.asStateFlow()
 
+    private val _isLoading = MutableStateFlow(true)
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _isLoadFailed = MutableStateFlow(false)
+    override val isLoadFailed: StateFlow<Boolean> = _isLoadFailed.asStateFlow()
+
     private val _ignoreUserId: MutableStateFlow<String> = MutableStateFlow("")
     override val ignoreUserId: StateFlow<String> = _ignoreUserId.asStateFlow()
 
     private val _isUnblockUserConfirmEnabled = MutableStateFlow(true)
     override val isUnblockUserConfirmEnabled: StateFlow<Boolean> = _isUnblockUserConfirmEnabled.asStateFlow()
+
+    // A retry supersedes the in-flight attempt instead of racing it: on the client flavour a slow
+    // first load can otherwise land after a fast retry and overwrite the newer result.
+    private var loadJob: Job? = null
 
     override val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 
@@ -33,16 +45,31 @@ class IgnoredUsersPresenter(
     }
 
     private fun loadIgnoredUsers() {
-        presenterScope.launch {
-            try {
-                val ignoredUserIds = userProfileServiceFacade.getIgnoredUserProfileIds().toList()
-                val userProfiles = userProfileServiceFacade.findUserProfiles(ignoredUserIds)
-                _ignoredUsers.value = userProfiles
-            } catch (e: Exception) {
-                log.e(e) { "Failed to load ignored users" }
-                _ignoredUsers.value = emptyList()
+        loadJob?.cancel()
+        loadJob =
+            presenterScope.launch {
+                _isLoading.value = true
+                _isLoadFailed.value = false
+                try {
+                    val ignoredUserIds = userProfileServiceFacade.getIgnoredUserProfileIds().toList()
+                    val userProfiles = userProfileServiceFacade.findUserProfiles(ignoredUserIds)
+                    _ignoredUsers.value = userProfiles
+                    _isLoading.value = false
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // On the client flavour this is a node round-trip, so a failure here is a
+                    // connectivity problem rather than "no ignored peers" — say so and offer a retry.
+                    log.e(e) { "Failed to load ignored users" }
+                    _ignoredUsers.value = emptyList()
+                    _isLoadFailed.value = true
+                    _isLoading.value = false
+                }
             }
-        }
+    }
+
+    override fun onRetryLoad() {
+        loadIgnoredUsers()
     }
 
     override fun unblockUser(userId: String) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersPresenter.kt
@@ -5,6 +5,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -16,83 +19,87 @@ import network.bisq.mobile.presentation.main.MainPresenter
 class IgnoredUsersPresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     mainPresenter: MainPresenter,
-) : BasePresenter(mainPresenter),
-    IIgnoredUsersPresenter {
-    private val _ignoredUsers = MutableStateFlow<List<UserProfileVO>>(emptyList())
-    override val ignoredUsers: StateFlow<List<UserProfileVO>> = _ignoredUsers.asStateFlow()
+) : BasePresenter(mainPresenter) {
+    private val _uiState = MutableStateFlow(IgnoredUsersUiState())
+    val uiState: StateFlow<IgnoredUsersUiState> = _uiState.asStateFlow()
 
-    private val _isLoading = MutableStateFlow(true)
-    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    // Owned by `guardedSuspendAction`, which needs its own MutableStateFlow handle; the UI reads it
+    // through `uiState` only, so this flow stays the single source of truth for it.
+    private val _isUnblockConfirmEnabled = MutableStateFlow(true)
 
-    private val _isLoadFailed = MutableStateFlow(false)
-    override val isLoadFailed: StateFlow<Boolean> = _isLoadFailed.asStateFlow()
+    val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage
+        get() = userProfileServiceFacade::getUserProfileIcon
 
-    private val _ignoreUserId: MutableStateFlow<String> = MutableStateFlow("")
-    override val ignoreUserId: StateFlow<String> = _ignoreUserId.asStateFlow()
-
-    private val _isUnblockUserConfirmEnabled = MutableStateFlow(true)
-    override val isUnblockUserConfirmEnabled: StateFlow<Boolean> = _isUnblockUserConfirmEnabled.asStateFlow()
-
-    // A retry supersedes the in-flight attempt instead of racing it: on the client flavour a slow
-    // first load can otherwise land after a fast retry and overwrite the newer result.
+    // A retry supersedes the in-flight attempt instead of racing it: a slow first load can
+    // otherwise land after a fast retry and overwrite the newer result.
     private var loadJob: Job? = null
-
-    override val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage get() = userProfileServiceFacade::getUserProfileIcon
 
     override fun onViewAttached() {
         super.onViewAttached()
+        _isUnblockConfirmEnabled
+            .onEach { enabled -> _uiState.update { it.copy(isUnblockConfirmEnabled = enabled) } }
+            .launchIn(presenterScope)
         loadIgnoredUsers()
+    }
+
+    fun onAction(action: IgnoredUsersUiAction) {
+        when (action) {
+            IgnoredUsersUiAction.OnRetryLoadClick -> onRetryLoad()
+
+            is IgnoredUsersUiAction.OnUnblockClick -> onUnblockClick(action.userId)
+
+            IgnoredUsersUiAction.OnConfirmUnblock -> onConfirmUnblock()
+
+            IgnoredUsersUiAction.OnDismissUnblockDialog -> onDismissUnblockDialog()
+
+            is IgnoredUsersUiAction.OnPeerProfileClick -> onPeerProfileClick(action.userId)
+        }
+    }
+
+    private fun onRetryLoad() {
+        loadIgnoredUsers()
+    }
+
+    private fun onUnblockClick(userId: String) {
+        _uiState.update { it.copy(unblockUserId = userId) }
+    }
+
+    private fun onDismissUnblockDialog() {
+        _uiState.update { it.copy(unblockUserId = null) }
+    }
+
+    private fun onPeerProfileClick(userId: String) {
+        navigateTo(NavRoute.PeerProfile(userId))
     }
 
     private fun loadIgnoredUsers() {
         loadJob?.cancel()
         loadJob =
             presenterScope.launch {
-                _isLoading.value = true
-                _isLoadFailed.value = false
+                _uiState.update { it.copy(isLoading = true, isLoadFailed = false) }
                 try {
                     val ignoredUserIds = userProfileServiceFacade.getIgnoredUserProfileIds().toList()
                     val userProfiles = userProfileServiceFacade.findUserProfiles(ignoredUserIds)
-                    _ignoredUsers.value = userProfiles
-                    _isLoading.value = false
+                    _uiState.update { it.copy(ignoredUsers = userProfiles, isLoading = false) }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    // On the client flavour this is a node round-trip, so a failure here is a
-                    // connectivity problem rather than "no ignored peers" — say so and offer a retry.
                     log.e(e) { "Failed to load ignored users" }
-                    _ignoredUsers.value = emptyList()
-                    _isLoadFailed.value = true
-                    _isLoading.value = false
+                    _uiState.update { it.copy(ignoredUsers = emptyList(), isLoading = false, isLoadFailed = true) }
                 }
             }
     }
 
-    override fun onRetryLoad() {
-        loadIgnoredUsers()
-    }
-
-    override fun unblockUser(userId: String) {
-        _ignoreUserId.value = userId
-    }
-
-    override fun unblockUserConfirm(userId: String) {
-        guardedSuspendAction(_isUnblockUserConfirmEnabled, "unblockUserConfirm") {
+    private fun onConfirmUnblock() {
+        val userId = _uiState.value.unblockUserId ?: return
+        guardedSuspendAction(_isUnblockConfirmEnabled, "unblockUserConfirm") {
             try {
                 userProfileServiceFacade.undoIgnoreUserProfile(userId)
-                _ignoreUserId.value = ""
+                _uiState.update { it.copy(unblockUserId = null) }
                 loadIgnoredUsers()
             } catch (e: Exception) {
                 log.e(e) { "Failed to unblock user: $userId" }
             }
         }
-    }
-
-    override fun dismissConfirm() {
-        _ignoreUserId.value = ""
-    }
-
-    override fun openPeerProfile(userId: String) {
-        navigateTo(NavRoute.PeerProfile(userId))
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
@@ -12,13 +12,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.data.utils.createEmptyImage
 import network.bisq.mobile.i18n.i18n
-import network.bisq.mobile.presentation.common.ui.base.ViewPresenter
 import network.bisq.mobile.presentation.common.ui.components.ErrorState
 import network.bisq.mobile.presentation.common.ui.components.LoadingState
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
@@ -29,58 +30,51 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.icons.Warning
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
 import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileIcon
 import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.ConfirmationDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import org.koin.compose.koinInject
 
-interface IIgnoredUsersPresenter : ViewPresenter {
-    val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage
-    val ignoredUsers: StateFlow<List<UserProfileVO>>
-    val isLoading: StateFlow<Boolean>
-    val isLoadFailed: StateFlow<Boolean>
-    val ignoreUserId: StateFlow<String>
-    val isUnblockUserConfirmEnabled: StateFlow<Boolean>
+@Composable
+fun IgnoredUsersScreen() {
+    val presenter: IgnoredUsersPresenter = koinInject()
+    RememberPresenterLifecycle(presenter)
 
-    fun onRetryLoad()
+    val uiState by presenter.uiState.collectAsState()
 
-    fun unblockUser(userId: String)
-
-    fun unblockUserConfirm(userId: String)
-
-    fun dismissConfirm()
-
-    fun openPeerProfile(userId: String)
+    IgnoredUsersContent(
+        uiState = uiState,
+        userProfileIconProvider = presenter.userProfileIconProvider,
+        onAction = presenter::onAction,
+        topBar = { TopBar("mobile.settings.ignoredUsers".i18n()) },
+    )
 }
 
 @Composable
-fun IgnoredUsersScreen() {
-    val presenter: IIgnoredUsersPresenter = koinInject()
-    RememberPresenterLifecycle(presenter)
-
-    val ignoredUsers by presenter.ignoredUsers.collectAsState()
-    val isLoading by presenter.isLoading.collectAsState()
-    val isLoadFailed by presenter.isLoadFailed.collectAsState()
-    val ignoreUserId by presenter.ignoreUserId.collectAsState()
-    val isUnblockUserConfirmEnabled by presenter.isUnblockUserConfirmEnabled.collectAsState()
-    val showIgnoreUserWarnBox = ignoreUserId.isNotEmpty()
-
+internal fun IgnoredUsersContent(
+    uiState: IgnoredUsersUiState,
+    userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
+    onAction: (IgnoredUsersUiAction) -> Unit,
+    topBar: @Composable () -> Unit = {},
+) {
     BisqScrollScaffold(
-        topBar = { TopBar("mobile.settings.ignoredUsers".i18n()) },
+        topBar = topBar,
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         when {
-            isLoading -> LoadingState()
+            uiState.isLoading -> LoadingState()
 
-            isLoadFailed ->
+            uiState.isLoadFailed ->
                 ErrorState(
                     message = "mobile.settings.ignoredUsers.loadFailed".i18n(),
-                    onRetry = { presenter.onRetryLoad() },
+                    onRetry = { onAction(IgnoredUsersUiAction.OnRetryLoadClick) },
                 )
 
-            ignoredUsers.isEmpty() ->
+            uiState.ignoredUsers.isEmpty() ->
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                     BisqText.BaseRegular(
                         text = "mobile.settings.ignoredUsers.empty".i18n(),
@@ -90,18 +84,18 @@ fun IgnoredUsersScreen() {
 
             else ->
                 Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf)) {
-                    ignoredUsers.forEach { userProfile ->
+                    uiState.ignoredUsers.forEach { userProfile ->
                         IgnoredUserItem(
                             userProfile = userProfile,
-                            userProfileIconProvider = presenter.userProfileIconProvider,
-                            onUnblock = { presenter.unblockUser(userProfile.id) },
-                            onOpenProfile = { presenter.openPeerProfile(userProfile.id) },
+                            userProfileIconProvider = userProfileIconProvider,
+                            onUnblock = { onAction(IgnoredUsersUiAction.OnUnblockClick(userProfile.id)) },
+                            onOpenProfile = { onAction(IgnoredUsersUiAction.OnPeerProfileClick(userProfile.id)) },
                         )
                     }
                 }
         }
 
-        if (showIgnoreUserWarnBox) {
+        if (uiState.unblockUserId != null) {
             ConfirmationDialog(
                 headline = "mobile.error.warning".i18n(),
                 headlineColor = BisqTheme.colors.warning,
@@ -110,11 +104,9 @@ fun IgnoredUsersScreen() {
                 confirmButtonText = "user.profileCard.userActions.undoIgnore".i18n(),
                 dismissButtonText = "action.cancel".i18n(),
                 verticalButtonPlacement = true,
-                confirmButtonLoading = !isUnblockUserConfirmEnabled,
-                onConfirm = {
-                    presenter.unblockUserConfirm(ignoreUserId)
-                },
-                onDismiss = { presenter.dismissConfirm() },
+                confirmButtonLoading = !uiState.isUnblockConfirmEnabled,
+                onConfirm = { onAction(IgnoredUsersUiAction.OnConfirmUnblock) },
+                onDismiss = { onAction(IgnoredUsersUiAction.OnDismissUnblockDialog) },
             )
         }
     }
@@ -158,3 +150,52 @@ private fun IgnoredUserItem(
         )
     }
 }
+
+@ExcludeFromCoverage
+@Composable
+private fun IgnoredUsersPreviewTopBar() {
+    TopBarContent(
+        title = "mobile.settings.ignoredUsers".i18n(),
+        showBackButton = true,
+        showUserAvatar = false,
+    )
+}
+
+@ExcludeFromCoverage
+@Composable
+private fun IgnoredUsersPreview(uiState: IgnoredUsersUiState) {
+    BisqTheme.Preview {
+        IgnoredUsersContent(
+            uiState = uiState,
+            userProfileIconProvider = { createEmptyImage() },
+            onAction = {},
+            topBar = { IgnoredUsersPreviewTopBar() },
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(name = "Ignored peers — list")
+@Composable
+private fun IgnoredUsersScreenListPreview() =
+    IgnoredUsersPreview(
+        IgnoredUsersUiState(
+            ignoredUsers = listOf(createMockUserProfile("Satoshi"), createMockUserProfile("Hal")),
+            isLoading = false,
+        ),
+    )
+
+@ExcludeFromCoverage
+@Preview(name = "Ignored peers — empty")
+@Composable
+private fun IgnoredUsersScreenEmptyPreview() = IgnoredUsersPreview(IgnoredUsersUiState(isLoading = false))
+
+@ExcludeFromCoverage
+@Preview(name = "Ignored peers — loading")
+@Composable
+private fun IgnoredUsersScreenLoadingPreview() = IgnoredUsersPreview(IgnoredUsersUiState(isLoading = true))
+
+@ExcludeFromCoverage
+@Preview(name = "Ignored peers — load failed")
+@Composable
+private fun IgnoredUsersScreenLoadFailedPreview() = IgnoredUsersPreview(IgnoredUsersUiState(isLoading = false, isLoadFailed = true))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
@@ -19,6 +19,8 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.i
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.ViewPresenter
+import network.bisq.mobile.presentation.common.ui.components.ErrorState
+import network.bisq.mobile.presentation.common.ui.components.LoadingState
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -37,8 +39,12 @@ import org.koin.compose.koinInject
 interface IIgnoredUsersPresenter : ViewPresenter {
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage
     val ignoredUsers: StateFlow<List<UserProfileVO>>
+    val isLoading: StateFlow<Boolean>
+    val isLoadFailed: StateFlow<Boolean>
     val ignoreUserId: StateFlow<String>
     val isUnblockUserConfirmEnabled: StateFlow<Boolean>
+
+    fun onRetryLoad()
 
     fun unblockUser(userId: String)
 
@@ -55,6 +61,8 @@ fun IgnoredUsersScreen() {
     RememberPresenterLifecycle(presenter)
 
     val ignoredUsers by presenter.ignoredUsers.collectAsState()
+    val isLoading by presenter.isLoading.collectAsState()
+    val isLoadFailed by presenter.isLoadFailed.collectAsState()
     val ignoreUserId by presenter.ignoreUserId.collectAsState()
     val isUnblockUserConfirmEnabled by presenter.isUnblockUserConfirmEnabled.collectAsState()
     val showIgnoreUserWarnBox = ignoreUserId.isNotEmpty()
@@ -63,24 +71,34 @@ fun IgnoredUsersScreen() {
         topBar = { TopBar("mobile.settings.ignoredUsers".i18n()) },
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        if (ignoredUsers.isEmpty()) {
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                BisqText.BaseRegular(
-                    text = "mobile.settings.ignoredUsers.empty".i18n(),
-                    color = BisqTheme.colors.mid_grey20,
+        when {
+            isLoading -> LoadingState()
+
+            isLoadFailed ->
+                ErrorState(
+                    message = "mobile.settings.ignoredUsers.loadFailed".i18n(),
+                    onRetry = { presenter.onRetryLoad() },
                 )
-            }
-        } else {
-            Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf)) {
-                ignoredUsers.forEach { userProfile ->
-                    IgnoredUserItem(
-                        userProfile = userProfile,
-                        userProfileIconProvider = presenter.userProfileIconProvider,
-                        onUnblock = { presenter.unblockUser(userProfile.id) },
-                        onOpenProfile = { presenter.openPeerProfile(userProfile.id) },
+
+            ignoredUsers.isEmpty() ->
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    BisqText.BaseRegular(
+                        text = "mobile.settings.ignoredUsers.empty".i18n(),
+                        color = BisqTheme.colors.mid_grey20,
                     )
                 }
-            }
+
+            else ->
+                Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf)) {
+                    ignoredUsers.forEach { userProfile ->
+                        IgnoredUserItem(
+                            userProfile = userProfile,
+                            userProfileIconProvider = presenter.userProfileIconProvider,
+                            onUnblock = { presenter.unblockUser(userProfile.id) },
+                            onOpenProfile = { presenter.openPeerProfile(userProfile.id) },
+                        )
+                    }
+                }
         }
 
         if (showIgnoreUserWarnBox) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersScreen.kt
@@ -2,8 +2,8 @@ package network.bisq.mobile.presentation.settings.ignored_users
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -28,7 +28,8 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.debouncedClickable
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
-import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollScaffold
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScrollLayout
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
 import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileIcon
@@ -61,21 +62,22 @@ internal fun IgnoredUsersContent(
     onAction: (IgnoredUsersUiAction) -> Unit,
     topBar: @Composable () -> Unit = {},
 ) {
-    BisqScrollScaffold(
-        topBar = topBar,
-        verticalArrangement = Arrangement.SpaceBetween,
-    ) {
+    BisqScaffold(topBar = topBar) { paddingValues ->
         when {
-            uiState.isLoading -> LoadingState()
+            uiState.isLoading -> LoadingState(paddingValues)
 
             uiState.isLoadFailed ->
                 ErrorState(
                     message = "mobile.settings.ignoredUsers.loadFailed".i18n(),
+                    paddingValues = paddingValues,
                     onRetry = { onAction(IgnoredUsersUiAction.OnRetryLoadClick) },
                 )
 
             uiState.ignoredUsers.isEmpty() ->
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentAlignment = Alignment.Center,
+                ) {
                     BisqText.BaseRegular(
                         text = "mobile.settings.ignoredUsers.empty".i18n(),
                         color = BisqTheme.colors.mid_grey20,
@@ -83,7 +85,10 @@ internal fun IgnoredUsersContent(
                 }
 
             else ->
-                Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf)) {
+                BisqScrollLayout(
+                    scaffoldPadding = paddingValues,
+                    verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+                ) {
                     uiState.ignoredUsers.forEach { userProfile ->
                         IgnoredUserItem(
                             userProfile = userProfile,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersUiAction.kt
@@ -1,0 +1,17 @@
+package network.bisq.mobile.presentation.settings.ignored_users
+
+sealed interface IgnoredUsersUiAction {
+    data object OnRetryLoadClick : IgnoredUsersUiAction
+
+    data class OnUnblockClick(
+        val userId: String,
+    ) : IgnoredUsersUiAction
+
+    data object OnConfirmUnblock : IgnoredUsersUiAction
+
+    data object OnDismissUnblockDialog : IgnoredUsersUiAction
+
+    data class OnPeerProfileClick(
+        val userId: String,
+    ) : IgnoredUsersUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/ignored_users/IgnoredUsersUiState.kt
@@ -1,0 +1,17 @@
+package network.bisq.mobile.presentation.settings.ignored_users
+
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+
+data class IgnoredUsersUiState(
+    val ignoredUsers: List<UserProfileVO> = emptyList(),
+    val isLoading: Boolean = true,
+    /**
+     * The lookup failed, on either flavour. Kept apart from an empty result so a failure is never
+     * shown as "you ignore nobody": the user gets the failure plus a retry instead.
+     */
+    val isLoadFailed: Boolean = false,
+    /** Peer the undo-ignore confirmation is open for; null while no dialog is shown. */
+    val unblockUserId: String? = null,
+    /** False while an undo-ignore is in flight, so the dialog shows progress and ignores re-taps. */
+    val isUnblockConfirmEnabled: Boolean = true,
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -10,17 +10,13 @@ import bisqapps.shared.presentation.generated.resources.nav_resources
 import bisqapps.shared.presentation.generated.resources.nav_settings
 import bisqapps.shared.presentation.generated.resources.nav_support
 import bisqapps.shared.presentation.generated.resources.nav_user
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
 import network.bisq.mobile.i18n.UiString
@@ -29,32 +25,23 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 
 abstract class MiscItemsPresenter(
-    private val userProfileService: UserProfileServiceFacade,
     private val backendCapabilitiesService: BackendCapabilitiesService,
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
     private val _uiState = MutableStateFlow(MiscItemsUiState())
     val uiState: StateFlow<MiscItemsUiState> = _uiState.asStateFlow()
 
-    private val showIgnoredUsers = MutableStateFlow(false)
-
     override fun onViewAttached() {
         super.onViewAttached()
-        combine(
-            showIgnoredUsers,
-            backendCapabilitiesService.capabilities.map { it.isSupported(Feature.NETWORK_INFO) },
-        ) { showIgnoredUser, showNetwork -> buildSections(showIgnoredUser, showNetwork) }
+        backendCapabilitiesService.capabilities
+            .map { buildSections(showNetwork = it.isSupported(Feature.NETWORK_INFO)) }
             .onEach { sections -> _uiState.update { it.copy(sections = sections) } }
             .launchIn(presenterScope)
-        loadIgnoredUsers()
     }
 
     abstract fun getPaymentAccountNavRoute(): NavRoute
 
-    private fun buildSections(
-        showIgnoredUser: Boolean,
-        showNetwork: Boolean,
-    ): List<MenuSection> {
+    private fun buildSections(showNetwork: Boolean): List<MenuSection> {
         val identityItems =
             listOf(
                 MenuItem(
@@ -66,7 +53,6 @@ abstract class MiscItemsPresenter(
                     label = UiString("mobile.settings.ignoredUsers"),
                     icon = Res.drawable.nav_ignored_users,
                     route = NavRoute.IgnoredUsers,
-                    isEnabled = showIgnoredUser,
                 ),
                 MenuItem(
                     label = UiString("mobile.more.reputation"),
@@ -125,18 +111,6 @@ abstract class MiscItemsPresenter(
             MenuSection(title = UiString("mobile.more.section.help"), items = helpItems),
             MenuSection(title = UiString("mobile.more.section.app"), items = appMenuItems),
         )
-    }
-
-    private fun loadIgnoredUsers() {
-        presenterScope.launch {
-            try {
-                showIgnoredUsers.value = userProfileService.getIgnoredUserProfileIds().isNotEmpty()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log.e(e) { "Failed to load ignored users" }
-            }
-        }
     }
 
     fun onAction(action: MiscItemsUiAction) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -97,19 +96,16 @@ private fun ItemButton(
     onClick: () -> Unit,
 ) {
     val label = item.label.resolve()
-    val iconTint = if (item.isEnabled) null else ColorFilter.tint(BisqTheme.colors.mid_grey20)
     BisqButton(
         text = label,
         onClick = onClick,
         fullWidth = true,
         backgroundColor = BisqTheme.colors.dark_grey40,
-        disabled = !item.isEnabled,
         leftIcon = {
             Image(
                 painter = painterResource(item.icon),
                 contentDescription = label,
                 modifier = Modifier.size(20.dp),
-                colorFilter = iconTint,
             )
         },
         rightIcon = { ArrowRightIcon() },
@@ -131,7 +127,6 @@ private val miscItemsPreviewState =
                                 label = UiString("mobile.settings.ignoredUsers"),
                                 icon = Res.drawable.nav_ignored_users,
                                 route = NavRoute.IgnoredUsers,
-                                isEnabled = false,
                             ),
                             MenuItem(
                                 UiString("mobile.more.reputation"),
@@ -171,7 +166,7 @@ private val miscItemsPreviewState =
     )
 
 @ExcludeFromCoverage
-@Preview(name = "More — sections (Ignored users disabled)")
+@Preview(name = "More — sections")
 @Composable
 private fun MiscItemsContentPreview() {
     BisqTheme.Preview {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsUiState.kt
@@ -17,5 +17,4 @@ data class MenuItem(
     val label: UiString,
     val icon: DrawableResource,
     val route: NavRoute,
-    val isEnabled: Boolean = true,
 )


### PR DESCRIPTION
resolves #1713

The state is now handled inside the screen
Migrated to MVI
Removed now unused disabled style of MenuItem 

<img width="1232" height="715" alt="image" src="https://github.com/user-attachments/assets/a86dcc4c-3cc4-488e-8873-75b69320db49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete ignored-users experience with loading, empty, and error states.
  * Added retry support when ignored users fail to load.
  * Added unblock confirmation, successful removal from the list, and peer profile navigation.
  * Made the Ignored Users menu item consistently available.
* **Bug Fixes**
  * Added localized messages for ignored-user loading and unblock failures.
  * Improved handling of repeated loading and unblock actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->