### PR TITLE
design/community_hub_design_simplifications_improvements

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityEntryPointDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityEntryPointDesign.kt
@@ -60,17 +60,25 @@
  * BADGE SEMANTICS — what the number means, precisely (review pass, rodvar's #1)
  * ----------------------------------------------------------------------------------------
  * DEFINITION: `unreadCount` is the GLOBAL community unread count — the sum of
- *   (a) Discussions public-channel unread (per bisq2's own per-channel notification
- *       rule, `ChatChannelNotificationTypeEnum` — GLOBAL_DEFAULT/ALL/MENTION/OFF; see
- *       CommunityPushNotificationsDesign.kt for why MENTION is the recommended default
- *       for busy public channels) — SHIPS THIS MILESTONE, and
+ *   (a) the Discussion channel's own unread count (`CommunityHubUiState.discussionsUnreadCount`,
+ *       per bisq2's own per-channel notification rule, `ChatChannelNotificationTypeEnum` —
+ *       GLOBAL_DEFAULT/ALL/MENTION/OFF; see CommunityPushNotificationsDesign.kt for why
+ *       MENTION is the recommended default for a busy public channel) — SHIPS THIS
+ *       MILESTONE, and
  *   (b) private-DM unread (#590, folds in once Messages ships) — NOT counted this
  *       milestone because there is nothing to count yet.
  * THIS MILESTONE, `CommunityHubUiState.liveSegments = {DISCUSSIONS}` (see
- * CommunityHubScreenDesign.kt's "CANONICAL DESIGN, GATED ROLLOUT"), so `unreadCount` ==
- * total unread across Discussions channels only — there's nothing else live to sum yet.
- * The badge's math does not change shape when DMs ship — it simply gains a second
- * addend as `liveSegments` grows. No caller code needs to change, only what it sums.
+ * CommunityHubScreenDesign.kt's "GATED ROLLOUT"), so `unreadCount` == the Discussion
+ * channel's unread only — there's nothing else live to sum yet. The badge's math does not
+ * change shape when DMs ship — it simply gains a second addend as `liveSegments` grows.
+ * No caller code needs to change, only what it sums.
+ *
+ * The Support channel is DELIBERATELY EXCLUDED from this sum, permanently — not just this
+ * milestone. Support isn't a segment (see CommunityHubScreenDesign.kt's "SUPPORT —
+ * HUB-SIDE REFERENCE"), so it has no `liveSegments` entry to grow into and never will
+ * under this design. This keeps the aggregate a strict 2-source sum (Discussions +
+ * Messages) rather than reopening the "what kind of unread is this" ambiguity discussed
+ * below with a third, un-badged source.
  *
  * "HOW DOES THE USER KNOW THEY HAVE A NEW DM SPECIFICALLY?" — the drill-down path (once
  * Messages is live and its segment tab is visible):
@@ -136,6 +144,15 @@
  * behaviour: a persistent global icon that always opens a real, navigable screen, so the
  * destination has room to grow (segmented tabs, search, etc.) without redesigning the
  * entry point later.
+ *
+ * WHAT THE USER ACTUALLY SEES ON TAP, today vs. later — see
+ * `CommunityHubScreenDesign.kt`'s "WHAT OPENS WHEN THE USER TAPS THE ICON" for the
+ * canonical answer (don't duplicate the full explanation here, just the pointer): the
+ * destination is always the SAME `CommunityHubScreenContent`; at milestone 11 it renders
+ * with no tab row at all — straight into the Discussion channel's thread with a pinned
+ * Support reference — and only grows the segmented tab row as #590/#1238 ship. The
+ * "segmented tabs" mentioned in the paragraph above is room the destination has to grow
+ * INTO, not what it looks like on day one.
  *
  * ======================================================================================
  * i18n KEYS NEEDED

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
@@ -4,151 +4,178 @@
  * STATUS: Design proof-of-concept. NOT wired to any presenter or production code.
  *
  * ======================================================================================
- * PURPOSE
+ * WHAT OPENS WHEN THE USER TAPS THE ICON (one-glance answer)
  * ======================================================================================
- * The full screen pushed when the user taps `CommunityTopBarIcon` (see
- * CommunityEntryPointDesign.kt). This IS the canonical Community hub design — a 3-tab
- * segmented shell: **Discussions | Messages | Contacts**. There is no separate
- * "future" version of this screen; this is the target design at every milestone,
- * including milestone 11.
+ * Tapping the Community top-bar icon (`CommunityEntryPointDesign.kt`) ALWAYS pushes THIS
+ * screen, `CommunityHubScreenContent` — there is no other destination and no intermediate
+ * screen. What renders INSIDE it depends entirely on `liveSegments`:
+ *   - **RIGHT NOW (milestone 11, `liveSegments = {DISCUSSIONS}`)**: the user lands
+ *     DIRECTLY on the Discussions content — a shared TopBar reading "Community", then the
+ *     pinned "Need help?" Support row, then the Discussion channel's own message thread.
+ *     NO tab row, NO channel list, NO picker of any kind in front of it. This is the
+ *     preview named **"Community Hub — MAIN SCREEN on icon tap (ships milestone 11)..."**
+ *     below — THAT preview, not the 2-or-3-segment ones further down, is what the user
+ *     actually sees today when they tap the icon.
+ *   - **LATER, as #590/#1238 ship**: this SAME screen grows a segmented tab row
+ *     (Discussions | Messages | Contacts) above that same content — see the previews
+ *     named **"Community Hub — FUTURE: ..."** further down in this file. Those are NOT
+ *     what ships now; don't mistake them for the current main screen.
  *
  * ======================================================================================
- * CANONICAL DESIGN, GATED ROLLOUT (consolidation, rodvar's 3rd review pass)
+ * WHAT SHIPS THIS MILESTONE (detail)
  * ======================================================================================
- * Earlier drafts of this file shipped a Discussions-only screen for milestone 11 PLUS a
- * separately-named "future segmented hub" preview showing the eventual 3-tab shape.
- * rodvar had those consolidated: nothing is built yet, so there is no repaint-twice cost
- * to designing the full target now, and maintaining two hub designs invited drift
- * between them. There is now exactly ONE hub design, `CommunityHubScreenContent`,
- * structured as the full 3-tab shell from the start — not a Discussions screen that
- * later grows tabs.
+ * Milestone 11's `liveSegments = {DISCUSSIONS}` means the segmented tab row does not
+ * render at all (see "GATED ROLLOUT" below), and the Discussions tab body IS the whole
+ * screen: pinned Support reference, then straight into the single Discussion channel's
+ * message thread (`DiscussionsChannelScreenDesign.kt`, embedded via `showTopBar = false`).
+ * There is no channel list and no search-across-channels — bisq2 wires exactly one
+ * Discussion channel and one Support channel today
+ * (`chat/src/main/java/bisq/chat/ChatService.java`), so there is nothing to pick between.
+ * See `DiscussionsChannelScreenDesign.kt`'s "WHY THERE'S NO CHANNEL LIST" for the
+ * evidence (bisq2's own channel-consolidation history) and "REINTRODUCING A CHANNEL
+ * PICKER" for the explicit, code-level trigger to revisit this.
  *
- * THE ROLLOUT IS GATED, NOT THE DESIGN. `CommunityHubUiState.liveSegments` is the set of
- * segments whose backing feature actually exists yet. `CommunitySegmentedTabRow` renders
- * ONLY the tabs present in `liveSegments` — a segment whose feature hasn't shipped is
- * NEVER rendered as a disabled/greyed/"coming soon" tab; it simply isn't in the row.
- * Further, when `liveSegments.size <= 1` the tab row doesn't render AT ALL — a segmented
- * control with a single segment has nothing to switch between, so showing one would be
- * pure visual noise, not a real affordance. In that state Discussions renders directly
- * with no tab chrome at all, which is exactly what a milestone-11 user sees.
+ * The 3-segment shell (Discussions | Messages | Contacts) described below is still the
+ * eventual target once #590/#1238 ship — it just isn't visible yet, by design, not by
+ * omission. Don't let the shell's generality below read as "this is what ships now"; the
+ * section above is what ships now.
+ *
+ * ======================================================================================
+ * GATED ROLLOUT
+ * ======================================================================================
+ * `CommunityHubUiState.liveSegments` is the set of segments whose backing feature
+ * actually exists. `CommunitySegmentedTabRow` renders ONLY the tabs present in
+ * `liveSegments` — a segment whose feature hasn't shipped is NEVER rendered as a
+ * disabled/greyed/"coming soon" tab; it simply isn't in the row. When
+ * `liveSegments.size <= 1` the tab row doesn't render AT ALL, since a segmented control
+ * with one segment has nothing to switch between.
  *
  * Milestone-by-milestone `liveSegments` (same composable, same code, different state):
- *   - **Milestone 11 (now)**: `{DISCUSSIONS}`. #589 ships; #590/#1238 don't exist yet.
- *     Tab row is invisible; the user sees a plain Discussions screen. This is the
- *     REALISTIC shipping state — see the `CommunityHubScreen_Milestone11_*` previews.
- *   - **#590 ships**: `{DISCUSSIONS, MESSAGES}`. Tab row appears with exactly 2 tabs;
- *     Contacts is still simply absent, not a disabled 3rd tab. See
+ *   - **Milestone 11 (now)**: `{DISCUSSIONS}`. Tab row invisible — see lede above.
+ *     `CommunityHubScreen_Milestone11_*` previews.
+ *   - **#590 ships**: `{DISCUSSIONS, MESSAGES}`. Tab row appears with exactly 2 tabs.
  *     `CommunityHubScreen_TwoSegmentsLivePreview`.
- *   - **#1238 ships**: `{DISCUSSIONS, MESSAGES, CONTACTS}`. The full target design. See
+ *   - **#1238 ships**: `{DISCUSSIONS, MESSAGES, CONTACTS}`. Full target shape.
  *     `CommunityHubScreen_AllSegmentsLiveInteractivePreview`.
- * No caller changes the composable's shape between these states — only what's in
- * `liveSegments` changes, which is exactly the point of designing the target now.
  *
  * ======================================================================================
- * SEGMENT MAPPING (decided)
+ * SEGMENT MAPPING
  * ======================================================================================
- *   - **Discussions** = public multi-party channels, #589. `DiscussionsTabContent`
- *     below (search + section-grouped channel list) is the tab's body. This used to be
- *     this file's entire standalone screen; it is now purely the Discussions tab's
- *     content, with its own TopBar removed — the shell owns ONE shared TopBar for all
- *     tabs (see LAYOUT below).
+ *   - **Discussions** = the single public Discussion channel, #589. `DiscussionsTabContent`
+ *     is the tab's body: the pinned Support reference (see below) followed directly by
+ *     `DiscussionsChannelScreenContent` (`DiscussionsChannelScreenDesign.kt`,
+ *     `showTopBar = false` since this shell owns the shared TopBar).
  *   - **Messages** = the private-DM inbox, #590. `PrivateChatListScreenContent`
  *     (design/community/private_chat/PrivateChatListScreenDesign.kt) reused directly,
- *     `showTopBar = false` since the shell owns the TopBar. See that file's "ROLE IN THE
- *     HUB" section for why DMs and public channels stay in separate segments rather than
- *     one merged list (they are distinct objects: a DM is a persistent 1:1 relationship
- *     you can leave; a channel is implicit, non-exclusive membership with no "leave").
+ *     `showTopBar = false`. See that file's "ROLE IN THE HUB" section for why DMs and the
+ *     Discussion channel stay in separate segments rather than one merged list (a DM is a
+ *     persistent 1:1 relationship you can leave; a channel is implicit, non-exclusive
+ *     membership with no "leave").
  *   - **Contacts** = the relationship directory, #1238, NOT designed yet — deliberately
  *     not a message list, see project_milestone11_community_ia.md agent memory.
- *     `ContactsDirectoryPlaceholder` below is a labelled stand-in only.
+ *     `ContactsDirectoryPlaceholder` below is a labelled stand-in only. Rendered with a
+ *     MUTED visual treatment even once live — see "CONTACTS — MUTED SEGMENT TREATMENT".
  *
  * ======================================================================================
- * WHY DISCUSSIONS + SUPPORT SHARE ONE LIST WITHIN THE DISCUSSIONS TAB (NOT TWO TABS)
+ * SUPPORT — HUB-SIDE REFERENCE (not a segment)
  * ======================================================================================
- * Desktop treats "Discussions" and "Support" as two instances of the same reusable
- * channel-tab shape (bisq2/.../desktop/main/content/chat/common/pub/ — CommonChatTabView
- * driven by a channel "kind"). On mobile there is no room for a second layer of tabs
- * inside the Discussions tab, so channels are grouped with section headers in a single
- * scrollable list instead, tagged via `SimulatedChannelCategory`. This keeps the two
- * categories visually distinct (a user browsing casual discussion doesn't want
- * support-ticket channels interleaved) without adding another navigation layer on top
- * of the hub's own 3-tab layer.
+ * DECISION: the in-app Support public channel is referenced from BOTH the existing
+ * More → Help → Support screen (`SupportScreen.kt`, today a static list of external
+ * links — Matrix, forum) AND from here, in the Community hub. They coexist rather than
+ * one replacing the other, because support is critical in a fully decentralized app that
+ * many users find hard to reason about — a single, easy-to-miss entry point isn't good
+ * enough for something this important. This resolves the previously-deferred "does the
+ * new Support channel replace or coexist with More → Help → Support" question:
+ * COEXIST, both pointing at the same underlying channel.
+ *
+ * What Support is NOT, deliberately: a 4th co-equal segment in `CommunitySegmentedTabRow`.
+ * Reasons (design-review finding, not a style preference):
+ *   1. Desktop precedent contradicts tab-parity: `NavigationTarget.java` places `SUPPORT`
+ *      as its OWN top-level `CONTENT` section, a sibling of `CHAT` (not nested inside it)
+ *      alongside `SUPPORT_ASSISTANCE` (the same channel, reached via desktop's Help area)
+ *      and `SUPPORT_RESOURCES` (static help content). Desktop keeps "official support"
+ *      institutionally separate from casual Discussion chat, at the same rank as Academy
+ *      or User settings — not as a sibling browsing tab.
+ *   2. Badge-math complexity: the hub's aggregate unread badge
+ *      (`CommunityEntryPointDesign.kt` "BADGE SEMANTICS") deliberately sums only
+ *      Discussions + Messages. Adding Support as a THIRD countable, badge-carrying tab
+ *      reopens an ambiguity question (channel mention vs. DM vs. support reply) that
+ *      hasn't been designed for — see `CommunityEntryPointDesign.kt`'s "BADGE SEMANTICS".
+ *
+ * THE CHOSEN TREATMENT — a pinned reference row, not a tab: `SupportChannelPinnedReference`
+ * renders as the first thing in the Discussions tab body, above the channel thread — a
+ * "Need help?" row with the Support icon, always visible (not dismissible, not buried in
+ * a menu), one tap into the Support channel. Tapping it navigates to the SAME
+ * `DiscussionsChannelScreenContent` composable, parameterized for the Support channel
+ * (`channelName = "Support"`, `showTopBar = true` since it's now a standalone pushed
+ * screen) — see `DiscussionsChannelScreenDesign.kt`'s "REUSED FOR THE SUPPORT CHANNEL".
+ * No new screen type, no new tab, no badge-math change — just a persistent, always-visible
+ * doorway from the one place users are already looking (Community) into a channel that
+ * already exists.
+ *
+ * IS THIS THE RIGHT LEVEL OF PROMINENCE, GIVEN "SUPPORT IS CRITICAL"? A persistent,
+ * unmissable, always-on-screen row reachable in exactly one tap is a deliberately strong
+ * treatment for something that isn't a tab — this is not a buried menu item. If real
+ * usage later shows people still miss it (e.g. support-channel traffic stays flat while
+ * More → Help → Support traffic doesn't), that's the trigger to reconsider promoting it
+ * further — but escalate on evidence, not preemptively. Flagged here explicitly per
+ * design-review instruction rather than silently building something bigger.
  *
  * ======================================================================================
- * OPEN QUESTION — NOT RESOLVED HERE (per explicit instruction, left as a question)
+ * CONTACTS — MUTED SEGMENT TREATMENT (design-review finding)
  * ======================================================================================
- * The existing More → Help → Support entry (MiscItemsPresenter.buildSections, `help`
- * section) may need to be reconciled with the new Support channel category shown here —
- * does the old entry redirect into the Discussions tab's Support section, or do both
- * coexist? Do NOT remove the existing More-menu Support entry as part of this design
- * pass; this screen assumes the community Support channel simply exists alongside it
- * for now. Decide when implementing.
+ * Contacts stays a segment in `CommunitySegmentedTabRow`, not a FAB (rejected pattern —
+ * see agent memory for the full reasoning: a FAB borrows the app's ONE existing FAB
+ * convention, `BisqFABAddButton` in `OfferbookScreen.kt`, whose established job is
+ * "author new content," which doesn't match Contacts being a reference/browse surface;
+ * a FAB would also hide the reputation/trust data this app's whole design philosophy
+ * says should be prominent, not tucked in a corner). Desktop precedent supports keeping
+ * it a peer destination too: `NavigationTarget.CONTACTS_LIST` is its own top-level
+ * `CONTENT` section on desktop, sibling to `CHAT`.
+ *
+ * What DOES change: Contacts renders with a deliberately MUTED visual weight relative to
+ * Discussions/Messages, reflecting that it's a reference surface (no unread state, no
+ * live-update reason to poll) rather than an inbox. `CommunitySegmentedTabRow`'s
+ * `mutedSegments` param (default `{CONTACTS}`) controls this:
+ *   - Selected-state color: muted segments use `BisqTheme.colors.light_grey50` instead of
+ *     `BisqTheme.colors.primary` for both the label and the underline indicator — so
+ *     tapping into Contacts never reads as "you're in an active inbox" the way Discussions
+ *     or Messages does when selected.
+ *   - Unselected-state color: unchanged (`mid_grey20`, same as any other unselected tab).
+ *   - Badge slot: unchanged — Contacts was never in the `counts` map (only Discussions and
+ *     Messages contribute), so it already never shows a pill. This was previously
+ *     undocumented as intentional; now explicit.
+ *   - Position, tap target size, gating: unchanged.
+ * See `CommunityHubScreen_ContactsMutedVsPrimaryComparisonPreview` for both selected
+ * states side by side.
  *
  * ======================================================================================
- * SEARCH (#589 "reuses ... a search component")
+ * SEARCH
  * ======================================================================================
- * This is the DIRECTORY-level search inside the Discussions tab — filters the channel
- * list by name/description. It is a DIFFERENT search from the per-channel message
- * search inside a channel thread (see DiscussionsChannelScreenDesign.kt's
- * search-in-channel toggle). Reuses the real production `BisqSearchField` molecule
- * directly (common/ui/components/molecules/inputfield/SearchField.kt) — it only takes
- * primitives, so no Simulated stand-in is needed here.
- *
- * ======================================================================================
- * LAYOUT
- * ======================================================================================
- * Milestone 11 (liveSegments = {DISCUSSIONS} — tab row hidden):
- * ┌─────────────────────────────────────────┐
- * │ TopBar: "← Community"                    │
- * ├─────────────────────────────────────────┤
- * │ [ Search channels...            🔍 ]     │
- * ├─────────────────────────────────────────┤
- * │ DISCUSSION                               │  section label
- * │  💬 General Discussion      3 unread     │
- * │  💬 Market Chat                          │
- * ├─────────────────────────────────────────┤
- * │ SUPPORT                                  │  section label
- * │  ❓ New Trader Help          1 unread     │
- * └─────────────────────────────────────────┘
- *
- * Once a 2nd/3rd segment is live (tab row appears — same TopBar, same tab bodies):
- * ┌─────────────────────────────────────────┐
- * │ TopBar: "← Community"                    │
- * ├─────────────────────────────────────────┤
- * │  Discussions ⑤ │  Messages ③ │ Contacts  │  ← CommunitySegmentedTabRow
- * ├─────────────────────────────────────────┤
- * │            (selected tab's body)         │
- * └─────────────────────────────────────────┘
- *
- * Section-label styling reuses the exact decision made for issue #1520
- * (see agent memory: project_more_menu_redesign.md) — mid_grey20 + XSmallMedium + all
- * caps, chosen over small-caps because IBM Plex Sans has no small-caps axis and OpenType
- * "smcp" is unreliable on Android.
+ * There is no directory-level search anymore (see lede — nothing to search across when
+ * there's one channel). The only search in Discussions is the search-in-channel toggle,
+ * now documented in `DiscussionsChannelScreenDesign.kt`'s "SEARCH-IN-CHANNEL" section.
  *
  * ======================================================================================
  * i18n KEYS NEEDED
  * ======================================================================================
- * mobile.community.hub.title              → "Community"
- * mobile.community.hub.search.hint        → "Search channels..."
- * mobile.community.hub.section.discussion → "Discussion"
- * mobile.community.hub.section.support    → "Support"
- * mobile.community.hub.empty              → "No channels available"
- * mobile.community.hub.search.noResults   → "No channels match \"{0}\""
- * mobile.community.hub.memberCount        → "{0} members"
- * mobile.community.hub.tab.discussions    → "Discussions" (CommunitySegmentedTabRow
+ * mobile.community.hub.title                      → "Community"
+ * mobile.community.hub.tab.discussions             → "Discussions" (CommunitySegmentedTabRow
  *   currently derives this from the enum name in English as a PoC placeholder — needs a
  *   real key at implementation time)
- * mobile.community.hub.tab.messages       → "Messages"
- * mobile.community.hub.tab.contacts       → "Contacts"
+ * mobile.community.hub.tab.messages                → "Messages"
+ * mobile.community.hub.tab.contacts                → "Contacts"
+ * mobile.community.hub.supportReference.title      → "Need help?"
+ * mobile.community.hub.supportReference.subtitle   → "Visit the Support channel"
+ * (Discussions channel body's own keys — search, empty state, member count — are declared
+ * in DiscussionsChannelScreenDesign.kt, not duplicated here.)
  *
  * ======================================================================================
  * TEXT EXPANSION
  * ======================================================================================
- * Channel names are operator-authored short labels (2-3 words typically) — low risk.
- * "members" count suffix in German ("Mitglieder") is noticeably longer; the member-count
- * text uses SmallLight sized text with no fixed-width container, so it wraps naturally
- * rather than truncating. Tab labels ("Discussions"/"Messages"/"Contacts") are short in
- * every supported language — low risk for the segmented row.
+ * Tab labels ("Discussions"/"Messages"/"Contacts") are short in every supported language
+ * — low risk for the segmented row. "Need help?" / "Visit the Support channel" are short
+ * phrases; German ("Brauchst du Hilfe?" / "Zum Support-Kanal") is comparable length.
  */
 package network.bisq.mobile.presentation.design.community
 
@@ -165,8 +192,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -178,10 +203,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ChatIconOutlined
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowRightIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.QuestionIcon
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
-import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.BisqSearchField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
@@ -194,21 +218,6 @@ import network.bisq.mobile.presentation.design.community.private_chat.simulatedC
 // Simulated data — no domain type dependencies
 // ============================================================================================
 
-internal enum class SimulatedChannelCategory {
-    DISCUSSION,
-    SUPPORT,
-}
-
-internal data class SimulatedChannel(
-    val id: String,
-    val name: String,
-    val category: SimulatedChannelCategory,
-    val lastMessagePreview: String,
-    val lastMessageTime: String,
-    val unreadCount: Int,
-    val memberCount: Int,
-)
-
 internal enum class SimulatedHubSegment {
     DISCUSSIONS,
     MESSAGES,
@@ -220,17 +229,28 @@ internal enum class SimulatedHubSegment {
 // ============================================================================================
 
 /**
- * The shell's own state. Composes the two sub-screens' state types directly
- * (`DiscussionsTabUiState`, `PrivateChatListUiState`) rather than duplicating their
+ * The shell's own state. Composes the sub-screens' state types directly
+ * (`DiscussionsChannelUiState`, `PrivateChatListUiState`) rather than duplicating their
  * fields — this screen owns tab selection and gating, not the tabs' own data.
  *
  * @param liveSegments which tabs actually have a shipped feature behind them — see file
- *   KDoc "CANONICAL DESIGN, GATED ROLLOUT". Defaults to milestone 11's real state.
+ *   KDoc "GATED ROLLOUT". Defaults to milestone 11's real state.
+ * @param discussions the Discussion channel's own content state (messages, search,
+ *   loading) — see `DiscussionsChannelScreenDesign.kt`. Has no unread concept of its own
+ *   (you're actively viewing it), which is why unread tracking lives separately below.
+ * @param discussionsUnreadCount SHELL-level unread count for the Discussion channel —
+ *   deliberately not a field on `DiscussionsChannelUiState`, because "how many messages
+ *   are unread" is a property of the relationship between the user and the channel
+ *   (last-read timestamp vs. latest message), not a property of the currently-open
+ *   channel view itself. Feeds `CommunitySegmentedTabRow`'s `counts` and, once summed
+ *   with Messages, `CommunityTopBarIcon`'s global badge (see
+ *   `CommunityEntryPointDesign.kt` "BADGE SEMANTICS").
  */
 internal data class CommunityHubUiState(
     val selectedSegment: SimulatedHubSegment = SimulatedHubSegment.DISCUSSIONS,
     val liveSegments: Set<SimulatedHubSegment> = setOf(SimulatedHubSegment.DISCUSSIONS),
-    val discussions: DiscussionsTabUiState = DiscussionsTabUiState(),
+    val discussions: DiscussionsChannelUiState = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 0),
+    val discussionsUnreadCount: Int = 0,
     val messages: PrivateChatListUiState = PrivateChatListUiState(),
 )
 
@@ -240,32 +260,15 @@ internal sealed interface CommunityHubUiAction {
     ) : CommunityHubUiAction
 
     data class OnDiscussionsAction(
-        val action: DiscussionsTabUiAction,
+        val action: DiscussionsChannelUiAction,
     ) : CommunityHubUiAction
 
     data class OnMessagesAction(
         val action: PrivateChatListUiAction,
     ) : CommunityHubUiAction
-}
 
-// ============================================================================================
-// UiState / UiAction — DISCUSSIONS TAB (formerly this file's entire standalone screen)
-// ============================================================================================
-
-internal data class DiscussionsTabUiState(
-    val channels: List<SimulatedChannel> = emptyList(),
-    val searchQuery: String = "",
-    val isLoading: Boolean = false,
-)
-
-internal sealed interface DiscussionsTabUiAction {
-    data class OnSearchQueryChange(
-        val query: String,
-    ) : DiscussionsTabUiAction
-
-    data class OnChannelClick(
-        val channelId: String,
-    ) : DiscussionsTabUiAction
+    /** Opens the Support channel as its own pushed screen — see "SUPPORT — HUB-SIDE REFERENCE" above. */
+    data object OnOpenSupportChannel : CommunityHubUiAction
 }
 
 // ============================================================================================
@@ -286,9 +289,9 @@ internal fun CommunityHubScreenContent(
     Column(modifier = Modifier.fillMaxSize().background(BisqTheme.colors.backgroundColor)) {
         TopBarContent(title = "Community", showBackButton = true, showUserAvatar = true)
 
-        // See file KDoc "CANONICAL DESIGN, GATED ROLLOUT": the tab row only renders once
-        // there is more than one live segment to switch between. A single-segment row
-        // would be a control with nothing to control.
+        // See file KDoc "GATED ROLLOUT": the tab row only renders once there is more
+        // than one live segment to switch between. A single-segment row would be a
+        // control with nothing to control.
         if (uiState.liveSegments.size > 1) {
             CommunitySegmentedTabRow(
                 selected = effectiveSegment,
@@ -296,7 +299,7 @@ internal fun CommunityHubScreenContent(
                 liveSegments = uiState.liveSegments,
                 counts =
                     mapOf(
-                        SimulatedHubSegment.DISCUSSIONS to uiState.discussions.channels.sumOf { it.unreadCount },
+                        SimulatedHubSegment.DISCUSSIONS to uiState.discussionsUnreadCount,
                         SimulatedHubSegment.MESSAGES to uiState.messages.conversations.sumOf { it.unreadCount },
                     ),
             )
@@ -308,6 +311,7 @@ internal fun CommunityHubScreenContent(
                     DiscussionsTabContent(
                         uiState = uiState.discussions,
                         onAction = { onAction(CommunityHubUiAction.OnDiscussionsAction(it)) },
+                        onOpenSupportChannel = { onAction(CommunityHubUiAction.OnOpenSupportChannel) },
                     )
                 }
                 SimulatedHubSegment.MESSAGES -> {
@@ -333,12 +337,15 @@ internal fun CommunityHubScreenContent(
  * why demonstrating "global badge count == sum of segment counts" matters.
  *
  * @param liveSegments only these segments are rendered as tabs — see file KDoc
- *   "CANONICAL DESIGN, GATED ROLLOUT". A segment absent from this set is never shown as
- *   a disabled/greyed tab, it is simply not in the row.
+ *   "GATED ROLLOUT". A segment absent from this set is never shown as a
+ *   disabled/greyed tab, it is simply not in the row.
  * @param counts renders a small unread pill next to a segment's label when its count is
- *   > 0, matching the same manual-`Box`-pill style used by `ChannelRow`/`ConversationRow`
+ *   > 0, matching the same manual-`Box`-pill style used by `ConversationRow`
  *   (not `BadgedBox` — see the badge-clipping bug documented in
  *   `CommunityEntryPointDesign.kt` for why that pattern is avoided here too).
+ * @param mutedSegments segments that never get the full `primary` selected-state color —
+ *   see file KDoc "CONTACTS — MUTED SEGMENT TREATMENT". Defaults to muting Contacts only;
+ *   Discussions and Messages always use full `primary` when selected.
  */
 @Composable
 internal fun CommunitySegmentedTabRow(
@@ -346,11 +353,13 @@ internal fun CommunitySegmentedTabRow(
     onSelect: (SimulatedHubSegment) -> Unit,
     liveSegments: Set<SimulatedHubSegment> = SimulatedHubSegment.entries.toSet(),
     counts: Map<SimulatedHubSegment, Int> = emptyMap(),
+    mutedSegments: Set<SimulatedHubSegment> = setOf(SimulatedHubSegment.CONTACTS),
 ) {
     Row(modifier = Modifier.fillMaxWidth().padding(horizontal = BisqUIConstants.ScreenPadding)) {
         SimulatedHubSegment.entries.filter { it in liveSegments }.forEach { segment ->
             val isSelected = segment == selected
             val count = counts[segment] ?: 0
+            val selectedColor = if (segment in mutedSegments) BisqTheme.colors.light_grey50 else BisqTheme.colors.primary
             Column(
                 modifier =
                     Modifier
@@ -362,7 +371,7 @@ internal fun CommunitySegmentedTabRow(
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingQuarter)) {
                     BisqText.SmallRegular(
                         text = segment.name.lowercase().replaceFirstChar { it.uppercase() },
-                        color = if (isSelected) BisqTheme.colors.primary else BisqTheme.colors.mid_grey20,
+                        color = if (isSelected) selectedColor else BisqTheme.colors.mid_grey20,
                     )
                     if (count > 0) {
                         Box(
@@ -381,7 +390,7 @@ internal fun CommunitySegmentedTabRow(
                             .padding(top = BisqUIConstants.ScreenPaddingQuarter)
                             .width(BisqUIConstants.ScreenPadding4X)
                             .height(2.dp)
-                            .background(if (isSelected) BisqTheme.colors.primary else BisqTheme.colors.dark_grey50),
+                            .background(if (isSelected) selectedColor else BisqTheme.colors.dark_grey50),
                 )
             }
         }
@@ -404,173 +413,60 @@ private fun ContactsDirectoryPlaceholder() {
 }
 
 // ============================================================================================
-// Content — DISCUSSIONS TAB (search + section-grouped channel list, no TopBar of its own)
+// Content — DISCUSSIONS TAB (pinned Support reference + the single channel's thread)
 // ============================================================================================
 
+/**
+ * The Discussions tab's body: a pinned reference into the Support channel above the
+ * Discussion channel's own thread. This IS the tab now that there's no channel list — see
+ * file KDoc lede and `DiscussionsChannelScreenDesign.kt`'s "WHY THERE'S NO CHANNEL LIST".
+ * If bisq2 ever ships a second Discussion channel, this is the reinsertion point for a
+ * picker (see that file's "REINTRODUCING A CHANNEL PICKER").
+ */
 @Composable
 internal fun DiscussionsTabContent(
-    uiState: DiscussionsTabUiState,
-    onAction: (DiscussionsTabUiAction) -> Unit,
+    uiState: DiscussionsChannelUiState,
+    onAction: (DiscussionsChannelUiAction) -> Unit,
+    onOpenSupportChannel: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        Row(modifier = Modifier.fillMaxWidth().padding(BisqUIConstants.ScreenPadding)) {
-            BisqSearchField(
-                value = uiState.searchQuery,
-                onValueChange = { onAction(DiscussionsTabUiAction.OnSearchQueryChange(it)) },
-                placeholder = "Search channels...",
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-
-        when {
-            uiState.isLoading -> DiscussionsTabLoadingState()
-            uiState.channels.isEmpty() && uiState.searchQuery.isEmpty() -> DiscussionsTabEmptyState()
-            uiState.channels.isEmpty() -> DiscussionsTabNoSearchResultsState(uiState.searchQuery)
-            else -> {
-                val discussionChannels = uiState.channels.filter { it.category == SimulatedChannelCategory.DISCUSSION }
-                val supportChannels = uiState.channels.filter { it.category == SimulatedChannelCategory.SUPPORT }
-
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    if (discussionChannels.isNotEmpty()) {
-                        ChannelSectionLabel("Discussion")
-                        discussionChannels.forEach { channel ->
-                            ChannelRow(channel = channel, onClick = { onAction(DiscussionsTabUiAction.OnChannelClick(channel.id)) })
-                            HorizontalDivider(
-                                thickness = 0.5.dp,
-                                color = BisqTheme.colors.dark_grey50,
-                                modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding),
-                            )
-                        }
-                    }
-                    if (supportChannels.isNotEmpty()) {
-                        ChannelSectionLabel("Support")
-                        supportChannels.forEach { channel ->
-                            ChannelRow(channel = channel, onClick = { onAction(DiscussionsTabUiAction.OnChannelClick(channel.id)) })
-                            HorizontalDivider(
-                                thickness = 0.5.dp,
-                                color = BisqTheme.colors.dark_grey50,
-                                modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding),
-                            )
-                        }
-                    }
-                }
-            }
-        }
+        SupportChannelPinnedReference(onClick = onOpenSupportChannel)
+        DiscussionsChannelScreenContent(
+            uiState = uiState,
+            onAction = onAction,
+            showTopBar = false,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
 // ---------------------------------------------------------------------------
-// Section label — mirrors the #1520 More-menu section-header decision
+// Support channel pinned reference — see file KDoc "SUPPORT — HUB-SIDE REFERENCE"
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun ChannelSectionLabel(text: String) {
-    BisqText.XSmallMedium(
-        text = text.uppercase(),
-        color = BisqTheme.colors.mid_grey20,
-        modifier =
-            Modifier.padding(
-                start = BisqUIConstants.ScreenPadding,
-                top = BisqUIConstants.ScreenPadding,
-                bottom = BisqUIConstants.ScreenPaddingHalf,
-            ),
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Channel row
-// ---------------------------------------------------------------------------
-
-@Composable
-private fun ChannelRow(
-    channel: SimulatedChannel,
-    onClick: () -> Unit,
-) {
+private fun SupportChannelPinnedReference(onClick: () -> Unit) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
-                .padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPaddingHalfQuarter),
-        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+                .background(BisqTheme.colors.dark_grey40)
+                .padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPaddingHalf),
+        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
-            modifier =
-                Modifier
-                    .size(BisqUIConstants.ScreenPadding4X)
-                    .background(BisqTheme.colors.dark_grey50, shape = CircleShape),
+            modifier = Modifier.size(BisqUIConstants.ScreenPadding3X).background(BisqTheme.colors.dark_grey50, shape = CircleShape),
             contentAlignment = Alignment.Center,
         ) {
-            if (channel.category == SimulatedChannelCategory.SUPPORT) {
-                QuestionIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X))
-            } else {
-                ChatIconOutlined(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X))
-            }
+            QuestionIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X))
         }
-
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingQuarter)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BisqText.BaseRegular(text = channel.name, color = BisqTheme.colors.white, singleLine = true, modifier = Modifier.weight(1f))
-                BisqText.SmallRegular(text = channel.lastMessageTime, color = BisqTheme.colors.mid_grey20)
-            }
-            BisqText.SmallLight(text = channel.lastMessagePreview, color = BisqTheme.colors.mid_grey30)
-            BisqText.SmallLight(text = "${channel.memberCount} members", color = BisqTheme.colors.mid_grey20)
+        Column(modifier = Modifier.weight(1f)) {
+            BisqText.SmallMedium(text = "Need help?", color = BisqTheme.colors.white)
+            BisqText.XSmallLight(text = "Visit the Support channel", color = BisqTheme.colors.mid_grey20)
         }
-
-        if (channel.unreadCount > 0) {
-            Box(
-                modifier =
-                    Modifier
-                        .background(BisqTheme.colors.primary, shape = CircleShape)
-                        .padding(horizontal = BisqUIConstants.ScreenPaddingHalf, vertical = BisqUIConstants.ScreenPaddingQuarter),
-            ) {
-                BisqText.XSmallMedium(text = channel.unreadCount.toString(), color = BisqTheme.colors.white)
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Loading / empty / no-results states
-// ---------------------------------------------------------------------------
-
-@Composable
-private fun DiscussionsTabLoadingState() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        CircularProgressIndicator(color = BisqTheme.colors.primary, strokeWidth = 2.dp)
-    }
-}
-
-@Composable
-private fun DiscussionsTabEmptyState() {
-    Box(
-        modifier = Modifier.fillMaxSize().padding(BisqUIConstants.ScreenPadding2X),
-        contentAlignment = Alignment.Center,
-    ) {
-        BisqText.BaseLight(
-            text = "No channels available",
-            color = BisqTheme.colors.mid_grey20,
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@Composable
-private fun DiscussionsTabNoSearchResultsState(query: String) {
-    Box(
-        modifier = Modifier.fillMaxSize().padding(BisqUIConstants.ScreenPadding2X),
-        contentAlignment = Alignment.Center,
-    ) {
-        BisqText.BaseLight(
-            text = "No channels match \"$query\"",
-            color = BisqTheme.colors.mid_grey20,
-            textAlign = TextAlign.Center,
-        )
+        ArrowRightIcon()
     }
 }
 
@@ -578,146 +474,114 @@ private fun DiscussionsTabNoSearchResultsState(query: String) {
 // Preview fixtures
 // ============================================================================================
 
-private fun simulatedChannels() =
-    listOf(
-        SimulatedChannel(
-            id = "general",
-            name = "General Discussion",
-            category = SimulatedChannelCategory.DISCUSSION,
-            lastMessagePreview = "Anyone had luck with SEPA transfers over 500 EUR?",
-            lastMessageTime = "2 min",
-            unreadCount = 3,
-            memberCount = 1284,
-        ),
-        SimulatedChannel(
-            id = "market-chat",
-            name = "Market Chat",
-            category = SimulatedChannelCategory.DISCUSSION,
-            lastMessagePreview = "BTC volatility is wild today",
-            lastMessageTime = "1 h",
-            unreadCount = 0,
-            memberCount = 812,
-        ),
-        SimulatedChannel(
-            id = "new-trader-help",
-            name = "New Trader Help",
-            category = SimulatedChannelCategory.SUPPORT,
-            lastMessagePreview = "How do I increase my reputation score?",
-            lastMessageTime = "5 min",
-            unreadCount = 1,
-            memberCount = 456,
-        ),
-        SimulatedChannel(
-            id = "app-support",
-            name = "App Support",
-            category = SimulatedChannelCategory.SUPPORT,
-            lastMessagePreview = "You: Thanks, that fixed it!",
-            lastMessageTime = "Yesterday",
-            unreadCount = 0,
-            memberCount = 301,
-        ),
-    )
+private fun discussionsPreviewState() = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = simulatedMessages())
 
 // ============================================================================================
-// Previews — MILESTONE 11 realistic state: liveSegments = {DISCUSSIONS}, tab row hidden
+// Previews — MAIN SCREEN: what the user actually sees on icon tap TODAY
+// (liveSegments = {DISCUSSIONS}, tab row hidden). See file KDoc "WHAT OPENS WHEN THE USER
+// TAPS THE ICON" — these come first in the file deliberately.
 // ============================================================================================
 
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — Milestone 11 (Discussions only, tab row hidden), Populated")
+@Preview(name = "Community Hub — MAIN SCREEN on icon tap (ships milestone 11): Discussions + Support reference, Populated")
 @Composable
 private fun CommunityHubScreen_Milestone11_PopulatedPreview() {
     BisqTheme.Preview {
         CommunityHubScreenContent(
-            uiState = CommunityHubUiState(discussions = DiscussionsTabUiState(channels = simulatedChannels())),
+            uiState = CommunityHubUiState(discussions = discussionsPreviewState()),
             onAction = {},
         )
     }
 }
 
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — Milestone 11, Loading")
+@Preview(name = "Community Hub — MAIN SCREEN on icon tap (ships milestone 11): Loading")
 @Composable
 private fun CommunityHubScreen_Milestone11_LoadingPreview() {
     BisqTheme.Preview {
         CommunityHubScreenContent(
-            uiState = CommunityHubUiState(discussions = DiscussionsTabUiState(isLoading = true)),
+            uiState =
+                CommunityHubUiState(
+                    discussions = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, isLoading = true),
+                ),
             onAction = {},
         )
     }
 }
 
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — Milestone 11, Empty (no channels at all)")
+@Preview(name = "Community Hub — MAIN SCREEN on icon tap (ships milestone 11): Empty (no messages yet)")
 @Composable
 private fun CommunityHubScreen_Milestone11_EmptyPreview() {
     BisqTheme.Preview {
         CommunityHubScreenContent(
-            uiState = CommunityHubUiState(discussions = DiscussionsTabUiState(channels = emptyList())),
+            uiState =
+                CommunityHubUiState(
+                    discussions = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = emptyList()),
+                ),
             onAction = {},
         )
     }
 }
 
 /**
- * Interactive preview: typing in the search field filters the channel list live,
- * demonstrating both the "results" and "no results" states of the directory-level
- * search in one preview rather than two separate static ones.
+ * Interactive preview: tapping the inline search icon (in the member-count row, since
+ * this embedded context has no TopBar of its own) reveals the search-in-channel field.
+ * Also demonstrates the pinned Support reference row is present and tappable.
  */
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — Milestone 11, Interactive search")
+@Preview(name = "Community Hub — MAIN SCREEN on icon tap (ships milestone 11): Interactive (search toggle + Support reference)")
 @Composable
-private fun CommunityHubScreen_Milestone11_InteractiveSearchPreview() {
-    var query by remember { mutableStateOf("") }
-    val all = simulatedChannels()
+private fun CommunityHubScreen_Milestone11_InteractivePreview() {
+    var searchActive by remember { mutableStateOf(false) }
+    var supportTapped by remember { mutableStateOf(false) }
     BisqTheme.Preview {
-        CommunityHubScreenContent(
-            uiState =
-                CommunityHubUiState(
-                    discussions =
-                        DiscussionsTabUiState(
-                            channels = if (query.isEmpty()) all else all.filter { it.name.contains(query, ignoreCase = true) },
-                            searchQuery = query,
-                        ),
-                ),
-            onAction = { action ->
-                if (action is CommunityHubUiAction.OnDiscussionsAction &&
-                    action.action is DiscussionsTabUiAction.OnSearchQueryChange
-                ) {
-                    query = action.action.query
-                }
-            },
-        )
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(name = "Channel row — Discussion, unread")
-@Composable
-private fun ChannelRow_Discussion_UnreadPreview() {
-    BisqTheme.Preview {
-        ChannelRow(channel = simulatedChannels()[0], onClick = {})
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(name = "Channel row — Support, no unread")
-@Composable
-private fun ChannelRow_Support_NoUnreadPreview() {
-    BisqTheme.Preview {
-        ChannelRow(channel = simulatedChannels()[3], onClick = {})
+        Column {
+            if (supportTapped) {
+                BisqText.SmallRegular(
+                    text = "→ OnOpenSupportChannel fired (would push the Support channel screen)",
+                    color = BisqTheme.colors.primary,
+                    modifier = Modifier.padding(BisqUIConstants.ScreenPaddingHalf),
+                )
+            }
+            CommunityHubScreenContent(
+                uiState =
+                    CommunityHubUiState(
+                        discussions =
+                            DiscussionsChannelUiState(
+                                channelName = "Discussion",
+                                memberCount = 1284,
+                                messages = simulatedMessages(),
+                                isSearchActive = searchActive,
+                            ),
+                    ),
+                onAction = { action ->
+                    when {
+                        action is CommunityHubUiAction.OnDiscussionsAction &&
+                            action.action is DiscussionsChannelUiAction.OnToggleSearch -> searchActive = !searchActive
+                        action is CommunityHubUiAction.OnOpenSupportChannel -> supportTapped = true
+                        else -> {}
+                    }
+                },
+            )
+        }
     }
 }
 
 // ============================================================================================
-// Previews — ROLLOUT PROGRESSION: 2 segments live, then all 3 (the canonical target)
+// Previews — FUTURE: rollout progression, NOT what ships at milestone 11
+// (2 segments live, then all 3 — the eventual target once #590/#1238 ship). Named
+// "FUTURE: ..." deliberately so these are never mistaken for the current main screen —
+// see file KDoc "WHAT OPENS WHEN THE USER TAPS THE ICON".
 // ============================================================================================
 
 /**
  * Preview: `liveSegments = {DISCUSSIONS, MESSAGES}` — the state right after #590 ships,
  * Contacts still absent. Proves the tab row shows exactly 2 tabs, not 3-with-one-greyed.
+ * NOT the current main screen — see file KDoc lede.
  */
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — 2 segments live (post-#590, pre-#1238)")
+@Preview(name = "Community Hub — FUTURE: 2 segments live, after #590 ships (NOT what ships at milestone 11)")
 @Composable
 private fun CommunityHubScreen_TwoSegmentsLivePreview() {
     var tab by remember { mutableStateOf(SimulatedHubSegment.MESSAGES) }
@@ -727,7 +591,8 @@ private fun CommunityHubScreen_TwoSegmentsLivePreview() {
                 CommunityHubUiState(
                     selectedSegment = tab,
                     liveSegments = setOf(SimulatedHubSegment.DISCUSSIONS, SimulatedHubSegment.MESSAGES),
-                    discussions = DiscussionsTabUiState(channels = simulatedChannels()),
+                    discussions = discussionsPreviewState(),
+                    discussionsUnreadCount = 3,
                     messages = PrivateChatListUiState(conversations = simulatedConversations()),
                 ),
             onAction = { action -> if (action is CommunityHubUiAction.OnSegmentSelect) tab = action.segment },
@@ -738,12 +603,13 @@ private fun CommunityHubScreen_TwoSegmentsLivePreview() {
 /**
  * Preview: `liveSegments` = all 3 — the full canonical target design, once #1238 ships
  * too. Interactive tab switching between the real Discussions content, the real Messages
- * (private-chat inbox) content, and the Contacts placeholder. This replaces the old,
- * separately-named "future segmented hub" preview — it is now just another state of the
- * SAME canonical `CommunityHubScreenContent`, not a distinct screen.
+ * (private-chat inbox) content, and the Contacts placeholder (muted tab treatment).
+ * NOT the current main screen — see file KDoc lede. rodvar flagged (2026-08-17) that this
+ * preview was mistaken for "what the icon opens today"; it is the target AFTER #590 and
+ * #1238 both ship, not before.
  */
 @ExcludeFromCoverage
-@Preview(name = "Community Hub — All 3 segments live (canonical target design)")
+@Preview(name = "Community Hub — FUTURE: all 3 segments live, after #590 + #1238 ship (NOT what ships at milestone 11)")
 @Composable
 private fun CommunityHubScreen_AllSegmentsLiveInteractivePreview() {
     var tab by remember { mutableStateOf(SimulatedHubSegment.MESSAGES) }
@@ -753,10 +619,44 @@ private fun CommunityHubScreen_AllSegmentsLiveInteractivePreview() {
                 CommunityHubUiState(
                     selectedSegment = tab,
                     liveSegments = SimulatedHubSegment.entries.toSet(),
-                    discussions = DiscussionsTabUiState(channels = simulatedChannels()),
+                    discussions = discussionsPreviewState(),
+                    discussionsUnreadCount = 3,
                     messages = PrivateChatListUiState(conversations = simulatedConversations()),
                 ),
             onAction = { action -> if (action is CommunityHubUiAction.OnSegmentSelect) tab = action.segment },
         )
+    }
+}
+
+// ============================================================================================
+// Preview — Contacts muted-tab treatment, side by side with a full-primary tab
+// ============================================================================================
+
+/**
+ * Preview: proves the "CONTACTS — MUTED SEGMENT TREATMENT" claim — Discussions selected
+ * (full `primary` color) directly above Contacts selected (muted `light_grey50`), so the
+ * visual weight difference is checkable in one glance without switching tabs.
+ */
+@ExcludeFromCoverage
+@Preview(name = "Community Hub — Contacts muted vs Discussions full-primary (tab row comparison)")
+@Composable
+private fun CommunityHubScreen_ContactsMutedVsPrimaryComparisonPreview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            BisqText.SmallRegular("Discussions selected (full primary):", color = BisqTheme.colors.mid_grey20)
+            CommunitySegmentedTabRow(
+                selected = SimulatedHubSegment.DISCUSSIONS,
+                onSelect = {},
+                liveSegments = SimulatedHubSegment.entries.toSet(),
+                counts = mapOf(SimulatedHubSegment.DISCUSSIONS to 3, SimulatedHubSegment.MESSAGES to 2),
+            )
+            BisqText.SmallRegular("Contacts selected (muted — no badge slot, deliberately):", color = BisqTheme.colors.mid_grey20)
+            CommunitySegmentedTabRow(
+                selected = SimulatedHubSegment.CONTACTS,
+                onSelect = {},
+                liveSegments = SimulatedHubSegment.entries.toSet(),
+                counts = mapOf(SimulatedHubSegment.DISCUSSIONS to 3, SimulatedHubSegment.MESSAGES to 2),
+            )
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
@@ -73,6 +73,9 @@
  *     membership with no "leave").
  *   - **Contacts** = the relationship directory, #1238, NOT designed yet — deliberately
  *     not a message list, see project_milestone11_community_ia.md agent memory.
+ *     Auto-populates from trade history AND private chats (bisq2 `ContactReason`:
+ *     PRIVATE_CHAT, BISQ_EASY_TRADE, MUSIG_TRADE, MANUALLY_ADDED) plus manual add from
+ *     Peer Profile — not trades alone.
  *     `ContactsDirectoryPlaceholder` below is a labelled stand-in only. Rendered with a
  *     MUTED visual treatment even once live — see "CONTACTS — MUTED SEGMENT TREATMENT".
  *

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityPushNotificationsDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityPushNotificationsDesign.kt
@@ -122,14 +122,20 @@
  * ======================================================================================
  * bisq2 already models this exact choice per channel:
  * `ChatChannelNotificationTypeEnum` (data/replicated/chat/notifications/) —
- * `GLOBAL_DEFAULT | ALL | MENTION | OFF`. RECOMMENDATION: default new Discussions channel
- * memberships to `MENTION`, not `ALL`. Public channels are many-to-many and can be
- * high-traffic (see CommunityHubScreenDesign.kt's "General Discussion" fixture: 1284
- * members) — notifying on every single message would be Discord/Slack's exact
- * well-known anti-pattern for large channels. `ALL` stays available as a per-channel
- * opt-in for smaller/quieter channels a user explicitly wants full coverage on. Both
- * copy variants above exist because both modes are real, reachable states — not because
- * MENTION is the only one shipping.
+ * `GLOBAL_DEFAULT | ALL | MENTION | OFF`. RECOMMENDATION: default the Discussion channel
+ * membership to `MENTION`, not `ALL`. It's a many-to-many public channel and can be
+ * high-traffic (see CommunityHubScreenDesign.kt's "Discussion" fixture: 1284 members) —
+ * notifying on every single message would be Discord/Slack's exact well-known
+ * anti-pattern for large channels. `ALL` stays available as an opt-in for a user who
+ * explicitly wants full coverage. Both copy variants above exist because both modes are
+ * real, reachable states — not because MENTION is the only one shipping.
+ *
+ * OUT OF SCOPE HERE: notification copy/defaults specifically for the Support channel.
+ * Support is reached via a pinned hub reference and the existing More → Help → Support
+ * screen, not a segment (see CommunityHubScreenDesign.kt's "SUPPORT — HUB-SIDE
+ * REFERENCE") — whether/how it needs its own notification treatment is a separate design
+ * pass, not addressed by this file's MENTION/ALL recommendation, which is scoped to the
+ * Discussion channel only.
  *
  * ======================================================================================
  * RELAYED (killed-app / opted-into-relay) COPY — reuses existing keys, no new ones
@@ -318,7 +324,7 @@ private fun Notification_Local_ChannelMentionPreview() {
         ) {
             MockLabel("MOCK — illustrative only, not real OS chrome. LOCAL path, MENTION mode (recommended default):")
             MockSystemNotificationCard(
-                title = "You were mentioned in General Discussion",
+                title = "You were mentioned in Discussion",
                 body = "BitcoinBee#5678: @you what do you think about the new fee model?",
             )
         }
@@ -336,7 +342,7 @@ private fun Notification_Local_ChannelMessagePreview() {
         ) {
             MockLabel("MOCK — illustrative only, not real OS chrome. LOCAL path, ALL mode (opt-in, busier channels):")
             MockSystemNotificationCard(
-                title = "New message in General Discussion",
+                title = "New message in Discussion",
                 body = "CryptoNomad#9012: Anyone had luck with SEPA transfers over 500 EUR?",
             )
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
@@ -4,10 +4,61 @@
  * STATUS: Design proof-of-concept. NOT wired to any presenter or production code.
  *
  * ======================================================================================
- * PURPOSE
+ * WHAT SHIPS THIS MILESTONE (lede — read this first)
  * ======================================================================================
- * The individual public, many-to-many channel thread — what you land on after tapping a
- * row in CommunityHubScreenDesign.kt (e.g. "General Discussion" or "New Trader Help").
+ * bisq2 wires exactly ONE Discussion channel and ONE Support channel today —
+ * `chat/src/main/java/bisq/chat/ChatService.java` passes a singleton `List.of(...)` to
+ * `addToCommonPublicChatChannelServices(...)` for each of `ChatChannelDomain.DISCUSSION`
+ * and `ChatChannelDomain.SUPPORT`. There is no channel directory to browse. This screen
+ * IS the entire Discussions experience: `CommunityHubScreenDesign.kt`'s Discussions tab
+ * renders this composable directly (`showTopBar = false`) — tapping the Community icon
+ * takes you straight into the Discussion channel's message thread, no list or picker in
+ * front of it.
+ *
+ * This same composable is reused, unchanged, as the Support channel's thread — see
+ * "REUSED FOR THE SUPPORT CHANNEL" below — because bisq2 models both as the same kind of
+ * object (`CommonPublicChatChannel`), differing only by `ChatChannelDomain`.
+ *
+ * ======================================================================================
+ * WHY THERE'S NO CHANNEL LIST (evidence, not a stylistic choice)
+ * ======================================================================================
+ * An earlier pass of this PoC modeled Discussions as a searchable, section-grouped list
+ * of several channels ("General Discussion," "Market Chat," "New Trader Help," "App
+ * Support"). That was invented fixture data with no backend counterpart. bisq2's own
+ * `ChatChannelDomain`/`SubDomain` enums (`chat` module) show it already ran that
+ * experiment and reversed it: `SubDomain.java` carries `@Deprecated DISCUSSION_BITCOIN`,
+ * `DISCUSSION_MARKETS`, `DISCUSSION_OFF_TOPIC`, and a whole `EVENTS` domain
+ * (`CONFERENCES`/`MEETUPS`/`PODCASTS`/`TRADE_EVENTS`) — all migrated back onto the single
+ * surviving `DISCUSSION_BISQ` channel. `SUPPORT_QUESTIONS`/`SUPPORT_REPORTS` were folded
+ * the same way into `SUPPORT_SUPPORT`. A list UI with one row per section is ceremony,
+ * not browsing, when there's nothing to browse — this screen drops it accordingly.
+ *
+ * ======================================================================================
+ * REINTRODUCING A CHANNEL PICKER — the explicit trigger (not built preemptively)
+ * ======================================================================================
+ * If bisq2 ever ships a second live Discussion channel (a new non-deprecated
+ * `SubDomain` under `ChatChannelDomain.DISCUSSION`, wired into `ChatService.java`'s
+ * channel list), THAT is the moment to reintroduce a channel picker — not before. The
+ * deprecation history above already shows this exact expansion was tried once and
+ * reversed, so don't pre-build multi-channel UI speculatively. `DiscussionsTabContent`
+ * in `CommunityHubScreenDesign.kt` is the reinsertion point: it currently renders this
+ * screen directly; it would instead render a list that pushes into this same
+ * channel-thread screen per row.
+ *
+ * ======================================================================================
+ * REUSED FOR THE SUPPORT CHANNEL
+ * ======================================================================================
+ * `CommunityHubScreenDesign.kt`'s pinned "Need help?" reference in the Discussions tab
+ * (see that file's "SUPPORT — HUB-SIDE REFERENCE" section) pushes to THIS SAME
+ * `DiscussionsChannelScreenContent`, parameterized with the Support channel's data
+ * (`channelName = "Support"`) and `showTopBar = true` (pushed as its own screen, not
+ * embedded in a tab, so it needs its own back button). No new screen type — bisq2 itself
+ * renders Discussion and Support through the same view shape on desktop
+ * (`CommonChatTabController`/`CommonChatTabView`, `chatChannelDomain` is the only thing
+ * that varies), and this mirrors that. The Support channel is also linked from the
+ * existing More → Help → Support screen (`SupportScreen.kt`) — the two entry points
+ * coexist and land on the same channel; see that reconciliation documented in
+ * `CommunityHubScreenDesign.kt`.
  *
  * ======================================================================================
  * REUSE MAP — what production reuses as-is vs what needs new work
@@ -80,11 +131,21 @@
  * ======================================================================================
  * SEARCH-IN-CHANNEL (#589 "reuses ... a search component")
  * ======================================================================================
- * Distinct from CommunityHubScreenDesign.kt's directory-level channel search. Toggled by
- * a search icon in the TopBar's `extraActions` slot; reveals a `BisqSearchField` row
- * below the TopBar that filters/highlights matching messages in the current channel
- * (`isHighlighted` flag on `SimulatedChannelMessage`, shown with a subtle primary-tinted
- * background + border on the matching bubble).
+ * Filters/highlights matching messages in the current channel (`isHighlighted` flag on
+ * `SimulatedChannelMessage`, shown with a subtle primary-tinted background + border on
+ * the matching bubble) via a `BisqSearchField` row. There is no other, directory-level
+ * search anymore — with exactly one Discussion channel and one Support channel (see
+ * "WHY THERE'S NO CHANNEL LIST" above), this is the ONLY search in the Discussions
+ * surface. The toggle affordance's PLACEMENT depends on [DiscussionsChannelScreenContent]'s
+ * `showTopBar` param, since it needs a home whether or not this screen owns its own
+ * TopBar:
+ *   - `showTopBar = true` (opened as its own pushed screen, e.g. via the Support
+ *     reference or a future deep link): the search icon sits in the TopBar's
+ *     `extraActions` slot, as before.
+ *   - `showTopBar = false` (embedded as the Discussions tab body inside
+ *     `CommunityHubScreenDesign.kt` — the shell owns the TopBar): the search icon moves
+ *     inline into the member-count row, since there is no TopBar slot available in this
+ *     context. Same `OnToggleSearch` action either way.
  *
  * ======================================================================================
  * i18n KEYS NEEDED
@@ -185,28 +246,54 @@ internal sealed interface DiscussionsChannelUiAction {
 // Content
 // ============================================================================================
 
+/**
+ * @param showTopBar `true` when this screen owns its own back-button TopBar (opened as a
+ *   standalone pushed screen — e.g. the Support channel reference navigates here). `false`
+ *   when embedded as the Discussions tab body inside `CommunityHubScreenDesign.kt`, which
+ *   owns ONE shared TopBar for all tabs — see that file's "LAYOUT" section. The
+ *   search-toggle icon relocates accordingly; see file KDoc "SEARCH-IN-CHANNEL".
+ * @param modifier applied to the root `Column`, in addition to `fillMaxSize()`. Lets a
+ *   caller such as `DiscussionsTabContent` constrain this composable to a `weight(1f)`
+ *   slice of a taller `Column` (e.g. below the pinned Support reference row) instead of
+ *   claiming the full available height unconditionally.
+ */
 @Composable
 internal fun DiscussionsChannelScreenContent(
     uiState: DiscussionsChannelUiState,
     onAction: (DiscussionsChannelUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+    showTopBar: Boolean = true,
 ) {
-    Column(modifier = Modifier.fillMaxSize().background(BisqTheme.colors.backgroundColor)) {
-        TopBarContent(
-            title = uiState.channelName,
-            showBackButton = true,
-            showUserAvatar = false,
-            extraActions = {
+    Column(modifier = modifier.fillMaxSize().background(BisqTheme.colors.backgroundColor)) {
+        if (showTopBar) {
+            TopBarContent(
+                title = uiState.channelName,
+                showBackButton = true,
+                showUserAvatar = false,
+                extraActions = {
+                    IconButton(onClick = { onAction(DiscussionsChannelUiAction.OnToggleSearch) }) {
+                        SearchIcon()
+                    }
+                },
+            )
+
+            BisqText.SmallLight(
+                text = "${uiState.memberCount} members",
+                color = BisqTheme.colors.mid_grey20,
+                modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPaddingQuarter),
+            )
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPaddingQuarter),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BisqText.SmallLight(text = "${uiState.memberCount} members", color = BisqTheme.colors.mid_grey20)
                 IconButton(onClick = { onAction(DiscussionsChannelUiAction.OnToggleSearch) }) {
                     SearchIcon()
                 }
-            },
-        )
-
-        BisqText.SmallLight(
-            text = "${uiState.memberCount} members",
-            color = BisqTheme.colors.mid_grey20,
-            modifier = Modifier.padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPaddingQuarter),
-        )
+            }
+        }
 
         if (uiState.isSearchActive) {
             Column(modifier = Modifier.fillMaxWidth().padding(horizontal = BisqUIConstants.ScreenPadding)) {
@@ -323,7 +410,12 @@ private fun SimulatedChannelMessageBubble(
 // Preview fixtures
 // ============================================================================================
 
-private fun simulatedMessages() =
+/**
+ * `internal` (not `private`) so `CommunityHubScreenDesign.kt`'s Discussions-tab previews
+ * can reuse the exact same fixture instead of duplicating it — mirrors
+ * `simulatedConversations()` in `private_chat/PrivateChatListScreenDesign.kt`.
+ */
+internal fun simulatedMessages() =
     listOf(
         SimulatedChannelMessage(
             id = "1",
@@ -351,17 +443,37 @@ private fun simulatedMessages() =
         ),
     )
 
+private fun simulatedSupportMessages() =
+    listOf(
+        SimulatedChannelMessage(
+            id = "s1",
+            senderId = "peer-3",
+            senderName = "NewTrader#4321",
+            text = "My trade has been stuck on \"waiting for confirmation\" for an hour, is that normal?",
+            timeLabel = "09:41",
+            isMine = false,
+        ),
+        SimulatedChannelMessage(
+            id = "s2",
+            senderId = "me",
+            senderName = "You",
+            text = "It can take a while depending on network fees — check the tx in a block explorer to be sure.",
+            timeLabel = "09:44",
+            isMine = true,
+        ),
+    )
+
 // ============================================================================================
 // Previews
 // ============================================================================================
 
 @ExcludeFromCoverage
-@Preview(name = "Discussions channel — Populated, multi-sender")
+@Preview(name = "Discussions channel — Populated, multi-sender, standalone (showTopBar = true)")
 @Composable
 private fun DiscussionsChannelScreen_PopulatedPreview() {
     BisqTheme.Preview {
         DiscussionsChannelScreenContent(
-            uiState = DiscussionsChannelUiState(channelName = "General Discussion", memberCount = 1284, messages = simulatedMessages()),
+            uiState = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = simulatedMessages()),
             onAction = {},
         )
     }
@@ -373,7 +485,7 @@ private fun DiscussionsChannelScreen_PopulatedPreview() {
 private fun DiscussionsChannelScreen_EmptyPreview() {
     BisqTheme.Preview {
         DiscussionsChannelScreenContent(
-            uiState = DiscussionsChannelUiState(channelName = "New Trader Help", memberCount = 456, messages = emptyList()),
+            uiState = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = emptyList()),
             onAction = {},
         )
     }
@@ -385,7 +497,7 @@ private fun DiscussionsChannelScreen_EmptyPreview() {
 private fun DiscussionsChannelScreen_LoadingPreview() {
     BisqTheme.Preview {
         DiscussionsChannelScreenContent(
-            uiState = DiscussionsChannelUiState(channelName = "General Discussion", memberCount = 1284, isLoading = true),
+            uiState = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, isLoading = true),
             onAction = {},
         )
     }
@@ -399,7 +511,7 @@ private fun DiscussionsChannelScreen_SearchActiveWithMatchPreview() {
         DiscussionsChannelScreenContent(
             uiState =
                 DiscussionsChannelUiState(
-                    channelName = "General Discussion",
+                    channelName = "Discussion",
                     memberCount = 1284,
                     messages = simulatedMessages().mapIndexed { i, m -> if (i == 0) m.copy(isHighlighted = true) else m },
                     isSearchActive = true,
@@ -419,7 +531,7 @@ private fun DiscussionsChannelScreen_SearchActiveNoMatchPreview() {
         DiscussionsChannelScreenContent(
             uiState =
                 DiscussionsChannelUiState(
-                    channelName = "General Discussion",
+                    channelName = "Discussion",
                     memberCount = 1284,
                     messages = simulatedMessages(),
                     isSearchActive = true,
@@ -439,7 +551,7 @@ private fun DiscussionsChannelScreen_LongMessagePreview() {
         DiscussionsChannelScreenContent(
             uiState =
                 DiscussionsChannelUiState(
-                    channelName = "General Discussion",
+                    channelName = "Discussion",
                     memberCount = 1284,
                     messages =
                         listOf(
@@ -473,10 +585,11 @@ private fun SimulatedChannelMessageBubble_TapTargetPreview() {
 /**
  * Interactive preview: tapping the search icon reveals the in-channel search field,
  * and typing filters the visible match count. Demonstrates the search-in-channel flow
- * end to end, distinct from the channel-directory search in CommunityHubScreenDesign.kt.
+ * end to end — the only search in the Discussions surface now (see file KDoc "WHY
+ * THERE'S NO CHANNEL LIST").
  */
 @ExcludeFromCoverage
-@Preview(name = "Discussions channel — Interactive search toggle")
+@Preview(name = "Discussions channel — Interactive search toggle, standalone")
 @Composable
 private fun DiscussionsChannelScreen_InteractiveSearchPreview() {
     var searchActive by remember { mutableStateOf(false) }
@@ -485,7 +598,7 @@ private fun DiscussionsChannelScreen_InteractiveSearchPreview() {
         DiscussionsChannelScreenContent(
             uiState =
                 DiscussionsChannelUiState(
-                    channelName = "General Discussion",
+                    channelName = "Discussion",
                     memberCount = 1284,
                     messages = simulatedMessages(),
                     isSearchActive = searchActive,
@@ -499,6 +612,46 @@ private fun DiscussionsChannelScreen_InteractiveSearchPreview() {
                     else -> {}
                 }
             },
+        )
+    }
+}
+
+/**
+ * Preview: `showTopBar = false` — how this screen actually renders embedded as the
+ * Discussions tab body inside `CommunityHubScreenDesign.kt` (the shell owns the TopBar,
+ * so there's no back button here, and the search toggle moves inline into the
+ * member-count row). This is the REALISTIC milestone-11 shape; see that file's
+ * `CommunityHubScreen_Milestone11_*` previews for it in full hub context including the
+ * pinned Support reference row above it.
+ */
+@ExcludeFromCoverage
+@Preview(name = "Discussions channel — Embedded in hub (showTopBar = false)")
+@Composable
+private fun DiscussionsChannelScreen_EmbeddedPreview() {
+    BisqTheme.Preview {
+        DiscussionsChannelScreenContent(
+            uiState = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = simulatedMessages()),
+            onAction = {},
+            showTopBar = false,
+        )
+    }
+}
+
+/**
+ * Preview: this same composable reused, unchanged, for the SUPPORT channel — proves the
+ * "REUSED FOR THE SUPPORT CHANNEL" claim in the file KDoc. `showTopBar = true` because
+ * this is how it's reached: pushed as its own screen from the hub's pinned "Need help?"
+ * reference, not embedded in a tab.
+ */
+@ExcludeFromCoverage
+@Preview(name = "Discussions channel — reused for Support channel (standalone)")
+@Composable
+private fun DiscussionsChannelScreen_SupportChannelReusePreview() {
+    BisqTheme.Preview {
+        DiscussionsChannelScreenContent(
+            uiState = DiscussionsChannelUiState(channelName = "Support", memberCount = 301, messages = simulatedSupportMessages()),
+            onAction = {},
+            showTopBar = true,
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/private_chat/PrivateChatListScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/private_chat/PrivateChatListScreenDesign.kt
@@ -36,23 +36,25 @@
  * ROLE IN THE HUB (decision, documented here per rodvar's request)
  * ======================================================================================
  * Per the milestone-11 IA: the Community hub has three logical segments —
- * **Discussions** (public channels, #589, shipping this milestone) · **Messages**
- * (this screen — the DM inbox, #590, fast-follow) · **Contacts** (#1238, fast-follow,
- * a relationship directory, NOT a message list — do not confuse the two).
+ * **Discussions** (the single public Discussion channel, #589, shipping this milestone —
+ * see CommunityHubScreenDesign.kt's "WHAT SHIPS THIS MILESTONE" for why it's one channel,
+ * not a browsable list) · **Messages** (this screen — the DM inbox, #590, fast-follow) ·
+ * **Contacts** (#1238, fast-follow, a relationship directory, NOT a message list — do not
+ * confuse the two).
  *
- * Private 1:1 DMs and public channels are deliberately kept in SEPARATE segments, not
- * merged into one combined list. They are distinct objects with different lifecycles:
- * a DM is a persistent relationship with one specific peer (has a "leave chat" — see
- * PrivateChatScreenDesign.kt); a public channel is an implicit, non-exclusive membership
- * in a many-to-many space (no "leave"). Interleaving them in one list would blur that
- * distinction and make the "who is this conversation with" question harder to answer
- * at a glance — exactly the trust-clarity problem this app's whole design philosophy
- * exists to avoid.
+ * Private 1:1 DMs and the public Discussion channel are deliberately kept in SEPARATE
+ * segments, not merged into one combined list. They are distinct objects with different
+ * lifecycles: a DM is a persistent relationship with one specific peer (has a "leave
+ * chat" — see PrivateChatScreenDesign.kt); a public channel is an implicit, non-exclusive
+ * membership in a many-to-many space (no "leave"). Interleaving them in one list would
+ * blur that distinction and make the "who is this conversation with" question harder to
+ * answer at a glance — exactly the trust-clarity problem this app's whole design
+ * philosophy exists to avoid.
  *
- * See CommunityHubScreenDesign.kt's "CANONICAL DESIGN, GATED ROLLOUT" section — and its
+ * See CommunityHubScreenDesign.kt's "GATED ROLLOUT" section — and its
  * `CommunityHubScreen_TwoSegmentsLivePreview` and
  * `CommunityHubScreen_AllSegmentsLiveInteractivePreview` previews — for this screen
- * mounted live as the Messages tab. The hub is one canonical 3-tab design now, not a
+ * mounted live as the Messages tab. The hub is one canonical shell design now, not a
  * separate "future" screen.
  *
  * ======================================================================================


### PR DESCRIPTION
 - contribs designs to #590 #1238 #589 

<img width="788" height="585" alt="Screenshot 2026-08-17 at 10 46 58" src="https://github.com/user-attachments/assets/1934b69d-4a00-461f-a881-678bec09e29a" />
<img width="1036" height="578" alt="Screenshot 2026-08-17 at 10 46 49" src="https://github.com/user-attachments/assets/1bc150b9-2467-4874-9d1c-bf3b215139eb" />
<img width="1054" height="639" alt="Screenshot 2026-08-17 at 10 45 06" src="https://github.com/user-attachments/assets/2b004450-1eee-47e5-bfad-66d11e931967" />

 - updated AI designer re-iteration on community hub designs to simplify it: we do not need a channels list as an entry point since channels rarely change and are a handful at most. Improved docs in this direction + previews
 - more visibility / access to support discussions with separte top-hint container
 - get rid of channel list screens in favour of chats top-tab-controller
 - **PLEASE NOTE**: not all previews show the same, please read composable docs + preview labels to understand what the preview is showing (e.g. community hub tabs displayed is phased per channel impl)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedded Discussion channel view within the Community hub.
  * Added a pinned “Need help?” Support entry for quick access.
  * Added in-channel search for standalone and embedded layouts.
  * Updated Community navigation to distinguish Discussions, Messages, and Contacts.
  * Added unread-count handling for Discussion activity.
  * Refined Contacts tab styling and refreshed preview states.

* **Documentation**
  * Clarified notification recommendations and Community channel behavior.
  * Documented the current single-Discussion rollout and future channel expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->