### PR TITLE
fix: remove edge to edge deprecated apis

### DIFF
--- a/apps/clientApp/src/androidMain/res/values-v33/themes.xml
+++ b/apps/clientApp/src/androidMain/res/values-v33/themes.xml
@@ -8,5 +8,8 @@
 
         <!-- The theme of the Activity that directly follows splash screen -->
         <item name="postSplashScreenTheme">@style/Theme.Bisq</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/apps/clientApp/src/androidMain/res/values/themes.xml
+++ b/apps/clientApp/src/androidMain/res/values/themes.xml
@@ -2,6 +2,12 @@
 <resources>
     <style name="Theme.Bisq" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@color/windowBackground</item>
+        <!-- Android 15 forces transparent system bars; earlier versions fall back to the theme
+             default (a light grey under DayNight), which would sit opaque over the dark app. Set
+             here rather than via Window.setStatusBarColor/setNavigationBarColor, which are the
+             deprecated APIs this replaces. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
@@ -10,5 +16,8 @@
 
         <!-- The theme of the Activity that directly follows splash screen -->
         <item name="postSplashScreenTheme">@style/Theme.Bisq</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/apps/nodeApp/src/androidMain/res/values-v33/themes.xml
+++ b/apps/nodeApp/src/androidMain/res/values-v33/themes.xml
@@ -8,5 +8,8 @@
 
         <!-- The theme of the Activity that directly follows splash screen -->
         <item name="postSplashScreenTheme">@style/Theme.Bisq</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/apps/nodeApp/src/androidMain/res/values/themes.xml
+++ b/apps/nodeApp/src/androidMain/res/values/themes.xml
@@ -2,6 +2,12 @@
 <resources>
     <style name="Theme.Bisq" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@color/windowBackground</item>
+        <!-- Android 15 forces transparent system bars; earlier versions fall back to the theme
+             default (a light grey under DayNight), which would sit opaque over the dark app. Set
+             here rather than via Window.setStatusBarColor/setNavigationBarColor, which are the
+             deprecated APIs this replaces. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
@@ -10,5 +16,8 @@
 
         <!-- The theme of the Activity that directly follows splash screen -->
         <item name="postSplashScreenTheme">@style/Theme.Bisq</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/EdgeToEdgeCompat.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/EdgeToEdgeCompat.kt
@@ -12,11 +12,20 @@ import androidx.core.view.WindowInsetsControllerCompat
  * `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` - all deprecated in Android 15 and reported by the
  * Play Console.
  *
- * The system bars stay transparent; the app paints its own background behind them (see
- * `SafeInsetsContainer`) and pads content by the system bar and display cutout insets.
+ * The system bars are kept transparent by the theme (`android:statusBarColor` /
+ * `android:navigationBarColor`), which Android 15 enforces anyway but earlier versions do not: the
+ * app paints its own background behind them (see `SafeInsetsContainer`) and pads content by the
+ * system bar and display cutout insets.
  */
 fun ComponentActivity.enableEdgeToEdgeCompat() {
     WindowCompat.setDecorFitsSystemWindows(window, false)
+
+    // Without this the system re-adds its translucent contrast scrim behind the transparent
+    // navigation bar in 3-button mode. setNavigationBarContrastEnforced is not deprecated, unlike
+    // the status bar counterpart and the colour setters.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        window.isNavigationBarContrastEnforced = false
+    }
 
     // Render into the cutout area on all orientations. LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS exists
     // from API 30 on; older devices keep the platform default (letterboxed cutout in landscape).

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/EdgeToEdgeCompat.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/EdgeToEdgeCompat.kt
@@ -1,0 +1,36 @@
+package network.bisq.mobile.presentation.main
+
+import android.os.Build
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * Lays the window out edge-to-edge without androidx.activity's `enableEdgeToEdge`, which still
+ * calls `Window.setStatusBarColor`, `Window.setNavigationBarColor` and requests
+ * `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` - all deprecated in Android 15 and reported by the
+ * Play Console.
+ *
+ * The system bars stay transparent; the app paints its own background behind them (see
+ * `SafeInsetsContainer`) and pads content by the system bar and display cutout insets.
+ */
+fun ComponentActivity.enableEdgeToEdgeCompat() {
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+
+    // Render into the cutout area on all orientations. LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS exists
+    // from API 30 on; older devices keep the platform default (letterboxed cutout in landscape).
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        window.attributes =
+            window.attributes.apply {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+            }
+    }
+
+    // The app is dark-only, so the system bar icons must always be light.
+    WindowInsetsControllerCompat(window, window.decorView).apply {
+        isAppearanceLightStatusBars = false
+        isAppearanceLightNavigationBars = false
+    }
+}

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
@@ -58,6 +58,10 @@ abstract class MainActivity :
             super.onCreate(savedInstanceState)
         }
 
+        // Configure the window before anything can observe or draw into it: subclasses call
+        // setContent() right after super.onCreate(), and the presenter may act on the attached view.
+        enableEdgeToEdgeCompat()
+
         // Set up coroutine exception handler after DI is initialized
         GenericErrorHandler.setupCoroutineExceptionHandler(exceptionHandlerSetup)
 
@@ -65,8 +69,6 @@ abstract class MainActivity :
         intent?.let { intent = sanitizeDeepLinkIntent(it) }
 
         presenter.attachView(this)
-
-        enableEdgeToEdgeCompat()
     }
 
     override fun onStart() {

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/main/MainActivity.kt
@@ -3,15 +3,10 @@ package network.bisq.mobile.presentation.main
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.presentation.common.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.common.ui.navigation.ExternalUriHandler
-import network.bisq.mobile.presentation.common.ui.theme.adjustGamma
 import org.koin.android.ext.android.inject
 
 /**
@@ -20,10 +15,6 @@ import org.koin.android.ext.android.inject
 abstract class MainActivity :
     ComponentActivity(),
     Logging {
-    companion object {
-        const val BACKGROUND_COLOR_CODE = 0xFF1C1C1C
-    }
-
     private val presenter: MainPresenter by inject()
     private val exceptionHandlerSetup: CoroutineExceptionHandlerSetup by inject()
 
@@ -75,11 +66,7 @@ abstract class MainActivity :
 
         presenter.attachView(this)
 
-        val bgColor = Color(BACKGROUND_COLOR_CODE).adjustGamma().toArgb()
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(bgColor),
-            navigationBarStyle = SystemBarStyle.dark(bgColor),
-        )
+        enableEdgeToEdgeCompat()
     }
 
     override fun onStart() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollScaffold.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
@@ -38,6 +39,8 @@ fun BisqScrollScaffold(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Scaffold(
+        // See BisqStaticScaffold: without imePadding the bottomBar stays behind the keyboard while
+        // the content slot keeps reserving its height, which leaves a gap above the keyboard.
         modifier =
             modifier
                 .then(
@@ -46,7 +49,7 @@ fun BisqScrollScaffold(
                     } else {
                         Modifier
                     },
-                ),
+                ).imePadding(),
         containerColor = BisqTheme.colors.backgroundColor,
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticScaffold.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.layout
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -33,7 +34,13 @@ fun BisqStaticScaffold(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Scaffold(
-        modifier = Modifier.blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero),
+        // imePadding() belongs on the Scaffold, not only on the inner layout: the bottomBar sits
+        // outside the content slot, so without it the bar stays behind the keyboard while the
+        // content slot still reserves its height, leaving an empty gap above the keyboard.
+        modifier =
+            Modifier
+                .blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero)
+                .imePadding(),
         containerColor = BisqTheme.colors.backgroundColor,
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputField.kt
@@ -35,6 +35,7 @@ private const val MAX_CHAT_INPUT_LENGTH = 10_000
 @Composable
 fun ChatInputField(
     onMessageSend: (String) -> Unit,
+    modifier: Modifier = Modifier,
     quotedMessage: BisqEasyOpenTradeMessageModel? = null,
     placeholder: String = EMPTY_STRING,
     resetScroll: () -> Unit = {},
@@ -47,7 +48,7 @@ fun ChatInputField(
         if (text.length > MAX_CHAT_INPUT_LENGTH) "mobile.tradeChat.chatInput.maxLength".i18n(MAX_CHAT_INPUT_LENGTH) else null
     val isTextValid = validationMessage == null
 
-    Column {
+    Column(modifier = modifier) {
         if (quotedMessage != null) {
             QuotedMessage(quotedMessage, onCloseReply)
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -73,29 +73,31 @@ interface AppPresenter : ViewPresenter {
     fun onTerminateApp()
 }
 
+/**
+ * Paints the app background edge to edge and keeps content clear of the system bars and of display
+ * cutouts (a landscape cutout sits on the left or right edge). The background is painted before the
+ * padding is applied, so the bars never show a stripe.
+ *
+ * The IME inset is deliberately NOT handled here, which makes keyboard handling opt-in: the Bisq
+ * scaffolds apply `imePadding()` themselves, and anything composed outside them gets none. A screen
+ * built from a raw column, or content in a popup-backed sheet, has to apply its own `imePadding()`
+ * or its inputs end up behind the keyboard. Handling it here instead would double-pad every screen
+ * that already resizes for the keyboard.
+ *
+ * `windowInsetsPadding` consumes what it applies, so nested layouts don't pad twice.
+ */
 @Composable
 fun SafeInsetsContainer(
     content: @Composable BoxScope.() -> Unit,
 ) {
-    // Outer container paints the background edge-to-edge, so the system bars never show a stripe
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
-                .background(BisqTheme.colors.backgroundColor),
+                .background(BisqTheme.colors.backgroundColor)
+                .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout)),
     ) {
-        // Inner container keeps the content clear of the system bars and of display cutouts (a
-        // landscape cutout sits on the left or right edge). The IME inset is left out on purpose:
-        // the scaffolds apply `imePadding()` themselves. `windowInsetsPadding` consumes what it
-        // applies, so nested layouts don't pad twice.
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout)),
-        ) {
-            content()
-        }
+        content()
     }
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/main/App.kt
@@ -5,12 +5,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -20,8 +19,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -77,38 +74,25 @@ interface AppPresenter : ViewPresenter {
 }
 
 @Composable
-fun WindowInsets.topPaddingDp(): Dp {
-    val density = LocalDensity.current
-    val topPx = getTop(density)
-    return with(density) { topPx.toDp() }
-}
-
-@Composable
-fun WindowInsets.bottomPaddingDp(): Dp {
-    val density = LocalDensity.current
-    val bottomPx = getBottom(density)
-    return with(density) { bottomPx.toDp() }
-}
-
-@Composable
 fun SafeInsetsContainer(
     content: @Composable BoxScope.() -> Unit,
 ) {
-    // Outer container consumes insets and paints the background
+    // Outer container paints the background edge-to-edge, so the system bars never show a stripe
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
-                .consumeWindowInsets(WindowInsets.systemBars) // Eat insets, so no white stripes
                 .background(BisqTheme.colors.backgroundColor),
     ) {
-        // Inner container adds padding for content
+        // Inner container keeps the content clear of the system bars and of display cutouts (a
+        // landscape cutout sits on the left or right edge). The IME inset is left out on purpose:
+        // the scaffolds apply `imePadding()` themselves. `windowInsetsPadding` consumes what it
+        // applies, so nested layouts don't pad twice.
         Box(
             modifier =
-                Modifier.fillMaxSize().padding(
-                    top = WindowInsets.statusBars.topPaddingDp(),
-                    bottom = WindowInsets.navigationBars.bottomPaddingDp(),
-                ),
+                Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout)),
         ) {
             content()
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.trade.trade_chat
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,9 +58,19 @@ fun TradeChatScreen(tradeId: String) {
     val scope = rememberCoroutineScope()
 
     BisqStaticScaffold(
+        // The input carries the bottom margin itself now, so the content column must not add one:
+        // that padding would otherwise land between the message list and the input, where the
+        // list used to run straight into it.
+        padding =
+            PaddingValues(
+                top = BisqUIConstants.ScreenPadding,
+                start = BisqUIConstants.ScreenPadding,
+                end = BisqUIConstants.ScreenPadding,
+                bottom = BisqUIConstants.Zero,
+            ),
         bottomBar = {
-            // Moved out of the content column, so the scaffold's contentPadding no longer applies:
-            // the side and bottom insets are restored here to keep the previous spacing.
+            // Moved out of the content column, so the scaffold's contentPadding no longer applies
+            // to it: the side and bottom insets are restored here.
             ChatInputField(
                 modifier =
                     Modifier.padding(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.trade.trade_chat
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -19,6 +20,7 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Co
 import network.bisq.mobile.presentation.common.ui.components.organisms.chat.ChatMessageList
 import network.bisq.mobile.presentation.common.ui.components.organisms.chat.UndoIgnoreDialog
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
@@ -55,6 +57,23 @@ fun TradeChatScreen(tradeId: String) {
     val scope = rememberCoroutineScope()
 
     BisqStaticScaffold(
+        bottomBar = {
+            // Moved out of the content column, so the scaffold's contentPadding no longer applies:
+            // the side and bottom insets are restored here to keep the previous spacing.
+            ChatInputField(
+                modifier =
+                    Modifier.padding(
+                        start = BisqUIConstants.ScreenPadding,
+                        end = BisqUIConstants.ScreenPadding,
+                        bottom = BisqUIConstants.ScreenPadding,
+                    ),
+                quotedMessage = quotedMessage,
+                placeholder = "chat.message.input.prompt".i18n(),
+                onMessageSend = presenter::sendChatMessage,
+                onCloseReply = { presenter.onReply(null) },
+                sendEnabled = isSendChatMessageEnabled,
+            )
+        },
         topBar = {
             TopBar(
                 title =
@@ -96,13 +115,6 @@ fun TradeChatScreen(tradeId: String) {
                 userNameProvider = { messageId -> presenter.getUserName(messageId) },
             )
         }
-        ChatInputField(
-            quotedMessage = quotedMessage,
-            placeholder = "chat.message.input.prompt".i18n(),
-            onMessageSend = presenter::sendChatMessage,
-            onCloseReply = { presenter.onReply(null) },
-            sendEnabled = isSendChatMessageEnabled,
-        )
 
         reportUserTradeMessage?.let { message ->
             if (showReportUserDialog) {


### PR DESCRIPTION
helps resolve https://github.com/bisq-network/bisq-mobile/issues/1699

this should help along with merging https://github.com/bisq-network/bisq-mobile/pull/1723 

fixed some ime paddings issues present in main (visible in offers screen), and moved chat input to bottom bar in trade chat

needs help testing things on iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved edge-to-edge display with transparent system bars and better display-cutout support.
  * Updated layouts to adjust automatically for on-screen keyboards, keeping content and bottom controls visible.
  * Improved system inset handling to prevent duplicated spacing.
  * Positioned trade chat input in a dedicated bottom bar for a more consistent layout.
  * Added flexible layout customization for chat input fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->