### PR TITLE
Refactor/consolidate ime inset handling across shared scaffolds

### DIFF
--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/BisqScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/BisqScaffold.kt
@@ -7,24 +7,47 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import network.bisq.mobile.presentation.common.ui.components.organisms.BisqSnackbar
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
+/**
+ * Base scaffold that owns the window-inset behavior shared by all Bisq scaffolds
+ * ([BisqStaticScaffold] and [BisqScrollScaffold] delegate here).
+ *
+ * imePadding() belongs on the Scaffold, not only on the inner layout: the bottomBar sits
+ * outside the content slot, so without it the bar stays behind the keyboard while the
+ * content slot still reserves its height, leaving an empty gap above the keyboard.
+ */
 @Composable
 fun BisqScaffold(
     modifier: Modifier = Modifier,
     topBar: @Composable (() -> Unit) = {},
     bottomBar: @Composable (() -> Unit) = {},
+    snackbarHostState: SnackbarHostState? = null,
     floatingActionButton: @Composable (() -> Unit) = {},
+    shouldBlurBg: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
         modifier =
             modifier
                 .fillMaxSize()
-                .imePadding(),
+                .then(
+                    if (shouldBlurBg) {
+                        Modifier.blur(BisqUIConstants.ScreenPaddingHalf)
+                    } else {
+                        Modifier
+                    },
+                ).imePadding(),
         topBar = topBar,
         bottomBar = bottomBar,
+        snackbarHost = {
+            if (snackbarHostState != null) {
+                BisqSnackbar(snackbarHostState = snackbarHostState)
+            }
+        },
         containerColor = BisqTheme.colors.backgroundColor,
         floatingActionButton = floatingActionButton,
         content = content,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollLayout.kt
@@ -54,6 +54,8 @@ fun BisqScrollLayout(
                         it
                     }
                 }.fillMaxSize()
+                // for standalone use (no scaffoldPadding); a no-op inside BisqScaffold, which
+                // already consumes the IME inset
                 .imePadding()
                 .background(BisqTheme.colors.backgroundColor),
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/ScrollScaffold.kt
@@ -4,19 +4,18 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
-import network.bisq.mobile.presentation.common.ui.components.organisms.BisqSnackbar
-import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
-// FinalTODO: Merge StaticScaffold and ScrollScaffold
+/**
+ * Scrolling flavor of [BisqScaffold], which owns the shared scaffold behavior
+ * (IME insets, snackbar, blur). This wrapper only adds the [BisqScrollLayout] content slot;
+ * [BisqStaticScaffold] is its non-scrolling sibling.
+ */
 @Composable
 fun BisqScrollScaffold(
     modifier: Modifier = Modifier,
@@ -38,38 +37,23 @@ fun BisqScrollScaffold(
     scrollState: ScrollState = rememberScrollState(),
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Scaffold(
-        // See BisqStaticScaffold: without imePadding the bottomBar stays behind the keyboard while
-        // the content slot keeps reserving its height, which leaves a gap above the keyboard.
-        modifier =
-            modifier
-                .then(
-                    if (shouldBlurBg) {
-                        Modifier.blur(BisqUIConstants.ScreenPaddingHalf)
-                    } else {
-                        Modifier
-                    },
-                ).imePadding(),
-        containerColor = BisqTheme.colors.backgroundColor,
+    BisqScaffold(
+        modifier = modifier,
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},
-        snackbarHost = {
-            if (snackbarHostState != null) {
-                BisqSnackbar(snackbarHostState = snackbarHostState)
-            }
-        },
+        snackbarHostState = snackbarHostState,
         floatingActionButton = fab ?: {},
-        content = { scaffoldPadding ->
-            BisqScrollLayout(
-                scaffoldPadding = scaffoldPadding,
-                contentPadding = padding,
-                verticalArrangement = verticalArrangement,
-                showJumpToBottom = showJumpToBottom,
-                horizontalAlignment = horizontalAlignment,
-                scrollState = scrollState,
-            ) {
-                content()
-            }
-        },
-    )
+        shouldBlurBg = shouldBlurBg,
+    ) { scaffoldPadding ->
+        BisqScrollLayout(
+            scaffoldPadding = scaffoldPadding,
+            contentPadding = padding,
+            verticalArrangement = verticalArrangement,
+            showJumpToBottom = showJumpToBottom,
+            horizontalAlignment = horizontalAlignment,
+            scrollState = scrollState,
+        ) {
+            content()
+        }
+    }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticLayout.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticLayout.kt
@@ -33,7 +33,10 @@ fun BisqStaticLayout(
                     } else {
                         it
                     }
-                }.imePadding()
+                }
+                // for standalone use (no scaffoldPadding); a no-op inside BisqScaffold, which
+                // already consumes the IME inset
+                .imePadding()
                 .background(BisqTheme.colors.backgroundColor),
     ) {
         Column(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/layout/StaticScaffold.kt
@@ -3,18 +3,16 @@ package network.bisq.mobile.presentation.common.ui.components.layout
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
-import network.bisq.mobile.presentation.common.ui.components.organisms.BisqSnackbar
-import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
-// FinalTODO: Merge StaticScaffold and ScrollScaffold
+/**
+ * Non-scrolling flavor of [BisqScaffold], which owns the shared scaffold behavior
+ * (IME insets, snackbar, blur). This wrapper only adds the [BisqStaticLayout] content slot;
+ * [BisqScrollScaffold] is its scrolling sibling.
+ */
 @Composable
 fun BisqStaticScaffold(
     padding: PaddingValues =
@@ -33,32 +31,20 @@ fun BisqStaticScaffold(
     shouldBlurBg: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Scaffold(
-        // imePadding() belongs on the Scaffold, not only on the inner layout: the bottomBar sits
-        // outside the content slot, so without it the bar stays behind the keyboard while the
-        // content slot still reserves its height, leaving an empty gap above the keyboard.
-        modifier =
-            Modifier
-                .blur(if (shouldBlurBg) BisqUIConstants.ScreenPaddingHalf else BisqUIConstants.Zero)
-                .imePadding(),
-        containerColor = BisqTheme.colors.backgroundColor,
+    BisqScaffold(
         topBar = topBar ?: {},
         bottomBar = bottomBar ?: {},
-        snackbarHost = {
-            if (snackbarHostState != null) {
-                BisqSnackbar(snackbarHostState = snackbarHostState)
-            }
-        },
+        snackbarHostState = snackbarHostState,
         floatingActionButton = floatingButton ?: {},
-        content = { scaffoldPadding ->
-            BisqStaticLayout(
-                contentPadding = padding,
-                scaffoldPadding = scaffoldPadding,
-                horizontalAlignment = horizontalAlignment,
-                verticalArrangement = verticalArrangement,
-            ) {
-                content()
-            }
-        },
-    )
+        shouldBlurBg = shouldBlurBg,
+    ) { scaffoldPadding ->
+        BisqStaticLayout(
+            contentPadding = padding,
+            scaffoldPadding = scaffoldPadding,
+            horizontalAlignment = horizontalAlignment,
+            verticalArrangement = verticalArrangement,
+        ) {
+            content()
+        }
+    }
 }


### PR DESCRIPTION
 - resolves #1739 
 - refactor different scaffoldings to use **BisqScaffold** as the main code for such purpose in our apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional snackbar display support to shared scaffold layouts.
  * Added configurable background blur for scaffold-based screens.
  * Improved keyboard inset handling for standalone and scaffold layouts.

* **Refactor**
  * Standardized static and scrolling layouts on shared scaffold behavior.
  * Preserved existing scrolling, alignment, content padding, and floating action button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->