### PR TITLE
refactor(chat): mirror bisq2's chat message and channel hierarchy and add the public discussion and support types

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
@@ -224,7 +224,7 @@ class NodeTradeChatMessagesServiceFacade(
                 citationAuthorUserProfile,
                 myUserProfile,
             )
-        openTradeItem.bisqEasyOpenTradeChannelModel.addChatMessages(model)
+        openTradeItem.bisqEasyOpenTradeChannelModel.addChatMessage(model)
 
         // PROTOCOL_LOG_MESSAGE's persist() is always rate-limited (arrives ~200 ms after
         // TAKE_BISQ_EASY_OFFER, inside the 1 000 ms window). Force a persist once the window clears.

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -735,7 +735,7 @@ class NodeTradesServiceFacade(
         // associated channel — see the early-return log above). tradeItemsLock serializes the two
         // invocations so the findListItem guard closes that race; the atomic dedup below stays as
         // defence-in-depth against a duplicate tradeId, which would crash OpenTradeListScreen's
-        // keyed LazyColumn (key = tradeId). Last write wins, mirroring addChatMessages / client facade.
+        // keyed LazyColumn (key = tradeId). Last write wins, mirroring addChatMessage / client facade.
         _openTradeItems.update { current -> current.filterNot { it.tradeId == openTradeItem.tradeId } + openTradeItem }
 
         val tradeId = trade.id

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/README.md
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/README.md
@@ -75,11 +75,13 @@ Model classes can contain also domain methods or util fields.
 The classes under `chat/` deliberately drop their postfix and mirror the Bisq Easy class names one to
 one, together with the class hierarchy and package layout:
 
-- messages and channels drop `Model` — `PrivateChatMessage`, `BisqEasyOpenTradeMessage`,
-  `TwoPartyPrivateChatMessage`, `BisqEasyOpenTradeChannel`, `TwoPartyPrivateChatChannel`
+- messages and channels drop `Model` — `ChatMessage`, `PrivateChatMessage`, `PublicChatMessage`,
+  `BisqEasyOpenTradeMessage`, `TwoPartyPrivateChatMessage`, `CommonPublicChatMessage`,
+  `ChatChannel`, `PublicChatChannel`, `BisqEasyOpenTradeChannel`, `TwoPartyPrivateChatChannel`,
+  `CommonPublicChatChannel`
 - reactions drop `VO` — `ChatMessageReaction`, `PrivateChatMessageReaction`,
   `BisqEasyOpenTradeMessageReaction`, `BisqEasyOfferbookMessageReaction`,
-  `TwoPartyPrivateChatMessageReaction`
+  `TwoPartyPrivateChatMessageReaction`, `CommonPublicChatMessageReaction`
 - `Citation` drops `VO` for the same reason, being a chat type carried by every message
 
 The messages and channels are still models in the sense above — mutability is the `StateFlow` fields,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/ChatChannel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/ChatChannel.kt
@@ -1,0 +1,45 @@
+package network.bisq.mobile.data.replicated.chat
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * What every chat channel has in common, mirroring Bisq 2's `bisq.chat.ChatChannel<M>`: an id, a
+ * domain and the messages. The private channels extend it directly; the public ones go through
+ * [network.bisq.mobile.data.replicated.chat.pub.PublicChatChannel].
+ *
+ * [unreadCount] is a mobile addition: Bisq 2 keeps that number in `ChatNotificationService`, keyed
+ * by channel id, and mobile hangs it off the channel because that is where the presenters read it.
+ * It is sourced from the persisted service rather than counted locally, so it survives an app
+ * restart. Trade chat tracks its read state in `TradeReadStateRepository` instead and leaves it at 0.
+ */
+abstract class ChatChannel<M : ChatMessage<*>>(
+    val id: String,
+    val chatChannelDomain: ChatChannelDomainEnum,
+) {
+    private val _chatMessages: MutableStateFlow<Set<M>> = MutableStateFlow(emptySet())
+    val chatMessages: StateFlow<Set<M>> = _chatMessages.asStateFlow()
+
+    private val _unreadCount: MutableStateFlow<Long> = MutableStateFlow(0L)
+    val unreadCount: StateFlow<Long> = _unreadCount.asStateFlow()
+
+    fun addChatMessage(message: M) {
+        // Last write wins: equals/hashCode is not enough, because a message keeps its id while its
+        // reactions and delivery status change.
+        _chatMessages.update { current ->
+            current
+                .filterNot { it.id == message.id }
+                .toSet() + message
+        }
+    }
+
+    fun setAllChatMessages(messages: Set<M>) {
+        _chatMessages.value = messages.associateBy { it.id }.values.toSet()
+    }
+
+    fun setUnreadCount(value: Long) {
+        _unreadCount.value = value
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/ChatMessage.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/ChatMessage.kt
@@ -1,0 +1,73 @@
+package network.bisq.mobile.data.replicated.chat
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
+import network.bisq.mobile.domain.utils.DateUtils
+import network.bisq.mobile.i18n.I18nSupport
+
+/**
+ * Everything a chat message has in common, mirroring Bisq 2's `bisq.chat.ChatMessage`: the root
+ * of both the private branch ([network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage]:
+ * trade chat, DMs) and the public one ([network.bisq.mobile.data.replicated.chat.pub.PublicChatMessage]:
+ * discussion, support, offerbook). The shared chat composables are typed to this class, so a
+ * message of either branch renders through the same list.
+ *
+ * Bisq 2 keeps only the author's id here and resolves the profile in the UI; mobile resolves it
+ * once at construction ([senderUserProfile]) and derives [isMyMessage] from [myUserProfile], so a
+ * composable never has to look a profile up. `channelId` and `chatChannelDomain` are left out for
+ * the same reason as before: the channel that holds the message already carries both.
+ *
+ * Takes plain values rather than a DTO: the private chat DTOs are a client-side transport concern
+ * and live in `apps/clientApp`, so a type in `:shared:domain` must not depend on one (the offerbook
+ * is the exception — `BisqEasyOfferbookMessageDto` predates this hierarchy and feeds the offerbook,
+ * not a chat). The node maps Bisq 2 objects straight into these arguments; a client implementation
+ * destructures its own DTO into the same ones.
+ *
+ * Generic in [R] for the same reason Bisq 2 is: [isMyChatReaction] takes a reaction, so a
+ * non-generic parameter type would force every caller that removes a reaction to widen and then
+ * down-cast before handing it to a service facade.
+ *
+ * [wasEdited] sits on the base because upstream has it there, although only a public message can be
+ * edited.
+ */
+abstract class ChatMessage<R : ChatMessageReaction>(
+    val id: String,
+    val chatMessageType: ChatMessageTypeEnum,
+    val text: String?,
+    val citation: Citation?,
+    citationAuthorUserProfile: UserProfileVO?,
+    val date: Long,
+    val senderUserProfile: UserProfileVO,
+    myUserProfile: UserProfileVO,
+    chatReactions: List<R>,
+    val wasEdited: Boolean = false,
+) {
+    private val myUserProfileId = myUserProfile.id
+
+    private val _chatReactions: MutableStateFlow<List<R>> = MutableStateFlow(chatReactions)
+    val chatReactions: StateFlow<List<R>> = _chatReactions.asStateFlow()
+
+    val textString: String get() = text ?: ""
+
+    // Used for protocol log message. Eager like `citationAuthorUserName` below, and for the same
+    // reason: both are pure functions of constructor vals, and a `get()` would re-run the i18n decode
+    // and the platform date format every time a row enters composition in the chat list.
+    val decodedText: String = text?.let { I18nSupport.decode(it) } ?: ""
+
+    val dateString: String = DateUtils.toDateTime(date)
+    val citationString: String get() = citation?.text ?: ""
+    val citationAuthorUserName: String? = citationAuthorUserProfile?.userName
+    val senderUserProfileId get() = senderUserProfile.id
+    val senderUserName get() = senderUserProfile.userName
+    val isMyMessage: Boolean get() = senderUserProfileId == myUserProfileId
+
+    fun isMyChatReaction(reaction: R): Boolean = myUserProfileId == reaction.userProfileId
+
+    fun setReactions(chatMessageReactions: List<R>) {
+        _chatReactions.value = chatMessageReactions
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.kt
@@ -3,7 +3,8 @@ package network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import network.bisq.mobile.data.replicated.chat.ChatChannel
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
 import network.bisq.mobile.data.replicated.chat.notifications.ChatChannelNotificationTypeEnum
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.user.identity.UserIdentityVO
@@ -14,18 +15,17 @@ import network.bisq.mobile.i18n.i18n
 
 // todo will get completed with work on chat
 class BisqEasyOpenTradeChannel(
-    val id: String,
+    id: String,
     val tradeId: String,
     val bisqEasyOffer: BisqEasyOfferVO,
     val myUserIdentity: UserIdentityVO,
     val traders: Set<UserProfileVO>,
     val mediator: UserProfileVO?,
-) : Logging {
+) : ChatChannel<BisqEasyOpenTradeMessage>(id, ChatChannelDomainEnum.BISQ_EASY_OPEN_TRADES),
+    Logging {
     // Mutable properties
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
-    private val _chatMessages: MutableStateFlow<Set<BisqEasyOpenTradeMessage>> = MutableStateFlow(emptySet())
-    val chatMessages: StateFlow<Set<BisqEasyOpenTradeMessage>> = _chatMessages.asStateFlow()
     val chatChannelNotificationType: MutableStateFlow<ChatChannelNotificationTypeEnum> =
         MutableStateFlow(ChatChannelNotificationTypeEnum.ALL)
     val userProfileIdsOfActiveParticipants: MutableSet<String> = mutableSetOf()
@@ -62,20 +62,5 @@ class BisqEasyOpenTradeChannel(
     fun getPeer(): UserProfileVO {
         require(traders.size == 1) { "traders is expected to has size 1 at getPeer()" }
         return traders.iterator().next()
-    }
-
-    fun addChatMessages(message: BisqEasyOpenTradeMessage) {
-        // last write wins
-        // relying on equals and hashcode is not enough for us
-        // because while the message id can stay the same, reactions and messageDeliveryStatus can be updated
-        _chatMessages.update { current ->
-            current
-                .filterNot { it.id == message.id }
-                .toSet() + message
-        }
-    }
-
-    fun setAllChatMessages(messages: Set<BisqEasyOpenTradeMessage>) {
-        _chatMessages.value = messages.associateBy { it.id }.values.toSet()
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannel.kt
@@ -1,0 +1,15 @@
+package network.bisq.mobile.data.replicated.chat.common
+
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.chat.pub.PublicChatChannel
+
+/**
+ * The discussion or support channel, mirroring Bisq 2's `bisq.chat.common.CommonPublicChatChannel`.
+ * [id] is `<domain>.<title>` (`discussion.bisq`, `support.support`), the one channel per domain
+ * that upstream still serves. The admin and moderator ids are left out: nothing in the UI reads them.
+ */
+class CommonPublicChatChannel(
+    id: String,
+    chatChannelDomain: ChatChannelDomainEnum,
+    val channelTitle: String,
+) : PublicChatChannel<CommonPublicChatMessage>(id, chatChannelDomain)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatMessage.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatMessage.kt
@@ -1,0 +1,71 @@
+package network.bisq.mobile.data.replicated.chat.common
+
+import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
+import network.bisq.mobile.data.replicated.chat.Citation
+import network.bisq.mobile.data.replicated.chat.pub.PublicChatMessage
+import network.bisq.mobile.data.replicated.chat.reactions.CommonPublicChatMessageReaction
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.domain.utils.createUuid
+
+/**
+ * A message in the discussion or support channel, replicating Bisq 2's
+ * `bisq.chat.common.CommonPublicChatMessage`. Adds nothing to [PublicChatMessage], exactly as
+ * upstream; the offerbook sibling is where the offer lives.
+ */
+class CommonPublicChatMessage(
+    id: String,
+    chatMessageType: ChatMessageTypeEnum,
+    text: String?,
+    citation: Citation?,
+    citationAuthorUserProfile: UserProfileVO?,
+    date: Long,
+    senderUserProfile: UserProfileVO,
+    myUserProfile: UserProfileVO,
+    chatReactions: List<CommonPublicChatMessageReaction>,
+    wasEdited: Boolean,
+) : PublicChatMessage<CommonPublicChatMessageReaction>(
+        id = id,
+        chatMessageType = chatMessageType,
+        text = text,
+        citation = citation,
+        citationAuthorUserProfile = citationAuthorUserProfile,
+        date = date,
+        senderUserProfile = senderUserProfile,
+        myUserProfile = myUserProfile,
+        chatReactions = chatReactions,
+        wasEdited = wasEdited,
+    )
+
+/**
+ * A fast way to create a mock public channel message. Mirrors
+ * [network.bisq.mobile.data.replicated.chat.two_party.createMockTwoPartyPrivateChatMessage] and
+ * lives in `commonMain` because its consumers span modules: `ChatMessageListUiTest` is in
+ * `:shared:presentation` and cannot see this module's `commonTest`.
+ *
+ * The [senderUserProfile] and [myUserProfile] defaults are *different* profiles, so an unqualified
+ * mock is someone else's message; pass the same instance to both for one of mine.
+ */
+fun createMockCommonPublicChatMessage(
+    id: String = createUuid(),
+    chatMessageType: ChatMessageTypeEnum = ChatMessageTypeEnum.TEXT,
+    text: String? = "Hello",
+    citation: Citation? = null,
+    citationAuthorUserProfile: UserProfileVO? = null,
+    date: Long = 1234567890000L,
+    senderUserProfile: UserProfileVO = createMockUserProfile("Alice"),
+    myUserProfile: UserProfileVO = createMockUserProfile("Bob"),
+    chatReactions: List<CommonPublicChatMessageReaction> = emptyList(),
+    wasEdited: Boolean = false,
+) = CommonPublicChatMessage(
+    id = id,
+    chatMessageType = chatMessageType,
+    text = text,
+    citation = citation,
+    citationAuthorUserProfile = citationAuthorUserProfile,
+    date = date,
+    senderUserProfile = senderUserProfile,
+    myUserProfile = myUserProfile,
+    chatReactions = chatReactions,
+    wasEdited = wasEdited,
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/priv/PrivateChatMessage.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/priv/PrivateChatMessage.kt
@@ -4,72 +4,46 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
 import network.bisq.mobile.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
-import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
-import network.bisq.mobile.domain.utils.DateUtils
-import network.bisq.mobile.i18n.I18nSupport
 
 /**
- * Everything a private chat message has in common, mirroring Bisq 2's
- * `bisq.chat.priv.PrivateChatMessage<R extends ChatMessageReaction>`.
+ * What a private chat message adds to [ChatMessage], mirroring Bisq 2's
+ * `bisq.chat.priv.PrivateChatMessage<R extends ChatMessageReaction>`: the delivery status of a
+ * message sent point to point. A public message is broadcast through the P2P store and has none.
  *
  * Bisq 2 models trade chat and peer-to-peer DMs as siblings under this base:
  * `BisqEasyOpenTradeMessage` adds only `tradeId` / `mediator` / `bisqEasyOffer`, and
- * `TwoPartyPrivateChatMessage` adds nothing at all. This class holds the shared body so neither
- * subclass has to repeat it.
- *
- * Takes plain values rather than a DTO: DTOs are a client-side transport concern and live in
- * `apps/clientApp`, so a type in `:shared:domain` must not depend on one. The node maps Bisq 2
- * objects straight into these arguments; a client implementation destructures its own DTO into the
- * same ones.
- *
- * Generic in [R] for the same reason Bisq 2 is: [isMyChatReaction] takes a reaction, so a
- * non-generic parameter type would force every caller that removes a reaction to widen and then
- * down-cast before handing it to a service facade.
+ * `TwoPartyPrivateChatMessage` adds nothing at all.
  */
 abstract class PrivateChatMessage<R : ChatMessageReaction>(
-    val id: String,
-    val chatMessageType: ChatMessageTypeEnum,
-    val text: String?,
-    val citation: Citation?,
+    id: String,
+    chatMessageType: ChatMessageTypeEnum,
+    text: String?,
+    citation: Citation?,
     citationAuthorUserProfile: UserProfileVO?,
-    val date: Long,
-    val senderUserProfile: UserProfileVO,
+    date: Long,
+    senderUserProfile: UserProfileVO,
     myUserProfile: UserProfileVO,
     chatReactions: List<R>,
-) {
-    private val myUserProfileId = myUserProfile.id
-
-    private val _chatReactions: MutableStateFlow<List<R>> = MutableStateFlow(chatReactions)
-    val chatReactions: StateFlow<List<R>> = _chatReactions.asStateFlow()
-
+) : ChatMessage<R>(
+        id = id,
+        chatMessageType = chatMessageType,
+        text = text,
+        citation = citation,
+        citationAuthorUserProfile = citationAuthorUserProfile,
+        date = date,
+        senderUserProfile = senderUserProfile,
+        myUserProfile = myUserProfile,
+        chatReactions = chatReactions,
+    ) {
     private val _messageDeliveryStatus = MutableStateFlow<Map<String, MessageDeliveryInfoVO>>(emptyMap())
     val messageDeliveryStatus = _messageDeliveryStatus.asStateFlow()
-
-    val textString: String get() = text ?: ""
-
-    // Used for protocol log message. Eager like `citationAuthorUserName` below, and for the same
-    // reason: both are pure functions of constructor vals, and a `get()` would re-run the i18n decode
-    // and the platform date format every time a row enters composition in the chat list.
-    val decodedText: String = text?.let { I18nSupport.decode(it) } ?: ""
-
-    val dateString: String = DateUtils.toDateTime(date)
-    val citationString: String get() = citation?.text ?: ""
-    val citationAuthorUserName: String? = citationAuthorUserProfile?.userName
-    val senderUserProfileId get() = senderUserProfile.id
-    val senderUserName get() = senderUserProfile.userName
-    val isMyMessage: Boolean get() = senderUserProfileId == myUserProfileId
-
-    fun isMyChatReaction(reaction: R): Boolean = myUserProfileId == reaction.userProfileId
-
-    fun setReactions(chatMessageReactions: List<R>) {
-        _chatReactions.value = chatMessageReactions
-    }
 
     fun removeMessageDeliveryStatusObserver(messageDeliveryServiceFacade: MessageDeliveryServiceFacade) {
         messageDeliveryServiceFacade.removeMessageDeliveryStatusObserver(id)
@@ -81,3 +55,11 @@ abstract class PrivateChatMessage<R : ChatMessageReaction>(
         }
     }
 }
+
+/**
+ * The delivery status of a message sent point to point, or null for a broadcast public one. The
+ * one place the shared chat composables tell the two branches apart, as desktop does in
+ * `ChatMessageListItem`.
+ */
+val ChatMessage<*>.messageDeliveryStatusOrNull: StateFlow<Map<String, MessageDeliveryInfoVO>>?
+    get() = (this as? PrivateChatMessage<*>)?.messageDeliveryStatus

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/pub/PublicChatChannel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/pub/PublicChatChannel.kt
@@ -1,0 +1,14 @@
+package network.bisq.mobile.data.replicated.chat.pub
+
+import network.bisq.mobile.data.replicated.chat.ChatChannel
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+
+/**
+ * A public channel, mirroring Bisq 2's `bisq.chat.pub.PublicChatChannel<M>`. Adds nothing to
+ * [ChatChannel] that mobile reads — upstream's additions are the P2P-store bookkeeping — and exists
+ * for the same reason [PublicChatMessage] does: to keep the hierarchy readable next to Bisq 2's.
+ */
+abstract class PublicChatChannel<M : PublicChatMessage<*>>(
+    id: String,
+    chatChannelDomain: ChatChannelDomainEnum,
+) : ChatChannel<M>(id, chatChannelDomain)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/pub/PublicChatMessage.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/pub/PublicChatMessage.kt
@@ -1,0 +1,38 @@
+package network.bisq.mobile.data.replicated.chat.pub
+
+import network.bisq.mobile.data.replicated.chat.ChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
+import network.bisq.mobile.data.replicated.chat.Citation
+import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+
+/**
+ * A message in a public channel, mirroring Bisq 2's `bisq.chat.pub.PublicChatMessage`: the
+ * discussion and support channels ([network.bisq.mobile.data.replicated.chat.common.CommonPublicChatMessage])
+ * and, upstream, the offerbook. Adds nothing to [ChatMessage] that the UI reads — upstream's additions are
+ * the P2P-store concerns (`DistributedData`, `isDataInvalid`) — and, unlike the private branch,
+ * carries no delivery status: a broadcast message has no single receiver to acknowledge it.
+ */
+abstract class PublicChatMessage<R : ChatMessageReaction>(
+    id: String,
+    chatMessageType: ChatMessageTypeEnum,
+    text: String?,
+    citation: Citation?,
+    citationAuthorUserProfile: UserProfileVO?,
+    date: Long,
+    senderUserProfile: UserProfileVO,
+    myUserProfile: UserProfileVO,
+    chatReactions: List<R>,
+    wasEdited: Boolean,
+) : ChatMessage<R>(
+        id = id,
+        chatMessageType = chatMessageType,
+        text = text,
+        citation = citation,
+        citationAuthorUserProfile = citationAuthorUserProfile,
+        date = date,
+        senderUserProfile = senderUserProfile,
+        myUserProfile = myUserProfile,
+        chatReactions = chatReactions,
+        wasEdited = wasEdited,
+    )

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/reactions/ChatMessageReaction.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/reactions/ChatMessageReaction.kt
@@ -7,7 +7,7 @@ import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
  * `bisq.chat.reactions.ChatMessageReaction` field for field.
  *
  * Not every member is read polymorphically today — shared code groups and renders by [reactionId],
- * and [network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage.isMyChatReaction] compares
+ * and [network.bisq.mobile.data.replicated.chat.ChatMessage.isMyChatReaction] compares
  * [userProfileId] — but the hierarchy is kept faithful so a mobile type can be read next to its
  * Bisq 2 counterpart without translating it.
  */

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/reactions/CommonPublicChatMessageReaction.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/reactions/CommonPublicChatMessageReaction.kt
@@ -1,0 +1,20 @@
+package network.bisq.mobile.data.replicated.chat.reactions
+
+import kotlinx.serialization.Serializable
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+
+/**
+ * A reaction on a discussion or support message. Like [BisqEasyOfferbookMessageReaction], it
+ * implements [ChatMessageReaction] directly — Bisq 2's `CommonPublicChatMessageReaction extends
+ * ChatMessageReaction` — with no sender/receiver envelope and no removed state.
+ */
+@Serializable
+data class CommonPublicChatMessageReaction(
+    override val id: String,
+    override val userProfileId: String,
+    override val chatChannelId: String,
+    override val chatChannelDomain: ChatChannelDomainEnum,
+    override val chatMessageId: String,
+    override val reactionId: Int,
+    override val date: Long,
+) : ChatMessageReaction

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/two_party/TwoPartyPrivateChatChannel.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/replicated/chat/two_party/TwoPartyPrivateChatChannel.kt
@@ -1,9 +1,6 @@
 package network.bisq.mobile.data.replicated.chat.two_party
 
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import network.bisq.mobile.data.replicated.chat.ChatChannel
 import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 
@@ -23,36 +20,8 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
  * profile has been pruned.
  */
 class TwoPartyPrivateChatChannel(
-    val id: String,
-    val chatChannelDomain: ChatChannelDomainEnum,
+    id: String,
+    chatChannelDomain: ChatChannelDomainEnum,
     val peer: UserProfileVO,
     val myUserProfile: UserProfileVO,
-) {
-    private val _chatMessages: MutableStateFlow<Set<TwoPartyPrivateChatMessage>> = MutableStateFlow(emptySet())
-    val chatMessages: StateFlow<Set<TwoPartyPrivateChatMessage>> = _chatMessages.asStateFlow()
-
-    /**
-     * Number of unread messages, sourced from Bisq 2's persisted `ChatNotificationService` rather
-     * than counted locally, so it survives an app restart.
-     */
-    private val _unreadCount: MutableStateFlow<Long> = MutableStateFlow(0L)
-    val unreadCount: StateFlow<Long> = _unreadCount.asStateFlow()
-
-    fun addChatMessage(message: TwoPartyPrivateChatMessage) {
-        // Last write wins: equals/hashCode is not enough, because a message keeps its id while its
-        // reactions and delivery status change.
-        _chatMessages.update { current ->
-            current
-                .filterNot { it.id == message.id }
-                .toSet() + message
-        }
-    }
-
-    fun setAllChatMessages(messages: Set<TwoPartyPrivateChatMessage>) {
-        _chatMessages.value = messages.associateBy { it.id }.values.toSet()
-    }
-
-    fun setUnreadCount(value: Long) {
-        _unreadCount.value = value
-    }
-}
+) : ChatChannel<TwoPartyPrivateChatMessage>(id, chatChannelDomain)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/ChatMessageTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/ChatMessageTest.kt
@@ -1,0 +1,132 @@
+package network.bisq.mobile.data.replicated.chat
+
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.domain.utils.DateUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [ChatMessage] is abstract, so everything here goes through [BisqEasyOpenTradeMessage] — the
+ * subclasses add fields and inherit the whole body under test.
+ */
+class ChatMessageTest {
+    private val me = createMockUserProfile("Bob")
+    private val peer = createMockUserProfile("Alice")
+
+    @Test
+    fun `nullable text and citation fall back to empty strings`() {
+        val message = createMessage(text = null, citation = null)
+
+        assertEquals("", message.textString)
+        assertEquals("", message.citationString)
+        assertEquals("", message.decodedText)
+        assertNull(message.citationAuthorUserName)
+    }
+
+    @Test
+    fun `text and citation are exposed when present`() {
+        val message =
+            createMessage(
+                text = "Payment sent",
+                citation = Citation(authorUserProfileId = peer.id, text = "When do we settle?", chatMessageId = "msg-0"),
+                citationAuthorUserProfile = peer,
+            )
+
+        assertEquals("Payment sent", message.textString)
+        assertEquals("When do we settle?", message.citationString)
+        assertEquals("Alice", message.citationAuthorUserName)
+    }
+
+    /**
+     * `decodedText` runs the text through [network.bisq.mobile.i18n.I18nSupport.decode], which
+     * returns the input untouched when it is not a known key — which is what a plain chat message is.
+     */
+    @Test
+    fun `decodedText passes a non-key through unchanged`() {
+        assertEquals("Payment sent", createMessage(text = "Payment sent").decodedText)
+    }
+
+    @Test
+    fun `dateString formats the epoch millis`() {
+        val message = createMessage()
+
+        assertEquals(DateUtils.toDateTime(MESSAGE_DATE), message.dateString)
+    }
+
+    @Test
+    fun `isMyMessage compares the sender against my profile`() {
+        assertTrue(createMessage(sender = me).isMyMessage)
+        assertFalse(createMessage(sender = peer).isMyMessage)
+    }
+
+    @Test
+    fun `senderUserName and senderUserProfileId come from the sender`() {
+        val message = createMessage(sender = peer)
+
+        assertEquals("Alice", message.senderUserName)
+        assertEquals(peer.id, message.senderUserProfileId)
+    }
+
+    @Test
+    fun `isMyChatReaction is true only for a reaction I sent`() {
+        val message = createMessage()
+
+        assertTrue(message.isMyChatReaction(createReaction("r-1", sender = me)))
+        assertFalse(message.isMyChatReaction(createReaction("r-2", sender = peer)))
+    }
+
+    @Test
+    fun `setReactions replaces the reaction flow`() {
+        val message = createMessage(reactions = listOf(createReaction("r-1", sender = peer)))
+
+        message.setReactions(listOf(createReaction("r-2", sender = me), createReaction("r-3", sender = peer)))
+
+        assertEquals(listOf("r-2", "r-3"), message.chatReactions.value.map { it.id })
+    }
+
+    private fun createMessage(
+        text: String? = "hello",
+        citation: Citation? = null,
+        citationAuthorUserProfile: UserProfileVO? = null,
+        sender: UserProfileVO = peer,
+        reactions: List<BisqEasyOpenTradeMessageReaction> = emptyList(),
+    ) = createMockBisqEasyOpenTradeMessage(
+        id = MESSAGE_ID,
+        text = text,
+        citation = citation,
+        citationAuthorUserProfile = citationAuthorUserProfile,
+        date = MESSAGE_DATE,
+        senderUserProfile = sender,
+        myUserProfile = me,
+        chatReactions = reactions,
+    )
+
+    private fun createReaction(
+        id: String,
+        sender: UserProfileVO,
+    ) = BisqEasyOpenTradeMessageReaction(
+        id = id,
+        senderUserProfile = sender,
+        receiverUserProfileId = me.id,
+        receiverNetworkId = me.networkId,
+        chatChannelId = "channel-1",
+        chatChannelDomain = ChatChannelDomainEnum.BISQ_EASY_OPEN_TRADES,
+        chatMessageId = MESSAGE_ID,
+        reactionId = 0,
+        date = MESSAGE_DATE,
+        isRemoved = false,
+    )
+
+    private companion object {
+        const val MESSAGE_ID = "msg-1"
+        const val MESSAGE_DATE = 1234567890000L
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertSame
 
 class BisqEasyOpenTradeChannelTest {
     @Test
-    fun addChatMessages_replacesExistingMessageWithSameId() {
+    fun addChatMessage_replacesExistingMessageWithSameId() {
         val myUserProfile = createMockUserProfile("me")
         val sender = createMockUserProfile("sender")
         val channelModel = createChannel(myUserProfile, sender)
@@ -46,8 +46,8 @@ class BisqEasyOpenTradeChannelTest {
                 reactionId = 2,
             )
 
-        channelModel.addChatMessages(original)
-        channelModel.addChatMessages(updated)
+        channelModel.addChatMessage(original)
+        channelModel.addChatMessage(updated)
 
         val storedMessage = channelModel.chatMessages.value.single()
         assertEquals(1, channelModel.chatMessages.value.size)

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannelTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannelTest.kt
@@ -40,9 +40,18 @@ class CommonPublicChatChannelTest {
     fun `setAllChatMessages keeps one copy per id`() {
         val channel = createChannel()
 
-        channel.setAllChatMessages(setOf(createMessage("message-1"), createMessage("message-1"), createMessage("message-2")))
+        channel.setAllChatMessages(
+            setOf(
+                createMessage("message-1", text = "first"),
+                createMessage("message-1", text = "updated"),
+                createMessage("message-2"),
+            ),
+        )
 
+        val stored = channel.chatMessages.value
+        assertEquals(2, stored.size)
         assertEquals(setOf("message-1", "message-2"), channel.ids())
+        assertEquals("updated", stored.single { it.id == "message-1" }.text)
     }
 
     @Test

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannelTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatChannelTest.kt
@@ -1,0 +1,75 @@
+package network.bisq.mobile.data.replicated.chat.common
+
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Same identity rule as `TwoPartyPrivateChatChannelTest`: a message keeps its id while its
+ * reactions move, so re-adding it must replace the old copy rather than keep both.
+ */
+class CommonPublicChatChannelTest {
+    private val me = createMockUserProfile("Bob")
+    private val peer = createMockUserProfile("Alice")
+
+    @Test
+    fun `a message re-added with the same id replaces the old copy`() {
+        val channel = createChannel()
+        val original = createMessage("message-1", text = "first")
+        val updated = createMessage("message-1", text = "edited")
+
+        channel.addChatMessage(original)
+        channel.addChatMessage(updated)
+
+        assertSame(updated, channel.chatMessages.value.single())
+    }
+
+    @Test
+    fun `messages with different ids all stay`() {
+        val channel = createChannel()
+
+        channel.addChatMessage(createMessage("message-1"))
+        channel.addChatMessage(createMessage("message-2"))
+
+        assertEquals(setOf("message-1", "message-2"), channel.ids())
+    }
+
+    @Test
+    fun `setAllChatMessages keeps one copy per id`() {
+        val channel = createChannel()
+
+        channel.setAllChatMessages(setOf(createMessage("message-1"), createMessage("message-1"), createMessage("message-2")))
+
+        assertEquals(setOf("message-1", "message-2"), channel.ids())
+    }
+
+    @Test
+    fun `unread count starts at zero and follows the setter`() {
+        val channel = createChannel()
+
+        assertEquals(0L, channel.unreadCount.value)
+        channel.setUnreadCount(3)
+        assertEquals(3L, channel.unreadCount.value)
+    }
+
+    private fun CommonPublicChatChannel.ids() = chatMessages.value.map { it.id }.toSet()
+
+    private fun createChannel() =
+        CommonPublicChatChannel(
+            id = "discussion.bisq",
+            chatChannelDomain = ChatChannelDomainEnum.DISCUSSION,
+            channelTitle = "bisq",
+        )
+
+    private fun createMessage(
+        id: String,
+        text: String = "hello",
+    ) = createMockCommonPublicChatMessage(
+        id = id,
+        text = text,
+        senderUserProfile = peer,
+        myUserProfile = me,
+    )
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatMessageTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/common/CommonPublicChatMessageTest.kt
@@ -1,0 +1,31 @@
+package network.bisq.mobile.data.replicated.chat.common
+
+import network.bisq.mobile.data.replicated.chat.ChatMessage
+import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.pub.PublicChatMessage
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertIsNot
+import kotlin.test.assertTrue
+
+/**
+ * The shared body is covered by `ChatMessageTest`; this pins what the public branch adds and the
+ * one thing it must not have — a public message is not a private one, so the UI cannot ask it for
+ * a delivery status.
+ */
+class CommonPublicChatMessageTest {
+    @Test
+    fun `is a public chat message and not a private one`() {
+        val message: ChatMessage<*> = createMockCommonPublicChatMessage()
+
+        assertIs<PublicChatMessage<*>>(message)
+        assertIsNot<PrivateChatMessage<*>>(message)
+    }
+
+    @Test
+    fun `wasEdited defaults to false and is carried when set`() {
+        assertFalse(createMockCommonPublicChatMessage().wasEdited)
+        assertTrue(createMockCommonPublicChatMessage(wasEdited = true).wasEdited)
+    }
+}

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/priv/PrivateChatMessageTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/priv/PrivateChatMessageTest.kt
@@ -1,101 +1,23 @@
 package network.bisq.mobile.data.replicated.chat.priv
 
-import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
-import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
-import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
 import network.bisq.mobile.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.data.replicated.network.confidential.ack.MessageDeliveryStatusEnum
-import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
-import network.bisq.mobile.domain.utils.DateUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
- * [PrivateChatMessage] is abstract, so everything here goes through [BisqEasyOpenTradeMessage] — the
- * subclass adds three fields and inherits the whole body under test.
+ * Only what the private branch adds to [network.bisq.mobile.data.replicated.chat.ChatMessage] — the
+ * shared body is covered by `ChatMessageTest`. [PrivateChatMessage] is abstract, so this goes through
+ * [BisqEasyOpenTradeMessage].
  */
 class PrivateChatMessageTest {
     private val me = createMockUserProfile("Bob")
     private val peer = createMockUserProfile("Alice")
-
-    @Test
-    fun `nullable text and citation fall back to empty strings`() {
-        val message = createMessage(text = null, citation = null)
-
-        assertEquals("", message.textString)
-        assertEquals("", message.citationString)
-        assertEquals("", message.decodedText)
-        assertNull(message.citationAuthorUserName)
-    }
-
-    @Test
-    fun `text and citation are exposed when present`() {
-        val message =
-            createMessage(
-                text = "Payment sent",
-                citation = Citation(authorUserProfileId = peer.id, text = "When do we settle?", chatMessageId = "msg-0"),
-                citationAuthorUserProfile = peer,
-            )
-
-        assertEquals("Payment sent", message.textString)
-        assertEquals("When do we settle?", message.citationString)
-        assertEquals("Alice", message.citationAuthorUserName)
-    }
-
-    /**
-     * `decodedText` runs the text through [network.bisq.mobile.i18n.I18nSupport.decode], which
-     * returns the input untouched when it is not a known key — which is what a plain chat message is.
-     */
-    @Test
-    fun `decodedText passes a non-key through unchanged`() {
-        assertEquals("Payment sent", createMessage(text = "Payment sent").decodedText)
-    }
-
-    @Test
-    fun `dateString formats the epoch millis`() {
-        val message = createMessage()
-
-        assertEquals(DateUtils.toDateTime(MESSAGE_DATE), message.dateString)
-    }
-
-    @Test
-    fun `isMyMessage compares the sender against my profile`() {
-        assertTrue(createMessage(sender = me).isMyMessage)
-        assertFalse(createMessage(sender = peer).isMyMessage)
-    }
-
-    @Test
-    fun `senderUserName and senderUserProfileId come from the sender`() {
-        val message = createMessage(sender = peer)
-
-        assertEquals("Alice", message.senderUserName)
-        assertEquals(peer.id, message.senderUserProfileId)
-    }
-
-    @Test
-    fun `isMyChatReaction is true only for a reaction I sent`() {
-        val message = createMessage()
-
-        assertTrue(message.isMyChatReaction(createReaction("r-1", sender = me)))
-        assertFalse(message.isMyChatReaction(createReaction("r-2", sender = peer)))
-    }
-
-    @Test
-    fun `setReactions replaces the reaction flow`() {
-        val message = createMessage(reactions = listOf(createReaction("r-1", sender = peer)))
-
-        message.setReactions(listOf(createReaction("r-2", sender = me), createReaction("r-3", sender = peer)))
-
-        assertEquals(listOf("r-2", "r-3"), message.chatReactions.value.map { it.id })
-    }
 
     @Test
     fun `delivery status observer feeds the status flow and is keyed by message id`() {
@@ -119,38 +41,12 @@ class PrivateChatMessageTest {
         assertEquals(listOf(MESSAGE_ID), facade.removed)
     }
 
-    private fun createMessage(
-        text: String? = "hello",
-        citation: Citation? = null,
-        citationAuthorUserProfile: UserProfileVO? = null,
-        sender: UserProfileVO = peer,
-        reactions: List<BisqEasyOpenTradeMessageReaction> = emptyList(),
-    ) = createMockBisqEasyOpenTradeMessage(
-        id = MESSAGE_ID,
-        text = text,
-        citation = citation,
-        citationAuthorUserProfile = citationAuthorUserProfile,
-        date = MESSAGE_DATE,
-        senderUserProfile = sender,
-        myUserProfile = me,
-        chatReactions = reactions,
-    )
-
-    private fun createReaction(
-        id: String,
-        sender: UserProfileVO,
-    ) = BisqEasyOpenTradeMessageReaction(
-        id = id,
-        senderUserProfile = sender,
-        receiverUserProfileId = me.id,
-        receiverNetworkId = me.networkId,
-        chatChannelId = "channel-1",
-        chatChannelDomain = ChatChannelDomainEnum.BISQ_EASY_OPEN_TRADES,
-        chatMessageId = MESSAGE_ID,
-        reactionId = 0,
-        date = MESSAGE_DATE,
-        isRemoved = false,
-    )
+    private fun createMessage() =
+        createMockBisqEasyOpenTradeMessage(
+            id = MESSAGE_ID,
+            senderUserProfile = peer,
+            myUserProfile = me,
+        )
 
     /** No mockk in `commonTest`, and the observer callback has to actually fire for line 78 to run. */
     private class RecordingMessageDeliveryServiceFacade : MessageDeliveryServiceFacade() {
@@ -181,6 +77,5 @@ class PrivateChatMessageTest {
 
     private companion object {
         const val MESSAGE_ID = "msg-1"
-        const val MESSAGE_DATE = 1234567890000L
     }
 }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/reactions/CommonPublicChatMessageReactionTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/replicated/chat/reactions/CommonPublicChatMessageReactionTest.kt
@@ -1,0 +1,43 @@
+package network.bisq.mobile.data.replicated.chat.reactions
+
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Like [BisqEasyOfferbookMessageReactionTest]: a public reaction implements [ChatMessageReaction]
+ * directly, with no sender/receiver envelope and no removed state.
+ */
+class CommonPublicChatMessageReactionTest {
+    @Test
+    fun `carries the ChatMessageReaction surface`() {
+        val reaction: ChatMessageReaction = createReaction()
+
+        assertEquals("reaction-1", reaction.id)
+        assertEquals("author-1", reaction.userProfileId)
+        assertEquals("discussion.bisq", reaction.chatChannelId)
+        assertEquals(ChatChannelDomainEnum.DISCUSSION, reaction.chatChannelDomain)
+        assertEquals("msg-1", reaction.chatMessageId)
+        assertEquals(ReactionEnum.THUMBS_UP.ordinal, reaction.reactionId)
+        assertEquals(1234567890000L, reaction.date)
+    }
+
+    @Test
+    fun `survives a json round trip`() {
+        val reaction = createReaction()
+
+        assertEquals(reaction, Json.decodeFromString<CommonPublicChatMessageReaction>(Json.encodeToString(reaction)))
+    }
+
+    private fun createReaction() =
+        CommonPublicChatMessageReaction(
+            id = "reaction-1",
+            userProfileId = "author-1",
+            chatChannelId = "discussion.bisq",
+            chatChannelDomain = ChatChannelDomainEnum.DISCUSSION,
+            chatMessageId = "msg-1",
+            reactionId = ReactionEnum.THUMBS_UP.ordinal,
+            date = 1234567890000L,
+        )
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatMessageListUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatMessageListUiTest.kt
@@ -6,9 +6,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.chat.common.createMockCommonPublicChatMessage
+import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.utils.createEmptyImage
@@ -45,15 +48,14 @@ class ChatMessageListUiTest : BisqComposeUiTestBase() {
 
     @Test
     fun `renders an empty conversation without crashing`() {
-        setTestContent { MessageList(emptyList()) }
+        setTestContent { MessageList(emptyList<BisqEasyOpenTradeMessage>()) }
 
         composeTestRule.waitForIdle()
     }
 
     /**
      * A `LEAVE` message goes through the `leaveMessageContent` slot instead of the text bubble. The
-     * default is the trade wording, which is what a caller inside a trade wants; a caller outside one
-     * has to override it.
+     * slot has no default: a caller inside a trade passes the trade wording, one outside it its own.
      */
     @Test
     fun `a leave message renders the default trade wording, not a text bubble`() {
@@ -63,6 +65,7 @@ class ChatMessageListUiTest : BisqComposeUiTestBase() {
                     message("msg-2", sender = peer, text = null, type = ChatMessageTypeEnum.LEAVE),
                     message("msg-1", sender = peer, text = "Payment received, thanks!"),
                 ),
+                leaveMessageContent = { message, modifier -> TradePeerLeftMessageBox(message, modifier) },
             )
         }
 
@@ -70,8 +73,30 @@ class ChatMessageListUiTest : BisqComposeUiTestBase() {
         composeTestRule.onNodeWithText("Payment received, thanks!").assertIsDisplayed()
     }
 
+    /**
+     * A public channel message has no delivery status and no peer, and the list must not need
+     * either: it is generic over the shared [ChatMessage] base, not the private branch.
+     */
+    @Test
+    fun `renders a public channel conversation`() {
+        setTestContent {
+            MessageList(
+                listOf(
+                    createMockCommonPublicChatMessage(id = "msg-2", text = "Welcome to Bisq", senderUserProfile = me, myUserProfile = me),
+                    createMockCommonPublicChatMessage(id = "msg-1", text = "Hi all", senderUserProfile = peer, myUserProfile = me),
+                ),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Welcome to Bisq").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Hi all").assertIsDisplayed()
+    }
+
     @Composable
-    private fun MessageList(messages: List<BisqEasyOpenTradeMessage>) {
+    private fun <M : ChatMessage<R>, R : ChatMessageReaction> MessageList(
+        messages: List<M>,
+        leaveMessageContent: @Composable (M, Modifier) -> Unit = { _, _ -> },
+    ) {
         Column(modifier = Modifier.fillMaxSize()) {
             ChatMessageList(
                 messages = messages,
@@ -83,7 +108,7 @@ class ChatMessageListUiTest : BisqComposeUiTestBase() {
                 userNameProvider = { it },
                 onPeerProfileClick = {},
                 modifier = Modifier.fillMaxSize(),
-                leaveMessageContent = { message, modifier -> TradePeerLeftMessageBox(message, modifier) },
+                leaveMessageContent = leaveMessageContent,
             )
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputBottomBar.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputBottomBar.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
@@ -19,7 +19,7 @@ import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 fun ChatInputBottomBar(
     onMessageSend: (String) -> Unit,
     modifier: Modifier = Modifier,
-    quotedMessage: PrivateChatMessage<*>? = null,
+    quotedMessage: ChatMessage<*>? = null,
     placeholder: String = EMPTY_STRING,
     resetScroll: () -> Unit = {},
     onCloseReply: () -> Unit = {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputField.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatInputField.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.tooling.preview.Preview
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.two_party.createMockTwoPartyPrivateChatMessage
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.i18n.i18n
@@ -40,7 +40,7 @@ private const val MAX_CHAT_INPUT_LENGTH = 10_000
 fun ChatInputField(
     onMessageSend: (String) -> Unit,
     modifier: Modifier = Modifier,
-    quotedMessage: PrivateChatMessage<*>? = null,
+    quotedMessage: ChatMessage<*>? = null,
     placeholder: String = EMPTY_STRING,
     resetScroll: () -> Unit = {},
     onCloseReply: () -> Unit = {},
@@ -85,7 +85,7 @@ fun ChatInputField(
 
 @Composable
 fun QuotedMessage(
-    quotedMessage: PrivateChatMessage<*>,
+    quotedMessage: ChatMessage<*>,
     onCloseReply: () -> Unit = {},
 ) {
     AnimatedVisibility(visible = quotedMessage.text != null) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatMessageContextMenu.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatMessageContextMenu.kt
@@ -7,9 +7,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.i18n.i18n
@@ -24,7 +24,7 @@ import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
 @Composable
 fun ChatMessageContextMenu(
-    message: PrivateChatMessage<*>,
+    message: ChatMessage<*>,
     isIgnored: Boolean,
     onSetShowMenu: (Boolean) -> Unit,
     onAddReaction: (ReactionEnum) -> Unit,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatTextMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ChatTextMessageBox.kt
@@ -22,9 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.priv.messageDeliveryStatusOrNull
 import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
@@ -43,7 +44,7 @@ fun <R : ChatMessageReaction> ChatTextMessageBox(
     isIgnored: Boolean,
     onAddReaction: (ReactionEnum) -> Unit,
     onRemoveReaction: (R) -> Unit,
-    message: PrivateChatMessage<R>,
+    message: ChatMessage<R>,
     userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
     onResendMessage: (String) -> Unit,
     userNameProvider: suspend (String) -> String,
@@ -79,7 +80,7 @@ fun <R : ChatMessageReaction> ChatTextMessageBox(
             message = message,
             onResendMessage = onResendMessage,
             userNameProvider = userNameProvider,
-            messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatus,
+            messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatusOrNull,
             onPeerProfileClick = onPeerProfileClick,
             onLongClick = { showMenu = true },
         )
@@ -217,7 +218,7 @@ private fun ChatTextMessageBox_PeerMessagePreview() {
 
 /**
  * [ReactionDisplay] reads only the reaction id and its sender — it groups by the resolved
- * [ReactionEnum] and asks [PrivateChatMessage.isMyChatReaction] who reacted. The rest is filled with
+ * [ReactionEnum] and asks [ChatMessage.isMyChatReaction] who reacted. The rest is filled with
  * plausible values so the object stays a faithful one.
  */
 @ExcludeFromCoverage

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ProfileIconAndText.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ProfileIconAndText.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -27,7 +27,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ProfileIconAndText(
-    message: PrivateChatMessage<*>,
+    message: ChatMessage<*>,
     userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage,
     onPeerProfileClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/QuoteMessageBubble.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/QuoteMessageBubble.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.Citation
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
 import network.bisq.mobile.data.replicated.chat.two_party.TwoPartyPrivateChatMessage
 import network.bisq.mobile.data.replicated.chat.two_party.createMockTwoPartyPrivateChatMessage
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
@@ -27,7 +27,7 @@ import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
 @Composable
 fun QuoteMessageBubble(
-    message: PrivateChatMessage<*>,
+    message: ChatMessage<*>,
     onClick: () -> Unit,
     content: @Composable () -> Unit,
 ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ReactionDisplay.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/ReactionDisplay.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -29,7 +29,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
 @Composable
 fun <R : ChatMessageReaction> ReactionDisplay(
-    message: PrivateChatMessage<R>,
+    message: ChatMessage<R>,
     onAddReaction: (ReactionEnum) -> Unit,
     onRemoveReaction: (R) -> Unit,
     modifier: Modifier = Modifier,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/UsernameMessageDeliveryAndDate.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
 import network.bisq.mobile.data.replicated.network.confidential.ack.MessageDeliveryInfoVO
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -38,10 +38,11 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun UsernameMessageDeliveryAndDate(
-    message: PrivateChatMessage<*>,
+    message: ChatMessage<*>,
     onResendMessage: (String) -> Unit,
     userNameProvider: suspend (String) -> String,
-    messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>>,
+    /** Null for a public channel message: only a private one is sent point to point and acknowledged. */
+    messageDeliveryInfoByPeersProfileId: StateFlow<Map<String, MessageDeliveryInfoVO>>?,
     onPeerProfileClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
 ) {
@@ -57,16 +58,17 @@ fun UsernameMessageDeliveryAndDate(
             modifier =
                 Modifier
                     .semantics(mergeDescendants = true) {}
-                    // Always tappable, but to different ends: my own messages open the
-                    // delivery-status popup, a peer's opens their profile.
+                    // Tappable to different ends: a peer's message opens their profile, my own
+                    // opens the delivery-status popup — which a public message does not have, so
+                    // there a tap on my own message does nothing rather than arming a popup that
+                    // never renders.
                     .combinedClickable(
                         role = Role.Button,
                         onLongClick = onLongClick,
                         onClick = {
-                            if (message.isMyMessage) {
-                                showInfo = true
-                            } else {
-                                openPeerProfile()
+                            when {
+                                !message.isMyMessage -> openPeerProfile()
+                                messageDeliveryInfoByPeersProfileId != null -> showInfo = true
                             }
                         },
                     ),
@@ -92,16 +94,18 @@ fun UsernameMessageDeliveryAndDate(
             if (message.isMyMessage) {
                 Spacer(Modifier.weight(1f))
                 date()
-                Spacer(Modifier.width(BisqUIConstants.ScreenPaddingHalfQuarter))
-                MessageDeliveryBox(
-                    onResendMessage = onResendMessage,
-                    userNameProvider = userNameProvider,
-                    messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
-                    showInfo,
-                    onDismissMenu = {
-                        showInfo = false
-                    },
-                )
+                if (messageDeliveryInfoByPeersProfileId != null) {
+                    Spacer(Modifier.width(BisqUIConstants.ScreenPaddingHalfQuarter))
+                    MessageDeliveryBox(
+                        onResendMessage = onResendMessage,
+                        userNameProvider = userNameProvider,
+                        messageDeliveryInfoByPeersProfileId = messageDeliveryInfoByPeersProfileId,
+                        showInfo,
+                        onDismissMenu = {
+                            showInfo = false
+                        },
+                    )
+                }
                 username()
             } else {
                 username()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/trade/ProtocolLogMessageBox.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/molecules/chat/trade/ProtocolLogMessageBox.kt
@@ -15,7 +15,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
+import network.bisq.mobile.data.replicated.chat.priv.messageDeliveryStatusOrNull
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.molecules.chat.MessageDeliveryBox
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
@@ -23,12 +24,15 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 
 @Composable
 fun ProtocolLogMessageBox(
-    message: PrivateChatMessage<*>,
+    message: ChatMessage<*>,
     onResendMessage: (String) -> Unit,
     userNameProvider: suspend (String) -> String,
     modifier: Modifier = Modifier,
 ) {
     var showInfo by remember { mutableStateOf(false) }
+    // Only a trade emits this type, but the list is generic over ChatMessage, so the box and its
+    // tap target are both gated on the private branch.
+    val messageDeliveryStatus = message.messageDeliveryStatusOrNull
 
     Row(
         modifier =
@@ -48,17 +52,21 @@ fun ProtocolLogMessageBox(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalfQuarter),
                 modifier =
-                    Modifier.clickable {
-                        showInfo = true
+                    if (messageDeliveryStatus != null) {
+                        Modifier.clickable { showInfo = true }
+                    } else {
+                        Modifier
                     },
             ) {
-                MessageDeliveryBox(
-                    onResendMessage = onResendMessage,
-                    userNameProvider = userNameProvider,
-                    messageDeliveryInfoByPeersProfileId = message.messageDeliveryStatus,
-                    showInfo,
-                    onDismissMenu = { showInfo = false },
-                )
+                if (messageDeliveryStatus != null) {
+                    MessageDeliveryBox(
+                        onResendMessage = onResendMessage,
+                        userNameProvider = userNameProvider,
+                        messageDeliveryInfoByPeersProfileId = messageDeliveryStatus,
+                        showInfo,
+                        onDismissMenu = { showInfo = false },
+                    )
+                }
 
                 BisqText.XSmallLightGrey(message.dateString)
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatMessageList.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatMessageList.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.data.replicated.chat.ChatMessageTypeEnum
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
 import network.bisq.mobile.data.replicated.chat.reactions.ChatMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.data.replicated.chat.two_party.TwoPartyPrivateChatMessage
@@ -53,7 +53,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
 @Composable
-fun <M : PrivateChatMessage<R>, R : ChatMessageReaction> ChatMessageList(
+fun <M : ChatMessage<R>, R : ChatMessageReaction> ChatMessageList(
     messages: List<M>,
     ignoredUserIds: Set<String>,
     showChatRulesWarnBox: Boolean,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatScaffold.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/organisms/chat/ChatScaffold.kt
@@ -3,7 +3,7 @@ package network.bisq.mobile.presentation.common.ui.components.organisms.chat
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import network.bisq.mobile.data.replicated.chat.priv.PrivateChatMessage
+import network.bisq.mobile.data.replicated.chat.ChatMessage
 import network.bisq.mobile.presentation.common.ui.components.layout.BisqStaticScaffold
 import network.bisq.mobile.presentation.common.ui.components.molecules.chat.ChatInputBottomBar
 import network.bisq.mobile.presentation.common.ui.components.molecules.chat.ChatInputField
@@ -21,7 +21,7 @@ import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 fun ChatScaffold(
     onMessageSend: (String) -> Unit,
     topBar: @Composable (() -> Unit)? = null,
-    quotedMessage: PrivateChatMessage<*>? = null,
+    quotedMessage: ChatMessage<*>? = null,
     placeholder: String = EMPTY_STRING,
     resetScroll: () -> Unit = {},
     onCloseReply: () -> Unit = {},

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
@@ -75,15 +75,12 @@
  *
  * NOT reusable as-is in a domain-type-free PoC, but reused unchanged in PRODUCTION:
  *   - `ChatMessageList` / `ChatTextMessageBox` (organisms/chat, molecules/chat) — both are
- *     now generic over `PrivateChatMessage<R>` rather than pinned to the TRADE-scoped
- *     `BisqEasyOpenTradeMessage`, so the DM adapter this note used to call for no longer
- *     exists. A public channel message is still NOT covered: `PrivateChatMessage` models a
- *     conversation with one peer, and a public channel has no single "receiver". Reusing
- *     these here needs the shared base widened, not an adapter.
- *   - `ChatMessageContextMenu` — same domain-type constraint; reused unchanged in
- *     production once the base above covers public channels. Its ignore/report menu items should now
- *     route to the Peer Profile screen's canonical handlers (see peer_profile/
- *     PeerProfileScreenDesign.kt) rather than trade-chat-local ones.
+ *     generic over `ChatMessage<R>`, the root shared by the private branch (trade, DM) and
+ *     the public one (`CommonPublicChatMessage`), so a public channel message renders through
+ *     them unchanged; only the delivery status is gated on the private branch.
+ *   - `ChatMessageContextMenu` — same domain-type constraint; reused unchanged in production.
+ *     Its ignore/report menu items should now route to the Peer Profile screen's canonical
+ *     handlers (see peer_profile/PeerProfileScreenDesign.kt) rather than trade-chat-local ones.
  *   - `ReactionInput` / `QuoteMessageBubble` (used inside ChatTextMessageBox) — unchanged.
  *
  * Because ChatMessageList/ChatTextMessageBox can't be previewed here without domain
@@ -114,7 +111,7 @@
  * Private DM's 1:1 assumption doesn't hold for a many-to-many public channel — messages
  * need each sender's name visible, not just an inbound/outbound binary. This is largely
  * already covered: `ChatTextMessageBox`'s existing `UsernameMessageDeliveryAndDate` row
- * already renders the sender's name above every bubble (see ChatTextMessageBox.kt L72-77),
+ * already renders the sender's name above every bubble,
  * because trade chat already supports a mediator as a third party. The gap is specifically
  * the tap-targetability called out above, not the name display itself.
  *

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/private_chat/PrivateChatScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/private_chat/PrivateChatScreenDesign.kt
@@ -72,7 +72,7 @@
  * ======================================================================================
  * - `ChatMessageList` — SUPERSEDED. This PoC assumed an adapter in the presenter
  *   (`msg.toBisqEasyOpenTradeMessageModel()`) that forged a trade message out of a DM.
- *   `ChatMessageList` is now generic over `PrivateChatMessage<R>`, so a DM is passed
+ *   `ChatMessageList` is now generic over `ChatMessage<R>`, so a DM is passed
  *   straight in and no adapter exists or is wanted. The one thing a non-trade caller
  *   must supply is `leaveMessageContent`: the slot has no default, because "has left
  *   the trade" is the wrong copy outside a trade.


### PR DESCRIPTION
resolves: https://github.com/bisq-network/bisq-mobile/issues/1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shared chat message and channel handling across private and public conversations.
  * Added public discussion messages, channels, reactions, unread counts, and message replacement for duplicate IDs.
  * Enabled common chat UI components to display both private and public messages.
* **Bug Fixes**
  * Corrected single-message updates so new messages are added and replaced consistently.
* **Documentation**
  * Updated chat model naming and component usage documentation.
* **Tests**
  * Added coverage for public messages, channels, reactions, unread counts, and shared message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->