### PR TITLE
fix: drop kotlinx-datetime to stop java.time crash on API 24 & 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The node reaches Bisq's P2P network over its own bundled Tor; pair the mobile ap
 
 8. [Testing guide](./docs/TESTING.md) — agents: [AGENTS.md](./AGENTS.md)
 
+9. [Android platform constraints](./docs/android.md) — API floor, `java.time`, date handling
+
 ## Goal
 
 This project aims to make Bisq Network accesible in Mobile Platforms following the philosofy of Bisq2 - to make it

--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -60,6 +60,18 @@ dependencies {
     implementation(libs.androidx.test.compose.manifest)
 }
 
+// kotlinx-datetime maps to java.time, which is API 26+; clientApp has minSdk 24 and no core
+// library desugaring, so it crashed API 24/25 devices. Fails resolution if any module leaks it
+// back onto the clientApp classpath, directly or transitively. See docs/android.md.
+configurations.configureEach {
+    resolutionStrategy.eachDependency {
+        check(!(requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-datetime"))) {
+            "kotlinx-datetime is banned from the clientApp classpath: it maps to java.time (API 26+) " +
+                "and crashes API 24/25 devices. See docs/android.md."
+        }
+    }
+}
+
 // -------------------- Kotlin Multiplatform Configuration --------------------
 kotlin {
     androidTarget {

--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -202,7 +202,6 @@ kotlin {
             implementation(libs.androidx.datastore.okio)
 
             // KotlinX
-            implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -63,12 +63,12 @@ is the replacement, and the only date API shared code should use.
   `formatDateTime` formatter is the exception: its styles follow device date/time settings that no
   cache key can observe, so it is rebuilt per call on purpose.
 
-Two platform divergences worth knowing:
+An unknown zone id falls back to the device zone on both platforms. Android needs help there:
+`TimeZone.getTimeZone` answers GMT for an id it does not know, so the actual compares the resolved
+id against the requested one and substitutes the device zone on a mismatch.
 
-- An unknown zone id silently resolves to GMT on Android, while iOS keeps the formatter's default
-  zone.
-- Java renders pre-1582 dates in the Julian calendar, so the lower clamp bound `0001-01-01` prints
-  as `0001-01-03` on Android.
+One platform divergence remains: Java renders pre-1582 dates in the Julian calendar, so the lower
+clamp bound `0001-01-01` prints as `0001-01-03` on Android.
 
 Tests: `DateUtilsCharacterizationTest` (common) pins the output of every function against the values
 the previous kotlinx-datetime implementation produced, so a future swap can be verified against it.

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,0 +1,87 @@
+# Android platform constraints
+
+What the Android API floor rules out, and the workarounds already in place. Read this before adding
+a dependency or an API call that assumes a modern JDK.
+
+---
+
+## API floor per app
+
+| App | `minSdk` | Core library desugaring |
+|-----|----------|-------------------------|
+| `:apps:clientApp` (Bisq Connect) | 24 | No |
+| `:apps:nodeApp` (Bisq Easy Node) | 33 | Yes — needed by the bisq2 jars |
+
+Values live in [gradle/libs.versions.toml](../gradle/libs.versions.toml) (`android-minSdk`,
+`android-node-minSdk`).
+
+---
+
+## `java.time` is off limits in shared code
+
+`java.time` only exists from API 26. clientApp runs from API 24 without desugaring, so any code path
+that resolves a `java.time` class dies on API 24 and 25 devices:
+
+```text
+java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/LocalDateTime;
+    at kotlinx.datetime.LocalDateTime.<clinit>(LocalDateTimeJvm.kt:103)
+    at network.bisq.mobile.domain.utils.DateUtils.<clinit>(DateUtils.kt:79)
+```
+
+kotlinx-datetime maps straight onto `java.time` on Android, which is what produced the crash above.
+It was removed from the project rather than papered over with desugaring.
+
+Anything on the clientApp classpath is in scope, not just first-party code. Third-party libraries
+that reference `java.time` are only safe when they gate those paths behind an API level check, as
+`androidx.compose.material3` does with `CalendarModelImpl` vs `LegacyCalendarModelImpl`.
+
+To audit a build:
+
+```bash
+./gradlew :apps:clientApp:assembleDebug
+cd $(mktemp -d) && unzip -q <path-to>/Bisq_Connect-*-debug.apk 'classes*.dex'
+grep -al 'java/time' classes*.dex   # then disassemble with build-tools/dexdump to find the owner
+```
+
+---
+
+## Date handling: `DateUtils`
+
+[`DateUtils`](../shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/DateUtils.kt)
+is the replacement, and the only date API shared code should use.
+
+- Common code does plain epoch-millis arithmetic — no calendar library.
+- Calendar formatting is delegated to `expect` / `actual` functions in
+  [`PlatformDomainAbstractions`](../shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt):
+  `SimpleDateFormat` on Android, `NSDateFormatter` on iOS.
+- Time zones cross that boundary as IANA id strings (`"UTC"`, `"America/New_York"`), or null for the
+  device default.
+- Timestamps are clamped to years 1–9999, so a corrupt or hostile value cannot overflow the
+  elapsed-millis subtraction or truncate the year count when it is narrowed to `Int`.
+- Formatters are cached per thread, keyed by pattern, locale, and zone, because constructing one
+  costs more than formatting with it and these run per visible row per recomposition. The iOS
+  `formatDateTime` formatter is the exception: its styles follow device date/time settings that no
+  cache key can observe, so it is rebuilt per call on purpose.
+
+Two platform divergences worth knowing:
+
+- An unknown zone id silently resolves to GMT on Android, while iOS keeps the formatter's default
+  zone.
+- Java renders pre-1582 dates in the Julian calendar, so the lower clamp bound `0001-01-01` prints
+  as `0001-01-03` on Android.
+
+Tests: `DateUtilsCharacterizationTest` (common) pins the output of every function against the values
+the previous kotlinx-datetime implementation produced, so a future swap can be verified against it.
+`DateUtilsFormatAndroidTest` and `DateUtilsFormatIosTest` cover the locale- and zone-dependent
+formatting per platform.
+
+---
+
+## Adding a dependency that handles dates
+
+1. Check whether it reaches for `java.time` — inspect the artifact:
+   `unzip -p <artifact>.jar '*.class' | grep -ao 'java/time/[A-Za-z]*' | sort -u`
+2. If it does, either keep it out of the clientApp classpath, or enable core library desugaring in
+   [apps/clientApp/build.gradle.kts](../apps/clientApp/build.gradle.kts) — deliberately left off
+   today, so treat turning it on as a decision, not a formality.
+3. Re-run the dex audit above before shipping.

--- a/docs/android.md
+++ b/docs/android.md
@@ -29,7 +29,9 @@ java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/LocalDateTime;
 ```
 
 kotlinx-datetime maps straight onto `java.time` on Android, which is what produced the crash above.
-It was removed from the project rather than papered over with desugaring.
+It was removed from the project rather than papered over with desugaring. A resolution guard in
+[apps/clientApp/build.gradle.kts](../apps/clientApp/build.gradle.kts) fails any clientApp build in
+which it reappears, directly or transitively.
 
 Anything on the clientApp classpath is in scope, not just first-party code. Third-party libraries
 that reference `java.time` are only safe when they gate those paths behind an API level check, as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,4 +168,5 @@ When changing or testing code:
 | Compose | [compose-guidelines](compose-guidelines/README.md) |
 | Navigation | [presentation/.../navigation/README.md](../shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/README.md) |
 | Testing | [TESTING.md](TESTING.md), [testing/](testing/README.md) |
+| Android platform constraints | [android.md](android.md) |
 | Design | [design/DESIGN_GUIDE.md](design/DESIGN_GUIDE.md) |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ bisq-api-commit = "932201100b181e1ecf6fd5f0fb3f0943c8ddd453"
 # -------------------- Kotlin & JetBrains --------------------
 kotlin = "2.4.0"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 atomicfu = "0.31.0"
 compose-plugin = "1.11.1"
@@ -36,6 +35,8 @@ agp = "8.13.2"
 android-ndk = "26.1.10909125"
 android-compileSdk = "37"
 android-targetSdk = "36"
+# clientApp ships without core library desugaring, so nothing on its classpath may touch java.time,
+# which is API 26+. See DateUtils for the date handling this rules out.
 android-minSdk = "24"
 # TODO analyse lowering back to API 31 when Bisq2 full J17 support is returned and we can get rid of desugaring
 android-node-minSdk = "33"
@@ -131,7 +132,6 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -248,7 +248,6 @@ kotlin {
 
             // KotlinX
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)
 

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -50,8 +50,11 @@ actual fun formatMediumDateTime(
 // per visible row per recomposition. SimpleDateFormat is not thread-safe, so the cache is per
 // thread; the key carries locale and zone so an in-app language change or a device zone change is
 // still picked up. Both patterns are explicit, so unlike the iOS styled formatter nothing here
-// depends on a device date/time preference the key could miss. Key count is bounded by the patterns
-// and zones this file passes in.
+// depends on a device date/time preference the key could miss. Zone ids come from callers, so the
+// map is capped rather than trusted to stay small; dropping everything on overflow costs one
+// rebuild.
+private const val MAX_CACHED_FORMATTERS = 32
+
 private val dateFormatters =
     object : ThreadLocal<MutableMap<String, SimpleDateFormat>>() {
         override fun initialValue() = mutableMapOf<String, SimpleDateFormat>()
@@ -63,13 +66,24 @@ private fun format(
     pattern: String,
     locale: Locale,
 ): String {
-    val zone = timeZoneId?.let { TimeZone.getTimeZone(it) } ?: TimeZone.getDefault()
+    val zone = resolveTimeZone(timeZoneId)
     val key = "$pattern|${locale.toLanguageTag()}|${zone.id}"
+    val cache = dateFormatters.get()!!
+    if (cache.size >= MAX_CACHED_FORMATTERS && key !in cache) cache.clear()
     val formatter =
-        dateFormatters.get()!!.getOrPut(key) {
+        cache.getOrPut(key) {
             SimpleDateFormat(pattern, locale).apply { timeZone = zone }
         }
     return formatter.format(Date(epochMillis))
+}
+
+// TimeZone.getTimeZone silently answers GMT for an id it does not know, which would render a
+// different wall clock than iOS does for the same bad input. Detect that by comparing ids and fall
+// back to the device zone, matching resolveTimeZone in the iOS actual.
+private fun resolveTimeZone(timeZoneId: String?): TimeZone {
+    if (timeZoneId == null) return TimeZone.getDefault()
+    val zone = TimeZone.getTimeZone(timeZoneId)
+    return if (zone.id == timeZoneId) zone else TimeZone.getDefault()
 }
 
 actual fun encodeURIParam(param: String): String = Uri.encode(param)

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.android.kt
@@ -14,9 +14,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.net.toUri
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.domain.model.PlatformInfo
 import network.bisq.mobile.domain.model.PlatformType
@@ -33,13 +30,46 @@ import java.util.Currency
 import java.util.Date
 import java.util.Locale
 import java.util.Properties
+import java.util.TimeZone
 
-actual fun formatDateTime(dateTime: LocalDateTime): String {
-    val timeZone = TimeZone.currentSystemDefault()
-    val instant = dateTime.toInstant(TimeZone.of(timeZone.id)) // Convert to Instant
-    val date = Date(instant.toEpochMilliseconds()) // Convert to Java Date
-    val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-    return formatter.format(date)
+actual fun formatDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+): String = format(epochMillis, timeZoneId, "yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+
+actual fun formatMediumDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+    includeSeconds: Boolean,
+): String {
+    val pattern = if (includeSeconds) "MMM d, yyyy  HH:mm:ss" else "MMM d, yyyy  HH:mm"
+    return format(epochMillis, timeZoneId, pattern, Locale.ENGLISH)
+}
+
+// Constructing a SimpleDateFormat dominates the cost of rendering a timestamp, and these run once
+// per visible row per recomposition. SimpleDateFormat is not thread-safe, so the cache is per
+// thread; the key carries locale and zone so an in-app language change or a device zone change is
+// still picked up. Both patterns are explicit, so unlike the iOS styled formatter nothing here
+// depends on a device date/time preference the key could miss. Key count is bounded by the patterns
+// and zones this file passes in.
+private val dateFormatters =
+    object : ThreadLocal<MutableMap<String, SimpleDateFormat>>() {
+        override fun initialValue() = mutableMapOf<String, SimpleDateFormat>()
+    }
+
+private fun format(
+    epochMillis: Long,
+    timeZoneId: String?,
+    pattern: String,
+    locale: Locale,
+): String {
+    val zone = timeZoneId?.let { TimeZone.getTimeZone(it) } ?: TimeZone.getDefault()
+    val key = "$pattern|${locale.toLanguageTag()}|${zone.id}"
+    val formatter =
+        dateFormatters.get()!!.getOrPut(key) {
+            SimpleDateFormat(pattern, locale).apply { timeZone = zone }
+        }
+    return formatter.format(Date(epochMillis))
 }
 
 actual fun encodeURIParam(param: String): String = Uri.encode(param)

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatAndroidTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatAndroidTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.time.Instant
 
 /**
@@ -86,12 +87,20 @@ class DateUtilsFormatAndroidTest {
     }
 
     @Test
-    fun `toDateTime resolves an unknown zone id to GMT`() {
-        // java.util.TimeZone.getTimeZone falls back to GMT rather than throwing. Documented here
-        // because the iOS actual instead keeps the default zone.
+    fun `toDateTime falls back to the default zone for an unknown zone id`() {
+        // java.util.TimeZone.getTimeZone answers GMT for an unknown id; the actual detects that and
+        // uses the device zone instead, so both platforms render the same thing for a bad id
+        assertEquals(
+            "2024-01-15 07:00:00",
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "Not/AZone"),
+        )
+    }
+
+    @Test
+    fun `toDateTime still honours an explicit GMT zone id`() {
         assertEquals(
             "2024-01-15 12:00:00",
-            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "Not/AZone"),
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "GMT"),
         )
     }
 
@@ -117,12 +126,16 @@ class DateUtilsFormatAndroidTest {
     @Test
     fun `cached formatters follow a change of the default locale`() {
         val noonUtc = millisOf("2024-01-15T12:00:00Z")
-        assertEquals("2024-01-15 12:00:00", DateUtils.toDateTime(noonUtc, "UTC"))
+        val beforeLocaleChange = DateUtils.toDateTime(noonUtc, "UTC")
+        assertEquals("2024-01-15 12:00:00", beforeLocaleChange)
 
-        // Thai renders Buddhist era years, so a stale cached formatter would show 2024
-        Locale.setDefault(Locale.forLanguageTag("th-TH"))
+        // The calendar is requested explicitly rather than relying on th-TH defaulting to Buddhist,
+        // so the expected year does not depend on the platform's locale data
+        Locale.setDefault(Locale.forLanguageTag("th-TH-u-ca-buddhist"))
 
-        assertEquals("2567-01-15 12:00:00", DateUtils.toDateTime(noonUtc, "UTC"))
+        val afterLocaleChange = DateUtils.toDateTime(noonUtc, "UTC")
+        assertNotEquals(beforeLocaleChange, afterLocaleChange, "a stale cached formatter would repeat the old year")
+        assertEquals("2567-01-15 12:00:00", afterLocaleChange)
     }
 
     @Test

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatAndroidTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatAndroidTest.kt
@@ -1,0 +1,136 @@
+package network.bisq.mobile.domain.utils
+
+import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+/**
+ * Pins the [DateUtils] formatting that depends on the JVM default locale and time zone, against the
+ * values the previous kotlinx-datetime implementation produced. Lives in androidUnitTest because
+ * only here can both defaults be fixed, and it also covers the per-thread formatter cache the
+ * Android actuals use.
+ */
+class DateUtilsFormatAndroidTest {
+    private val originalLocale = Locale.getDefault()
+    private val originalTimeZone = java.util.TimeZone.getDefault()
+
+    @BeforeTest
+    fun setup() {
+        Locale.setDefault(Locale.US)
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/New_York"))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+        java.util.TimeZone.setDefault(originalTimeZone)
+    }
+
+    private fun millisOf(isoInstant: String) = Instant.parse(isoInstant).toEpochMilliseconds()
+
+    @Test
+    fun `toDateTime formats in the requested zone`() {
+        assertEquals(
+            "2024-01-15 12:00:00",
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "UTC"),
+        )
+    }
+
+    @Test
+    fun `toDateTime falls back to the system default zone`() {
+        assertEquals(
+            "2024-01-15 07:00:00",
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z")),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime falls back to the system default zone`() {
+        // The shape both production callers use: no explicit zone
+        assertEquals(
+            "Jan 15, 2024  07:00",
+            DateUtils.toMediumDateTime(millisOf("2024-01-15T12:00:00Z")),
+        )
+    }
+
+    @Test
+    fun `toDateTime applies daylight saving time of the default zone`() {
+        assertEquals(
+            "2024-07-15 08:00:00",
+            DateUtils.toDateTime(millisOf("2024-07-15T12:00:00Z")),
+        )
+    }
+
+    @Test
+    fun `toDateTime applies a sub hour zone offset`() {
+        assertEquals(
+            "2024-01-15 17:45:00",
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "Asia/Kathmandu"),
+        )
+    }
+
+    @Test
+    fun `toDateTime handles the epoch`() {
+        assertEquals("1970-01-01 00:00:00", DateUtils.toDateTime(0L, "UTC"))
+    }
+
+    @Test
+    fun `toDateTime handles pre epoch timestamps`() {
+        assertEquals(
+            "1969-12-31 23:59:30",
+            DateUtils.toDateTime(millisOf("1969-12-31T23:59:30Z"), "UTC"),
+        )
+    }
+
+    @Test
+    fun `toDateTime resolves an unknown zone id to GMT`() {
+        // java.util.TimeZone.getTimeZone falls back to GMT rather than throwing. Documented here
+        // because the iOS actual instead keeps the default zone.
+        assertEquals(
+            "2024-01-15 12:00:00",
+            DateUtils.toDateTime(millisOf("2024-01-15T12:00:00Z"), "Not/AZone"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime ignores the default locale`() {
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals(
+            "Jan 15, 2024  12:00",
+            DateUtils.toMediumDateTime(millisOf("2024-01-15T12:00:00Z"), "UTC"),
+        )
+    }
+
+    @Test
+    fun `cached formatters follow a change of the default zone`() {
+        val noonUtc = millisOf("2024-01-15T12:00:00Z")
+        assertEquals("2024-01-15 07:00:00", DateUtils.toDateTime(noonUtc))
+
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Kathmandu"))
+
+        assertEquals("2024-01-15 17:45:00", DateUtils.toDateTime(noonUtc))
+    }
+
+    @Test
+    fun `cached formatters follow a change of the default locale`() {
+        val noonUtc = millisOf("2024-01-15T12:00:00Z")
+        assertEquals("2024-01-15 12:00:00", DateUtils.toDateTime(noonUtc, "UTC"))
+
+        // Thai renders Buddhist era years, so a stale cached formatter would show 2024
+        Locale.setDefault(Locale.forLanguageTag("th-TH"))
+
+        assertEquals("2567-01-15 12:00:00", DateUtils.toDateTime(noonUtc, "UTC"))
+    }
+
+    @Test
+    fun `absurd timestamps are clamped to the supported range`() {
+        // The clamp bound is 0001-01-01 proleptic Gregorian; SimpleDateFormat renders pre-1582
+        // dates in the Julian calendar, which is two days behind
+        assertEquals("0001-01-03 00:00:00", DateUtils.toDateTime(Long.MIN_VALUE, "UTC"))
+        assertEquals("9999-12-31 23:59:59", DateUtils.toDateTime(Long.MAX_VALUE, "UTC"))
+        assertEquals("Dec 31, 9999  23:59", DateUtils.toMediumDateTime(Long.MAX_VALUE, "UTC"))
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.kt
@@ -2,7 +2,6 @@
 
 package network.bisq.mobile.data.utils
 
-import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -23,7 +22,31 @@ interface AppUpdateLinker {
     fun getUpdateUrl(): String
 }
 
-expect fun formatDateTime(dateTime: LocalDateTime): String
+/**
+ * Locale dependent date and time of [epochMillis] in [timeZoneId].
+ *
+ * Formatting is a platform concern here because the shared code cannot use kotlinx-datetime: it
+ * maps to java.time, which needs API 26, while clientApp has minSdk 24 and no desugaring. See
+ * [network.bisq.mobile.domain.utils.DateUtils].
+ *
+ * @param timeZoneId IANA zone id, or null for the system default zone
+ */
+expect fun formatDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+): String
+
+/**
+ * Date and time of [epochMillis] in [timeZoneId] as `MMM d, yyyy  HH:mm[:ss]` with English month
+ * abbreviations, independent of the device locale. The double space is intentional.
+ *
+ * @param timeZoneId IANA zone id, or null for the system default zone
+ */
+expect fun formatMediumDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+    includeSeconds: Boolean,
+): String
 
 expect fun encodeURIParam(param: String): String
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/DateUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/DateUtils.kt
@@ -1,35 +1,59 @@
 package network.bisq.mobile.domain.utils
 
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.format.MonthNames
-import kotlinx.datetime.format.Padding
-import kotlinx.datetime.format.char
-import kotlinx.datetime.toLocalDateTime
-import kotlinx.datetime.until
 import network.bisq.mobile.data.utils.formatDateTime
+import network.bisq.mobile.data.utils.formatMediumDateTime
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.i18n.i18nPlural
 import kotlin.time.Clock
-import kotlin.time.Instant
 
+/**
+ * Date handling for the shared domain, deliberately free of kotlinx-datetime.
+ *
+ * kotlinx-datetime maps to java.time on Android, which only exists from API 26. clientApp has
+ * minSdk 24 and ships without core library desugaring, so any kotlinx-datetime call crashed on API
+ * 24 and 25 devices with `NoClassDefFoundError: Ljava/time/LocalDateTime;`. Everything here is
+ * therefore plain epoch-millis arithmetic, with the calendar work delegated to the platform
+ * formatters in `PlatformDomainAbstractions` (SimpleDateFormat on Android, NSDateFormatter on iOS).
+ *
+ * Before reintroducing a date library, check that it does not reach for java.time, or enable
+ * desugaring in apps/clientApp/build.gradle.kts. `DateUtilsCharacterizationTest` pins the output of
+ * every function against the values the previous kotlinx-datetime implementation produced.
+ */
 object DateUtils {
+    private const val MILLIS_PER_DAY = 86_400_000L
+
+    // 0001-01-01T00:00:00Z and 9999-12-31T23:59:59.999Z. Timestamps are clamped to this range so a
+    // corrupt or hostile value cannot overflow the elapsed-millis subtraction, truncate the year
+    // count when it is narrowed to Int, or push a formatter into an absurd calendar year.
+    //
+    // The clamp is deliberately silent — no log, no exception. These functions run on a hot path
+    // (once per visible row per recomposition), so logging here would need rate limiting to be
+    // affordable, and a bad timestamp is a data problem that the layer receiving it should report,
+    // not something the renderer can act on. The accepted trade-off is that a corrupt value shows
+    // up as a nonsense date on screen rather than in the logs; if that ever needs investigating,
+    // validate at ingestion instead of unpicking it here.
+    // kotlinx-datetime used to provide this bound implicitly by saturating at the Instant limits,
+    // so the clamp also keeps the pre-removal behaviour rather than introducing a new policy.
+    private const val MIN_TIMESTAMP = -62_135_596_800_000L
+    private const val MAX_TIMESTAMP = 253_402_300_799_999L
+
     // Allow clock injection for testing
     internal var clock: Clock = Clock.System
 
     fun now() = clock.now().toEpochMilliseconds()
 
+    private fun Long.clampToSupportedRange() = coerceIn(MIN_TIMESTAMP, MAX_TIMESTAMP)
+
     /**
      * @return years, months, days past since timestamp
      */
-    fun periodFrom(timetamp: Long): Triple<Int, Int, Int> {
-        val creationInstant = Instant.fromEpochMilliseconds(timetamp)
-        val creationDate = creationInstant.toLocalDateTime(TimeZone.UTC).date
-        val currentDate = clock.now().toLocalDateTime(TimeZone.UTC).date
+    fun periodFrom(timestamp: Long): Triple<Int, Int, Int> {
+        // Epoch day in UTC; floorDiv keeps pre-epoch timestamps on the correct day
+        val creationDay = timestamp.clampToSupportedRange().floorDiv(MILLIS_PER_DAY)
+        val currentDay = clock.now().toEpochMilliseconds().floorDiv(MILLIS_PER_DAY)
 
         // Calculate the difference
-        val period = creationDate.until(currentDate, DateTimeUnit.DAY)
+        val period = currentDay - creationDay
         val years = (period / 365).toInt()
         val remainingDaysAfterYears = period % 365
         val months = (remainingDaysAfterYears / 30).toInt()
@@ -45,12 +69,8 @@ object DateUtils {
      * @return Formatted string like "3 min ago", "2 hours ago", etc.
      */
     fun lastSeen(epochMillis: Long): String {
-        val lastActivityInstant = Instant.fromEpochMilliseconds(epochMillis)
-        val currentInstant = clock.now()
-
         val durationInSeconds =
-            lastActivityInstant
-                .until(currentInstant, DateTimeUnit.SECOND)
+            ((clock.now().toEpochMilliseconds() - epochMillis.clampToSupportedRange()) / 1_000)
                 .coerceAtLeast(0)
 
         // Treat "now" as online instead of "0 sec ago"
@@ -66,54 +86,22 @@ object DateUtils {
         }
     }
 
+    /**
+     * @param timeZoneId IANA zone id, or null for the system default zone
+     */
     fun toDateTime(
         epochMillis: Long,
-        timeZone: TimeZone = TimeZone.currentSystemDefault(),
-    ): String {
-        val instant = Instant.fromEpochMilliseconds(epochMillis)
-        val localDateTime = instant.toLocalDateTime(timeZone)
-        return formatDateTime(localDateTime)
-    }
+        timeZoneId: String? = null,
+    ): String = formatDateTime(epochMillis.clampToSupportedRange(), timeZoneId)
 
-    private val mediumDateTimeFormat =
-        LocalDateTime.Format {
-            monthName(MonthNames.ENGLISH_ABBREVIATED)
-            char(' ')
-            day(Padding.NONE)
-            chars(", ")
-            year()
-            // the double space is intentional
-            chars("  ")
-            hour()
-            char(':')
-            minute()
-        }
-
-    private val mediumDateTimeWithSecondsFormat =
-        LocalDateTime.Format {
-            monthName(MonthNames.ENGLISH_ABBREVIATED)
-            char(' ')
-            day(Padding.NONE)
-            chars(", ")
-            year()
-            // the double space is intentional
-            chars("  ")
-            hour()
-            char(':')
-            minute()
-            char(':')
-            second()
-        }
-
+    /**
+     * @param timeZoneId IANA zone id, or null for the system default zone
+     */
     fun toMediumDateTime(
         epochMillis: Long,
-        timeZone: TimeZone = TimeZone.currentSystemDefault(),
+        timeZoneId: String? = null,
         includeSeconds: Boolean = false,
-    ): String {
-        val instant = Instant.fromEpochMilliseconds(epochMillis)
-        val format = if (includeSeconds) mediumDateTimeWithSecondsFormat else mediumDateTimeFormat
-        return format.format(instant.toLocalDateTime(timeZone))
-    }
+    ): String = formatMediumDateTime(epochMillis.clampToSupportedRange(), timeZoneId, includeSeconds)
 
     /**
      * Format profile age with proper i18n and pluralization

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsCharacterizationTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsCharacterizationTest.kt
@@ -1,0 +1,242 @@
+package network.bisq.mobile.domain.utils
+
+import network.bisq.mobile.i18n.I18nSupport
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Pins the observable behaviour of [DateUtils] so the kotlinx-datetime removal can be verified
+ * against the values the kotlinx-based implementation produced.
+ */
+class DateUtilsCharacterizationTest {
+    private val originalClock = DateUtils.clock
+    private val fixedInstant = Instant.parse("2024-01-15T12:00:00Z")
+    private val now = fixedInstant.toEpochMilliseconds()
+    private val fixedClock =
+        object : Clock {
+            override fun now(): Instant = fixedInstant
+        }
+
+    @BeforeTest
+    fun setup() {
+        I18nSupport.initialize("en")
+        DateUtils.clock = fixedClock
+    }
+
+    @AfterTest
+    fun tearDown() {
+        DateUtils.clock = originalClock
+    }
+
+    private fun millisOf(isoInstant: String) = Instant.parse(isoInstant).toEpochMilliseconds()
+
+    private fun daysAgo(days: Long) = now - days * 86_400_000L
+
+    // -------------------- periodFrom: UTC calendar-day arithmetic --------------------
+
+    @Test
+    fun `periodFrom returns zero period for the current instant`() {
+        assertEquals(Triple(0, 0, 0), DateUtils.periodFrom(now))
+    }
+
+    @Test
+    fun `periodFrom counts UTC day boundaries crossed, not elapsed 24h spans`() {
+        // 13 hours earlier, but on the previous UTC day
+        assertEquals(Triple(0, 0, 1), DateUtils.periodFrom(millisOf("2024-01-14T23:00:00Z")))
+    }
+
+    @Test
+    fun `periodFrom ignores time of day within the same UTC day`() {
+        assertEquals(Triple(0, 0, 0), DateUtils.periodFrom(millisOf("2024-01-15T00:00:00Z")))
+    }
+
+    @Test
+    fun `periodFrom treats 365 days as exactly one year`() {
+        assertEquals(Triple(1, 0, 0), DateUtils.periodFrom(daysAgo(365)))
+    }
+
+    @Test
+    fun `periodFrom folds 364 days into 12 months and 4 days`() {
+        // Documents the 365-day year over 30-day month approximation
+        assertEquals(Triple(0, 12, 4), DateUtils.periodFrom(daysAgo(364)))
+    }
+
+    @Test
+    fun `periodFrom handles multi year spans`() {
+        assertEquals(Triple(2, 0, 0), DateUtils.periodFrom(daysAgo(730)))
+    }
+
+    @Test
+    fun `periodFrom returns negative components for future timestamps`() {
+        assertEquals(Triple(-1, -1, -5), DateUtils.periodFrom(daysAgo(-400)))
+    }
+
+    @Test
+    fun `periodFrom handles the epoch`() {
+        assertEquals(Triple(54, 0, 27), DateUtils.periodFrom(0L))
+    }
+
+    @Test
+    fun `periodFrom handles pre epoch timestamps`() {
+        assertEquals(Triple(54, 0, 28), DateUtils.periodFrom(millisOf("1969-12-31T12:00:00Z")))
+    }
+
+    @Test
+    fun `periodFrom clamps an absurdly old timestamp to year 1`() {
+        assertEquals(Triple(2024, 4, 19), DateUtils.periodFrom(Long.MIN_VALUE))
+    }
+
+    @Test
+    fun `periodFrom clamps an absurdly future timestamp to year 9999`() {
+        assertEquals(Triple(-7981, -3, -4), DateUtils.periodFrom(Long.MAX_VALUE))
+    }
+
+    // -------------------- lastSeen: unit thresholds --------------------
+
+    @Test
+    fun `lastSeen reports online below one second`() {
+        assertEquals("Online", DateUtils.lastSeen(now - 999))
+    }
+
+    @Test
+    fun `lastSeen reports online for future timestamps`() {
+        assertEquals("Online", DateUtils.lastSeen(daysAgo(-365)))
+    }
+
+    @Test
+    fun `lastSeen switches units at the second boundaries`() {
+        assertEquals("1 sec ago", DateUtils.lastSeen(now - 1_000))
+        assertEquals("59 sec ago", DateUtils.lastSeen(now - 59_000))
+        assertEquals("1 min ago", DateUtils.lastSeen(now - 60_000))
+    }
+
+    @Test
+    fun `lastSeen switches units at the minute boundary`() {
+        assertEquals("59 min ago", DateUtils.lastSeen(now - 3_599_000))
+        assertEquals("1 hour ago", DateUtils.lastSeen(now - 3_600_000))
+    }
+
+    @Test
+    fun `lastSeen switches units at the hour boundary`() {
+        assertEquals("23 hours ago", DateUtils.lastSeen(now - 86_399_000))
+        assertEquals("1 day ago", DateUtils.lastSeen(now - 86_400_000))
+    }
+
+    @Test
+    fun `lastSeen switches units at the 30 day boundary`() {
+        assertEquals("29 days ago", DateUtils.lastSeen(now - 2_591_999_000))
+        assertEquals("1 month ago", DateUtils.lastSeen(now - 2_592_000_000))
+    }
+
+    @Test
+    fun `lastSeen switches units at the 365 day boundary`() {
+        assertEquals("12 months ago", DateUtils.lastSeen(now - 31_535_999_000))
+        assertEquals("1 year ago", DateUtils.lastSeen(now - 31_536_000_000))
+    }
+
+    @Test
+    fun `lastSeen truncates sub second remainders`() {
+        assertEquals("1 min ago", DateUtils.lastSeen(now - 60_999))
+    }
+
+    @Test
+    fun `lastSeen handles the epoch`() {
+        assertEquals("54 years ago", DateUtils.lastSeen(0L))
+    }
+
+    @Test
+    fun `lastSeen handles pre epoch timestamps`() {
+        assertEquals("54 years ago", DateUtils.lastSeen(-1_000L))
+    }
+
+    @Test
+    fun `lastSeen clamps an absurdly old timestamp to year 1 instead of overflowing`() {
+        assertEquals("2024 years ago", DateUtils.lastSeen(Long.MIN_VALUE))
+    }
+
+    @Test
+    fun `lastSeen reports online for an absurdly future timestamp`() {
+        assertEquals("Online", DateUtils.lastSeen(Long.MAX_VALUE))
+    }
+
+    // -------------------- toMediumDateTime: fixed English format --------------------
+
+    @Test
+    fun `toMediumDateTime formats a single digit day without padding`() {
+        assertEquals(
+            "Jan 5, 2024  09:07",
+            DateUtils.toMediumDateTime(millisOf("2024-01-05T09:07:03Z"), "UTC"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime pads hours minutes and seconds`() {
+        assertEquals(
+            "Jan 5, 2024  09:07:03",
+            DateUtils.toMediumDateTime(millisOf("2024-01-05T09:07:03Z"), "UTC", includeSeconds = true),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime abbreviates every month the way kotlinx did`() {
+        // September is the one that differs between abbreviation sets (Sep vs Sept)
+        val abbreviations =
+            (1..12).map { month ->
+                val padded = month.toString().padStart(2, '0')
+                DateUtils.toMediumDateTime(millisOf("2024-$padded-01T00:00:00Z"), "UTC").substringBefore(' ')
+            }
+        assertEquals(
+            listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
+            abbreviations,
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime handles the epoch`() {
+        assertEquals("Jan 1, 1970  00:00", DateUtils.toMediumDateTime(0L, "UTC"))
+    }
+
+    @Test
+    fun `toMediumDateTime handles pre epoch timestamps`() {
+        assertEquals(
+            "Dec 31, 1969  23:59:30",
+            DateUtils.toMediumDateTime(millisOf("1969-12-31T23:59:30Z"), "UTC", includeSeconds = true),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime applies a negative zone offset`() {
+        assertEquals(
+            "Jan 15, 2024  07:00",
+            DateUtils.toMediumDateTime(now, "America/New_York"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime applies daylight saving time`() {
+        assertEquals(
+            "Jul 15, 2024  08:00",
+            DateUtils.toMediumDateTime(millisOf("2024-07-15T12:00:00Z"), "America/New_York"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime applies a sub hour zone offset`() {
+        assertEquals(
+            "Jan 15, 2024  17:45",
+            DateUtils.toMediumDateTime(now, "Asia/Kathmandu"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime shifts the year when the zone crosses new year`() {
+        assertEquals(
+            "Dec 31, 2023  19:30",
+            DateUtils.toMediumDateTime(millisOf("2024-01-01T00:30:00Z"), "America/New_York"),
+        )
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsCharacterizationTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsCharacterizationTest.kt
@@ -44,7 +44,7 @@ class DateUtilsCharacterizationTest {
     }
 
     @Test
-    fun `periodFrom counts UTC day boundaries crossed, not elapsed 24h spans`() {
+    fun `periodFrom counts UTC day boundaries crossed rather than elapsed 24h spans`() {
         // 13 hours earlier, but on the previous UTC day
         assertEquals(Triple(0, 0, 1), DateUtils.periodFrom(millisOf("2024-01-14T23:00:00Z")))
     }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsTest.kt
@@ -1,8 +1,5 @@
 package network.bisq.mobile.domain.utils
 
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import network.bisq.mobile.i18n.I18nSupport
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -39,21 +36,21 @@ class DateUtilsTest {
 
     @Test
     fun `formatProfileAge should return less than a day for timestamp within same day`() {
-        val sameDay = LocalDate(2024, 1, 15).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        val sameDay = Instant.parse("2024-01-15T00:00:00Z").toEpochMilliseconds()
         val result = DateUtils.formatProfileAge(sameDay)
         assertEquals("less than a day", result)
     }
 
     @Test
     fun `formatProfileAge should format single day correctly`() {
-        val oneDayAgo = LocalDate(2024, 1, 14).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        val oneDayAgo = Instant.parse("2024-01-14T00:00:00Z").toEpochMilliseconds()
         val result = DateUtils.formatProfileAge(oneDayAgo)
         assertEquals("1 day", result)
     }
 
     @Test
     fun `formatProfileAge should format multiple days correctly`() {
-        val fiveDaysAgo = LocalDate(2024, 1, 10).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        val fiveDaysAgo = Instant.parse("2024-01-10T00:00:00Z").toEpochMilliseconds()
         val result = DateUtils.formatProfileAge(fiveDaysAgo)
         assertEquals("5 days", result)
     }
@@ -194,19 +191,19 @@ class DateUtilsTest {
 
     @Test
     fun `toMediumDateTime with seconds should include the seconds component`() {
-        val result = DateUtils.toMediumDateTime(fixedInstant.toEpochMilliseconds(), TimeZone.UTC, includeSeconds = true)
+        val result = DateUtils.toMediumDateTime(fixedInstant.toEpochMilliseconds(), "UTC", includeSeconds = true)
         assertEquals("Jan 15, 2024  12:00:00", result)
     }
 
     @Test
     fun `toMediumDateTime without seconds should omit the seconds component`() {
-        val result = DateUtils.toMediumDateTime(fixedInstant.toEpochMilliseconds(), TimeZone.UTC)
+        val result = DateUtils.toMediumDateTime(fixedInstant.toEpochMilliseconds(), "UTC")
         assertEquals("Jan 15, 2024  12:00", result)
     }
 
     @Test
     fun `toDateTime should format timestamp correctly`() {
-        val result = DateUtils.toDateTime(fixedInstant.toEpochMilliseconds(), TimeZone.UTC)
+        val result = DateUtils.toDateTime(fixedInstant.toEpochMilliseconds(), "UTC")
         // The format is locale-dependent (e.g., "Jan 15, 2024" or "15/01/2024")
         assertTrue(result.isNotEmpty(), "toDateTime should return a non-empty string")
         assertTrue(result.contains("2024"), "Result '$result' should contain year 2024")
@@ -215,7 +212,7 @@ class DateUtilsTest {
 
     @Test
     fun `toDateTime should handle epoch zero`() {
-        val result = DateUtils.toDateTime(0L, TimeZone.UTC)
+        val result = DateUtils.toDateTime(0L, "UTC")
         assertTrue(result.isNotEmpty(), "toDateTime should return a non-empty string for epoch zero")
         assertTrue(result.contains("1970"), "Result '$result' should contain year 1970")
     }

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
@@ -51,7 +51,6 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.languageCode
 import platform.Foundation.localTimeZone
 import platform.Foundation.localeWithLocaleIdentifier
-import platform.Foundation.name
 import platform.Foundation.setValue
 import platform.Foundation.stringByAddingPercentEncodingWithAllowedCharacters
 import platform.Foundation.timeZoneWithName
@@ -138,13 +137,16 @@ actual fun formatMediumDateTime(
     return formatter.stringFromDate(epochMillis.toNSDate())
 }
 
-// An unknown zone id leaves the device zone in place, mirroring what NSDateFormatter does on its own
+// An unknown zone id falls back to the device zone; the Android actual is written to match
 private fun resolveTimeZone(timeZoneId: String?): NSTimeZone = timeZoneId?.let { NSTimeZone.timeZoneWithName(it) } ?: NSTimeZone.localTimeZone
 
 // Constructing an NSDateFormatter dominates the cost of rendering a timestamp, and the medium format
 // runs once per visible row per recomposition. Only the fixed-pattern formatter is cached: its
 // pattern and locale are constants, so the zone is the only thing the key has to carry.
-// @ThreadLocal keeps the map free of cross-thread races.
+// @ThreadLocal keeps the map free of cross-thread races. Zone ids come from callers, so the map is
+// capped rather than trusted to stay small; dropping everything on overflow costs one rebuild.
+private const val MAX_CACHED_FORMATTERS = 32
+
 @ThreadLocal
 private object DateFormatterCache {
     val formatters = mutableMapOf<String, NSDateFormatter>()
@@ -153,7 +155,11 @@ private object DateFormatterCache {
 private fun cachedFormatter(
     key: String,
     create: () -> NSDateFormatter,
-): NSDateFormatter = DateFormatterCache.formatters.getOrPut(key, create)
+): NSDateFormatter {
+    val cache = DateFormatterCache.formatters
+    if (cache.size >= MAX_CACHED_FORMATTERS && key !in cache) cache.clear()
+    return cache.getOrPut(key, create)
+}
 
 // NSDate() constructor expects seconds since Jan 1, 2001 (Apple reference date)
 // Unix epoch is Jan 1, 1970, so we need to subtract the difference (978307200 seconds)

--- a/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/network/bisq/mobile/data/utils/PlatformDomainAbstractions.ios.kt
@@ -12,9 +12,6 @@ import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 import kotlinx.serialization.Serializable
 import network.bisq.mobile.domain.model.PlatformInfo
 import network.bisq.mobile.domain.model.PlatformType
@@ -42,6 +39,7 @@ import platform.Foundation.NSNumberFormatterDecimalStyle
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSSetUncaughtExceptionHandler
 import platform.Foundation.NSString
+import platform.Foundation.NSTimeZone
 import platform.Foundation.NSURL
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.NSUserDomainMask
@@ -51,9 +49,12 @@ import platform.Foundation.create
 import platform.Foundation.currentLocale
 import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.languageCode
+import platform.Foundation.localTimeZone
 import platform.Foundation.localeWithLocaleIdentifier
+import platform.Foundation.name
 import platform.Foundation.setValue
 import platform.Foundation.stringByAddingPercentEncodingWithAllowedCharacters
+import platform.Foundation.timeZoneWithName
 import platform.UIKit.NSLineBreakByWordWrapping
 import platform.UIKit.NSTextAlignmentLeft
 import platform.UIKit.UIAlertAction
@@ -97,23 +98,68 @@ import platform.posix.memcpy
 import platform.posix.raise
 import platform.posix.signal
 import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.concurrent.ThreadLocal
 
-actual fun formatDateTime(dateTime: LocalDateTime): String {
+actual fun formatDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+): String {
+    // Deliberately not cached: the styles resolve against the device's date and time settings, and
+    // toggling e.g. 24-Hour Time changes the output without changing the locale identifier a cache
+    // could key on. A fresh formatter always reflects the current settings.
     val formatter =
         NSDateFormatter().apply {
             dateStyle = NSDateFormatterMediumStyle
             timeStyle = NSDateFormatterShortStyle
             locale = NSLocale.currentLocale
+            timeZone = resolveTimeZone(timeZoneId)
         }
 
-    val instant = dateTime.toInstant(TimeZone.currentSystemDefault())
-    // NSDate() constructor expects seconds since Jan 1, 2001 (Apple reference date)
-    // Unix epoch is Jan 1, 1970, so we need to subtract the difference (978307200 seconds)
-    val unixEpochSeconds = instant.toEpochMilliseconds() / 1000.0
-    val appleReferenceOffset = 978307200.0 // Seconds between 1970-01-01 and 2001-01-01
-    val nsDate = NSDate(timeIntervalSinceReferenceDate = unixEpochSeconds - appleReferenceOffset)
+    return formatter.stringFromDate(epochMillis.toNSDate())
+}
 
-    return formatter.stringFromDate(nsDate)
+actual fun formatMediumDateTime(
+    epochMillis: Long,
+    timeZoneId: String?,
+    includeSeconds: Boolean,
+): String {
+    val pattern = if (includeSeconds) "MMM d, yyyy  HH:mm:ss" else "MMM d, yyyy  HH:mm"
+    val zone = resolveTimeZone(timeZoneId)
+    val formatter =
+        cachedFormatter("$pattern|${zone.name}") {
+            NSDateFormatter().apply {
+                // en_US_POSIX keeps the pattern literal and the month names English on every device
+                locale = NSLocale.localeWithLocaleIdentifier("en_US_POSIX")
+                dateFormat = pattern
+                timeZone = zone
+            }
+        }
+
+    return formatter.stringFromDate(epochMillis.toNSDate())
+}
+
+// An unknown zone id leaves the device zone in place, mirroring what NSDateFormatter does on its own
+private fun resolveTimeZone(timeZoneId: String?): NSTimeZone = timeZoneId?.let { NSTimeZone.timeZoneWithName(it) } ?: NSTimeZone.localTimeZone
+
+// Constructing an NSDateFormatter dominates the cost of rendering a timestamp, and the medium format
+// runs once per visible row per recomposition. Only the fixed-pattern formatter is cached: its
+// pattern and locale are constants, so the zone is the only thing the key has to carry.
+// @ThreadLocal keeps the map free of cross-thread races.
+@ThreadLocal
+private object DateFormatterCache {
+    val formatters = mutableMapOf<String, NSDateFormatter>()
+}
+
+private fun cachedFormatter(
+    key: String,
+    create: () -> NSDateFormatter,
+): NSDateFormatter = DateFormatterCache.formatters.getOrPut(key, create)
+
+// NSDate() constructor expects seconds since Jan 1, 2001 (Apple reference date)
+// Unix epoch is Jan 1, 1970, so we need to subtract the difference (978307200 seconds)
+private fun Long.toNSDate(): NSDate {
+    val appleReferenceOffset = 978307200.0 // Seconds between 1970-01-01 and 2001-01-01
+    return NSDate(timeIntervalSinceReferenceDate = this / 1000.0 - appleReferenceOffset)
 }
 
 @OptIn(BetaInteropApi::class)

--- a/shared/domain/src/iosTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatIosTest.kt
+++ b/shared/domain/src/iosTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatIosTest.kt
@@ -54,8 +54,8 @@ class DateUtilsFormatIosTest {
 
     @Test
     fun `toMediumDateTime falls back to the default zone for an unknown zone id`() {
-        // NSTimeZone.timeZoneWithName returns null for an unknown id, so the formatter keeps its
-        // default zone. Android instead silently resolves an unknown id to GMT.
+        // NSTimeZone.timeZoneWithName returns null for an unknown id, so the device zone is used.
+        // The Android actual detects its own GMT fallback and matches this.
         assertEquals(
             DateUtils.toMediumDateTime(noonUtc),
             DateUtils.toMediumDateTime(noonUtc, "Not/AZone"),

--- a/shared/domain/src/iosTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatIosTest.kt
+++ b/shared/domain/src/iosTest/kotlin/network/bisq/mobile/domain/utils/DateUtilsFormatIosTest.kt
@@ -1,0 +1,103 @@
+package network.bisq.mobile.domain.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * iOS side of the [DateUtils] formatting contract, which is served by NSDateFormatter since the
+ * kotlinx-datetime removal (see the note in DateUtils).
+ *
+ * [DateUtils.toDateTime] is locale dependent by design, so its exact output cannot be pinned here
+ * the way the Android test pins it: the simulator locale is whatever the run inherits. These tests
+ * assert the parts that must hold on every device, plus the zone handling that only exists in the
+ * iOS actual.
+ */
+class DateUtilsFormatIosTest {
+    private fun millisOf(isoInstant: String) = Instant.parse(isoInstant).toEpochMilliseconds()
+
+    private val noonUtc = millisOf("2024-01-15T12:00:00Z")
+
+    @Test
+    fun `toMediumDateTime uses the English fixed format regardless of device locale`() {
+        assertEquals("Jan 15, 2024  12:00", DateUtils.toMediumDateTime(noonUtc, "UTC"))
+        assertEquals("Jan 15, 2024  12:00:00", DateUtils.toMediumDateTime(noonUtc, "UTC", includeSeconds = true))
+    }
+
+    @Test
+    fun `toMediumDateTime applies a negative zone offset`() {
+        assertEquals("Jan 15, 2024  07:00", DateUtils.toMediumDateTime(noonUtc, "America/New_York"))
+    }
+
+    @Test
+    fun `toMediumDateTime applies daylight saving time`() {
+        assertEquals(
+            "Jul 15, 2024  08:00",
+            DateUtils.toMediumDateTime(millisOf("2024-07-15T12:00:00Z"), "America/New_York"),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime applies a sub hour zone offset`() {
+        assertEquals("Jan 15, 2024  17:45", DateUtils.toMediumDateTime(noonUtc, "Asia/Kathmandu"))
+    }
+
+    @Test
+    fun `toMediumDateTime handles the epoch and pre epoch timestamps`() {
+        assertEquals("Jan 1, 1970  00:00", DateUtils.toMediumDateTime(0L, "UTC"))
+        assertEquals(
+            "Dec 31, 1969  23:59:30",
+            DateUtils.toMediumDateTime(millisOf("1969-12-31T23:59:30Z"), "UTC", includeSeconds = true),
+        )
+    }
+
+    @Test
+    fun `toMediumDateTime falls back to the default zone for an unknown zone id`() {
+        // NSTimeZone.timeZoneWithName returns null for an unknown id, so the formatter keeps its
+        // default zone. Android instead silently resolves an unknown id to GMT.
+        assertEquals(
+            DateUtils.toMediumDateTime(noonUtc),
+            DateUtils.toMediumDateTime(noonUtc, "Not/AZone"),
+        )
+    }
+
+    @Test
+    fun `toDateTime renders the date components of the requested zone`() {
+        val result = DateUtils.toDateTime(noonUtc, "UTC")
+        assertTrue(result.isNotEmpty(), "toDateTime should return a non-empty string")
+        assertTrue(result.contains("2024"), "Result '$result' should contain year 2024")
+        assertTrue(result.contains("15"), "Result '$result' should contain day 15")
+    }
+
+    @Test
+    fun `toDateTime shifts the day when the zone crosses midnight`() {
+        // 00:30 UTC is still the previous day in New York
+        val newYear = millisOf("2024-01-01T00:30:00Z")
+        assertTrue(DateUtils.toDateTime(newYear, "UTC").contains("2024"))
+        assertTrue(DateUtils.toDateTime(newYear, "America/New_York").contains("2023"))
+    }
+
+    @Test
+    fun `toDateTime handles the epoch`() {
+        assertTrue(DateUtils.toDateTime(0L, "UTC").contains("1970"))
+    }
+
+    @Test
+    fun `toDateTime handles pre epoch timestamps`() {
+        assertTrue(DateUtils.toDateTime(millisOf("1969-12-31T23:59:30Z"), "UTC").contains("1969"))
+    }
+
+    @Test
+    fun `absurd timestamps are clamped to the supported range`() {
+        // Exact rendering of year 1 differs per formatter, so compare against the clamp bounds
+        // rather than pinning a literal
+        val minSupported = -62_135_596_800_000L // 0001-01-01T00:00:00Z
+        val maxSupported = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
+        assertEquals(DateUtils.toDateTime(minSupported, "UTC"), DateUtils.toDateTime(Long.MIN_VALUE, "UTC"))
+        assertEquals(DateUtils.toDateTime(maxSupported, "UTC"), DateUtils.toDateTime(Long.MAX_VALUE, "UTC"))
+        assertEquals(DateUtils.toMediumDateTime(minSupported, "UTC"), DateUtils.toMediumDateTime(Long.MIN_VALUE, "UTC"))
+        assertEquals(DateUtils.toMediumDateTime(maxSupported, "UTC"), DateUtils.toMediumDateTime(Long.MAX_VALUE, "UTC"))
+        assertTrue(DateUtils.toMediumDateTime(Long.MAX_VALUE, "UTC").contains("9999"))
+    }
+}

--- a/shared/presentation/build.gradle.kts
+++ b/shared/presentation/build.gradle.kts
@@ -85,7 +85,6 @@ kotlin {
 
             // KotlinX
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.json)
 
             // Koin


### PR DESCRIPTION
Fixes crash on API 24 & 25

Note: the iOS sources and tests have not been compiled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved date and time formatting across Android and iOS, including time-zone support, daylight-saving adjustments, seconds, and locale-aware output.
  * Added safeguards for extreme timestamps and predictable handling of unknown time zones.

* **Documentation**
  * Added Android platform guidance covering API compatibility, date handling, and dependency considerations.

* **Tests**
  * Expanded date and time coverage for time zones, locales, boundaries, formatting, and timestamp calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->