### PR TITLE
bugfix/repairing_to_new_trusted_node_should_wipe_backend_capabilities_data_as_well

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
@@ -3,8 +3,10 @@ package network.bisq.mobile.client.common.domain.service.config
 import io.ktor.http.HttpStatusCode
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.client.common.domain.httpclient.BisqProxyOption
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettings
@@ -33,9 +35,12 @@ class ClientConfigServiceFacadeTest : ClientKoinIntegrationTestBase() {
     private val version = "2.1.12"
     private val fetched = TradeAmountLimitsVO.DEFAULT.copy(tolerance = 0.1, requiredReputationScorePerUsd = 150.0)
 
+    private val settingsFlow =
+        MutableStateFlow(SensitiveSettings(bisqApiUrl = "http://$host:8090", selectedProxyOption = BisqProxyOption.INTERNAL_TOR))
+
     override fun onSetup() {
-        coEvery { sensitiveSettingsRepository.fetch() } returns
-            SensitiveSettings(bisqApiUrl = "http://$host:8090", selectedProxyOption = BisqProxyOption.INTERNAL_TOR)
+        every { sensitiveSettingsRepository.data } returns settingsFlow
+        coEvery { sensitiveSettingsRepository.fetch() } coAnswers { settingsFlow.value }
         coEvery { settingsApiGateway.getApiVersion() } returns Result.success(ApiVersionSettingsVO(version))
         coEvery { configApiGateway.getTradeAmountLimits() } returns Result.success(fetched)
         coEvery { configApiGateway.getCapabilities() } returns Result.success(ApiCapabilitiesDto(version, emptyList()))
@@ -224,6 +229,41 @@ class ClientConfigServiceFacadeTest : ClientKoinIntegrationTestBase() {
             assertEquals(TradeAmountLimitsVO.DEFAULT, facade.tradeAmountLimits.value)
             assertNull(cacheRepository.get())
             coVerify(exactly = 0) { configApiGateway.getTradeAmountLimits() }
+        }
+
+    @Test
+    fun `re-pairing refetches the manifest even when host and version match the cache`() =
+        runTest {
+            // Cached manifest from before the node was updated in place: same host, same api
+            // version, but no private-chat yet.
+            cacheRepository.set(ConfigCacheEntry(hostHash, version, fetched, setOf(Feature.CLOSED_TRADES.key)))
+            val updated = setOf(Feature.CLOSED_TRADES.key, Feature.NETWORK_INFO.key)
+            coEvery { configApiGateway.getCapabilities() } returns Result.success(ApiCapabilitiesDto(version, updated.toList()))
+
+            facade.activate()
+            advanceUntilIdle()
+            coVerify(exactly = 0) { configApiGateway.getCapabilities() }
+
+            settingsFlow.value = settingsFlow.value.copy(clientId = "fresh-pairing")
+            advanceUntilIdle()
+
+            assertEquals(updated, facade.supportedFeatures.value)
+            coVerify(exactly = 1) { configApiGateway.getCapabilities() }
+            assertEquals(ConfigCacheEntry(hostHash, version, fetched, updated), cacheRepository.get())
+        }
+
+    @Test
+    fun `settings changes without a new client id do not drop the cache`() =
+        runTest {
+            cacheRepository.set(ConfigCacheEntry(hostHash, version, fetched, setOf(Feature.CLOSED_TRADES.key)))
+
+            facade.activate()
+            advanceUntilIdle()
+            settingsFlow.value = settingsFlow.value.copy(clientName = "renamed")
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { configApiGateway.getCapabilities() }
+            assertEquals(setOf(Feature.CLOSED_TRADES.key), facade.supportedFeatures.value)
         }
 }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
 import network.bisq.mobile.client.common.domain.service.settings.SettingsApiGateway
@@ -25,6 +28,11 @@ import network.bisq.mobile.domain.service.capabilities.Feature
  *  1. surface the cached values immediately for fast render;
  *  2. read the node's current API version; if it matches the cache we skip the fetches entirely;
  *  3. otherwise fetch, emit, and re-persist tagged with the new version.
+ *
+ * A completed (re-)pairing bypasses the version check: the node behind the same host and api version
+ * may have been updated in place with a different feature manifest, so pairing drops the cache and
+ * revalidates. Pairing is detected as a change of the server-issued client id, which every pairing
+ * renews — including a re-pair with the same node.
  *
  * Each field resolves independently. A genuine 404 is definitive: trade-amount limits fall back to
  * [TradeAmountLimitsVO.DEFAULT] (still usable), and the features manifest falls back to
@@ -49,7 +57,23 @@ class ClientConfigServiceFacade(
 
     override suspend fun activate() {
         super<ServiceFacade>.activate()
-        serviceScope.launch { loadConfig() }
+        serviceScope.launch {
+            // First emission is startup: load with the cache honored. Every later change of the
+            // client id is a completed (re-)pairing: drop the cache so the manifest is refetched
+            // even when host and api version are unchanged. collectLatest also cancels a load
+            // stranded by the pairing flow's connection churn once the new pairing lands.
+            var startedUp = false
+            sensitiveSettingsRepository.data
+                .map { it.clientId }
+                .distinctUntilChanged()
+                .collectLatest {
+                    if (startedUp) {
+                        runCatching { configCacheRepository.clear() }
+                    }
+                    startedUp = true
+                    loadConfig()
+                }
+        }
     }
 
     private suspend fun loadConfig() {


### PR DESCRIPTION
 - implemented sensitive backend data wipe when user deicides to switch to a different node (even if he ends up in the same one). This fixes backend capabilities gating update bug. implemented using TDD
 - found whilst testing private chat feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now reacts to client ID changes during device pairing.
  * Updated configuration data is fetched automatically after re-pairing.
  * Stale configuration loads are cancelled when connection settings change.

* **Bug Fixes**
  * Prevented unnecessary cache clearing and refetching when unrelated settings are updated.
  * Preserved cached configuration during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->