### PR TITLE
bugfix/sync_initial_data_load_stucked_on_node_r8d8_issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools:r8:9.4.12")
+//        FIXME causing initial data process to get stuck forever - seems to be D8/R8 desugaring issue
+//        classpath("com.android.tools:r8:9.4.12")
     }
 }
 


### PR DESCRIPTION
 - resolves #1757 
 - commented out android tools pinning to version r8:9.4.12 until we figure out a proper solution