### PR TITLE
chore/docker_distros_release_pass_granular_versioning_version

### DIFF
--- a/.github/workflows/release-umbrel-images.yml
+++ b/.github/workflows/release-umbrel-images.yml
@@ -200,6 +200,8 @@ jobs:
           file: bisq2/apps/api-app/docker/Dockerfile
           platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
           push: true
+          build-args: |
+            IMAGE_VERSION=${{ needs.resolve.outputs.version }}
           tags: ${{ vars.GHCR_NAMESPACE }}/bisq2-api:${{ needs.resolve.outputs.version }}
           provenance: false
 

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacadeTest.kt
@@ -90,6 +90,51 @@ class ClientConfigServiceFacadeTest : ClientKoinIntegrationTestBase() {
         }
 
     @Test
+    fun `image version keys the cache instead of the api version when reported`() =
+        runTest {
+            // Cache from before the node reported an image version (or from a pre-imageVersion
+            // node build): the containerised node may have been rebuilt in place, so the core
+            // api version alone no longer proves freshness.
+            cacheRepository.set(ConfigCacheEntry(hostHash, version, fetched))
+            coEvery { settingsApiGateway.getApiVersion() } returns
+                Result.success(ApiVersionSettingsVO(version, imageVersion = "$version.2"))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            assertEquals(ConfigCacheEntry(hostHash, "$version.2", fetched), cacheRepository.get())
+            coVerify(exactly = 1) { configApiGateway.getTradeAmountLimits() }
+        }
+
+    @Test
+    fun `changed image version under an unchanged core version refetches`() =
+        runTest {
+            cacheRepository.set(ConfigCacheEntry(hostHash, "$version.1", fetched))
+            coEvery { settingsApiGateway.getApiVersion() } returns
+                Result.success(ApiVersionSettingsVO(version, imageVersion = "$version.2"))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            assertEquals(ConfigCacheEntry(hostHash, "$version.2", fetched), cacheRepository.get())
+            coVerify(exactly = 1) { configApiGateway.getTradeAmountLimits() }
+        }
+
+    @Test
+    fun `same image version hits cache and does not fetch`() =
+        runTest {
+            cacheRepository.set(ConfigCacheEntry(hostHash, "$version.2", fetched))
+            coEvery { settingsApiGateway.getApiVersion() } returns
+                Result.success(ApiVersionSettingsVO(version, imageVersion = "$version.2"))
+
+            facade.activate()
+            advanceUntilIdle()
+
+            assertEquals(fetched, facade.tradeAmountLimits.value)
+            coVerify(exactly = 0) { configApiGateway.getTradeAmountLimits() }
+        }
+
+    @Test
     fun `different host refetches even when version matches`() =
         runTest {
             cacheRepository.set(ConfigCacheEntry(hashTrustedNodeHost("other.onion"), version, fetched))

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
@@ -23,11 +23,15 @@ import network.bisq.mobile.domain.service.capabilities.Feature
  * Client implementation of [ConfigServiceFacade].
  *
  * Static config (trade-amount limits + the supported-features manifest) changes only with the trusted
- * node's API version, so we cache it on disk keyed by (node host, api version) and follow a
+ * node's version, so we cache it on disk keyed by (node host, node version) and follow a
  * stale-while-revalidate flow on [activate]:
  *  1. surface the cached values immediately for fast render;
- *  2. read the node's current API version; if it matches the cache we skip the fetches entirely;
+ *  2. read the node's current version; if it matches the cache we skip the fetches entirely;
  *  3. otherwise fetch, emit, and re-persist tagged with the new version.
+ *
+ * Containerised nodes report a per-image `imageVersion` that advances with every image release even
+ * when the core api version does not, so it is the freshness key when present; other nodes only have
+ * the api version.
  *
  * A completed (re-)pairing bypasses the version check: the node behind the same host and api version
  * may have been updated in place with a different feature manifest, so pairing drops the cache and
@@ -93,7 +97,7 @@ class ClientConfigServiceFacade(
             _supportedFeatures.value = it.supportedFeatures
         }
 
-        val version = settingsApiGateway.getApiVersion().getOrNull()?.version
+        val version = settingsApiGateway.getApiVersion().getOrNull()?.let { it.imageVersion ?: it.version }
         if (version == null) {
             // Node unreachable / version unknown — can't validate freshness. Keep the cached values (or
             // defaults) and retry on the next bootstrap.

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/settings/ApiVersionSettingsVO.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/settings/ApiVersionSettingsVO.kt
@@ -6,6 +6,9 @@ import network.bisq.mobile.client.shared.BuildConfig
 @Serializable
 data class ApiVersionSettingsVO(
     val version: String,
+    // Only reported by containerised nodes (docker distributions): the per-image release
+    // (e.g. 2.1.11.2), which advances even when the core version does not.
+    val imageVersion: String? = null,
 )
 
 val apiVersionSettingsVO = ApiVersionSettingsVO(BuildConfig.BISQ_API_VERSION)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/settings/ApiVersionSettingsVOTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/settings/ApiVersionSettingsVOTest.kt
@@ -1,0 +1,30 @@
+package network.bisq.mobile.data.replicated.settings
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the wire compatibility of the /settings/version payload: nodes that predate
+ * imageVersion (or run outside a container) omit the field, and that must keep decoding.
+ */
+class ApiVersionSettingsVOTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `decodes a payload without imageVersion`() {
+        val decoded = json.decodeFromString<ApiVersionSettingsVO>("""{"version":"2.1.12"}""")
+
+        assertEquals("2.1.12", decoded.version)
+        assertNull(decoded.imageVersion)
+    }
+
+    @Test
+    fun `decodes a containerised node's payload with imageVersion`() {
+        val decoded = json.decodeFromString<ApiVersionSettingsVO>("""{"version":"2.1.12","imageVersion":"2.1.12.2"}""")
+
+        assertEquals("2.1.12", decoded.version)
+        assertEquals("2.1.12.2", decoded.imageVersion)
+    }
+}


### PR DESCRIPTION
 - pass granular versioning to image when genering dockerised distro releases
 - manage the DTOs comms using a new field `imageVersion` having preference over the std version if present
 - depends on https://github.com/bisq-network/bisq2/pull/4949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node images now correctly include the resolved release version during builds.
  * Configuration updates are detected correctly when a containerized node’s image version changes.
  * Cached configuration is reused when the node image version remains unchanged.

* **Improvements**
  * Added support for displaying and processing containerized-node image versions while retaining compatibility with nodes that do not provide one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->