### PR TITLE
bugfix/fs_not_launching_right_after_permissions_acceptance

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
 import network.bisq.mobile.client.common.domain.access.ApiAccessService
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.data.service.accounts.UserDefinedAccountsServiceFacade
@@ -39,11 +39,10 @@ import network.bisq.mobile.domain.analytics.NoOpAnalyticsService
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.presentation.common.notification.NotificationController
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
-import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class ClientApplicationLifecycleServiceTest {
+class ClientApplicationLifecycleServiceTest : ClientKoinIntegrationTestBase() {
     private val order = mutableListOf<String>()
 
     private val openTradesNotificationService: OpenTradesNotificationService = mockk(relaxed = true)
@@ -73,8 +72,7 @@ class ClientApplicationLifecycleServiceTest {
 
     private lateinit var service: ClientApplicationLifecycleService
 
-    @Before
-    fun setUp() {
+    override fun onSetup() {
         configureActivationTracking()
         configureDeactivationTracking()
         // Default the persisted opt-in to false and OS notification permission
@@ -385,6 +383,38 @@ class ClientApplicationLifecycleServiceTest {
             // Let the activation finish normally so the test leaves no dangling job.
             torGate.complete(Unit)
             activation.join()
+        }
+
+    /**
+     * Covers the `initialize()` entry point's [TorBootstrapNotReadyException] handling: the
+     * abort must be logged and swallowed — NOT escalated to `onUnrecoverableError`, which
+     * would run `deactivateServiceFacades` (cancelling the permission watcher and stopping
+     * the notification service). Runs on the real Koin-backed `serviceScope`, which is why
+     * this test needs the [ClientKoinIntegrationTestBase] fixture.
+     */
+    @Test
+    fun `initialize swallows Tor-bootstrap abort without escalating to unrecoverable error`() =
+        runTest {
+            order.clear()
+            val settingsFlow = MutableStateFlow(Settings(pushNotificationsEnabled = false))
+            every { settingsRepository.data } returns settingsFlow
+            coEvery { settingsRepository.fetch() } returns Settings(pushNotificationsEnabled = false)
+            coEvery { notificationController.hasPermission() } returns true
+            coEvery { apiAccessService.activate() } throws TorBootstrapNotReadyException()
+
+            service.initialize()
+            // initialize() launches activation on the Koin-backed serviceScope, which runs on
+            // Main — set to a StandardTestDispatcher by the base, so drive it explicitly.
+            runCurrent()
+
+            // The chain aborted at the first facade…
+            coVerify { apiAccessService.activate() }
+            assertEquals(false, order.contains("bootstrap.activate"))
+            // …but the orchestrator watcher stays alive and still drives the FG service.
+            // An escalation would have torn it down and stopped the notification service.
+            settingsFlow.value = settingsFlow.value.copy(notificationPermissionState = PermissionState.GRANTED)
+            coVerify(timeout = 2_000) { openTradesNotificationService.setKeepProcessAlive(true) }
+            coVerify(exactly = 0) { openTradesNotificationService.stopNotificationService() }
         }
 
     @Test

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleServiceTest.kt
@@ -4,9 +4,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import network.bisq.mobile.client.common.domain.access.ApiAccessService
+import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.data.service.accounts.UserDefinedAccountsServiceFacade
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
@@ -22,6 +26,7 @@ import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceF
 import network.bisq.mobile.data.service.network.ConnectivityService
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
+import network.bisq.mobile.data.service.network.TorBootstrapNotReadyException
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
@@ -320,6 +325,66 @@ class ClientApplicationLifecycleServiceTest {
 
             coVerify(timeout = 2_000) { openTradesNotificationService.setLocalDeliverySuppressed(true) }
             coVerify(timeout = 2_000) { openTradesNotificationService.setKeepProcessAlive(false) }
+        }
+
+    /**
+     * Regression test for issue #1749 (fresh-install: FG service never starts after the
+     * user grants POST_NOTIFICATIONS from the dashboard cards).
+     *
+     * The orchestrator job used to be launched at the END of `activateServiceFacades()`;
+     * when activation stalled or aborted partway (e.g. [TorBootstrapNotReadyException] on
+     * a fresh Tor pairing — swallowed by design in the `initialize()` entry point), the
+     * permission grant had no listener and the FG service stayed off until an app restart.
+     * The job now launches BEFORE the fallible facade chain.
+     *
+     * The stall is modeled by gating the FIRST facade (`apiAccessService.activate()`)
+     * rather than throwing: the real Tor-abort path runs through `initialize()`, which
+     * needs the Koin-backed `serviceScope` this fixture intentionally doesn't bootstrap,
+     * and a throw through `activate()` escalates to `onUnrecoverableError` (a teardown
+     * path where cancelling the watcher is correct). The pinned property is the same:
+     * the watcher must be live before the facade chain completes.
+     */
+    @Test
+    fun `permission grant still starts FG service while facade activation is stuck on the first facade`() =
+        runTest {
+            order.clear()
+            val settingsFlow = MutableStateFlow(Settings(pushNotificationsEnabled = false))
+            every { settingsRepository.data } returns settingsFlow
+            coEvery { settingsRepository.fetch() } returns Settings(pushNotificationsEnabled = false)
+            // Fresh install: POST_NOTIFICATIONS not granted at bootstrap.
+            var osPermissionGranted = false
+            coEvery { notificationController.hasPermission() } coAnswers { osPermissionGranted }
+            // Fresh Tor pairing: the first facade never completes within this session phase.
+            val torGate = CompletableDeferred<Unit>()
+            coEvery { apiAccessService.activate() } coAnswers {
+                torGate.await()
+                order += "apiAccess.activate"
+            }
+
+            val activation = launch { service.activate() }
+            runCurrent() // drive activation up to the gate suspension
+
+            // Both the bootstrap decision AND the orchestrator's initial emission must have
+            // evaluated with permission denied (exactly 2 suppression calls) before we flip
+            // the permission — this pins the ordering and keeps the next asserts race-free.
+            coVerify(timeout = 2_000, exactly = 2) {
+                openTradesNotificationService.setLocalDeliverySuppressed(true)
+            }
+            // Activation is really stuck on the first facade, and the FG service stayed off.
+            assertEquals(false, order.contains("apiAccess.activate"))
+            assertEquals(false, order.contains("notification.start"))
+
+            // User grants the permission from the dashboard cards; the dashboard writes
+            // the new state into settings. The watcher must react despite the stuck
+            // activation.
+            osPermissionGranted = true
+            settingsFlow.value = settingsFlow.value.copy(notificationPermissionState = PermissionState.GRANTED)
+
+            coVerify(timeout = 2_000) { openTradesNotificationService.setKeepProcessAlive(true) }
+
+            // Let the activation finish normally so the test leaves no dangling job.
+            torGate.complete(Unit)
+            activation.join()
         }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/ClientApplicationLifecycleService.kt
@@ -111,6 +111,14 @@ class ClientApplicationLifecycleService(
         // Decide BEFORE the start call whether the local foreground service should run.
         maybeLaunchForegroundNotificationService()
 
+        // Launch the settings/permission watcher BEFORE the fallible facade activation
+        // below: it only needs the settings repo and the OS permission check, and it must
+        // be alive when the user grants POST_NOTIFICATIONS from the dashboard cards. When
+        // it sat at the end of this method, an activation abort partway through (e.g.
+        // TorBootstrapNotReadyException on a fresh Tor pairing) meant the grant had no
+        // listener and the FG service never started until an app restart (issue #1749).
+        launchForegroundNotificationServiceSuppressorJob()
+
         apiAccessService.activate()
         applicationBootstrapFacade.activate() // sets bootstraps states and listeners
         networkServiceFacade.activate()
@@ -136,8 +144,6 @@ class ClientApplicationLifecycleService(
 
         // Activate push notification service - will auto-register if user has granted permission
         pushNotificationServiceFacade.activate()
-
-        launchForegroundNotificationServiceSuppressorJob()
     }
 
     override suspend fun deactivateServiceFacades() {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/NodeApplicationLifecycleService.kt
@@ -2,10 +2,19 @@ package network.bisq.mobile.node.common.domain.service
 
 import android.app.Activity
 import bisq.application.State
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import network.bisq.mobile.data.model.PermissionState
 import network.bisq.mobile.data.service.accounts.UserDefinedAccountsServiceFacade
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
@@ -66,7 +75,7 @@ class NodeApplicationLifecycleService(
     analyticsBootstrapConfig: AnalyticsBootstrapConfig,
     bufferedAnalyticsService: BufferedAnalyticsService? = null,
     analyticsSocksPortProvider: AnalyticsSocksPortProvider? = null,
-    settingsRepository: SettingsRepository? = null,
+    private val settingsRepository: SettingsRepository? = null,
     analyticsSettingsBaseline: AnalyticsSettingsBaseline? = null,
 ) : ApplicationLifecycleService(
         applicationBootstrapFacade,
@@ -78,6 +87,14 @@ class NodeApplicationLifecycleService(
         settingsRepository,
         analyticsSettingsBaseline,
     ) {
+    /**
+     * Dedicated scope for the notification-permission watcher, mirroring the client's
+     * pushModeScope: intentionally NOT cancelled in [deactivateServiceFacades] (only the
+     * job is), so a deactivate/activate cycle can relaunch the watcher on a live scope.
+     */
+    private val permissionWatchScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var notifPermissionWatchJob: Job? = null
+
     fun restartForRestoreDataDirectory(view: Any?) {
         val activity =
             view as? Activity ?: throw IllegalStateException("Passed view is not an Activity")
@@ -135,6 +152,7 @@ class NodeApplicationLifecycleService(
         // ForegroundServiceDidNotStartInTimeException
         log.i { "Starting foreground notification service" }
         openTradesNotificationService.startService()
+        launchNotificationPermissionWatchJob()
 
         androidMemoryReportService.initialize()
         applicationBootstrapFacade.activate() // sets bootstraps states and listeners
@@ -167,6 +185,11 @@ class NodeApplicationLifecycleService(
     }
 
     override suspend fun deactivateServiceFacades() {
+        // Join (not just cancel) so an in-flight refreshServiceNotification can't land
+        // after stopNotificationService has already torn the service down.
+        notifPermissionWatchJob?.cancelAndJoin()
+        notifPermissionWatchJob = null
+
         // tear down notification service, since we may be terminating the app
         // and cleaning it up later makes it unnecessarily complex
         try {
@@ -205,6 +228,34 @@ class NodeApplicationLifecycleService(
 
         applicationBootstrapFacade.deactivate()
         networkServiceFacade.deactivate()
+    }
+
+    /**
+     * The foreground service starts unconditionally at bootstrap (it also keeps the P2P node
+     * alive, so it must run regardless of notification permission) — on a fresh install that
+     * is BEFORE the user grants POST_NOTIFICATIONS from the dashboard cards. Android silently
+     * drops the service notification posted while denied and never retro-displays it after a
+     * grant, leaving the running service invisible until an app restart (issue #1749).
+     * This watcher re-posts the notification when the permission state flips to GRANTED
+     * (written by the dashboard on the launcher result).
+     */
+    private fun launchNotificationPermissionWatchJob() {
+        val repository = settingsRepository
+        if (repository == null) {
+            log.w { "Settings repository unavailable — notification-permission watcher not started" }
+            return
+        }
+        notifPermissionWatchJob?.cancel()
+        notifPermissionWatchJob =
+            repository.data
+                .map { it.notificationPermissionState }
+                .distinctUntilChanged()
+                .onEach { state ->
+                    log.i { "Notification permission state: $state" }
+                    if (state == PermissionState.GRANTED) {
+                        openTradesNotificationService.refreshServiceNotification()
+                    }
+                }.launchIn(permissionWatchScope)
     }
 
     /**

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -72,7 +72,10 @@ abstract class ApplicationLifecycleService(
         serviceScope.launch {
             try {
                 activateServiceFacades()
-            } catch (_: TorBootstrapNotReadyException) {
+            } catch (e: TorBootstrapNotReadyException) {
+                // Swallowed by design (the connection flow retries), but never silently:
+                // an abort here means the rest of activateServiceFacades did not run.
+                log.w(e) { "Service facade activation aborted — Tor bootstrap not ready yet" }
             } catch (e: Exception) {
                 onUnrecoverableError(e)
             }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/bootstrap/ApplicationLifecycleService.kt
@@ -1,6 +1,7 @@
 package network.bisq.mobile.data.service.bootstrap
 
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -76,6 +77,9 @@ abstract class ApplicationLifecycleService(
                 // Swallowed by design (the connection flow retries), but never silently:
                 // an abort here means the rest of activateServiceFacades did not run.
                 log.w(e) { "Service facade activation aborted — Tor bootstrap not ready yet" }
+            } catch (e: CancellationException) {
+                // Scope cancellation is not an unrecoverable error — rethrow so it propagates.
+                throw e
             } catch (e: Exception) {
                 onUnrecoverableError(e)
             }
@@ -223,6 +227,9 @@ abstract class ApplicationLifecycleService(
         }
         try {
             activateServiceFacades()
+        } catch (e: CancellationException) {
+            // Caller cancellation is not an unrecoverable error — rethrow so it propagates.
+            throw e
         } catch (e: Exception) {
             log.e { "Service activate error: $e" }
             onUnrecoverableError(e)

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundService.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundService.android.kt
@@ -33,6 +33,7 @@ open class ForegroundService :
         const val SERVICE_NOTIF_ID = 1
         const val DEFAULT_NOTIFICATION_TITLE = "Bisq"
         const val DEFAULT_NOTIFICATION_TEXT = "Foreground Service Starting.."
+        const val ACTION_REFRESH_NOTIFICATION = "network.bisq.mobile.action.REFRESH_SERVICE_NOTIFICATION"
     }
 
     private val serviceJob = SupervisorJob()
@@ -115,11 +116,29 @@ open class ForegroundService :
         }
     }
 
+    @SuppressLint("InlinedApi")
     override fun onStartCommand(
         intent: Intent?,
         flags: Int,
         startId: Int,
     ): Int {
+        if (intent?.action == ACTION_REFRESH_NOTIFICATION) {
+            // Android drops notifications posted while POST_NOTIFICATIONS was denied and never
+            // retro-displays them after a grant, so a service started pre-grant stays invisible
+            // until its notification is posted again (issue #1749).
+            log.i { "Re-posting foreground service notification" }
+            runCatching {
+                ServiceCompat.startForeground(
+                    this,
+                    SERVICE_NOTIF_ID,
+                    getServiceNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING,
+                )
+            }.onFailure { e ->
+                log.w(e) { "Failed to re-post foreground service notification" }
+            }
+            return START_STICKY
+        }
         log.i { "Service starting sticky" }
         return START_STICKY
     }

--- a/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImpl.android.kt
+++ b/shared/presentation/src/androidMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImpl.android.kt
@@ -66,6 +66,24 @@ class ForegroundServiceControllerImpl(
         }
     }
 
+    override fun refreshNotification() {
+        if (!isRunning) {
+            log.i { "ForegroundService not running — skipping notification refresh" }
+            return
+        }
+        log.i { "Requesting foreground service notification re-post" }
+        val intent =
+            Intent(context, ForegroundService::class.java)
+                .setAction(ForegroundService.ACTION_REFRESH_NOTIFICATION)
+        try {
+            // Plain startService is enough: the service is already in the foreground state,
+            // this only delivers the refresh action to onStartCommand.
+            context.startService(intent)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to request foreground service notification refresh" }
+        }
+    }
+
     override fun <T> registerObserver(
         flow: Flow<T>,
         onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImplTest.kt
@@ -1,0 +1,56 @@
+package network.bisq.mobile.presentation.common.notification
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.data.service.AppForegroundController
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for [ForegroundServiceControllerImpl.refreshNotification] (issue #1749): the refresh
+ * must reach the running service as an [ForegroundService.ACTION_REFRESH_NOTIFICATION] intent,
+ * and must be a no-op while the service isn't running — a refresh sent to a stopped service
+ * would throw from `startService` on modern Android.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ForegroundServiceControllerImplTest {
+    private val context: Application = ApplicationProvider.getApplicationContext()
+
+    private lateinit var controller: ForegroundServiceControllerImpl
+
+    @Before
+    fun setUp() {
+        val appForegroundController: AppForegroundController = mockk(relaxed = true)
+        every { appForegroundController.context } returns context
+        every { appForegroundController.isForeground } returns MutableStateFlow(false)
+        controller = ForegroundServiceControllerImpl(appForegroundController)
+    }
+
+    @Test
+    fun `refreshNotification is a no-op when the service is not running`() {
+        controller.refreshNotification()
+
+        assertNull(Shadows.shadowOf(context).nextStartedService)
+    }
+
+    @Test
+    fun `refreshNotification sends the refresh action to the running service`() {
+        controller.startService()
+        val startIntent = Shadows.shadowOf(context).nextStartedService
+        assertEquals(ForegroundService::class.java.name, startIntent?.component?.className)
+
+        controller.refreshNotification()
+
+        val refreshIntent = Shadows.shadowOf(context).nextStartedService
+        assertEquals(ForegroundService.ACTION_REFRESH_NOTIFICATION, refreshIntent?.action)
+        assertEquals(ForegroundService::class.java.name, refreshIntent?.component?.className)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceTest.kt
@@ -1,0 +1,64 @@
+package network.bisq.mobile.presentation.common.notification
+
+import android.app.Service
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import network.bisq.mobile.i18n.I18nSupport
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Tests for [ForegroundService.onStartCommand]'s refresh branch (issue #1749): after a
+ * POST_NOTIFICATIONS grant, an [ForegroundService.ACTION_REFRESH_NOTIFICATION] intent must
+ * re-run `startForeground` so the notification Android dropped while the permission was
+ * denied becomes visible. Without Koin the service falls back to its minimal notification,
+ * which is exactly the resilience path the production code documents.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ForegroundServiceTest {
+    @Before
+    fun setUp() {
+        I18nSupport.initialize("en")
+    }
+
+    /**
+     * Deliberately built WITHOUT `create()`: `onCreate` launches an async notification-upgrade
+     * coroutine on Dispatchers.Default with no suspension points, which can outlive the test
+     * (even past an @After `destroy()`, since a running coroutine can't be interrupted) and
+     * post its notification into a LATER test class's Robolectric environment — seen as
+     * NotificationControllerImplTest flaking on `allNotifications.single()`. The refresh
+     * branch under test lives entirely in `onStartCommand`, which only needs the attached
+     * base context that `buildService` already provides.
+     */
+    private fun createService(): ForegroundService = Robolectric.buildService(ForegroundService::class.java).get()
+
+    @Test
+    fun `onStartCommand with refresh action re-posts the foreground notification and stays sticky`() {
+        val service = createService()
+        val intent =
+            Intent(ApplicationProvider.getApplicationContext(), ForegroundService::class.java)
+                .setAction(ForegroundService.ACTION_REFRESH_NOTIFICATION)
+
+        val result = service.onStartCommand(intent, 0, 1)
+
+        assertEquals(Service.START_STICKY, result)
+        val shadow = Shadows.shadowOf(service)
+        assertNotNull(shadow.lastForegroundNotification)
+        assertEquals(ForegroundService.SERVICE_NOTIF_ID, shadow.lastForegroundNotificationId)
+    }
+
+    @Test
+    fun `onStartCommand without refresh action starts sticky`() {
+        val service = createService()
+
+        val result = service.onStartCommand(null, 0, 1)
+
+        assertEquals(Service.START_STICKY, result)
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
@@ -130,4 +130,16 @@ class OpenTradesNotificationServiceLifecycleTest {
             verify(exactly = 1) { foregroundServiceController.startService() }
             verify(exactly = 0) { foregroundServiceController.stopService() }
         }
+
+    @Test
+    fun `refreshServiceNotification delegates to the controller`() =
+        runTest {
+            // Used after a POST_NOTIFICATIONS grant to re-post the FG notification that
+            // Android dropped while the permission was denied (issue #1749). The
+            // running/not-running guard lives in the controller, so this is a plain
+            // pass-through regardless of service state.
+            service.refreshServiceNotification()
+
+            verify(exactly = 1) { foregroundServiceController.refreshNotification() }
+        }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -219,6 +219,8 @@ class CreateOfferPricePresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun stopService() {}
 
+        override fun refreshNotification() {}
+
         override fun <T> registerObserver(
             flow: Flow<T>,
             onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -232,6 +232,8 @@ class CreateOfferReviewPresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun stopService() {}
 
+        override fun refreshNotification() {}
+
         override fun <T> registerObserver(
             flow: Flow<T>,
             onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -229,6 +229,8 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
 
         override fun stopService() {}
 
+        override fun refreshNotification() {}
+
         override fun <T> registerObserver(
             flow: Flow<T>,
             onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceController.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceController.kt
@@ -10,6 +10,15 @@ interface ForegroundServiceController {
 
     fun stopService()
 
+    /**
+     * Re-posts the running service's foreground notification. Needed on Android after the
+     * user grants POST_NOTIFICATIONS while the service is already running: the notification
+     * posted pre-grant was silently dropped by the OS and is never retro-displayed, leaving
+     * the service invisible in the status bar (issue #1749). No-op if the service isn't
+     * running, and on platforms without a persistent service notification.
+     */
+    fun refreshNotification()
+
     fun <T> registerObserver(
         flow: Flow<T>,
         onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
@@ -138,6 +138,15 @@ class OpenTradesNotificationService(
     }
 
     /**
+     * Re-posts the foreground service notification if the service is running. See
+     * [ForegroundServiceController.refreshNotification] — used after a POST_NOTIFICATIONS
+     * grant so the service becomes visible in the status bar without an app restart.
+     */
+    fun refreshServiceNotification() {
+        foregroundServiceController.refreshNotification()
+    }
+
+    /**
      * Suppresses or resumes local notification posting. Controls observer
      * registration (so peer-chat / trade-state observers don't fire `notify(...)`
      * calls that would duplicate the relayed path) but does NOT touch the

--- a/shared/presentation/src/commonTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceRaceTest.kt
+++ b/shared/presentation/src/commonTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceRaceTest.kt
@@ -23,6 +23,8 @@ class FakeForegroundServiceController : network.bisq.mobile.presentation.common.
 
     override fun stopService() {}
 
+    override fun refreshNotification() {}
+
     override fun <T> registerObserver(
         flow: Flow<T>,
         onStateChange: suspend (T) -> Unit,

--- a/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImpl.ios.kt
+++ b/shared/presentation/src/iosMain/kotlin/network/bisq/mobile/presentation/common/notification/ForegroundServiceControllerImpl.ios.kt
@@ -137,6 +137,10 @@ class ForegroundServiceControllerImpl(
         }
     }
 
+    override fun refreshNotification() {
+        // No-op: iOS has no persistent foreground-service notification to re-post.
+    }
+
     override fun <T> registerObserver(
         flow: Flow<T>,
         onStateChange: suspend (T) -> Unit,


### PR DESCRIPTION
 - fixes #1749 
 - implemented new settings watcher that re-posts notification after …notification permissions are granted (fixes bug on node)
 - fixed android client orchestration job to launch before the fallible facade-activation chain, so a stalled/aborted activation cannot leave the permission grant without a listener
 - added AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreground service notifications now refresh automatically after notification permission is granted on Android.
  * Service startup continues safely while required network services initialize.
* **Bug Fixes**
  * Improved notification handling when permissions change during startup.
  * Failed Tor bootstrap activation preserves retry behavior without stopping notifications.
  * Cancellation during service activation is handled correctly.
* **Tests**
  * Added coverage for permission changes, startup ordering, notification refresh, and activation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->