### PR TITLE
chore/followup_cleanup_post_1767

### DIFF
--- a/apps/clientApp/proguard-rules.pro
+++ b/apps/clientApp/proguard-rules.pro
@@ -95,21 +95,6 @@
 -dontwarn java.lang.management.ManagementFactory
 -dontwarn java.lang.management.RuntimeMXBean
 
-## Tink (com.google.crypto.tink) — used transitively for EncryptedSharedPreferences /
-## push-notification-key encryption. Tink ships an unused KeysDownloader utility that
-## references google-http-client + joda-time; those are not on our classpath because
-## we never call KeysDownloader. R8 fails the build on the unresolved references unless
-## we explicitly tell it to ignore them.
--dontwarn com.google.api.client.http.GenericUrl
--dontwarn com.google.api.client.http.HttpHeaders
--dontwarn com.google.api.client.http.HttpRequest
--dontwarn com.google.api.client.http.HttpRequestFactory
--dontwarn com.google.api.client.http.HttpResponse
--dontwarn com.google.api.client.http.HttpTransport
--dontwarn com.google.api.client.http.javanet.NetHttpTransport
--dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
--dontwarn org.joda.time.Instant
-
 ########################################
 # Log stripping (active: requires optimization, which is on above)
 ########################################

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeActivateTest.kt
@@ -85,8 +85,8 @@ class ClientPushNotificationServiceFacadeActivateTest : ClientKoinIntegrationTes
         every { Settings.Secure.getString(mockContentResolver, Settings.Secure.ANDROID_ID) } returns "test-android-id"
         ApplicationContextProvider.initialize(mockContext)
 
-        // Robolectric can't run Tink-backed EncryptedSharedPreferences. Seed
-        // an in-memory fake so getOrCreatePushNotificationKeyBase64() returns
+        // Robolectric can't emulate AndroidKeyStore, which the production key store
+        // wraps with. Seed an in-memory fake so getOrCreatePushNotificationKeyBase64() returns
         // a valid key — otherwise validateSymmetricKey aborts registration
         // before the apiGateway.registerDevice mock is exercised.
         network.bisq.mobile.data.crypto.pushNotificationKeyStoreFactory = { InMemoryKeyStoreForTest() }

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacadeIntegrationTest.kt
@@ -95,8 +95,8 @@ class ClientPushNotificationServiceFacadeIntegrationTest {
         } returns "test-android-id-12345"
         ApplicationContextProvider.initialize(mockContext)
 
-        // Robolectric can't run Tink-backed EncryptedSharedPreferences. Seed
-        // an in-memory fake so getOrCreatePushNotificationKeyBase64() returns
+        // Robolectric can't emulate AndroidKeyStore, which the production key store
+        // wraps with. Seed an in-memory fake so getOrCreatePushNotificationKeyBase64() returns
         // a valid key — otherwise validateSymmetricKey aborts registration
         // before the apiGateway.registerDevice mock is exercised.
         pushNotificationKeyStoreFactory = { InMemoryKeyStoreForTest() }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/ClientPushNotificationServiceFacade.kt
@@ -218,7 +218,7 @@ class ClientPushNotificationServiceFacade(
         // Without a valid key, the trusted node would either fail to encrypt
         // or fall back to a path the device can't decrypt — abort registration.
         // Dispatched off the main thread because the Android implementation initializes
-        // Tink + AndroidKeyStore on first call (multi-second cost) and a synchronous
+        // the AndroidKeyStore wrapping key on first call and does a synchronous
         // `commit()` to disk — both block whatever thread they run on, and
         // `presenterScope` runs on `Dispatchers.Main`. Using `Default` instead of `IO`
         // because `Dispatchers.IO` is JVM-only (internal on Kotlin/Native).

--- a/apps/nodeApp/proguard-rules.pro
+++ b/apps/nodeApp/proguard-rules.pro
@@ -357,21 +357,6 @@
 # risky around SystemOutFilter's stream capture - and they are redundant since #767 silences the core's
 # logback (root OFF) and hard-blocks stdout in release builds at runtime.
 
-## Tink (com.google.crypto.tink) — used transitively for EncryptedSharedPreferences /
-## push-notification-key encryption. Tink ships an unused KeysDownloader utility that
-## references google-http-client + joda-time; those are not on our classpath because
-## we never call KeysDownloader. R8 fails the build on the unresolved references unless
-## we explicitly tell it to ignore them.
--dontwarn com.google.api.client.http.GenericUrl
--dontwarn com.google.api.client.http.HttpHeaders
--dontwarn com.google.api.client.http.HttpRequest
--dontwarn com.google.api.client.http.HttpRequestFactory
--dontwarn com.google.api.client.http.HttpResponse
--dontwarn com.google.api.client.http.HttpTransport
--dontwarn com.google.api.client.http.javanet.NetHttpTransport
--dontwarn com.google.api.client.http.javanet.NetHttpTransport$Builder
--dontwarn org.joda.time.Instant
-
 ## bisq2 2.1.11 transitive deps (Apache HttpClient5, Apache Commons, Jersey, Swagger,
 ## gRPC-Netty-shaded) reference JDK-only and optional classes that don't exist on
 ## Android. None are reachable at runtime on the node app:


### PR DESCRIPTION
 - removed all Tink (com.google.crypto.tink) references including now unnecessary proguard rules for releases