### PR TITLE
bugfix/remove_datetime_guard_for_ios

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -62,15 +62,19 @@ dependencies {
 
 // kotlinx-datetime maps to java.time, which is API 26+; clientApp has minSdk 24 and no core
 // library desugaring, so it crashed API 24/25 devices. Fails resolution if any module leaks it
-// back onto the clientApp classpath, directly or transitively. See docs/android.md.
-configurations.configureEach {
-    resolutionStrategy.eachDependency {
-        check(!(requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-datetime"))) {
-            "kotlinx-datetime is banned from the clientApp classpath: it maps to java.time (API 26+) " +
-                "and crashes API 24/25 devices. See docs/android.md."
+// back onto the clientApp Android classpath, directly or transitively. iOS configurations are
+// exempt: there kotlinx-datetime compiles to native code (no java.time), and Compose material3's
+// ios variant legitimately depends on it. See docs/android.md.
+configurations
+    .matching { cfg -> listOf("debug", "release", "android").any { cfg.name.startsWith(it) } }
+    .configureEach {
+        resolutionStrategy.eachDependency {
+            check(!(requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-datetime"))) {
+                "kotlinx-datetime is banned from the clientApp Android classpath: it maps to java.time " +
+                    "(API 26+) and crashes API 24/25 devices. See docs/android.md."
+            }
         }
     }
-}
 
 // -------------------- Kotlin Multiplatform Configuration --------------------
 kotlin {

--- a/docs/android.md
+++ b/docs/android.md
@@ -30,8 +30,10 @@ java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/LocalDateTime;
 
 kotlinx-datetime maps straight onto `java.time` on Android, which is what produced the crash above.
 It was removed from the project rather than papered over with desugaring. A resolution guard in
-[apps/clientApp/build.gradle.kts](../apps/clientApp/build.gradle.kts) fails any clientApp build in
-which it reappears, directly or transitively.
+[apps/clientApp/build.gradle.kts](../apps/clientApp/build.gradle.kts) fails any clientApp Android
+build in which it reappears, directly or transitively. iOS configurations are exempt: there
+kotlinx-datetime compiles to native code (no `java.time`), and Compose material3's ios variant
+legitimately depends on it.
 
 Anything on the clientApp classpath is in scope, not just first-party code. Third-party libraries
 that reference `java.time` are only safe when they gate those paths behind an API level check, as


### PR DESCRIPTION
 - issue added on last PR merged
 - only apply datetime ban for android, iOS needs it and its ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Android build validation now correctly detects direct or transitive date/time library usage in supported configurations.
  - iOS builds continue to support native date/time dependencies without unnecessary build failures.

- **Documentation**
  - Clarified Android build requirements and explained why iOS configurations are exempt from the restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->