### PR TITLE
refactor(push): wrap key with Android Keystore

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -257,7 +257,6 @@ kotlin {
             // AndroidX
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.core.splashscreen)
-            implementation(libs.androidx.security.crypto)
 
             // Koin
             implementation(libs.koin.android)

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -39,8 +39,8 @@ import javax.crypto.spec.SecretKeySpec
  *
  * - The relay pushes a data-only FCM message with `data["encrypted"]` carrying
  *   a Base64 string of `nonce(12) || ciphertext || tag(16)`.
- * - We decrypt with AES-256-GCM using the per-device symmetric key stored in
- *   `EncryptedSharedPreferences` (see `PushNotificationKey.android.kt`).
+ * - We decrypt with AES-256-GCM using the per-device symmetric key, sealed at
+ *   rest with an AndroidKeyStore key (see `PushNotificationKey.android.kt`).
  * - The lock-screen banner shows only a category-based summary
  *   ("Trade update", "New message", ...) — never counterparty details / amounts.
  *   Same privacy posture as iOS.

--- a/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/apps/clientApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -96,11 +96,14 @@
       Generated CatHash avatar PNGs (BaseClientCatHashService).
       -> Deterministic from the profile id. Pure backup-quota waste.
 
-  shared_prefs/bisq_push_notification_keystore.xml
-      EncryptedSharedPreferences holding the AES-256 push notification
-      symmetric key, wrapped by a Keystore MasterKey (Tink keyset).
-      -> Key material, and the Tink keyset is unreadable on another device.
-         The key is rotated on every registration anyway.
+  shared_prefs/bisq_push_notification_key.xml
+      The AES-256 push notification symmetric key, sealed with an
+      AndroidKeyStore AES-GCM key (PushNotificationKey.android.kt).
+      -> Key material, and the sealing key is non-exportable, so the blob is
+         undecryptable on another device. The key is rotated on every
+         registration anyway.
+      (Replaced shared_prefs/bisq_push_notification_keystore.xml, the former
+       EncryptedSharedPreferences store; the app deletes that file on upgrade.)
 
   cache/            - never included by the platform. No rule needed.
   no_backup/        - never included by the platform. No rule needed. This is

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
@@ -161,6 +161,51 @@ class ClientPushNotificationServiceFacadeActivateTest : ClientKoinIntegrationTes
         }
 
     @Test
+    fun `activate defers auto-registration until the selected user profile arrives`() =
+        runTest {
+            // Cold start ordering: settings are read locally and are ready immediately, while the
+            // profile comes from the trusted node over Tor seconds later. Registering on the
+            // settings emission alone aborted with "no user profile selected" and never retried.
+            val userProfileFlow = MutableStateFlow<UserProfileVO?>(null)
+            every { userProfileServiceFacade.selectedUserProfile } returns userProfileFlow
+            sensitiveSettingsRepository.update { SensitiveSettings(bisqApiUrl = "http://localhost:8080") }
+            settingsRepository.update { it.copy(pushNotificationsEnabled = true) }
+            coEvery { tokenProvider.requestPermission() } returns true
+            coEvery { tokenProvider.requestDeviceToken() } returns Result.success("test-device-token")
+            coEvery { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) } returns Result.success(Unit)
+
+            facade.activate()
+            advanceUntilIdle()
+
+            assertFalse(facade.isDeviceRegistered.value, "must not register before a profile is selected")
+            coVerify(exactly = 0) { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) }
+
+            userProfileFlow.value = testUserProfile
+            advanceUntilIdle()
+
+            assertTrue(facade.isDeviceRegistered.value)
+            coVerify(exactly = 1) { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `activate registers once even though a successful registration writes settings again`() =
+        runTest {
+            // registerTokenWithTrustedNode persists pushNotificationsEnabled=true, which emits
+            // through the settings flow again; the device must not be registered twice.
+            sensitiveSettingsRepository.update { SensitiveSettings(bisqApiUrl = "http://localhost:8080") }
+            coEvery { tokenProvider.requestPermission() } returns true
+            coEvery { tokenProvider.requestDeviceToken() } returns Result.success("test-device-token")
+            coEvery { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) } returns Result.success(Unit)
+
+            facade.activate()
+            advanceUntilIdle()
+            settingsRepository.update { it.copy(pushNotificationsEnabled = true) }
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
     fun `activate with push enabled and onboarding complete but permission denied`() =
         runTest {
             sensitiveSettingsRepository.update { SensitiveSettings(bisqApiUrl = "http://localhost:8080") }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
@@ -11,7 +11,10 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -136,6 +139,41 @@ class ClientPushNotificationServiceFacadeIntegrationTest {
 
         override fun get(): String? = stored
     }
+
+    @Test
+    fun `concurrent registrations do not interleave rotation and registration`() =
+        runTest(testDispatcher) {
+            // Registration rotates the key before sending it, so two overlapping runs could
+            // register an already-superseded key last, leaving the node unable to produce
+            // pushes this device can decrypt. Slower first call, faster second: without
+            // serialization the second finishes first and the older key wins at the node.
+            val keyStore = InMemoryKeyStoreForTest()
+            pushNotificationKeyStoreFactory = { keyStore }
+            coEvery { tokenProvider.requestPermission() } returns true
+            coEvery { tokenProvider.requestDeviceToken() } returns Result.success("test-device-token")
+
+            var inFlight = 0
+            var maxInFlight = 0
+            val registeredKeys = mutableListOf<String?>()
+            coEvery { apiGateway.registerDevice(any(), any(), any(), any(), any(), any()) } coAnswers {
+                inFlight++
+                maxInFlight = maxOf(maxInFlight, inFlight)
+                val symmetricKeyBase64 = arg<String?>(5)
+                delay(if (registeredKeys.isEmpty()) 100 else 10)
+                registeredKeys += symmetricKeyBase64
+                inFlight--
+                Result.success(Unit)
+            }
+
+            listOf(
+                launch { facade.registerForPushNotifications() },
+                launch { facade.registerForPushNotifications() },
+            ).joinAll()
+
+            assertEquals(2, registeredKeys.size)
+            assertEquals(1, maxInFlight, "registrations must not overlap")
+            assertEquals(keyStore.get(), registeredKeys.last(), "the node must end up holding the key the device has")
+        }
 
     @Test
     fun `initial state has push notifications disabled`() =

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
 import network.bisq.mobile.data.crypto.getOrCreatePushNotificationKeyBase64
@@ -57,6 +59,16 @@ class ClientPushNotificationServiceFacade(
 
     private val _deviceId = MutableStateFlow<String?>(null)
     private val deviceId: StateFlow<String?> = _deviceId.asStateFlow()
+
+    // Registering is not idempotent: every run rotates the symmetric key and sends the new one
+    // to the trusted node. Two overlapping runs can interleave as rotate(k1), rotate(k2),
+    // register(k1), register(k2), leaving the node with a key the device no longer holds, which
+    // silently breaks decryption of every push until the next registration. Opting out has the
+    // same problem in reverse: a registration landing after it would leave the device registered
+    // at the node while the user believes they are off. The triggers are independent
+    // (auto-registration, Settings toggle, Support screen, FCM token refresh), so serialize them
+    // rather than assume they never overlap.
+    private val registrationMutex = Mutex()
 
     override suspend fun activate() {
         super<ServiceFacade>.activate()
@@ -174,7 +186,9 @@ class ClientPushNotificationServiceFacade(
             Result.failure(PushNotificationException("Device identifier temporarily unavailable", e))
         }
 
-    private suspend fun registerTokenWithTrustedNode(token: String): Result<Unit> {
+    private suspend fun registerTokenWithTrustedNode(token: String): Result<Unit> = registrationMutex.withLock { registerTokenWithTrustedNodeLocked(token) }
+
+    private suspend fun registerTokenWithTrustedNodeLocked(token: String): Result<Unit> {
         // Get the current user profile (needed for publicKeyBase64)
         val userProfile = userProfileServiceFacade.selectedUserProfile.value
         if (userProfile == null) {
@@ -232,7 +246,9 @@ class ClientPushNotificationServiceFacade(
         return result
     }
 
-    override suspend fun unregisterFromPushNotifications(): Result<Unit> {
+    override suspend fun unregisterFromPushNotifications(): Result<Unit> = registrationMutex.withLock { unregisterFromPushNotificationsLocked() }
+
+    private suspend fun unregisterFromPushNotificationsLocked(): Result<Unit> {
         log.i { "Unregistering from push notifications..." }
 
         // deviceId tells the server which device to unregister. On iOS it can be transiently

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.push_notification
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -114,6 +115,11 @@ class ClientPushNotificationServiceFacade(
             } else {
                 log.w { "Auto-registration failed: ${result.exceptionOrNull()?.message}" }
             }
+        } catch (e: CancellationException) {
+            // deactivate() cancels serviceScope while this may be suspended in fetch() or the
+            // registration network call. CancellationException is an Exception on JVM, so the
+            // handler below would swallow it and report a shutdown as a registration error.
+            throw e
         } catch (e: Exception) {
             log.e(e) { "Error during auto-registration" }
         }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -63,17 +65,32 @@ class ClientPushNotificationServiceFacade(
         // Load saved push notification preference
         serviceScope.launch {
             settingsRepository.data.collect { settings ->
-                val wasEnabled = _isPushNotificationsEnabled.value
                 _isPushNotificationsEnabled.value = settings.pushNotificationsEnabled
-
-                // Only auto-register if:
-                // 1. Push notifications are enabled in settings
-                // 2. Device is not already registered
-                // 3. User has completed onboarding (has a trusted node configured)
-                if (settings.pushNotificationsEnabled && !_isDeviceRegistered.value && !wasEnabled) {
-                    tryAutoRegisterIfOnboarded()
-                }
             }
+        }
+
+        // Auto-register once the opt-in AND a selected user profile are both present, and the
+        // device is not registered yet. Waiting for the profile is load-bearing: on a cold start
+        // it arrives from the trusted node seconds after the settings do, so registering on the
+        // settings emission alone aborted with "no user profile selected" and never retried,
+        // leaving the remaining paths manual (Settings toggle, Support screen) or an FCM token
+        // refresh. On Android that also skipped the key rotation registration performs, which
+        // silently breaks push decryption after the Keystore migration.
+        // Collecting the mirrored StateFlow rather than settingsRepository.data avoids a second
+        // DataStore read, and keeping this in its own coroutine keeps the mirror above
+        // responsive while a (slow, networked) registration is in flight.
+        serviceScope.launch {
+            combine(
+                _isPushNotificationsEnabled,
+                userProfileServiceFacade.selectedUserProfile,
+            ) { pushEnabled, userProfile ->
+                pushEnabled && userProfile != null
+            }.distinctUntilChanged()
+                .collect { canAutoRegister ->
+                    if (canAutoRegister && !_isDeviceRegistered.value) {
+                        tryAutoRegisterIfOnboarded()
+                    }
+                }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,13 @@ object KoverExclusions {
             // actually test in isolation.
             "network.bisq.mobile.domain.analytics.DefaultSentryClient*",
             "network.bisq.mobile.domain.analytics.NoOpAnalyticsService",
+            // Android Keystore adapters: Robolectric ships no AndroidKeyStore provider
+            // (KeyStore.getInstance("AndroidKeyStore") throws NoSuchAlgorithmException), so
+            // these run on a device only. Test changes to them in
+            // PushNotificationKeyStoreInstrumentedTest; do not try to unit test them.
+            "network.bisq.mobile.data.crypto.KeystoreKeyWrapper",
+            // Delete this line together with LegacyPushNotificationKeyCleanup.kt.
+            "network.bisq.mobile.data.crypto.LegacyMasterKey",
             // Koin DI modules — pure declarative wiring factories
             "network.bisq.mobile.client.common.di.*",
             "network.bisq.mobile.node.common.di.*",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,6 @@ desugar_jdk_libs = "2.1.5"
 android-mlkit-barcode-scanning = "17.3.0"
 firebase-bom = "33.7.0"
 google-services-plugin = "4.4.2"
-androidx-security-crypto = "1.1.0"
 kotlinx-coroutines-play-services = "1.10.2"
 
 # -------------------- AndroidX --------------------
@@ -147,7 +146,6 @@ androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "andr
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 android-mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "android-mlkit-barcode-scanning" }
-androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines-play-services" }

--- a/shared/domain/build.gradle.kts
+++ b/shared/domain/build.gradle.kts
@@ -248,7 +248,6 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.core)
-            implementation(libs.androidx.security.crypto)
             implementation(libs.koin.android)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kmp.tor.resource.exec)

--- a/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/LegacyPushNotificationKeyCleanupInstrumentedTest.kt
+++ b/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/LegacyPushNotificationKeyCleanupInstrumentedTest.kt
@@ -1,0 +1,100 @@
+package network.bisq.mobile.crypto
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.data.crypto.deleteLegacyPushNotificationStore
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the Keystore half of the migration, which Robolectric cannot reach. Deletes
+ * with the migration it belongs to (see `LegacyPushNotificationKeyCleanup`).
+ *
+ * The master key alias is androidx.security's shared default, hence the second test:
+ * dropping it on an install that never held our legacy store would destroy key material
+ * belonging to whatever else adopted that alias.
+ */
+@RunWith(AndroidJUnit4::class)
+class LegacyPushNotificationKeyCleanupInstrumentedTest {
+    private companion object {
+        const val LEGACY_PREFS_FILE = "bisq_push_notification_keystore"
+        const val LEGACY_PREF_KEY = "push_notification_symmetric_key_base64"
+        const val LEGACY_MASTER_KEY_ALIAS = "_androidx_security_master_key_"
+    }
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val legacyPrefs get() = context.getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
+
+    @Before
+    fun setUp() {
+        legacyPrefs.edit().clear().commit()
+        deleteMasterKey()
+    }
+
+    @After
+    fun tearDown() {
+        legacyPrefs.edit().clear().commit()
+        deleteMasterKey()
+    }
+
+    @Test
+    fun dropsTheLegacyEntriesAndTheOrphanedMasterKey() {
+        legacyPrefs
+            .edit()
+            .putString(LEGACY_PREF_KEY, "legacy")
+            .commit()
+        createMasterKey()
+
+        deleteLegacyPushNotificationStore(context)
+
+        assertNull(legacyPrefs.getString(LEGACY_PREF_KEY, null))
+        assertFalse(keyStore().containsAlias(LEGACY_MASTER_KEY_ALIAS), "orphaned master key should be gone")
+    }
+
+    @Test
+    fun keepsTheMasterKeyWhenThisInstallNeverHeldTheLegacyStore() {
+        createMasterKey()
+
+        deleteLegacyPushNotificationStore(context)
+
+        assertTrue(
+            keyStore().containsAlias(LEGACY_MASTER_KEY_ALIAS),
+            "the shared androidx.security alias must survive on installs without our legacy store",
+        )
+    }
+
+    private fun keyStore(): KeyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+
+    private fun createMasterKey() {
+        KeyGenerator
+            .getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+            .apply {
+                init(
+                    KeyGenParameterSpec
+                        .Builder(
+                            LEGACY_MASTER_KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                        ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .build(),
+                )
+            }.generateKey()
+    }
+
+    private fun deleteMasterKey() {
+        val keyStore = keyStore()
+        if (keyStore.containsAlias(LEGACY_MASTER_KEY_ALIAS)) {
+            keyStore.deleteEntry(LEGACY_MASTER_KEY_ALIAS)
+        }
+    }
+}

--- a/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/PushNotificationKeyStoreInstrumentedTest.kt
+++ b/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/PushNotificationKeyStoreInstrumentedTest.kt
@@ -1,0 +1,140 @@
+package network.bisq.mobile.crypto
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import network.bisq.mobile.data.crypto.deleteLegacyPushNotificationStore
+import network.bisq.mobile.data.crypto.getOrCreatePushNotificationKeyBase64
+import network.bisq.mobile.data.crypto.readPushNotificationKeyBase64
+import network.bisq.mobile.data.utils.AndroidAppContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the production (Android Keystore backed) push notification key store,
+ * which the Robolectric unit tests have to stub out. The storage names are spelled
+ * out here rather than imported so this test also pins the on-disk file name that
+ * `clientApp/res/xml/data_extraction_rules.xml` documents as backup-excluded.
+ */
+@RunWith(AndroidJUnit4::class)
+class PushNotificationKeyStoreInstrumentedTest {
+    private companion object {
+        const val PREFS_FILE = "bisq_push_notification_key"
+        const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
+        const val WRAPPING_KEY_ALIAS = "network.bisq.mobile.push_notification_key_wrapper"
+        const val LEGACY_PREFS_FILE = "bisq_push_notification_keystore"
+    }
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        AndroidAppContext.reset()
+        AndroidAppContext.initialize(context)
+        clearStore()
+    }
+
+    @After
+    fun tearDown() {
+        clearStore()
+        AndroidAppContext.reset()
+    }
+
+    @Test
+    fun rotatedKeyIsReadBack() {
+        val written = getOrCreatePushNotificationKeyBase64()
+
+        assertNotNull(written)
+        assertEquals(written, readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun rotationOverwritesThePreviousKey() {
+        val first = getOrCreatePushNotificationKeyBase64()
+        val second = getOrCreatePushNotificationKeyBase64()
+
+        assertNotEquals(first, second)
+        assertEquals(second, readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun keyIsNotStoredInPlaintext() {
+        val written = getOrCreatePushNotificationKeyBase64()
+        assertNotNull(written)
+
+        val stored = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE).getString(PREF_KEY_WRAPPED, null)
+
+        assertNotNull(stored, "expected a wrapped blob on disk")
+        assertNotEquals(written, stored)
+        assertTrue(!stored.contains(written), "the raw key must not appear in the stored blob")
+    }
+
+    @Test
+    fun readReturnsNullWhenNothingWasStored() {
+        assertNull(readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun corruptBlobDegradesToNoKey() {
+        getOrCreatePushNotificationKeyBase64()
+        context
+            .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString(PREF_KEY_WRAPPED, "not-a-wrapped-key")
+            .commit()
+
+        assertNull(readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun lostWrappingKeyDegradesToNoKeyAndRecoversOnRotation() {
+        getOrCreatePushNotificationKeyBase64()
+        // Simulates the Keystore dropping / invalidating the wrapping key (OEM quirks,
+        // lock-screen changes): the stored blob becomes undecryptable.
+        deleteWrappingKey()
+
+        assertNull(readPushNotificationKeyBase64())
+
+        val rotated = getOrCreatePushNotificationKeyBase64()
+        assertNotNull(rotated)
+        assertEquals(rotated, readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun legacyEncryptedSharedPrefsStoreIsDeleted() {
+        context
+            .getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString("push_notification_symmetric_key_base64", "legacy")
+            .commit()
+
+        deleteLegacyPushNotificationStore(context)
+
+        val legacy = context.getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
+        assertNull(legacy.getString("push_notification_symmetric_key_base64", null))
+    }
+
+    private fun clearStore() {
+        context
+            .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        deleteWrappingKey()
+    }
+
+    private fun deleteWrappingKey() {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        if (keyStore.containsAlias(WRAPPING_KEY_ALIAS)) {
+            keyStore.deleteEntry(WRAPPING_KEY_ALIAS)
+        }
+    }
+}

--- a/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/PushNotificationKeyStoreInstrumentedTest.kt
+++ b/shared/domain/src/androidInstrumentedTest/kotlin/network/bisq/mobile/crypto/PushNotificationKeyStoreInstrumentedTest.kt
@@ -3,7 +3,6 @@ package network.bisq.mobile.crypto
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import network.bisq.mobile.data.crypto.deleteLegacyPushNotificationStore
 import network.bisq.mobile.data.crypto.getOrCreatePushNotificationKeyBase64
 import network.bisq.mobile.data.crypto.readPushNotificationKeyBase64
 import network.bisq.mobile.data.utils.AndroidAppContext
@@ -30,7 +29,6 @@ class PushNotificationKeyStoreInstrumentedTest {
         const val PREFS_FILE = "bisq_push_notification_key"
         const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
         const val WRAPPING_KEY_ALIAS = "network.bisq.mobile.push_notification_key_wrapper"
-        const val LEGACY_PREFS_FILE = "bisq_push_notification_keystore"
     }
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -106,20 +104,6 @@ class PushNotificationKeyStoreInstrumentedTest {
         val rotated = getOrCreatePushNotificationKeyBase64()
         assertNotNull(rotated)
         assertEquals(rotated, readPushNotificationKeyBase64())
-    }
-
-    @Test
-    fun legacyEncryptedSharedPrefsStoreIsDeleted() {
-        context
-            .getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
-            .edit()
-            .putString("push_notification_symmetric_key_base64", "legacy")
-            .commit()
-
-        deleteLegacyPushNotificationStore(context)
-
-        val legacy = context.getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
-        assertNull(legacy.getString("push_notification_symmetric_key_base64", null))
     }
 
     private fun clearStore() {

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanup.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanup.kt
@@ -1,0 +1,85 @@
+package network.bisq.mobile.data.crypto
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import java.security.KeyStore
+import java.util.concurrent.atomic.AtomicBoolean
+
+// Temporary: this file exists only to retire the storage that shipped up to 0.8.2 and
+// can be deleted once every install has launched a build containing the migration.
+// Removing it means dropping this file, its test, the call in SharedPrefsKeyStore's
+// init block and the legacy case in PushNotificationKeyStoreInstrumentedTest.
+
+// Artifacts of the pre-Keystore-wrap implementation, which stored the key in
+// `EncryptedSharedPreferences` (androidx.security-crypto, deprecated in 1.1.0).
+// The Tink keyset lived inside the prefs file itself, so deleting the file
+// removes it; the master key is a separate AndroidKeyStore entry. Nothing else
+// in the app uses androidx.security-crypto, so both are safe to drop.
+private const val LEGACY_PREFS_FILE = "bisq_push_notification_keystore"
+private const val LEGACY_MASTER_KEY_ALIAS = "_androidx_security_master_key_"
+
+private val legacyStoreCleaned = AtomicBoolean(false)
+
+/**
+ * Drops the `EncryptedSharedPreferences` store used before the Keystore-wrap
+ * migration. The old key is deliberately not carried over: every registration
+ * rotates the key anyway, and the first `activate()` after the upgrade
+ * re-registers a fresh one with the trusted node. Pushes that arrive in between
+ * are dropped undecrypted, which is the same outcome as any other rotation gap.
+ *
+ * Runs once per process; repeat calls are a no-op.
+ */
+internal fun deleteLegacyPushNotificationStoreOnce(context: Context) {
+    if (legacyStoreCleaned.compareAndSet(false, true)) {
+        deleteLegacyPushNotificationStore(context)
+    }
+}
+
+/**
+ * The cleanup itself, without the once-per-process guard. Production goes through
+ * [deleteLegacyPushNotificationStoreOnce]; tests call this directly.
+ *
+ * Best-effort by design, because a Keystore that refuses to drop an orphan alias must
+ * not break key storage. The master key is only touched when the legacy prefs file was
+ * actually there: that alias is androidx.security's shared default, so on a device
+ * that never held our old store it may well belong to something else, and deleting
+ * it would destroy that owner's data with no way to recover it.
+ */
+@VisibleForTesting
+internal fun deleteLegacyPushNotificationStore(context: Context) {
+    val hadLegacyStore =
+        runCatching {
+            val legacyPrefs = context.getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
+            // Reading the entries back is the dependable "did this device hold the old
+            // store?" check: getSharedPreferences never creates the file on its own, while
+            // deleteSharedPreferences reports deletion of a backup file that normally does
+            // not exist, so its return value says nothing useful.
+            val hadEntries = legacyPrefs.all.isNotEmpty()
+            if (hadEntries) {
+                // Clear first: this is what actually removes the key material. Dropping the
+                // file afterwards is cosmetic, so a platform that refuses it changes nothing.
+                legacyPrefs.edit().clear().commit()
+                context.deleteSharedPreferences(LEGACY_PREFS_FILE)
+            }
+            hadEntries
+        }.getOrDefault(false)
+    if (!hadLegacyStore) return
+
+    LegacyMasterKey.deleteIfPresent()
+}
+
+/**
+ * The Keystore half of the cleanup, kept as its own type because Robolectric ships no
+ * `AndroidKeyStore` provider: these lines only ever run on a device, and the coverage
+ * gate excludes them by class name.
+ */
+private object LegacyMasterKey {
+    fun deleteIfPresent() {
+        runCatching {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+            if (keyStore.containsAlias(LEGACY_MASTER_KEY_ALIAS)) {
+                keyStore.deleteEntry(LEGACY_MASTER_KEY_ALIAS)
+            }
+        }
+    }
+}

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanup.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanup.kt
@@ -7,8 +7,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 // Temporary: this file exists only to retire the storage that shipped up to 0.8.2 and
 // can be deleted once every install has launched a build containing the migration.
-// Removing it means dropping this file, its test, the call in SharedPrefsKeyStore's
-// init block and the legacy case in PushNotificationKeyStoreInstrumentedTest.
+// Removing it means dropping this file, its two tests (LegacyPushNotificationKeyCleanupTest
+// and LegacyPushNotificationKeyCleanupInstrumentedTest), the call in SharedPrefsKeyStore's
+// init block and the LegacyMasterKey entry in KoverExclusions.
 
 // Artifacts of the pre-Keystore-wrap implementation, which stored the key in
 // `EncryptedSharedPreferences` (androidx.security-crypto, deprecated in 1.1.0).

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LocalEncryption.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/LocalEncryption.android.kt
@@ -11,7 +11,7 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 // All android 10+ devices support GCM
-private object LocalEncryption {
+internal object LocalEncryption {
     private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
     private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_GCM
     private const val PADDING = KeyProperties.ENCRYPTION_PADDING_NONE

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import network.bisq.mobile.data.utils.AndroidAppContext
+import network.bisq.mobile.domain.utils.getLogger
 import java.security.SecureRandom
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+
+private val log = getLogger("PushNotificationKey")
 
 private const val KEY_SIZE_BYTES = 32 // AES-256
 private const val PREFS_FILE = "bisq_push_notification_key"
@@ -59,6 +62,11 @@ actual fun getOrCreatePushNotificationKeyBase64(): String? =
         val base64 = Base64.encode(keyBytes)
         store.put(base64)
         base64
+    }.onFailure {
+        // Callers only see a null and abort registration, so without this the reason
+        // (Keystore refusal, failed commit) never reaches the logs. The exceptions carry
+        // no key material, so they are safe to log in full.
+        log.e(it) { "Failed to rotate the push notification key" }
     }.getOrNull()
 
 /**
@@ -72,6 +80,10 @@ actual fun getOrCreatePushNotificationKeyBase64(): String? =
 fun readPushNotificationKeyBase64(): String? =
     runCatching {
         pushNotificationKeyStoreFactory().get()
+    }.onFailure {
+        // Distinguishes "never registered" from "the Keystore blew up" in the field, which
+        // the messaging service cannot tell apart once this returns null.
+        log.e(it) { "Failed to read the push notification key; treating it as absent" }
     }.getOrNull()
 
 /**

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
@@ -3,29 +3,20 @@ package network.bisq.mobile.data.crypto
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import network.bisq.mobile.data.utils.AndroidAppContext
 import java.security.SecureRandom
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 private const val KEY_SIZE_BYTES = 32 // AES-256
-private const val PREFS_FILE = "bisq_push_notification_keystore"
-private const val PREF_KEY_SYMMETRIC = "push_notification_symmetric_key_base64"
-
-// TODO(follow-up): migrate from EncryptedSharedPreferences/MasterKey
-// (deprecated in androidx.security-crypto 1.1.0) to direct Android Keystore
-// APIs. The wrapper still works but Google now recommends generating an AES
-// key in Keystore and using it to wrap/unwrap the per-device symmetric key
-// stored in plain SharedPreferences. Tracked as a nitpick — the deprecated
-// APIs remain functional in 1.1.0.
+private const val PREFS_FILE = "bisq_push_notification_key"
+private const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
+private const val WRAPPING_KEY_ALIAS = "network.bisq.mobile.push_notification_key_wrapper"
 
 /**
  * Read/write port for the push notification symmetric key. Production swaps in
- * an `EncryptedSharedPreferences`-backed implementation; tests can swap in an
- * in-memory fake to bypass `AndroidKeyStore` (which Robolectric can't fully
- * emulate — Tink's master-key generation fails in unit tests).
+ * a Keystore-wrapped implementation; tests can swap in an in-memory fake to
+ * bypass `AndroidKeyStore` (which Robolectric can't fully emulate).
  */
 @VisibleForTesting
 interface PushNotificationKeyStore {
@@ -41,7 +32,7 @@ interface PushNotificationKeyStore {
  */
 @VisibleForTesting
 var pushNotificationKeyStoreFactory: () -> PushNotificationKeyStore = {
-    EncryptedSharedPrefsKeyStore(AndroidAppContext.context)
+    SharedPrefsKeyStore(AndroidAppContext.context)
 }
 
 /**
@@ -50,9 +41,9 @@ var pushNotificationKeyStoreFactory: () -> PushNotificationKeyStore = {
  * is ever compromised — this matches the iOS Keychain rotation behaviour
  * (see `iosClient/iosClient/interop/PushNotificationKeyStore.swift`).
  *
- * The key is stored in `EncryptedSharedPreferences`, whose contents are encrypted
- * at rest with a `MasterKey` held in the Android Keystore. The Base64-encoded key
- * is returned to the caller so it can be sent to the trusted node, which then
+ * The key is wrapped with an AES-GCM key held in the Android Keystore and the
+ * resulting blob is kept in plain SharedPreferences. The Base64-encoded key is
+ * returned to the caller so it can be sent to the trusted node, which then
  * encrypts notification payloads with AES-256-GCM that this device decrypts in
  * its `FirebaseMessagingService`.
  */
@@ -73,41 +64,75 @@ actual fun getOrCreatePushNotificationKeyBase64(): String? =
 /**
  * Reads the most recently stored symmetric key, used by `BisqFirebaseMessagingService`
  * to decrypt incoming pushes. Returns `null` if no key has been generated yet
- * (i.e. the user has not opted in / registered for push notifications).
+ * (i.e. the user has not opted in / registered for push notifications) or if the
+ * stored blob can no longer be unwrapped. A Keystore that lost or invalidated the
+ * wrapping key has to degrade to "no key" (drop the push) rather than crash the
+ * messaging service. The next registration rotates into a fresh, usable key.
  */
 fun readPushNotificationKeyBase64(): String? =
     runCatching {
         pushNotificationKeyStoreFactory().get()
     }.getOrNull()
 
-private class EncryptedSharedPrefsKeyStore(
-    context: Context,
-) : PushNotificationKeyStore {
-    private val prefs: SharedPreferences =
-        run {
-            val masterKey =
-                MasterKey
-                    .Builder(context)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build()
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_FILE,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-            )
-        }
+/**
+ * Wraps bytes with a non-exportable key so the result can live in plain storage.
+ * Production goes through the Android Keystore; unit tests substitute a trivial
+ * transform because Robolectric cannot emulate `AndroidKeyStore`.
+ *
+ * "Wrap" here is the key-encryption-key sense, one key protecting another. It is not
+ * `Cipher.WRAP_MODE` / `KeyProperties.PURPOSE_WRAP_KEY`, which exist for Keystore's
+ * secure key import and are not involved.
+ */
+internal interface PushNotificationKeyWrapper {
+    fun wrap(bytes: ByteArray): ByteArray
 
+    fun unwrap(bytes: ByteArray): ByteArray
+}
+
+/**
+ * AES-GCM through [LocalEncryption], the Keystore helper the sensitive-settings
+ * storage also uses. Same code path, but under its own alias, so the wrapping key
+ * is not shared with any other stored data.
+ */
+private object KeystoreKeyWrapper : PushNotificationKeyWrapper {
+    override fun wrap(bytes: ByteArray): ByteArray = LocalEncryption.encrypt(bytes, WRAPPING_KEY_ALIAS)
+
+    override fun unwrap(bytes: ByteArray): ByteArray = LocalEncryption.decrypt(bytes, WRAPPING_KEY_ALIAS)
+}
+
+/**
+ * Keeps the key as `Base64(iv || ciphertext)` in plain SharedPreferences, wrapped
+ * with a non-exportable Keystore key.
+ *
+ * SharedPreferences rather than DataStore because [put] must be durable before the
+ * caller registers the key with the trusted node (see the `commit()` note below);
+ * DataStore is async-first and would need `runBlocking` to offer the same guarantee.
+ */
+internal class SharedPrefsKeyStore(
+    context: Context,
+    private val wrapper: PushNotificationKeyWrapper = KeystoreKeyWrapper,
+) : PushNotificationKeyStore {
+    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+
+    init {
+        deleteLegacyPushNotificationStoreOnce(context)
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
     override fun put(base64: String) {
+        val wrapped = Base64.encode(wrapper.wrap(base64.toByteArray(Charsets.UTF_8)))
         // commit() (synchronous) rather than apply() (async): the symmetric
         // key is registered with the trusted node immediately after this
         // returns. If apply() were used and the process died before the
         // write hit disk, the server and device would diverge on the key
         // and decryption would silently fail.
-        val ok = prefs.edit().putString(PREF_KEY_SYMMETRIC, base64).commit()
+        val ok = prefs.edit().putString(PREF_KEY_WRAPPED, wrapped).commit()
         check(ok) { "Failed to persist push notification symmetric key" }
     }
 
-    override fun get(): String? = prefs.getString(PREF_KEY_SYMMETRIC, null)
+    @OptIn(ExperimentalEncodingApi::class)
+    override fun get(): String? {
+        val wrapped = prefs.getString(PREF_KEY_WRAPPED, null) ?: return null
+        return wrapper.unwrap(Base64.decode(wrapped)).toString(Charsets.UTF_8)
+    }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanupTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanupTest.kt
@@ -1,0 +1,63 @@
+package network.bisq.mobile.data.crypto
+
+import android.content.Context
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Deletes with the migration it covers (see `LegacyPushNotificationKeyCleanup`).
+ * The Keystore half of the cleanup, dropping the orphaned master key, only runs on
+ * a device and is covered by `PushNotificationKeyStoreInstrumentedTest`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LegacyPushNotificationKeyCleanupTest {
+    private companion object {
+        const val LEGACY_PREFS_FILE = "bisq_push_notification_keystore"
+        const val LEGACY_PREF_KEY = "push_notification_symmetric_key_base64"
+    }
+
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+    private val legacyPrefs get() = context.getSharedPreferences(LEGACY_PREFS_FILE, Context.MODE_PRIVATE)
+
+    @Before
+    fun setUp() {
+        legacyPrefs.edit().clear().commit()
+    }
+
+    @Test
+    fun `removes the key material the legacy store held`() {
+        legacyPrefs
+            .edit()
+            .putString(LEGACY_PREF_KEY, "legacy")
+            .commit()
+
+        deleteLegacyPushNotificationStore(context)
+
+        assertNull(legacyPrefs.getString(LEGACY_PREF_KEY, null))
+    }
+
+    @Test
+    fun `leaves an install that never held the legacy store untouched`() {
+        deleteLegacyPushNotificationStore(context)
+
+        assertEquals(0, legacyPrefs.all.size)
+    }
+
+    @Test
+    fun `runs only once per process`() {
+        deleteLegacyPushNotificationStoreOnce(context)
+        legacyPrefs
+            .edit()
+            .putString(LEGACY_PREF_KEY, "written after the one-shot cleanup")
+            .commit()
+
+        deleteLegacyPushNotificationStoreOnce(context)
+
+        assertEquals("written after the one-shot cleanup", legacyPrefs.getString(LEGACY_PREF_KEY, null))
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanupTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/LegacyPushNotificationKeyCleanupTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNull
 /**
  * Deletes with the migration it covers (see `LegacyPushNotificationKeyCleanup`).
  * The Keystore half of the cleanup, dropping the orphaned master key, only runs on
- * a device and is covered by `PushNotificationKeyStoreInstrumentedTest`.
+ * a device and is covered by `LegacyPushNotificationKeyCleanupInstrumentedTest`.
  */
 @RunWith(RobolectricTestRunner::class)
 class LegacyPushNotificationKeyCleanupTest {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
@@ -13,11 +13,10 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Unit tests for the rotation / read semantics. The actual
- * `EncryptedSharedPreferences` storage is swapped for an in-memory fake because
- * `AndroidKeyStore` does not work under Robolectric — Tink's master-key
- * generation fails. Production storage is exercised by instrumented tests
- * outside of unit-test scope.
+ * Unit tests for the rotation / read semantics. The actual Keystore-wrapped
+ * storage is swapped for an in-memory fake because `AndroidKeyStore` does not
+ * work under Robolectric. Production storage is exercised by
+ * `PushNotificationKeyStoreInstrumentedTest`.
  */
 @RunWith(RobolectricTestRunner::class)
 class PushNotificationKeyAndroidTest {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/SharedPrefsKeyStoreTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/SharedPrefsKeyStoreTest.kt
@@ -1,0 +1,118 @@
+package network.bisq.mobile.data.crypto
+
+import android.content.Context
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Covers the storage half of the production key store (persistence and encoding)
+ * with the Keystore wrapping swapped for a reversible stand-in,
+ * since Robolectric cannot emulate `AndroidKeyStore`. The real wrapping is covered
+ * by `PushNotificationKeyStoreInstrumentedTest`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalEncodingApi::class)
+class SharedPrefsKeyStoreTest {
+    private companion object {
+        const val PREFS_FILE = "bisq_push_notification_key"
+        const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
+        const val KEY = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+    }
+
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+    private val prefs get() = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+
+    private val originalFactory = pushNotificationKeyStoreFactory
+
+    @Before
+    fun setUp() {
+        prefs.edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        pushNotificationKeyStoreFactory = originalFactory
+    }
+
+    @Test
+    fun `round trips the key through wrap and unwrap`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+
+        store.put(KEY)
+
+        assertEquals(KEY, store.get())
+    }
+
+    @Test
+    fun `never writes the key in plaintext`() {
+        SharedPrefsKeyStore(context, XorWrapper).put(KEY)
+
+        val stored = prefs.getString(PREF_KEY_WRAPPED, null)
+
+        assertNotNull(stored)
+        assertNotEquals(KEY, stored)
+        assertNotEquals(KEY.toByteArray().toList(), Base64.decode(stored).toList())
+    }
+
+    @Test
+    fun `a second put replaces the previous key`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+        val other = "f".repeat(KEY.length)
+
+        store.put(KEY)
+        store.put(other)
+
+        assertEquals(other, store.get())
+    }
+
+    @Test
+    fun `get returns null when nothing was stored`() {
+        assertNull(SharedPrefsKeyStore(context, XorWrapper).get())
+    }
+
+    @Test
+    fun `a corrupt blob surfaces as no key rather than a crash`() {
+        prefs
+            .edit()
+            .putString(PREF_KEY_WRAPPED, "not a wrapped key")
+            .commit()
+        pushNotificationKeyStoreFactory = { SharedPrefsKeyStore(context, XorWrapper) }
+
+        assertNull(readPushNotificationKeyBase64())
+    }
+
+    @Test
+    fun `an unusable wrapping key surfaces as no key rather than a crash`() {
+        SharedPrefsKeyStore(context, XorWrapper).put(KEY)
+        // Stands in for a Keystore that lost or invalidated the wrapping key.
+        val store = SharedPrefsKeyStore(context, FailingWrapper)
+        pushNotificationKeyStoreFactory = { store }
+
+        assertFailsWith<IllegalStateException> { store.get() }
+        assertNull(readPushNotificationKeyBase64())
+    }
+
+    /** Reversible stand-in for the Keystore: not encryption, just not the identity. */
+    private object XorWrapper : PushNotificationKeyWrapper {
+        override fun wrap(bytes: ByteArray): ByteArray = ByteArray(bytes.size) { (bytes[it].toInt() xor 0x5A).toByte() }
+
+        override fun unwrap(bytes: ByteArray): ByteArray = wrap(bytes)
+    }
+
+    private object FailingWrapper : PushNotificationKeyWrapper {
+        override fun wrap(bytes: ByteArray): ByteArray = throw IllegalStateException("Keystore unavailable")
+
+        override fun unwrap(bytes: ByteArray): ByteArray = throw IllegalStateException("Keystore unavailable")
+    }
+}


### PR DESCRIPTION
androidx.security-crypto was deprecated wholesale in 1.1.0, so replace EncryptedSharedPreferences with an AES-GCM key in AndroidKeyStore that wraps the symmetric key, stored as Base64(iv || ciphertext) in plain SharedPreferences. This reuses LocalEncryption under its own alias, so there is no new crypto and no new dependency; the library is dropped from both modules and from the version catalog.

The old store is deleted rather than carried over. The key rotates on every registration and the first activate() after the upgrade re-registers a fresh one, so only pushes arriving before the next app launch are affected, and reading the old store would mean keeping the dependency this change removes.

Keystore failures degrade to "no key" so the messaging service drops the push instead of crashing, and the existing PushNotificationKeyStore test seam is preserved. Keystore-only code is excluded from Kover, since Robolectric ships no AndroidKeyStore provider; it is covered by an instrumented test instead.

resolves #1764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Push-notification keys are protected with Android Keystore-backed encryption before local storage.
  * Key access recovers safely after corruption or unavailable encryption keys.

* **Bug Fixes**
  * Push notifications now register automatically when enabled and a user profile becomes available.
  * Duplicate device registrations are prevented.

* **Maintenance**
  * Legacy push-notification encryption data is removed during migration.
  * Backup and restore documentation reflects the updated key-storage behavior.

* **Testing**
  * Added coverage for key protection, recovery, registration, and legacy-data cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->