### PR TITLE
fix: don't report cancelled trade steps as failures (#1706)

### DIFF
--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -3,10 +3,14 @@ package network.bisq.mobile.domain.service.trades
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
@@ -17,6 +21,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -67,6 +72,59 @@ class TradeAnalyticsTrackerTest {
             verify { analytics.captureException(any()) }
             verify(exactly = 0) { analytics.track(Trade.Action(Trade.Step.FIAT_RECEIPT, Trade.Outcome.CONFIRMED)) }
             verify(exactly = 0) { analytics.track(Trade.Action(Trade.Step.FIAT_RECEIPT, Trade.Outcome.STALLED)) }
+        }
+
+    @Test
+    fun `timeout-style cancellation with an active caller is reported as FAILED`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, stallTimeout)
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+            val result =
+                tracker.trackAction(Trade.Step.BTC_ADDRESS, state, scope) {
+                    Result.failure(CancellationException("request timed out"))
+                }
+
+            assertTrue(result.isFailure)
+            verify { analytics.track(Trade.Action(Trade.Step.BTC_ADDRESS, Trade.Outcome.FAILED)) }
+            verify { analytics.captureException(any()) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `genuine caller cancellation is not reported as FAILED`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, stallTimeout)
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+            val gate = CompletableDeferred<Unit>()
+
+            var outcome: Result<Unit>? = null
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    outcome =
+                        tracker.trackAction(Trade.Step.BTC_RECEIVED, state, scope) {
+                            try {
+                                gate.await()
+                                Result.success(Unit)
+                            } catch (e: CancellationException) {
+                                // Node facade wraps teardown into Result.failure; the tracker must
+                                // still refuse to report it when OUR job is already cancelled.
+                                Result.failure(e)
+                            }
+                        }
+                }
+
+            child.cancel()
+            child.join()
+
+            assertNull(outcome)
+            verify(exactly = 0) { analytics.track(any()) }
+            verify(exactly = 0) { analytics.captureException(any()) }
+            scope.cancel()
         }
 
     @Test

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -1,7 +1,10 @@
 package network.bisq.mobile.domain.service.trades
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -86,6 +89,10 @@ class TradeAnalyticsTracker(
      * the exception; on success watches [tradeState] for the user's own transition away from its current
      * value, emitting `CONFIRMED` if it advances within [stallTimeoutMs] or `STALLED` otherwise. The
      * action's [Result] is returned unchanged — the stall watch runs in the background.
+     *
+     * A [CancellationException] in [action]'s failure is gated with [ensureActive]: if this coroutine
+     * is already cancelled (navigate-away), the exception is rethrown and not reported. If the caller
+     * is still active (request timeout), it is reported as `FAILED`.
      */
     suspend fun trackAction(
         step: AnalyticsEvent.Trade.Step,
@@ -97,6 +104,9 @@ class TradeAnalyticsTracker(
         val result = action()
         result
             .onFailure { e ->
+                if (e is CancellationException) {
+                    currentCoroutineContext().ensureActive()
+                }
                 analyticsService.track(AnalyticsEvent.Trade.Action(step, AnalyticsEvent.Trade.Outcome.FAILED))
                 analyticsService.captureException(TradeActionException(step, e))
             }.onSuccess {


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1706
 - Tried hardware back during `btc address send` step. Issue not reproducible. The global loading overlay swallows `back navigate`, so the presenter never cancels.
 - The 0.7.1 reports (with same guardedSuspendAction() gate) probably came from other teardown (process death, rotation, etc.,)
 - `TradeAnalyticsTracker.trackAction` now uses `ensureActive()` before reporting, same gate as `WebSocketApiClient`.
    - If this screen’s job is already cancelled, skip `FAILED` / GlitchTip.
    - If the user is still on the confirm and the request times out, still report `FAILED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled trade actions.
  * Active request timeouts are recorded as failed analytics events.
  * Caller-initiated cancellations now stop processing without creating unnecessary analytics reports or captured exceptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->