### PR TITLE
refactor/prepare_code_reusals_for_community_hub_feature

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadCountBadgeUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadCountBadgeUiTest.kt
@@ -1,0 +1,38 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import androidx.compose.ui.test.onNodeWithText
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+
+/**
+ * UI tests for [UnreadCountBadge]: renders the formatted pill for positive counts,
+ * caps above 99, and emits nothing at zero.
+ */
+class UnreadCountBadgeUiTest : BisqComposeUiTestBase() {
+    @Test
+    fun `positive count renders as its exact number`() {
+        setTestContent {
+            UnreadCountBadge(count = 5)
+        }
+
+        composeTestRule.onNodeWithText("5").assertExists()
+    }
+
+    @Test
+    fun `count above 99 renders capped`() {
+        setTestContent {
+            UnreadCountBadge(count = 120)
+        }
+
+        composeTestRule.onNodeWithText("99+").assertExists()
+    }
+
+    @Test
+    fun `zero count renders no badge`() {
+        setTestContent {
+            UnreadCountBadge(count = 0)
+        }
+
+        composeTestRule.onNodeWithText("0").assertDoesNotExist()
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadCountBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadCountBadge.kt
@@ -1,0 +1,28 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import androidx.compose.runtime.Composable
+import network.bisq.mobile.presentation.common.ui.components.atoms.animations.AnimatedBadge
+
+/**
+ * The one unread-count → badge-pill contract, shared by every unread badge:
+ * hidden at zero or below, exact count up to 99, capped at "99+" above.
+ */
+fun formatUnreadBadgeCount(count: Int): String? =
+    when {
+        count <= 0 -> null
+        count > 99 -> "99+"
+        else -> count.toString()
+    }
+
+/**
+ * Unread-count badge pill. Renders nothing when [count] is zero or below, so call
+ * sites don't need their own visibility check.
+ */
+@Composable
+fun UnreadCountBadge(
+    count: Int,
+    showAnimation: Boolean = false,
+) {
+    val text = formatUnreadBadgeCount(count) ?: return
+    AnimatedBadge(text = text, showAnimation = showAnimation)
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/BottomNavigation.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/BottomNavigation.kt
@@ -26,7 +26,7 @@ import bisqapps.shared.presentation.generated.resources.nav_offers
 import bisqapps.shared.presentation.generated.resources.nav_trades
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.AutoResizeText
-import network.bisq.mobile.presentation.common.ui.components.atoms.animations.AnimatedBadge
+import network.bisq.mobile.presentation.common.ui.components.molecules.UnreadCountBadge
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.tabs.tab.BottomNavigationItem
 import org.jetbrains.compose.resources.painterResource
@@ -83,9 +83,7 @@ fun BottomNavigation(
                         if (index == MY_TRADES_TAB_INDEX && unreadTradeCount > 0) {
                             BadgedBox(
                                 badge = {
-                                    AnimatedBadge(
-                                        text = unreadTradeCount.toString(),
-                                    )
+                                    UnreadCountBadge(count = unreadTradeCount, showAnimation = showAnimation)
                                 },
                             ) {
                                 icon()

--- a/shared/presentation/src/commonTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadBadgeFormatTest.kt
+++ b/shared/presentation/src/commonTest/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/UnreadBadgeFormatTest.kt
@@ -1,0 +1,32 @@
+package network.bisq.mobile.presentation.common.ui.components.molecules
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the shared unread-count → badge-pill contract: hidden at zero or below,
+ * exact count up to 99, capped at "99+" above.
+ */
+class UnreadBadgeFormatTest {
+    @Test
+    fun `zero and negative counts render no badge`() {
+        assertNull(formatUnreadBadgeCount(0))
+        assertNull(formatUnreadBadgeCount(-1))
+        assertNull(formatUnreadBadgeCount(Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `counts up to 99 render exactly`() {
+        assertEquals("1", formatUnreadBadgeCount(1))
+        assertEquals("42", formatUnreadBadgeCount(42))
+        assertEquals("99", formatUnreadBadgeCount(99))
+    }
+
+    @Test
+    fun `counts above 99 cap at 99 plus`() {
+        assertEquals("99+", formatUnreadBadgeCount(100))
+        assertEquals("99+", formatUnreadBadgeCount(1234))
+        assertEquals("99+", formatUnreadBadgeCount(Int.MAX_VALUE))
+    }
+}


### PR DESCRIPTION
 - contribs to #1743 
 - refactor the animated count badge used in my trades into its own rusable component for community hub chats badges implementation + tests + fix count cap to 99+ instead of showing 3 digit numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unread-count badges that display counts up to 99 and show “99+” for larger values.
  * Badges are hidden when there are no unread items.
  * Updated the My Trades navigation badge to use the new count formatting.

* **Tests**
  * Added coverage for positive, zero, negative, large, and boundary count values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->