### PR TITLE
fix(tradeHistory): open the peer profile when the history card's avatar is tapped

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/components/ClosedTradeListCardUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/components/ClosedTradeListCardUiTest.kt
@@ -1,0 +1,109 @@
+package network.bisq.mobile.presentation.tabs.my_trades.closed.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
+import network.bisq.mobile.domain.model.trade.TradeOutcome
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.rememberStarPainters
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The whole card is a tap target — it opens the trade details — so the peer profile link must stay
+ * confined to the avatar. The first two tests pin both halves of that split.
+ */
+class ClosedTradeListCardUiTest : PresentationKoinComposeTestBase() {
+    private val peerName = "Satoshi"
+
+    private var detailsOpened = false
+    private var peerProfileOpened = false
+
+    private fun tradeWith(outcome: TradeOutcome): ClosedTradeListItem =
+        sampleClosedTrade(
+            tradeId = "t-abc123def456ghi789",
+            peerName = peerName,
+            reputation = ReputationScoreVO(totalScore = 1200L, fiveSystemScore = 4.5, ranking = 12),
+            fiatPaymentMethod = "SEPA",
+            bitcoinSettlementMethod = "MAIN_CHAIN",
+            isMaker = false,
+            isBuyer = true,
+            outcome = outcome,
+            takeOfferDate = 1_743_000_000_000L,
+            quoteAmount = 34210L,
+        )
+
+    private fun renderCard(outcome: TradeOutcome = TradeOutcome.COMPLETED) {
+        setTestContent {
+            ClosedTradeListCard(
+                item = tradeWith(outcome),
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onClick = { detailsOpened = true },
+                onPeerProfileClick = { peerProfileOpened = true },
+            )
+        }
+    }
+
+    @Test
+    fun `when the peer avatar is tapped then the peer profile is opened`() {
+        renderCard()
+
+        composeTestRule.onNodeWithContentDescription("mobile.createProfile.iconGenerated".i18n()).performClick()
+        composeTestRule.waitForIdle()
+
+        assertTrue(peerProfileOpened)
+        assertFalse(detailsOpened)
+    }
+
+    @Test
+    fun `when the card is tapped outside the avatar then the trade details are opened`() {
+        renderCard()
+
+        // The peer's name sits directly beside the avatar — the likeliest mis-tap.
+        composeTestRule.onNodeWithText(peerName).performClick()
+        composeTestRule.waitForIdle()
+
+        assertTrue(detailsOpened)
+        assertFalse(peerProfileOpened)
+    }
+
+    /**
+     * The outcome drives both the badge label and the card's accent colour, and nothing pinned that
+     * mapping until now. All four render in one composition — [setTestContent] wraps `setContent`,
+     * which a test may only call once.
+     */
+    @Test
+    fun `each outcome renders its own badge label`() {
+        val outcomes =
+            listOf(
+                TradeOutcome.COMPLETED to "mobile.tradeHistory.outcome.completed",
+                TradeOutcome.CANCELLED to "mobile.tradeHistory.outcome.cancelled",
+                TradeOutcome.REJECTED to "mobile.tradeHistory.outcome.rejected",
+                TradeOutcome.FAILED to "mobile.tradeHistory.outcome.failed",
+            )
+
+        setTestContent {
+            Column {
+                outcomes.forEach { (outcome, _) ->
+                    ClosedTradeListCard(
+                        item = tradeWith(outcome),
+                        userProfileIconProvider = { createEmptyImage() },
+                        starPainters = rememberStarPainters(),
+                        onPeerProfileClick = {},
+                    )
+                }
+            }
+        }
+
+        outcomes.forEach { (_, labelKey) ->
+            composeTestRule.onNodeWithText(labelKey.i18n()).assertExists()
+        }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/open_trades/ClosedTradeListPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/open_trades/ClosedTradeListPresenterTest.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.tabs.open_trades
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
@@ -15,6 +16,7 @@ import network.bisq.mobile.domain.model.trade.TradeSort
 import network.bisq.mobile.domain.usecase.trade.GetPaginatedClosedTradesUseCase
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.error.GenericErrorHandler
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.tabs.my_trades.closed.ClosedTradeListPresenter
 import network.bisq.mobile.presentation.tabs.my_trades.closed.ClosedTradeListUiAction
@@ -194,5 +196,16 @@ class ClosedTradeListPresenterTest : PresentationKoinTestBase() {
         // State update is immediate — the debounce only affects pager requery
         presenter.onAction(ClosedTradeListUiAction.OnSortChange(TradeSort.AMOUNT_HIGH_LOW))
         assertEquals(TradeSort.AMOUNT_HIGH_LOW, presenter.uiState.value.sortBy)
+    }
+
+    // -----------------------------------------------------------------------
+    // OnPeerProfileClick
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `OnPeerProfileClick navigates to PeerProfile`() {
+        presenter.onAction(ClosedTradeListUiAction.OnPeerProfileClick("peer-1"))
+
+        verify { navigationManager.navigate(NavRoute.PeerProfile("peer-1"), any(), any()) }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListPresenter.kt
@@ -121,6 +121,9 @@ class ClosedTradeListPresenter(
             is ClosedTradeListUiAction.OnSelectTrade ->
                 _uiState.update { it.copy(selectedTradeForDetails = action.item) }
 
+            is ClosedTradeListUiAction.OnPeerProfileClick ->
+                navigateTo(NavRoute.PeerProfile(action.profileId))
+
             ClosedTradeListUiAction.OnDismissDetails ->
                 _uiState.update { it.copy(selectedTradeForDetails = null) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListScreen.kt
@@ -1,12 +1,10 @@
 package network.bisq.mobile.presentation.tabs.my_trades.closed
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -23,10 +21,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
@@ -34,29 +28,20 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
-import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
-import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
-import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
-import network.bisq.mobile.data.utils.PlatformImage
-import network.bisq.mobile.data.utils.createEmptyImage
-import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
-import network.bisq.mobile.domain.model.trade.TradeOutcome
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.ListStateSection
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
-import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
-import network.bisq.mobile.presentation.common.ui.components.atoms.StarPainters
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.atoms.rememberStarPainters
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqStaticLayout
-import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethods
-import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileRow
 import network.bisq.mobile.presentation.common.ui.components.molecules.inputfield.SearchWithFilterField
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.tabs.my_trades.closed.components.ClosedTradeListCard
 import network.bisq.mobile.presentation.tabs.my_trades.closed.components.ClosedTradeListFilterSheet
 import network.bisq.mobile.presentation.tabs.my_trades.closed.components.TradeDetailsDialog
 import network.bisq.mobile.presentation.tabs.my_trades.shared.TradeResultBar
@@ -175,6 +160,9 @@ fun ClosedTradeListScreen() {
                             userProfileIconProvider = presenter.userProfileIconProvider,
                             starPainters = starPainters,
                             onClick = { presenter.onAction(ClosedTradeListUiAction.OnSelectTrade(item)) },
+                            onPeerProfileClick = {
+                                presenter.onAction(ClosedTradeListUiAction.OnPeerProfileClick(item.peersUserProfile.id))
+                            },
                         )
                     }
                 }
@@ -182,142 +170,6 @@ fun ClosedTradeListScreen() {
         }
     }
 }
-
-@Composable
-private fun ClosedTradeListCard(
-    item: ClosedTradeListItem,
-    userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
-    starPainters: StarPainters,
-    onClick: () -> Unit = {},
-) {
-    val borderColor = outcomeColor(item.outcome)
-    val borderWidth = 4.dp
-    val borderRadius = BisqUIConstants.BorderRadius
-    val cardBackground = BisqTheme.colors.dark_grey30
-    val shape =
-        RoundedCornerShape(
-            topStart = 0.dp,
-            bottomStart = 0.dp,
-            topEnd = borderRadius,
-            bottomEnd = borderRadius,
-        )
-
-    val outcomeLabel =
-        when (item.outcome) {
-            TradeOutcome.COMPLETED -> "mobile.tradeHistory.outcome.completed".i18n()
-            TradeOutcome.CANCELLED -> "mobile.tradeHistory.outcome.cancelled".i18n()
-            TradeOutcome.REJECTED -> "mobile.tradeHistory.outcome.rejected".i18n()
-            TradeOutcome.FAILED -> "mobile.tradeHistory.outcome.failed".i18n()
-        }
-    val fiatColor =
-        if (item.outcome == TradeOutcome.COMPLETED) BisqTheme.colors.primary else BisqTheme.colors.mid_grey30
-    val badgeBackground = borderColor.copy(alpha = 0.10f)
-
-    Column(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(shape)
-                .background(cardBackground)
-                .drawBehind {
-                    drawLine(
-                        color = borderColor,
-                        start = Offset(0f, 0f),
-                        end = Offset(0f, size.height),
-                        strokeWidth = borderWidth.toPx(),
-                    )
-                }.clickable(onClick = onClick)
-                .padding(BisqUIConstants.ScreenPadding),
-        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
-    ) {
-        // Outcome badge — tinted pill with 3dp colored left accent line + role label
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(BisqUIConstants.BorderRadiusSmall))
-                    .background(badgeBackground)
-                    .padding(
-                        horizontal = BisqUIConstants.ScreenPadding,
-                        vertical = BisqUIConstants.ScreenPaddingQuarter,
-                    ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(width = 3.dp, height = 14.dp)
-                            .clip(RoundedCornerShape(2.dp))
-                            .background(borderColor),
-                )
-                BisqText.SmallRegular(text = outcomeLabel, color = borderColor)
-            }
-            BisqText.XSmallLight(text = item.myRoleWithDirection, color = BisqTheme.colors.mid_grey20)
-        }
-
-        BisqGap.VQuarter()
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
-            ) {
-                BisqText.SmallLightGrey(item.directionalTitle.uppercase())
-                UserProfileRow(
-                    userProfile = item.peersUserProfile,
-                    reputation = item.peersReputationScore,
-                    userProfileIconProvider = userProfileIconProvider,
-                    showUserName = true,
-                    starPainters = starPainters,
-                )
-                BisqText.SmallLightGrey(item.formattedDateTime)
-                BisqText.SmallLightGrey("Trade #${item.shortTradeId}")
-            }
-            Column(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(top = 2.dp),
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
-            ) {
-                val formattedPrice = item.formattedPriceWithCode
-                BisqText.LargeRegular(text = item.formattedQuoteAmountWithCode, color = fiatColor)
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    BisqText.SmallRegularGrey("@ ")
-                    if (formattedPrice.length > 16) {
-                        BisqText.XSmallRegular(formattedPrice)
-                    } else {
-                        BisqText.SmallRegular(formattedPrice)
-                    }
-                }
-                BtcSatsText(item.formattedBaseAmount)
-                PaymentMethods(
-                    baseSidePaymentMethods = listOf(item.bitcoinSettlementMethod),
-                    quoteSidePaymentMethods = listOf(item.fiatPaymentMethod),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun outcomeColor(outcome: TradeOutcome): Color =
-    when (outcome) {
-        TradeOutcome.COMPLETED -> BisqTheme.colors.primary
-        TradeOutcome.CANCELLED -> BisqTheme.colors.danger
-        TradeOutcome.REJECTED -> BisqTheme.colors.danger
-        TradeOutcome.FAILED -> BisqTheme.colors.warning
-    }
 
 @Composable
 private fun ShimmerCard() {
@@ -451,221 +303,8 @@ private fun ClosedTradeListErrorState(
 }
 
 // -------------------------------------------------------------------------------------
-// Preview samples
-// -------------------------------------------------------------------------------------
-
-private fun sampleClosedTrade(
-    tradeId: String,
-    peerName: String,
-    reputation: ReputationScoreVO,
-    fiatPaymentMethod: String,
-    bitcoinSettlementMethod: String,
-    isMaker: Boolean,
-    isBuyer: Boolean,
-    outcome: TradeOutcome,
-    takeOfferDate: Long,
-    quoteAmount: Long,
-): ClosedTradeListItem =
-    ClosedTradeListItem(
-        tradeId = tradeId,
-        peersUserProfile = createMockUserProfile(peerName),
-        peersReputationScore = reputation,
-        myUserProfile = createMockUserProfile("Me"),
-        priceQuote = null,
-        fiatPaymentMethod = fiatPaymentMethod,
-        bitcoinSettlementMethod = bitcoinSettlementMethod,
-        isMaker = isMaker,
-        isBuyer = isBuyer,
-        outcome = outcome,
-        takeOfferDate = takeOfferDate,
-        tradeCompletedDate = null,
-        baseAmount = 0L,
-        quoteAmount = quoteAmount,
-        paymentAccountData = null,
-        bitcoinPaymentData = null,
-        paymentProof = null,
-    )
-
-private val sampleCompletedBuyerTrade =
-    sampleClosedTrade(
-        tradeId = "t-abc123def456ghi789",
-        peerName = "SatoshiFan42",
-        reputation = ReputationScoreVO(totalScore = 1200L, fiveSystemScore = 4.5, ranking = 12),
-        fiatPaymentMethod = "SEPA",
-        bitcoinSettlementMethod = "MAIN_CHAIN",
-        isMaker = false,
-        isBuyer = true,
-        outcome = TradeOutcome.COMPLETED,
-        takeOfferDate = 1_743_000_000_000L,
-        quoteAmount = 34210L,
-    )
-
-private val sampleCompletedSellerTrade =
-    sampleClosedTrade(
-        tradeId = "t-xyz789abc123def456",
-        peerName = "LightningLover99",
-        reputation = ReputationScoreVO(totalScore = 800L, fiveSystemScore = 3.0, ranking = 45),
-        fiatPaymentMethod = "REVOLUT",
-        bitcoinSettlementMethod = "LN",
-        isMaker = true,
-        isBuyer = false,
-        outcome = TradeOutcome.COMPLETED,
-        takeOfferDate = 1_742_800_000_000L,
-        quoteAmount = 82000L,
-    )
-
-private val sampleCancelledTrade =
-    sampleClosedTrade(
-        tradeId = "t-can000def456ghi789",
-        peerName = "CryptoNovice7",
-        reputation = ReputationScoreVO(totalScore = 200L, fiveSystemScore = 1.5, ranking = 200),
-        fiatPaymentMethod = "ZELLE",
-        bitcoinSettlementMethod = "MAIN_CHAIN",
-        isMaker = false,
-        isBuyer = true,
-        outcome = TradeOutcome.CANCELLED,
-        takeOfferDate = 1_742_700_000_000L,
-        quoteAmount = 20000L,
-    )
-
-private val sampleRejectedTrade =
-    sampleClosedTrade(
-        tradeId = "t-rej001abc123def456",
-        peerName = "FreshTrader",
-        reputation = ReputationScoreVO(totalScore = 0L, fiveSystemScore = 0.0, ranking = 999),
-        fiatPaymentMethod = "SEPA_INSTANT",
-        bitcoinSettlementMethod = "LN",
-        isMaker = false,
-        isBuyer = false,
-        outcome = TradeOutcome.REJECTED,
-        takeOfferDate = 1_742_500_000_000L,
-        quoteAmount = 50000L,
-    )
-
-private val sampleFailedTrade =
-    sampleClosedTrade(
-        tradeId = "t-fail002ghi789abc12",
-        peerName = "NodeOp_Berlin",
-        reputation = ReputationScoreVO(totalScore = 950L, fiveSystemScore = 4.0, ranking = 33),
-        fiatPaymentMethod = "TWINT",
-        bitcoinSettlementMethod = "MAIN_CHAIN",
-        isMaker = true,
-        isBuyer = true,
-        outcome = TradeOutcome.FAILED,
-        takeOfferDate = 1_742_300_000_000L,
-        quoteAmount = 15000L,
-    )
-
-// -------------------------------------------------------------------------------------
 // Previews
 // -------------------------------------------------------------------------------------
-
-@ExcludeFromCoverage
-@Preview(showBackground = true)
-@Composable
-private fun Card_Completed_Buyer_Preview() {
-    BisqTheme.Preview {
-        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
-            ClosedTradeListCard(
-                item = sampleCompletedBuyerTrade,
-                userProfileIconProvider = { createEmptyImage() },
-                starPainters = rememberStarPainters(),
-            )
-        }
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(showBackground = true)
-@Composable
-private fun Card_Completed_Seller_Preview() {
-    BisqTheme.Preview {
-        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
-            ClosedTradeListCard(
-                item = sampleCompletedSellerTrade,
-                userProfileIconProvider = { createEmptyImage() },
-                starPainters = rememberStarPainters(),
-            )
-        }
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(showBackground = true)
-@Composable
-private fun Card_Cancelled_Preview() {
-    BisqTheme.Preview {
-        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
-            ClosedTradeListCard(
-                item = sampleCancelledTrade,
-                userProfileIconProvider = { createEmptyImage() },
-                starPainters = rememberStarPainters(),
-            )
-        }
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(showBackground = true)
-@Composable
-private fun Card_Rejected_Preview() {
-    BisqTheme.Preview {
-        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
-            ClosedTradeListCard(
-                item = sampleRejectedTrade,
-                userProfileIconProvider = { createEmptyImage() },
-                starPainters = rememberStarPainters(),
-            )
-        }
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(showBackground = true)
-@Composable
-private fun Card_Failed_Preview() {
-    BisqTheme.Preview {
-        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
-            ClosedTradeListCard(
-                item = sampleFailedTrade,
-                userProfileIconProvider = { createEmptyImage() },
-                starPainters = rememberStarPainters(),
-            )
-        }
-    }
-}
-
-@ExcludeFromCoverage
-@Preview(showBackground = true, heightDp = 700)
-@Composable
-private fun List_MixedOutcomes_Preview() {
-    val items =
-        listOf(
-            sampleCompletedBuyerTrade,
-            sampleCompletedSellerTrade,
-            sampleCancelledTrade,
-            sampleRejectedTrade,
-            sampleFailedTrade,
-        )
-    BisqTheme.Preview {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(BisqTheme.colors.backgroundColor)
-                    .padding(BisqUIConstants.ScreenPadding),
-            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
-        ) {
-            items.forEach {
-                ClosedTradeListCard(
-                    item = it,
-                    userProfileIconProvider = { createEmptyImage() },
-                    starPainters = rememberStarPainters(),
-                )
-            }
-        }
-    }
-}
 
 @ExcludeFromCoverage
 @Preview(showBackground = true, heightDp = 500)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/ClosedTradeListUiAction.kt
@@ -14,6 +14,10 @@ sealed interface ClosedTradeListUiAction {
         val item: ClosedTradeListItem,
     ) : ClosedTradeListUiAction
 
+    data class OnPeerProfileClick(
+        val profileId: String,
+    ) : ClosedTradeListUiAction
+
     data object OnDismissDetails : ClosedTradeListUiAction
 
     data object OnShowFilterSheet : ClosedTradeListUiAction

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/components/ClosedTradeListCard.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/closed/components/ClosedTradeListCard.kt
@@ -1,0 +1,419 @@
+package network.bisq.mobile.presentation.tabs.my_trades.closed.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.data.utils.createEmptyImage
+import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
+import network.bisq.mobile.domain.model.trade.TradeOutcome
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
+import network.bisq.mobile.presentation.common.ui.components.atoms.StarPainters
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.components.atoms.rememberStarPainters
+import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethods
+import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileRow
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+
+@ExcludeFromCoverage
+@Composable
+fun ClosedTradeListCard(
+    item: ClosedTradeListItem,
+    userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
+    starPainters: StarPainters,
+    onClick: () -> Unit = {},
+    onPeerProfileClick: () -> Unit,
+) {
+    val borderColor = outcomeColor(item.outcome)
+    val borderWidth = 4.dp
+    val borderRadius = BisqUIConstants.BorderRadius
+    val cardBackground = BisqTheme.colors.dark_grey30
+    val shape =
+        RoundedCornerShape(
+            topStart = 0.dp,
+            bottomStart = 0.dp,
+            topEnd = borderRadius,
+            bottomEnd = borderRadius,
+        )
+
+    val outcomeLabel =
+        when (item.outcome) {
+            TradeOutcome.COMPLETED -> "mobile.tradeHistory.outcome.completed".i18n()
+            TradeOutcome.CANCELLED -> "mobile.tradeHistory.outcome.cancelled".i18n()
+            TradeOutcome.REJECTED -> "mobile.tradeHistory.outcome.rejected".i18n()
+            TradeOutcome.FAILED -> "mobile.tradeHistory.outcome.failed".i18n()
+        }
+    val fiatColor =
+        if (item.outcome == TradeOutcome.COMPLETED) BisqTheme.colors.primary else BisqTheme.colors.mid_grey30
+    val badgeBackground = borderColor.copy(alpha = 0.10f)
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(shape)
+                .background(cardBackground)
+                .drawBehind {
+                    drawLine(
+                        color = borderColor,
+                        start = Offset(0f, 0f),
+                        end = Offset(0f, size.height),
+                        strokeWidth = borderWidth.toPx(),
+                    )
+                }.clickable(onClick = onClick)
+                .padding(BisqUIConstants.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+    ) {
+        // Outcome badge — tinted pill with 3dp colored left accent line + role label
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(BisqUIConstants.BorderRadiusSmall))
+                    .background(badgeBackground)
+                    .padding(
+                        horizontal = BisqUIConstants.ScreenPadding,
+                        vertical = BisqUIConstants.ScreenPaddingQuarter,
+                    ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(width = 3.dp, height = 14.dp)
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(borderColor),
+                )
+                BisqText.SmallRegular(text = outcomeLabel, color = borderColor)
+            }
+            BisqText.XSmallLight(text = item.myRoleWithDirection, color = BisqTheme.colors.mid_grey20)
+        }
+
+        BisqGap.VQuarter()
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                BisqText.SmallLightGrey(item.directionalTitle.uppercase())
+                UserProfileRow(
+                    userProfile = item.peersUserProfile,
+                    reputation = item.peersReputationScore,
+                    userProfileIconProvider = userProfileIconProvider,
+                    showUserName = true,
+                    starPainters = starPainters,
+                    onIconClick = onPeerProfileClick,
+                )
+                BisqText.SmallLightGrey(item.formattedDateTime)
+                BisqText.SmallLightGrey("Trade #${item.shortTradeId}")
+            }
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(top = 2.dp),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),
+            ) {
+                val formattedPrice = item.formattedPriceWithCode
+                BisqText.LargeRegular(text = item.formattedQuoteAmountWithCode, color = fiatColor)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    BisqText.SmallRegularGrey("@ ")
+                    if (formattedPrice.length > 16) {
+                        BisqText.XSmallRegular(formattedPrice)
+                    } else {
+                        BisqText.SmallRegular(formattedPrice)
+                    }
+                }
+                BtcSatsText(item.formattedBaseAmount)
+                PaymentMethods(
+                    baseSidePaymentMethods = listOf(item.bitcoinSettlementMethod),
+                    quoteSidePaymentMethods = listOf(item.fiatPaymentMethod),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun outcomeColor(outcome: TradeOutcome): Color =
+    when (outcome) {
+        TradeOutcome.COMPLETED -> BisqTheme.colors.primary
+        TradeOutcome.CANCELLED -> BisqTheme.colors.danger
+        TradeOutcome.REJECTED -> BisqTheme.colors.danger
+        TradeOutcome.FAILED -> BisqTheme.colors.warning
+    }
+
+// -------------------------------------------------------------------------------------
+// Preview samples
+// -------------------------------------------------------------------------------------
+
+internal fun sampleClosedTrade(
+    tradeId: String,
+    peerName: String,
+    reputation: ReputationScoreVO,
+    fiatPaymentMethod: String,
+    bitcoinSettlementMethod: String,
+    isMaker: Boolean,
+    isBuyer: Boolean,
+    outcome: TradeOutcome,
+    takeOfferDate: Long,
+    quoteAmount: Long,
+): ClosedTradeListItem =
+    ClosedTradeListItem(
+        tradeId = tradeId,
+        peersUserProfile = createMockUserProfile(peerName),
+        peersReputationScore = reputation,
+        myUserProfile = createMockUserProfile("Me"),
+        priceQuote = null,
+        fiatPaymentMethod = fiatPaymentMethod,
+        bitcoinSettlementMethod = bitcoinSettlementMethod,
+        isMaker = isMaker,
+        isBuyer = isBuyer,
+        outcome = outcome,
+        takeOfferDate = takeOfferDate,
+        tradeCompletedDate = null,
+        baseAmount = 0L,
+        quoteAmount = quoteAmount,
+        paymentAccountData = null,
+        bitcoinPaymentData = null,
+        paymentProof = null,
+    )
+
+private val sampleCompletedBuyerTrade =
+    sampleClosedTrade(
+        tradeId = "t-abc123def456ghi789",
+        peerName = "SatoshiFan42",
+        reputation = ReputationScoreVO(totalScore = 1200L, fiveSystemScore = 4.5, ranking = 12),
+        fiatPaymentMethod = "SEPA",
+        bitcoinSettlementMethod = "MAIN_CHAIN",
+        isMaker = false,
+        isBuyer = true,
+        outcome = TradeOutcome.COMPLETED,
+        takeOfferDate = 1_743_000_000_000L,
+        quoteAmount = 34210L,
+    )
+
+private val sampleCompletedSellerTrade =
+    sampleClosedTrade(
+        tradeId = "t-xyz789abc123def456",
+        peerName = "LightningLover99",
+        reputation = ReputationScoreVO(totalScore = 800L, fiveSystemScore = 3.0, ranking = 45),
+        fiatPaymentMethod = "REVOLUT",
+        bitcoinSettlementMethod = "LN",
+        isMaker = true,
+        isBuyer = false,
+        outcome = TradeOutcome.COMPLETED,
+        takeOfferDate = 1_742_800_000_000L,
+        quoteAmount = 82000L,
+    )
+
+private val sampleCancelledTrade =
+    sampleClosedTrade(
+        tradeId = "t-can000def456ghi789",
+        peerName = "CryptoNovice7",
+        reputation = ReputationScoreVO(totalScore = 200L, fiveSystemScore = 1.5, ranking = 200),
+        fiatPaymentMethod = "ZELLE",
+        bitcoinSettlementMethod = "MAIN_CHAIN",
+        isMaker = false,
+        isBuyer = true,
+        outcome = TradeOutcome.CANCELLED,
+        takeOfferDate = 1_742_700_000_000L,
+        quoteAmount = 20000L,
+    )
+
+private val sampleRejectedTrade =
+    sampleClosedTrade(
+        tradeId = "t-rej001abc123def456",
+        peerName = "FreshTrader",
+        reputation = ReputationScoreVO(totalScore = 0L, fiveSystemScore = 0.0, ranking = 999),
+        fiatPaymentMethod = "SEPA_INSTANT",
+        bitcoinSettlementMethod = "LN",
+        isMaker = false,
+        isBuyer = false,
+        outcome = TradeOutcome.REJECTED,
+        takeOfferDate = 1_742_500_000_000L,
+        quoteAmount = 50000L,
+    )
+
+private val sampleFailedTrade =
+    sampleClosedTrade(
+        tradeId = "t-fail002ghi789abc12",
+        peerName = "NodeOp_Berlin",
+        reputation = ReputationScoreVO(totalScore = 950L, fiveSystemScore = 4.0, ranking = 33),
+        fiatPaymentMethod = "TWINT",
+        bitcoinSettlementMethod = "MAIN_CHAIN",
+        isMaker = true,
+        isBuyer = true,
+        outcome = TradeOutcome.FAILED,
+        takeOfferDate = 1_742_300_000_000L,
+        quoteAmount = 15000L,
+    )
+
+// -------------------------------------------------------------------------------------
+// Previews
+// -------------------------------------------------------------------------------------
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Completed_Buyer_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            ClosedTradeListCard(
+                item = sampleCompletedBuyerTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Completed_Seller_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            ClosedTradeListCard(
+                item = sampleCompletedSellerTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Cancelled_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            ClosedTradeListCard(
+                item = sampleCancelledTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Rejected_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            ClosedTradeListCard(
+                item = sampleRejectedTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true)
+@Composable
+private fun Card_Failed_Preview() {
+    BisqTheme.Preview {
+        Column(modifier = Modifier.padding(BisqUIConstants.ScreenPadding)) {
+            ClosedTradeListCard(
+                item = sampleFailedTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+private fun List_MixedOutcomes_Preview() {
+    // The samples are referenced directly rather than gathered into a local list: a lambda that
+    // captures nothing is hoisted into ComposableSingletons, which is what lets @ExcludeFromCoverage
+    // reach this body. Capturing a local would put these lines back in the coverage gate.
+    BisqTheme.Preview {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(BisqTheme.colors.backgroundColor)
+                    .padding(BisqUIConstants.ScreenPadding),
+            verticalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+        ) {
+            ClosedTradeListCard(
+                item = sampleCompletedBuyerTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+            ClosedTradeListCard(
+                item = sampleCompletedSellerTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+            ClosedTradeListCard(
+                item = sampleCancelledTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+            ClosedTradeListCard(
+                item = sampleRejectedTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+            ClosedTradeListCard(
+                item = sampleFailedTrade,
+                userProfileIconProvider = { createEmptyImage() },
+                starPainters = rememberStarPainters(),
+                onPeerProfileClick = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
resolves: https://github.com/bisq-network/bisq-mobile/issues/1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated cards for closed trades, displaying outcomes, peer details, trade information, pricing, and payment methods.
  * Peer avatars can be selected to open the peer’s profile.
  * Added visual labels and color treatments for completed, cancelled, rejected, and failed trades.

* **Bug Fixes**
  * Improved closed-trade card and peer-profile navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->