### PR TITLE
chore/migrate_to_v2.1.12_core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 
 # -------------------- Project Specific --------------------
-bisq-core = "2.1.11"
+bisq-core = "2.1.12"
 # Update this commit hash when bisq2 JARs are regenerated (even with same version) to bust CI cache
-bisq-core-commit = "7c981af404b783488fa01d23a51d78b72ca1cb94"
+bisq-core-commit = "a1f8db129d2a1a473d249ff19120f701c1a3be58"
 
 
 # Desktop pairing version: the minimum Bisq2 Desktop version that supports mobile pairing


### PR DESCRIPTION
 - resolves #1768 
 - Updated bisq-core dependencies for node, no code changes needed
 - for connect 2.1.11+ stands true so no update done yet. Tested all 3 apps working against 2.1.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bisq Core component to version 2.1.12.
  * Refreshed the associated version metadata for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->