### PR TITLE
Feature/community hub state and shell

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -119,7 +119,7 @@ import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.DefaultBackendCapabilitiesService
-import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunityHubService
 import okio.Path.Companion.toPath
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
@@ -341,7 +341,7 @@ val clientDomainModule =
         single { ClientConnectivityService(get()) } bind ConnectivityService::class
 
         single<BackendCapabilitiesService> { DefaultBackendCapabilitiesService(get()) }
-        single { CommunityHubState(get()) }
+        single { CommunityHubService(get()) }
 
         single { NetworkApiGateway(get()) }
         single {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -119,6 +119,7 @@ import network.bisq.mobile.domain.model.PlatformType
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.DefaultBackendCapabilitiesService
+import network.bisq.mobile.domain.service.community.CommunityHubState
 import okio.Path.Companion.toPath
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
@@ -340,6 +341,7 @@ val clientDomainModule =
         single { ClientConnectivityService(get()) } bind ConnectivityService::class
 
         single<BackendCapabilitiesService> { DefaultBackendCapabilitiesService(get()) }
+        single { CommunityHubState(get()) }
 
         single { NetworkApiGateway(get()) }
         single {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -12,6 +12,7 @@ import network.bisq.mobile.client.trusted_node_setup.TrustedNodeSetupPresenter
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPresenter
+import network.bisq.mobile.presentation.community.CommunityHubPresenter
 import network.bisq.mobile.presentation.main.AppPresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offerbook.OfferbookPresenter
@@ -99,6 +100,7 @@ val clientPresentationModule =
         factory { ClientNetworkConnectionsPresenter(get(), get(), get()) }
 
         factory<FaqPresenter> { FaqClientPresenter(get()) }
+        factory { CommunityHubPresenter(get(), get()) }
 
         factory<ClientSupportPresenter> {
             ClientSupportPresenter(

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -42,6 +42,7 @@ import network.bisq.mobile.domain.analytics.createBufferedAnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.DefaultBackendCapabilitiesService
+import network.bisq.mobile.domain.service.community.CommunityHubState
 import network.bisq.mobile.domain.utils.AndroidDeviceInfoProvider
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
 import network.bisq.mobile.domain.utils.VersionProvider
@@ -204,6 +205,7 @@ val androidNodeDomainModule =
         single { NodeConnectivityService(get()) } bind ConnectivityService::class
 
         single<BackendCapabilitiesService> { DefaultBackendCapabilitiesService(get()) }
+        single { CommunityHubState(get()) }
 
         single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
         single<AppUpdateLinker> { AndroidAppUpdateLinker(androidContext()) }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -42,7 +42,7 @@ import network.bisq.mobile.domain.analytics.createBufferedAnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.DefaultBackendCapabilitiesService
-import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.utils.AndroidDeviceInfoProvider
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
 import network.bisq.mobile.domain.utils.VersionProvider
@@ -205,7 +205,7 @@ val androidNodeDomainModule =
         single { NodeConnectivityService(get()) } bind ConnectivityService::class
 
         single<BackendCapabilitiesService> { DefaultBackendCapabilitiesService(get()) }
-        single { CommunityHubState(get()) }
+        single { CommunityHubService(get()) }
 
         single<UrlLauncher> { AndroidUrlLauncher(androidContext()) }
         single<AppUpdateLinker> { AndroidAppUpdateLinker(androidContext()) }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -20,6 +20,7 @@ import network.bisq.mobile.presentation.common.share.ShareFileService
 import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarPresenter
+import network.bisq.mobile.presentation.community.CommunityHubPresenter
 import network.bisq.mobile.presentation.main.AppPresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offerbook.OfferbookPresenter
@@ -75,6 +76,7 @@ val androidNodePresentationModule =
         factory<MiscItemsPresenter> { NodeMiscItemsPresenter(get(), get()) }
 
         factory<FaqPresenter> { FaqNodePresenter(get()) }
+        factory { CommunityHubPresenter(get(), get()) }
 
         factory { NodeNetworkOverviewPresenter(get(), get(), get()) }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,28 @@ apps/nodeApp   →  Node*ServiceFacade    (bisq2 core via AndroidApplicationServ
 
 Tests: mock shared facade interfaces in presenter tests; use client/node integration bases when testing a concrete facade. See [testing catalog](testing/catalog.md).
 
+### Feature availability services
+
+For plain backend gating, use `BackendCapabilitiesService` directly in the presenter — one
+capability, one consumer, no extra type (e.g. `MiscItemsPresenter` gating the Network item on
+`Feature.NETWORK_INFO`). That is the default.
+
+A dedicated availability service is the escalation, warranted only when the feature composes
+MORE than the capability check — a staged-rollout constant, a dev feature-flag override — or
+must answer "which parts of me exist right now" for more than one presenter (screen + chrome
+such as a top-bar icon). Then that answer lives in a domain-level service under
+`shared/domain/.../service/<feature>/`, not in any presenter or `UiState`:
+
+- Composes `(shipped ∪ devOverride) ∩ backend capabilities`, where the capability check goes
+  through `BackendCapabilitiesService` and **fails closed** — the dev override never bypasses it.
+- Exposes a reactive `StateFlow` computed on a process-lifetime scope (`stateIn(Eagerly)`),
+  because presenters are view-bound and the answer is needed between screens.
+- Screen-local state (e.g. which tab is selected) stays in the presenter's `UiState`; only the
+  shared, app-lifetime parts belong here.
+
+Current instance: `CommunityHubService`. If a second composite appears (e.g. MuSig-on-Connect
+gating), extract the shared core then — not before.
+
 ---
 
 ## Presenter lifecycle modes

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,6 +74,10 @@ kover.diff.coverage.minimum=80
 # Feature (client app only)
 feature.muSigEnabled=false
 
+# Feature Community-Hub (empty == disabled). Override in local.properties for development
+# e.g. feature.communityHubDevSegments=DISCUSSIONS,MESSAGES,CONTACTS
+feature.communityHubDevSegments=
+
 # Opt-in analytics (issue #525). DEV-ONLY override — debug builds only.
 # - false (default): debug builds will NEVER emit events even if a developer
 #   accidentally toggles the user-facing settings switch ON. Protects the

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -141,6 +141,15 @@ buildConfig {
                     ?: false
             }
         buildConfigField("ANALYTICS_DEV_ENABLED", analyticsDevEnabled)
+        // Community hub dev override: comma-separated CommunitySegment names forced live so
+        // the gated hub UI can be exercised before its features ship. Same trust model as
+        // feature.muSigEnabled: defaults empty in gradle.properties, overridden per developer
+        // in local.properties (resolveProperty gives local.properties precedence) — release
+        // machines must not carry the override.
+        buildConfigField(
+            "COMMUNITY_HUB_DEV_SEGMENTS",
+            resolveProperty("feature.communityHubDevSegments")?.trim().orEmpty(),
+        )
         // DSNs are public per Sentry's threat model — the public key alone
         // cannot read data, only post. Empty default = effectively disabled.
         // Connect's BuildConfig holds both Android + iOS DSNs; the runtime

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -142,14 +142,14 @@ buildConfig {
             }
         buildConfigField("ANALYTICS_DEV_ENABLED", analyticsDevEnabled)
         // Community hub dev override: comma-separated CommunitySegment names forced live so
-        // the gated hub UI can be exercised before its features ship. Same trust model as
-        // feature.muSigEnabled: defaults empty in gradle.properties, overridden per developer
-        // in local.properties (resolveProperty gives local.properties precedence) — release
-        // machines must not carry the override.
-        buildConfigField(
-            "COMMUNITY_HUB_DEV_SEGMENTS",
-            resolveProperty("feature.communityHubDevSegments")?.trim().orEmpty(),
-        )
+        // the gated hub UI can be exercised before its features ship. Defaults empty in
+        // gradle.properties, overridden per developer in local.properties (resolveProperty
+        // gives local.properties precedence). Gated like ANALYTICS_DEV_ENABLED: release
+        // builds force the empty string, so a forgotten local.properties entry cannot leak
+        // into assembleRelease/bundleRelease/Xcode Release artifacts.
+        val communityHubDevSegments =
+            if (!isDebugBuild) "" else resolveProperty("feature.communityHubDevSegments")?.trim().orEmpty()
+        buildConfigField("COMMUNITY_HUB_DEV_SEGMENTS", communityHubDevSegments)
         // DSNs are public per Sentry's threat model — the public key alone
         // cannot read data, only post. Empty default = effectively disabled.
         // Connect's BuildConfig holds both Android + iOS DSNs; the runtime

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubService.kt
@@ -30,7 +30,7 @@ import network.bisq.mobile.domain.service.capabilities.Feature
  *   app uses via [BackendCapabilitiesService]. A segment with no entry has no backend
  *   dependency. The dev override does not bypass this filter.
  */
-class CommunityHubState(
+class CommunityHubService(
     backendCapabilitiesService: BackendCapabilitiesService,
     private val shippedSegments: Set<CommunitySegment> = SHIPPED_SEGMENTS,
     private val devForcedSegments: Set<CommunitySegment> = devForcedSegmentsFromBuildConfig(),

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubState.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubState.kt
@@ -23,7 +23,8 @@ import network.bisq.mobile.domain.service.capabilities.Feature
  * - **shipped**: segments this app version implements ([SHIPPED_SEGMENTS]).
  * - **devForced**: developer override from `feature.communityHubDevSegments`, defaulting
  *   empty in gradle.properties and set per developer in local.properties, so the gated UI
- *   can be exercised before its features ship — same trust model as `feature.muSigEnabled`.
+ *   can be exercised before its features ship. Release builds force it empty at the
+ *   BuildConfig level, so it can never reach end users.
  * - **capabilities**: per-segment backend requirement ([REQUIRED_FEATURES]) checked against
  *   the trusted node's capability manifest, fail closed — the same gating the rest of the
  *   app uses via [BackendCapabilitiesService]. A segment with no entry has no backend

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubState.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunityHubState.kt
@@ -1,0 +1,97 @@
+package network.bisq.mobile.domain.service.community
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import network.bisq.mobile.client.shared.BuildConfig
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
+import network.bisq.mobile.domain.service.capabilities.Feature
+
+/**
+ * Single source of truth for which Community hub segments are live, and for the hub's
+ * aggregate unread count.
+ *
+ * `liveSegments = (shipped ∪ devForced) ∩ capabilities`:
+ * - **shipped**: segments this app version implements ([SHIPPED_SEGMENTS]).
+ * - **devForced**: developer override from `feature.communityHubDevSegments`, defaulting
+ *   empty in gradle.properties and set per developer in local.properties, so the gated UI
+ *   can be exercised before its features ship — same trust model as `feature.muSigEnabled`.
+ * - **capabilities**: per-segment backend requirement ([REQUIRED_FEATURES]) checked against
+ *   the trusted node's capability manifest, fail closed — the same gating the rest of the
+ *   app uses via [BackendCapabilitiesService]. A segment with no entry has no backend
+ *   dependency. The dev override does not bypass this filter.
+ */
+class CommunityHubState(
+    backendCapabilitiesService: BackendCapabilitiesService,
+    private val shippedSegments: Set<CommunitySegment> = SHIPPED_SEGMENTS,
+    private val devForcedSegments: Set<CommunitySegment> = devForcedSegmentsFromBuildConfig(),
+    private val requiredFeatures: Map<CommunitySegment, Feature> = REQUIRED_FEATURES,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    val liveSegments: StateFlow<Set<CommunitySegment>> =
+        backendCapabilitiesService.capabilities
+            .map { computeLiveSegments(it) }
+            .stateIn(
+                scope,
+                SharingStarted.Eagerly,
+                computeLiveSegments(backendCapabilitiesService.capabilities.value),
+            )
+
+    private val _unreadCount = MutableStateFlow(0)
+
+    /**
+     * Aggregate unread count across live segments, shown by the hub's entry-point badge.
+     * TODO feed from the Discussions unread source once it exists.
+     */
+    val unreadCount: StateFlow<Int> = _unreadCount.asStateFlow()
+
+    fun setUnreadCount(count: Int) {
+        _unreadCount.value = count.coerceAtLeast(0)
+    }
+
+    private fun computeLiveSegments(capabilities: BackendCapabilities): Set<CommunitySegment> =
+        (shippedSegments + devForcedSegments)
+            .filterTo(mutableSetOf()) { segment ->
+                requiredFeatures[segment]?.let { capabilities.isSupported(it) } ?: true
+            }
+
+    companion object {
+        /** Segments implemented in this app version. TODO add each segment as its wiring ships. */
+        val SHIPPED_SEGMENTS: Set<CommunitySegment> = emptySet()
+
+        /**
+         * Backend feature each segment requires from the trusted node; a segment without an
+         * entry has no backend dependency. TODO register each segment's feature as it ships.
+         */
+        val REQUIRED_FEATURES: Map<CommunitySegment, Feature> = emptyMap()
+
+        fun devForcedSegmentsFromBuildConfig(): Set<CommunitySegment> = parseDevForcedSegments(BuildConfig.COMMUNITY_HUB_DEV_SEGMENTS)
+
+        /**
+         * Parses a comma-separated list of [CommunitySegment] names, case-insensitively,
+         * ignoring surrounding whitespace. Unknown names fail fast — this only ever parses
+         * a developer-supplied build property.
+         */
+        fun parseDevForcedSegments(raw: String): Set<CommunitySegment> =
+            raw
+                .split(',')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .map { name ->
+                    requireNotNull(CommunitySegment.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }) {
+                        "Unknown community segment '$name' in feature.communityHubDevSegments; " +
+                            "valid values: ${CommunitySegment.entries.joinToString()}"
+                    }
+                }.toSet()
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunitySegment.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunitySegment.kt
@@ -1,0 +1,11 @@
+package network.bisq.mobile.domain.service.community
+
+/**
+ * The Community hub's gated segments. Declaration order is the tab order. A segment only
+ * renders when it is live — see [CommunityHubState.liveSegments].
+ */
+enum class CommunitySegment {
+    DISCUSSIONS,
+    MESSAGES,
+    CONTACTS,
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunitySegment.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/community/CommunitySegment.kt
@@ -2,7 +2,7 @@ package network.bisq.mobile.domain.service.community
 
 /**
  * The Community hub's gated segments. Declaration order is the tab order. A segment only
- * renders when it is live — see [CommunityHubState.liveSegments].
+ * renders when it is live — see [CommunityHubService.liveSegments].
  */
 enum class CommunitySegment {
     DISCUSSIONS,

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -944,3 +944,13 @@ mobile.tradeInterrupt.reason.paymentMethodIssue=Payment issue
 mobile.tradeInterrupt.reason.noProgress=Trade stalled
 mobile.tradeInterrupt.reason.changedMind=Changed my mind
 mobile.tradeInterrupt.reason.other=Other
+
+# Community hub
+mobile.community.title=Community
+mobile.community.tab.discussions=Discussions
+mobile.community.tab.messages=Messages
+mobile.community.tab.contacts=Contacts
+mobile.community.support.needHelp=Need help?
+mobile.community.support.openChannel=Visit the Support channel
+mobile.community.comingSoon=Coming soon
+mobile.more.communityDevPreview=Community (dev preview)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/community/CommunityHubServiceTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/community/CommunityHubServiceTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertFailsWith
  * unread-count slot.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class CommunityHubStateTest {
+class CommunityHubServiceTest {
     private class FakeCapabilities(
         initial: BackendCapabilities = BackendCapabilities.UNAVAILABLE,
     ) : BackendCapabilitiesService {
@@ -32,7 +32,7 @@ class CommunityHubStateTest {
     fun `no shipped and no forced segments means nothing is live`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = emptySet(),
                     devForcedSegments = emptySet(),
@@ -46,7 +46,7 @@ class CommunityHubStateTest {
     fun `shipped segment without a backend requirement is live`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
                     devForcedSegments = emptySet(),
@@ -60,7 +60,7 @@ class CommunityHubStateTest {
     fun `shipped segment with an unsupported backend feature is gated off`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
                     devForcedSegments = emptySet(),
@@ -75,7 +75,7 @@ class CommunityHubStateTest {
         runTest {
             val capabilities = FakeCapabilities()
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = capabilities,
                     shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
                     devForcedSegments = emptySet(),
@@ -93,7 +93,7 @@ class CommunityHubStateTest {
     fun `dev forced segments are unioned with shipped ones`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
                     devForcedSegments = setOf(CommunitySegment.MESSAGES),
@@ -107,7 +107,7 @@ class CommunityHubStateTest {
     fun `dev forced segment does not bypass the capability gate`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = emptySet(),
                     devForcedSegments = setOf(CommunitySegment.MESSAGES),
@@ -119,22 +119,22 @@ class CommunityHubStateTest {
 
     @Test
     fun `parse accepts empty and blank input as no segments`() {
-        assertEquals(emptySet(), CommunityHubState.parseDevForcedSegments(""))
-        assertEquals(emptySet(), CommunityHubState.parseDevForcedSegments("  "))
+        assertEquals(emptySet(), CommunityHubService.parseDevForcedSegments(""))
+        assertEquals(emptySet(), CommunityHubService.parseDevForcedSegments("  "))
     }
 
     @Test
     fun `parse is case insensitive and trims entries`() {
         assertEquals(
             setOf(CommunitySegment.DISCUSSIONS, CommunitySegment.MESSAGES),
-            CommunityHubState.parseDevForcedSegments(" discussions , MESSAGES "),
+            CommunityHubService.parseDevForcedSegments(" discussions , MESSAGES "),
         )
     }
 
     @Test
     fun `parse fails fast on an unknown segment name`() {
         assertFailsWith<IllegalArgumentException> {
-            CommunityHubState.parseDevForcedSegments("DISCUSSIONS,TYPO")
+            CommunityHubService.parseDevForcedSegments("DISCUSSIONS,TYPO")
         }
     }
 
@@ -142,7 +142,7 @@ class CommunityHubStateTest {
     fun `unread count is settable and never negative`() =
         runTest {
             val state =
-                CommunityHubState(
+                CommunityHubService(
                     backendCapabilitiesService = FakeCapabilities(),
                     shippedSegments = emptySet(),
                     devForcedSegments = emptySet(),

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/community/CommunityHubStateTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/community/CommunityHubStateTest.kt
@@ -1,0 +1,158 @@
+package network.bisq.mobile.domain.service.community
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
+import network.bisq.mobile.domain.service.capabilities.Feature
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Pins the gating composition rule: `liveSegments = (shipped ∪ devForced) ∩ capabilities`,
+ * fail closed on a missing backend capability, plus the dev-override parser and the
+ * unread-count slot.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommunityHubStateTest {
+    private class FakeCapabilities(
+        initial: BackendCapabilities = BackendCapabilities.UNAVAILABLE,
+    ) : BackendCapabilitiesService {
+        val flow = MutableStateFlow(initial)
+        override val capabilities: StateFlow<BackendCapabilities> = flow
+    }
+
+    private fun supporting(feature: Feature) = BackendCapabilities(setOf(feature.key))
+
+    @Test
+    fun `no shipped and no forced segments means nothing is live`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = emptySet(),
+                    devForcedSegments = emptySet(),
+                    requiredFeatures = emptyMap(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(emptySet(), state.liveSegments.value)
+        }
+
+    @Test
+    fun `shipped segment without a backend requirement is live`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
+                    devForcedSegments = emptySet(),
+                    requiredFeatures = emptyMap(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(setOf(CommunitySegment.DISCUSSIONS), state.liveSegments.value)
+        }
+
+    @Test
+    fun `shipped segment with an unsupported backend feature is gated off`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
+                    devForcedSegments = emptySet(),
+                    requiredFeatures = mapOf(CommunitySegment.DISCUSSIONS to Feature.NETWORK_INFO),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(emptySet(), state.liveSegments.value)
+        }
+
+    @Test
+    fun `segment goes live when the backend capability arrives`() =
+        runTest {
+            val capabilities = FakeCapabilities()
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = capabilities,
+                    shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
+                    devForcedSegments = emptySet(),
+                    requiredFeatures = mapOf(CommunitySegment.DISCUSSIONS to Feature.NETWORK_INFO),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(emptySet(), state.liveSegments.value)
+
+            capabilities.flow.value = supporting(Feature.NETWORK_INFO)
+
+            assertEquals(setOf(CommunitySegment.DISCUSSIONS), state.liveSegments.value)
+        }
+
+    @Test
+    fun `dev forced segments are unioned with shipped ones`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = setOf(CommunitySegment.DISCUSSIONS),
+                    devForcedSegments = setOf(CommunitySegment.MESSAGES),
+                    requiredFeatures = emptyMap(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(setOf(CommunitySegment.DISCUSSIONS, CommunitySegment.MESSAGES), state.liveSegments.value)
+        }
+
+    @Test
+    fun `dev forced segment does not bypass the capability gate`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = emptySet(),
+                    devForcedSegments = setOf(CommunitySegment.MESSAGES),
+                    requiredFeatures = mapOf(CommunitySegment.MESSAGES to Feature.NETWORK_INFO),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(emptySet(), state.liveSegments.value)
+        }
+
+    @Test
+    fun `parse accepts empty and blank input as no segments`() {
+        assertEquals(emptySet(), CommunityHubState.parseDevForcedSegments(""))
+        assertEquals(emptySet(), CommunityHubState.parseDevForcedSegments("  "))
+    }
+
+    @Test
+    fun `parse is case insensitive and trims entries`() {
+        assertEquals(
+            setOf(CommunitySegment.DISCUSSIONS, CommunitySegment.MESSAGES),
+            CommunityHubState.parseDevForcedSegments(" discussions , MESSAGES "),
+        )
+    }
+
+    @Test
+    fun `parse fails fast on an unknown segment name`() {
+        assertFailsWith<IllegalArgumentException> {
+            CommunityHubState.parseDevForcedSegments("DISCUSSIONS,TYPO")
+        }
+    }
+
+    @Test
+    fun `unread count is settable and never negative`() =
+        runTest {
+            val state =
+                CommunityHubState(
+                    backendCapabilitiesService = FakeCapabilities(),
+                    shippedSegments = emptySet(),
+                    devForcedSegments = emptySet(),
+                    requiredFeatures = emptyMap(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            assertEquals(0, state.unreadCount.value)
+            state.setUnreadCount(7)
+            assertEquals(7, state.unreadCount.value)
+            state.setUnreadCount(-3)
+            assertEquals(0, state.unreadCount.value)
+        }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
@@ -1,0 +1,126 @@
+package network.bisq.mobile.presentation.community
+
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
+import network.bisq.mobile.domain.service.capabilities.Feature
+import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommunityHubPresenterTest : PresentationKoinTestBase() {
+    private lateinit var mainPresenter: MainPresenter
+    private lateinit var capabilitiesFlow: MutableStateFlow<BackendCapabilities>
+
+    override fun onKoinReady() {
+        mainPresenter = mockk(relaxed = true)
+        capabilitiesFlow = MutableStateFlow(BackendCapabilities.UNAVAILABLE)
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.createAttachedPresenter(
+        shipped: Set<CommunitySegment> = emptySet(),
+        devForced: Set<CommunitySegment> = emptySet(),
+        requiredFeatures: Map<CommunitySegment, Feature> = emptyMap(),
+    ): CommunityHubPresenter {
+        val hubState =
+            CommunityHubState(
+                backendCapabilitiesService =
+                    object : BackendCapabilitiesService {
+                        override val capabilities: StateFlow<BackendCapabilities> = capabilitiesFlow
+                    },
+                shippedSegments = shipped,
+                devForcedSegments = devForced,
+                requiredFeatures = requiredFeatures,
+                dispatcher = UnconfinedTestDispatcher(testScheduler),
+            )
+        val presenter = CommunityHubPresenter(mainPresenter, hubState)
+        presenter.onViewAttached()
+        advanceUntilIdle()
+        return presenter
+    }
+
+    @Test
+    fun `live segments render in declaration order with the first selected`() =
+        runTest {
+            val presenter =
+                createAttachedPresenter(devForced = setOf(CommunitySegment.MESSAGES, CommunitySegment.DISCUSSIONS))
+
+            assertEquals(
+                listOf(CommunitySegment.DISCUSSIONS, CommunitySegment.MESSAGES),
+                presenter.uiState.value.liveSegments,
+            )
+            assertEquals(CommunitySegment.DISCUSSIONS, presenter.uiState.value.selectedSegment)
+        }
+
+    @Test
+    fun `selecting a live segment updates the selection`() =
+        runTest {
+            val presenter =
+                createAttachedPresenter(devForced = setOf(CommunitySegment.DISCUSSIONS, CommunitySegment.MESSAGES))
+
+            presenter.onAction(CommunityHubUiAction.OnSegmentSelect(CommunitySegment.MESSAGES))
+
+            assertEquals(CommunitySegment.MESSAGES, presenter.uiState.value.selectedSegment)
+        }
+
+    @Test
+    fun `selecting a segment that is not live is ignored`() =
+        runTest {
+            val presenter = createAttachedPresenter(devForced = setOf(CommunitySegment.DISCUSSIONS))
+
+            presenter.onAction(CommunityHubUiAction.OnSegmentSelect(CommunitySegment.CONTACTS))
+
+            assertEquals(CommunitySegment.DISCUSSIONS, presenter.uiState.value.selectedSegment)
+        }
+
+    @Test
+    fun `selection falls back to the first live segment when the selected one goes away`() =
+        runTest {
+            val presenter =
+                createAttachedPresenter(
+                    shipped = setOf(CommunitySegment.DISCUSSIONS),
+                    devForced = setOf(CommunitySegment.MESSAGES),
+                    requiredFeatures = mapOf(CommunitySegment.MESSAGES to Feature.NETWORK_INFO),
+                )
+            capabilitiesFlow.value = BackendCapabilities(setOf(Feature.NETWORK_INFO.key))
+            advanceUntilIdle()
+            presenter.onAction(CommunityHubUiAction.OnSegmentSelect(CommunitySegment.MESSAGES))
+            assertEquals(CommunitySegment.MESSAGES, presenter.uiState.value.selectedSegment)
+
+            capabilitiesFlow.value = BackendCapabilities.UNAVAILABLE
+            advanceUntilIdle()
+
+            assertEquals(listOf(CommunitySegment.DISCUSSIONS), presenter.uiState.value.liveSegments)
+            assertEquals(CommunitySegment.DISCUSSIONS, presenter.uiState.value.selectedSegment)
+        }
+
+    @Test
+    fun `no live segments means no selection`() =
+        runTest {
+            val presenter = createAttachedPresenter()
+
+            assertEquals(emptyList(), presenter.uiState.value.liveSegments)
+            assertNull(presenter.uiState.value.selectedSegment)
+        }
+
+    @Test
+    fun `support quick access action is a safe no-op for now`() =
+        runTest {
+            val presenter = createAttachedPresenter(devForced = setOf(CommunitySegment.DISCUSSIONS))
+
+            presenter.onAction(CommunityHubUiAction.OnOpenSupportChannel)
+            advanceUntilIdle()
+
+            assertEquals(CommunitySegment.DISCUSSIONS, presenter.uiState.value.selectedSegment)
+        }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
-import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
@@ -32,8 +32,8 @@ class CommunityHubPresenterTest : PresentationKoinTestBase() {
         devForced: Set<CommunitySegment> = emptySet(),
         requiredFeatures: Map<CommunitySegment, Feature> = emptyMap(),
     ): CommunityHubPresenter {
-        val hubState =
-            CommunityHubState(
+        val hubService =
+            CommunityHubService(
                 backendCapabilitiesService =
                     object : BackendCapabilitiesService {
                         override val capabilities: StateFlow<BackendCapabilities> = capabilitiesFlow
@@ -43,7 +43,7 @@ class CommunityHubPresenterTest : PresentationKoinTestBase() {
                 requiredFeatures = requiredFeatures,
                 dispatcher = UnconfinedTestDispatcher(testScheduler),
             )
-        val presenter = CommunityHubPresenter(mainPresenter, hubState)
+        val presenter = CommunityHubPresenter(mainPresenter, hubService)
         presenter.onViewAttached()
         advanceUntilIdle()
         return presenter

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenUiTest.kt
@@ -1,0 +1,79 @@
+package network.bisq.mobile.presentation.community
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.BisqComposeUiTestBase
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * UI tests for [CommunityHubScreenContent]: the gated tab row (hidden for a single live
+ * segment, rendered for several), the pinned Support quick access, and the placeholder body.
+ */
+class CommunityHubScreenUiTest : BisqComposeUiTestBase() {
+    private val actions = mutableListOf<CommunityHubUiAction>()
+
+    private fun setContent(uiState: CommunityHubUiState) {
+        actions.clear()
+        setTestContent {
+            CommunityHubScreenContent(uiState = uiState, onAction = actions::add)
+        }
+    }
+
+    private fun tabLabel(key: String) = key.i18n()
+
+    @Test
+    fun `single live segment renders no tab row but shows support row and placeholder`() {
+        setContent(
+            CommunityHubUiState(
+                liveSegments = listOf(CommunitySegment.DISCUSSIONS),
+                selectedSegment = CommunitySegment.DISCUSSIONS,
+            ),
+        )
+
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.tab.messages")).assertDoesNotExist()
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.support.needHelp")).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("mobile.community.comingSoon".i18n(), substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `multiple live segments render the tab row and tapping one selects it`() {
+        setContent(
+            CommunityHubUiState(
+                liveSegments = CommunitySegment.entries.toList(),
+                selectedSegment = CommunitySegment.DISCUSSIONS,
+            ),
+        )
+
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.tab.contacts")).assertIsDisplayed()
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.tab.messages")).performClick()
+
+        assertEquals(listOf<CommunityHubUiAction>(CommunityHubUiAction.OnSegmentSelect(CommunitySegment.MESSAGES)), actions)
+    }
+
+    @Test
+    fun `support row tap emits the open support action`() {
+        setContent(
+            CommunityHubUiState(
+                liveSegments = listOf(CommunitySegment.DISCUSSIONS),
+                selectedSegment = CommunitySegment.DISCUSSIONS,
+            ),
+        )
+
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.support.needHelp")).performClick()
+
+        assertEquals(listOf<CommunityHubUiAction>(CommunityHubUiAction.OnOpenSupportChannel), actions)
+    }
+
+    @Test
+    fun `no live segments renders the bare coming soon state`() {
+        setContent(CommunityHubUiState())
+
+        composeTestRule.onNodeWithText("mobile.community.comingSoon".i18n()).assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenterTest.kt
@@ -51,6 +51,41 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
             .any { it.route == NavRoute.NetworkOverview }
 
     @Test
+    fun `when community dev preview is enabled then its entry appears in the app section`() =
+        runTest {
+            // Given
+            presenter = TestMiscItemsPresenter(backendCapabilitiesService, mainPresenter, communityDevPreview = true)
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            val appSection =
+                presenter.uiState.value.sections
+                    .last()
+            assertTrue(appSection.items.any { it.route == NavRoute.CommunityHub })
+        }
+
+    @Test
+    fun `when community dev preview is disabled then no community entry exists`() =
+        runTest {
+            // Given
+            presenter = createPresenter()
+
+            // When
+            presenter.onViewAttached()
+            advanceUntilIdle()
+
+            // Then
+            assertTrue(
+                presenter.uiState.value.sections
+                    .flatMap { it.items }
+                    .none { it.route == NavRoute.CommunityHub },
+            )
+        }
+
+    @Test
     fun `when attached then exposes the four sections in order`() =
         runTest {
             // Given
@@ -198,7 +233,12 @@ class MiscItemsPresenterTest : PresentationKoinTestBase() {
     private class TestMiscItemsPresenter(
         backendCapabilitiesService: BackendCapabilitiesService,
         mainPresenter: MainPresenter,
+        private val communityDevPreview: Boolean = false,
     ) : MiscItemsPresenter(backendCapabilitiesService, mainPresenter) {
+        // Pinned instead of the BuildConfig read so the suite does not change behaviour
+        // with the developer's local.properties.
+        override fun communityDevPreviewVisible(): Boolean = communityDevPreview
+
         override fun getPaymentAccountNavRoute(): NavRoute = NavRoute.PaymentAccounts
 
         override fun addCustomSettings(appItems: MutableList<MenuItem>): List<MenuItem> {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
@@ -137,6 +137,9 @@ interface NavRoute {
     data object Faqs : NavRoute
 
     @Serializable
+    data object CommunityHub : NavRoute
+
+    @Serializable
     data object Reputation : NavRoute
 
     @Serializable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
@@ -18,6 +18,7 @@ import androidx.navigation.toRoute
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.NavUtils.getDeepLinkBasePath
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+import network.bisq.mobile.presentation.community.CommunityHubScreen
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideOverview
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideProcess
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideSecurity
@@ -118,6 +119,7 @@ fun NavGraphBuilder.addCommonAppRoutes(animationsEnabled: () -> Boolean) {
     addScreen<NavRoute.Settings>(animationsEnabled = animationsEnabled) { SettingsScreen() }
     addScreen<NavRoute.Support>(animationsEnabled = animationsEnabled) { SupportScreen() }
     addScreen<NavRoute.Faqs>(animationsEnabled = animationsEnabled) { FaqScreen() }
+    addScreen<NavRoute.CommunityHub>(animationsEnabled = animationsEnabled) { CommunityHubScreen() }
     addScreen<NavRoute.Reputation>(animationsEnabled = animationsEnabled) { ReputationScreen() }
     addScreen<NavRoute.UserProfile>(animationsEnabled = animationsEnabled) { UserProfileScreen() }
     addScreen<NavRoute.PaymentAccounts>(animationsEnabled = animationsEnabled) { PaymentAccountsScreen() }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
@@ -1,0 +1,48 @@
+package network.bisq.mobile.presentation.community
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.presentation.common.ui.base.BasePresenter
+import network.bisq.mobile.presentation.main.MainPresenter
+
+class CommunityHubPresenter(
+    mainPresenter: MainPresenter,
+    private val communityHubState: CommunityHubState,
+) : BasePresenter(mainPresenter) {
+    private val _uiState = MutableStateFlow(CommunityHubUiState())
+    val uiState: StateFlow<CommunityHubUiState> = _uiState.asStateFlow()
+
+    override fun onViewAttached() {
+        super.onViewAttached()
+        communityHubState.liveSegments
+            .onEach { live ->
+                _uiState.update { state ->
+                    val ordered = live.sortedBy { it.ordinal }
+                    state.copy(
+                        liveSegments = ordered,
+                        // Keep the selection while it stays live; fall back to the first live
+                        // segment (or the empty state) when it goes away.
+                        selectedSegment = state.selectedSegment?.takeIf { it in live } ?: ordered.firstOrNull(),
+                    )
+                }
+            }.launchIn(presenterScope)
+    }
+
+    fun onAction(action: CommunityHubUiAction) {
+        when (action) {
+            is CommunityHubUiAction.OnSegmentSelect ->
+                _uiState.update { state ->
+                    if (action.segment in state.liveSegments) state.copy(selectedSegment = action.segment) else state
+                }
+            CommunityHubUiAction.OnOpenSupportChannel -> {
+                // TODO push the in-app Support chat screen once it exists
+                log.i { "Support channel requested from the Community hub; screen not available yet" }
+            }
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
@@ -6,20 +6,20 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class CommunityHubPresenter(
     mainPresenter: MainPresenter,
-    private val communityHubState: CommunityHubState,
+    private val communityHubService: CommunityHubService,
 ) : BasePresenter(mainPresenter) {
     private val _uiState = MutableStateFlow(CommunityHubUiState())
     val uiState: StateFlow<CommunityHubUiState> = _uiState.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
-        communityHubState.liveSegments
+        communityHubService.liveSegments
             .onEach { live ->
                 _uiState.update { state ->
                     val ordered = live.sortedBy { it.ordinal }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreen.kt
@@ -1,0 +1,158 @@
+package network.bisq.mobile.presentation.community
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowRightIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.QuestionIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
+import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
+
+@Composable
+fun CommunityHubScreen() {
+    val presenter = RememberPresenterLifecycleBackStackAware<CommunityHubPresenter>()
+
+    val uiState by presenter.uiState.collectAsState()
+
+    CommunityHubScreenContent(
+        uiState = uiState,
+        onAction = presenter::onAction,
+        topBar = { TopBar("mobile.community.title".i18n()) },
+    )
+}
+
+@Composable
+fun CommunityHubScreenContent(
+    uiState: CommunityHubUiState,
+    onAction: (CommunityHubUiAction) -> Unit,
+    topBar: @Composable () -> Unit = {},
+) {
+    BisqScaffold(
+        topBar = topBar,
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+        ) {
+            if (uiState.liveSegments.size > 1) {
+                CommunitySegmentTabRow(
+                    liveSegments = uiState.liveSegments,
+                    selected = uiState.selectedSegment,
+                    onSelect = { onAction(CommunityHubUiAction.OnSegmentSelect(it)) },
+                )
+            }
+
+            BisqGap.V1()
+
+            SupportQuickAccessRow(onClick = { onAction(CommunityHubUiAction.OnOpenSupportChannel) })
+
+            Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                // TODO replace the placeholder bodies with the segments' real content as each ships
+                val label = uiState.selectedSegment?.label()
+                if (label == null) {
+                    BisqText.BaseRegularGrey(text = "mobile.community.comingSoon".i18n())
+                } else {
+                    BisqText.BaseRegularGrey(text = "$label — ${"mobile.community.comingSoon".i18n()}")
+                }
+            }
+        }
+    }
+}
+
+// Contacts renders muted even when live: it is a directory, not an inbox, and must not
+// compete visually with the conversation tabs.
+private val mutedSegments = setOf(CommunitySegment.CONTACTS)
+
+@Composable
+private fun CommunitySegmentTabRow(
+    liveSegments: List<CommunitySegment>,
+    selected: CommunitySegment?,
+    onSelect: (CommunitySegment) -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = BisqUIConstants.ScreenPadding)) {
+        liveSegments.forEach { segment ->
+            val isSelected = segment == selected
+            val selectedColor = if (segment in mutedSegments) BisqTheme.colors.light_grey50 else BisqTheme.colors.primary
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .clickable { onSelect(segment) }
+                        .padding(vertical = BisqUIConstants.ScreenPadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                BisqText.BaseRegular(
+                    text = segment.label(),
+                    color = if (isSelected) selectedColor else BisqTheme.colors.mid_grey20,
+                )
+                Box(
+                    modifier =
+                        Modifier
+                            .padding(top = BisqUIConstants.ScreenPaddingQuarter)
+                            .width(BisqUIConstants.ScreenPadding4X)
+                            .height(2.dp)
+                            .background(if (isSelected) selectedColor else BisqTheme.colors.dark_grey50),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SupportQuickAccessRow(onClick: () -> Unit) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .background(BisqTheme.colors.dark_grey40)
+                .padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPadding),
+        horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.size(BisqUIConstants.ScreenPadding3X).background(BisqTheme.colors.dark_grey50, shape = CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            QuestionIcon(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            BisqText.BaseMedium(text = "mobile.community.support.needHelp".i18n(), color = BisqTheme.colors.white)
+            BisqText.SmallLight(text = "mobile.community.support.openChannel".i18n(), color = BisqTheme.colors.mid_grey20)
+        }
+        ArrowRightIcon()
+    }
+}
+
+@Composable
+private fun CommunitySegment.label(): String =
+    when (this) {
+        CommunitySegment.DISCUSSIONS -> "mobile.community.tab.discussions".i18n()
+        CommunitySegment.MESSAGES -> "mobile.community.tab.messages".i18n()
+        CommunitySegment.CONTACTS -> "mobile.community.tab.contacts".i18n()
+    }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubUiState.kt
@@ -1,0 +1,23 @@
+package network.bisq.mobile.presentation.community
+
+import network.bisq.mobile.domain.service.community.CommunitySegment
+
+/**
+ * @param liveSegments the segments the hub may render, in tab order. The segmented tab row
+ *   only renders when there is more than one — a single-segment row would be a control with
+ *   nothing to control.
+ * @param selectedSegment the segment whose content fills the hub body; null when nothing is
+ *   live (the hub then shows its empty state).
+ */
+data class CommunityHubUiState(
+    val liveSegments: List<CommunitySegment> = emptyList(),
+    val selectedSegment: CommunitySegment? = null,
+)
+
+sealed interface CommunityHubUiAction {
+    data class OnSegmentSelect(
+        val segment: CommunitySegment,
+    ) : CommunityHubUiAction
+
+    data object OnOpenSupportChannel : CommunityHubUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -98,6 +98,8 @@ abstract class MiscItemsPresenter(
             )
         val appMenuItems = addCustomSettings(appItems).toMutableList()
         // TODO remove this dev-only entry once the Community top-bar entry point ships.
+        // Debug-only by construction: the backing build property is forced empty in
+        // release builds.
         if (communityDevPreviewVisible()) {
             appMenuItems.add(
                 MenuItem(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
-import network.bisq.mobile.domain.service.community.CommunityHubState
+import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -133,7 +133,7 @@ abstract class MiscItemsPresenter(
      * in a developer's local.properties. Overridable so tests stay independent of the
      * developer's local build configuration.
      */
-    protected open fun communityDevPreviewVisible(): Boolean = CommunityHubState.devForcedSegmentsFromBuildConfig().isNotEmpty()
+    protected open fun communityDevPreviewVisible(): Boolean = CommunityHubService.devForcedSegmentsFromBuildConfig().isNotEmpty()
 
     fun onAction(action: MiscItemsUiAction) {
         when (action) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.presentation.tabs.more
 
 import bisqapps.shared.presentation.generated.resources.Res
+import bisqapps.shared.presentation.generated.resources.icon_chat_outlined
 import bisqapps.shared.presentation.generated.resources.icon_question_mark
 import bisqapps.shared.presentation.generated.resources.nav_accounts
 import bisqapps.shared.presentation.generated.resources.nav_ignored_users
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
+import network.bisq.mobile.domain.service.community.CommunityHubState
 import network.bisq.mobile.i18n.UiString
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -95,6 +97,18 @@ abstract class MiscItemsPresenter(
                 ),
             )
         val appMenuItems = addCustomSettings(appItems).toMutableList()
+        // TODO remove this dev-only entry once the Community top-bar entry point ships.
+        // Only visible when feature.communityHubDevSegments is set, which defaults empty
+        // and is only overridden in a developer's local.properties.
+        if (CommunityHubState.devForcedSegmentsFromBuildConfig().isNotEmpty()) {
+            appMenuItems.add(
+                MenuItem(
+                    label = UiString("mobile.more.communityDevPreview"),
+                    icon = Res.drawable.icon_chat_outlined,
+                    route = NavRoute.CommunityHub,
+                ),
+            )
+        }
         if (showNetwork) {
             appMenuItems.add(
                 appMenuItems.size.coerceAtMost(2),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/more/MiscItemsPresenter.kt
@@ -98,9 +98,7 @@ abstract class MiscItemsPresenter(
             )
         val appMenuItems = addCustomSettings(appItems).toMutableList()
         // TODO remove this dev-only entry once the Community top-bar entry point ships.
-        // Only visible when feature.communityHubDevSegments is set, which defaults empty
-        // and is only overridden in a developer's local.properties.
-        if (CommunityHubState.devForcedSegmentsFromBuildConfig().isNotEmpty()) {
+        if (communityDevPreviewVisible()) {
             appMenuItems.add(
                 MenuItem(
                     label = UiString("mobile.more.communityDevPreview"),
@@ -126,6 +124,14 @@ abstract class MiscItemsPresenter(
             MenuSection(title = UiString("mobile.more.section.app"), items = appMenuItems),
         )
     }
+
+    /**
+     * Whether the dev-only Community hub entry shows. Only true when
+     * feature.communityHubDevSegments is set, which defaults empty and is only overridden
+     * in a developer's local.properties. Overridable so tests stay independent of the
+     * developer's local build configuration.
+     */
+    protected open fun communityDevPreviewVisible(): Boolean = CommunityHubState.devForcedSegmentsFromBuildConfig().isNotEmpty()
 
     fun onAction(action: MiscItemsUiAction) {
         when (action) {


### PR DESCRIPTION
 - contribs to #1743  (PR 2/3)
 - implemented scaffolding for community hub features
 - entry point is temporarily in More > App
 - gated per-tab UI feature with default empty to avoid interfering releases whilst feature is developed, and also allow per tab releases
 - added comments and AI generated tests
 - designs cleanup will be done on last PR
 
 ### Screenshots
 
<img width="332" height="686" alt="Screenshot 2026-08-19 at 16 04 16" src="https://github.com/user-attachments/assets/055ae237-e635-4eeb-96ec-c5014f85ee3b" />
<img width="343" height="698" alt="Screenshot 2026-08-19 at 16 51 42" src="https://github.com/user-attachments/assets/29eb5046-3d68-4f76-97fe-2d9993d022c2" />
<img width="347" height="707" alt="Screenshot 2026-08-19 at 16 51 35" src="https://github.com/user-attachments/assets/2ef1c941-f7ed-4b5b-a6b7-17b46d28d500" />
<img width="348" height="694" alt="Screenshot 2026-08-19 at 16 51 29" src="https://github.com/user-attachments/assets/5401a4e2-5736-4392-8849-8e1332dbf021" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Community Hub screen with Discussions, Messages, and Contacts sections.
  - Added support-channel access and “Coming soon” messaging where content is unavailable.
  - Added Community Hub navigation from the app’s settings and More menu.
  - Community Hub sections now appear based on feature availability and development preview settings.

- **Improvements**
  - Added localized labels and messaging for Community Hub features.
  - Improved handling of unavailable sections and selection fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->