### PR TITLE
bugfix/ux_out_of_sync_trade_status_for_trades_stucked_in_init_state

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
@@ -4,7 +4,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
@@ -168,7 +168,10 @@ class ClientTradesServiceFacadeTest : ClientKoinIntegrationTestBase() {
         runTest {
             coEvery { webSocketClientService.subscribe(any(), any()) } returns WebSocketEventObserver()
             facade.activate()
-            advanceUntilIdle()
+            // runCurrent, NOT advanceUntilIdle: activation starts the analytics out-of-sync recheck
+            // ticker (TimeUtils.tickerFlow), and an infinite ticker keeps the virtual-time scheduler
+            // busy forever — advanceUntilIdle would spin. Same constraint as OpenTradePresenterTest.
+            runCurrent()
             facade.deactivate()
         }
 

--- a/docs/testing/recipes.md
+++ b/docs/testing/recipes.md
@@ -34,7 +34,7 @@ class MyPresenterTest : PresentationKoinTestBase() {
 }
 ```
 
-Pitfalls: no `startKoin` in test class; no `ClientKoinIntegrationTestBase` for `:shared:presentation`; call `advanceUntilIdle()` before `StateFlow` asserts; abstract presenters need a test subclass in-file. If the test asserts localized copy (`.i18n()`, snackbar/error text), call `I18nSupport.initialize("en")` in `onKoinReady()` — VERIFY: needed for i18n keys? Skip it for guard-only tests.
+Pitfalls: no `startKoin` in test class; no `ClientKoinIntegrationTestBase` for `:shared:presentation`; call `advanceUntilIdle()` before `StateFlow` asserts — but never while a `TimeUtils.tickerFlow` collector is alive (an infinite ticker always has a next scheduled task, so `advanceUntilIdle` spins virtual time forever): use `runCurrent()` / bounded `advanceTimeBy()` and detach/cancel the ticker's scope before idling (proof: `OpenTradePresenterTest`, `ClientTradesServiceFacadeTest`); abstract presenters need a test subclass in-file. If the test asserts localized copy (`.i18n()`, snackbar/error text), call `I18nSupport.initialize("en")` in `onKoinReady()` — VERIFY: needed for i18n keys? Skip it for guard-only tests.
 
 ---
 
@@ -229,7 +229,7 @@ class MyClientPresenterTest : ClientKoinIntegrationTestBase() {
 }
 ```
 
-Pitfalls: construct facade/presenter manually in `onSetup()` or per-test; mock at gateway/repository boundary for facades; call `activate()` before facade flow asserts; no `TestApplication` in same class; no inline `startKoin` / `Dispatchers.setMain`; if overriding `beforeStartKoin` / `onTearDown`, always call `super` (`try/finally` for tear-down).
+Pitfalls: construct facade/presenter manually in `onSetup()` or per-test; mock at gateway/repository boundary for facades; call `activate()` before facade flow asserts; no `advanceUntilIdle()` after `activate()` if activation starts a `TimeUtils.tickerFlow` (e.g. the trades facades' analytics out-of-sync recheck) — the infinite ticker never lets the scheduler idle; use `runCurrent()` / bounded `advanceTimeBy()` and `deactivate()` before the test returns (proof: `ClientTradesServiceFacadeTest`); no `TestApplication` in same class; no inline `startKoin` / `Dispatchers.setMain`; if overriding `beforeStartKoin` / `onTearDown`, always call `super` (`try/finally` for tear-down).
 
 ---
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -19,6 +19,8 @@ import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade
 import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.domain.utils.DateUtils
+import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -204,6 +206,50 @@ class TradeAnalyticsTrackerTest {
         }
 
     @Test
+    fun `observeTrades emits OutOfSyncDetected once for a trade stuck in INIT past the threshold`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, clock = { TradeOutOfSyncDetector.OUT_OF_SYNC_THRESHOLD_MS + 1 })
+            val openTrades = MutableStateFlow(listOf(fakeTrade(takeOfferDate = 0L)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            // Several recheck ticks must still collapse into a single event for the same trade.
+            advanceTimeBy(TradeAnalyticsTracker.OUT_OF_SYNC_RECHECK_MS * 3)
+
+            verify(exactly = 1) { analytics.track(Trade.OutOfSyncDetected) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `observeTrades stays silent for fresh INIT trades and trades that progressed`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val now = TradeOutOfSyncDetector.OUT_OF_SYNC_THRESHOLD_MS * 2
+            val tracker = TradeAnalyticsTracker(analytics, clock = { now })
+            val openTrades =
+                MutableStateFlow(
+                    listOf(
+                        // INIT but taken just now — within the threshold.
+                        fakeTrade(id = "fresh", takeOfferDate = now),
+                        // Old take date but the state advanced — not stuck.
+                        fakeTrade(
+                            id = "progressed",
+                            tradeState = MutableStateFlow(BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION),
+                            takeOfferDate = 0L,
+                        ),
+                    ),
+                )
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            advanceTimeBy(TradeAnalyticsTracker.OUT_OF_SYNC_RECHECK_MS * 3)
+
+            verify(exactly = 0) { analytics.track(Trade.OutOfSyncDetected) }
+            scope.cancel()
+        }
+
+    @Test
     fun `stall bucket is UNKNOWN with no witnessed transition`() =
         runTest {
             val analytics = mockk<AnalyticsService>(relaxed = true)
@@ -271,9 +317,12 @@ class TradeAnalyticsTrackerTest {
         errorStackTrace: MutableStateFlow<String?> = MutableStateFlow(null),
         peersErrorMessage: MutableStateFlow<String?> = MutableStateFlow(null),
         peersErrorStackTrace: MutableStateFlow<String?> = MutableStateFlow(null),
+        // "Just taken" so INIT trades in unrelated tests never trip the out-of-sync detector.
+        takeOfferDate: Long = DateUtils.now(),
     ): TradeItemPresentationModel {
         val model = mockk<BisqEasyTradeModel>()
         every { model.tradeState } returns tradeState
+        every { model.takeOfferDate } returns takeOfferDate
         every { model.isSeller } returns isSeller
         every { model.errorMessage } returns errorMessage
         every { model.errorStackTrace } returns errorStackTrace

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
@@ -199,6 +199,14 @@ sealed class AnalyticsEvent(
         /** A protocol/peer error surfaced on the trade (from the trade model's error flows). */
         data object Errored : Trade("trade.errored")
 
+        /**
+         * A trade was detected desynced from the peer — parked in INIT past
+         * [network.bisq.mobile.domain.utils.TradeOutOfSyncDetector]'s threshold, the stuck-FSM
+         * symptom (bisq-network/bisq2 out-of-order eventQueue bug). Once per trade per session;
+         * measures how often users hit the situation the out-of-sync recovery pane exists for.
+         */
+        data object OutOfSyncDetected : Trade("trade.out_of_sync_detected")
+
         companion object {
             // `by lazy` for the same class-init-cycle reason as [ScreenOpened.all].
             val all: List<Trade> by lazy {
@@ -207,7 +215,7 @@ sealed class AnalyticsEvent(
                     Step.entries.flatMap { step -> Outcome.entries.map { outcome -> Action(step, outcome) } } +
                     InterruptReason.entries.flatMap { reason -> StallBucket.entries.map { Cancelled(reason, it) } } +
                     InterruptReason.entries.map { Rejected(it) } +
-                    listOf(Taken, Completed, Errored)
+                    listOf(Taken, Completed, Errored, OutOfSyncDetected)
             }
         }
     }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -18,6 +18,8 @@ import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.domain.utils.TimeUtils
+import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 
 /**
  * Shared trade-funnel analytics used by both the client and node [TradesServiceFacade] implementations
@@ -33,7 +35,9 @@ import network.bisq.mobile.domain.utils.Logging
  *    counterparty never trips the stall watch.
  *  - **lifecycle** via [track]: `Taken` / `Cancelled` / `Rejected` on the corresponding actions.
  *  - **completion & errors** via [observeTrades]: `Completed` when a trade reaches `BTC_CONFIRMED`,
- *    `Errored` (+ captured exception) when a trade surfaces a protocol/peer error.
+ *    `Errored` (+ captured exception) when a trade surfaces a protocol/peer error, and
+ *    `OutOfSyncDetected` when a trade sits in INIT past the [TradeOutOfSyncDetector] threshold —
+ *    the field measurement of the stuck-FSM desync the out-of-sync recovery pane exists for.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TradeAnalyticsTracker(
@@ -45,6 +49,11 @@ class TradeAnalyticsTracker(
         // Generous for Tor round-trips. Only the user's OWN local state transition is timed (fast), so
         // this never trips on a legitimate counterparty wait, which can span hours/days.
         const val DEFAULT_STALL_TIMEOUT_MS = 45_000L
+
+        // The out-of-sync signal is time-based (a stuck trade never transitions), so it needs a
+        // recheck ticker. One minute against a 10-minute detection threshold keeps detection
+        // near-immediate without meaningful wakeup cost.
+        const val OUT_OF_SYNC_RECHECK_MS = 60_000L
     }
 
     // In-memory only, by design: the trade DTO carries no per-state timestamps, so a
@@ -138,6 +147,7 @@ class TradeAnalyticsTracker(
         val completed = mutableSetOf<String>()
         val errored = mutableSetOf<String>()
         val reachedPhases = mutableSetOf<String>()
+        val outOfSync = mutableSetOf<String>()
 
         // Phase reached (state-based): emit once per (trade, phase) as a trade enters each phase,
         // whether or not the user is viewing it — the funnel denominator to compare against the
@@ -176,6 +186,26 @@ class TradeAnalyticsTracker(
                     if (state == BisqEasyTradeStateEnum.BTC_CONFIRMED && completed.add(id)) {
                         analyticsService.track(AnalyticsEvent.Trade.Completed)
                     }
+                }
+        }
+
+        // Out-of-sync: a trade parked in INIT past the detector threshold is desynced from the peer
+        // (the stuck-FSM bug the recovery pane exists for — see TradeOutOfSyncDetector). This signal
+        // is time-based, not state-based — a stuck trade never transitions — so it rechecks on a
+        // ticker instead of observing state flows. Once per trade per session.
+        scope.launch {
+            openTradeItems
+                .flatMapLatest { trades ->
+                    TimeUtils.tickerFlow(OUT_OF_SYNC_RECHECK_MS).map { trades }
+                }.collect { trades ->
+                    trades
+                        .filter { TradeOutOfSyncDetector.isOutOfSync(it.bisqEasyTradeModel, clock()) }
+                        .forEach { item ->
+                            if (outOfSync.add(tradeId(item))) {
+                                log.w { "Trade detected out of sync — stuck in INIT past the detection threshold" }
+                                analyticsService.track(AnalyticsEvent.Trade.OutOfSyncDetected)
+                            }
+                        }
                 }
         }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/TradeOutOfSyncDetector.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/TradeOutOfSyncDetector.kt
@@ -1,0 +1,23 @@
+package network.bisq.mobile.domain.utils
+
+import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeModel
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+
+/**
+ * A trade parked in [BisqEasyTradeStateEnum.INIT] beyond the threshold is desynced from the peer:
+ * the bisq2 trade FSM queues out-of-order protocol messages in memory only, so a restart strands
+ * the trade in INIT where no incoming message can move it forward and the trade screen renders no
+ * actionable step. The peer's side of the trade is typically healthy. A normal take-offer
+ * handshake completes within seconds even over Tor, so past the threshold this is the stuck-FSM
+ * bug, not latency.
+ */
+object TradeOutOfSyncDetector {
+    const val OUT_OF_SYNC_THRESHOLD_MS: Long = 10 * 60 * 1000L
+
+    fun isOutOfSync(
+        trade: BisqEasyTradeModel,
+        nowMs: Long = DateUtils.now(),
+    ): Boolean =
+        trade.tradeState.value == BisqEasyTradeStateEnum.INIT &&
+            nowMs - trade.takeOfferDate > OUT_OF_SYNC_THRESHOLD_MS
+}

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -243,6 +243,11 @@ mobile.bisqEasy.openTrades.warnIgnoredUser=Beware: This trade involves a user yo
 mobile.bisqEasy.openTrades.closeTrade.failed=Failed to close trade: {0}
 mobile.bisqEasy.openTrades.clearReadState.failed=Failed to update read state for trade: {0}
 mobile.bisqEasy.openTrades.tradeDetails.viewInBlockExplorer=View in block explorer →
+mobile.bisqEasy.openTrades.outOfSync.headline=This trade view is out of sync
+mobile.bisqEasy.openTrades.outOfSync.body=Your app hasn't received updates for this trade in a while, so the steps below may be frozen. This does not mean the trade was cancelled — your trading partner's screen may look completely normal. If you've already sent payment, do not send it again.
+mobile.bisqEasy.openTrades.outOfSync.openChat=Open trade chat
+mobile.bisqEasy.openTrades.outOfSync.listTag=Out of sync
+mobile.bisqEasy.openTrades.waitingForTradeData=Waiting for the trade to start...
 
 mobile.bisqEasy.tradeState.mediationFailed=Mediation reporting failed, please reach out to support
 mobile.bisqEasy.tradeState.info.seller.phase1.accountData.validations.minLength=Min length: 3 characters

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/TradeOutOfSyncDetectorTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/TradeOutOfSyncDetectorTest.kt
@@ -1,0 +1,121 @@
+package network.bisq.mobile.domain.utils
+
+import network.bisq.mobile.data.replicated.common.currency.MarketVO
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory.fromPrice
+import network.bisq.mobile.data.replicated.contract.BisqEasyContractVO
+import network.bisq.mobile.data.replicated.contract.PartyVO
+import network.bisq.mobile.data.replicated.contract.RoleEnum
+import network.bisq.mobile.data.replicated.identity.IdentityVO
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.offer.payment_method.BitcoinPaymentMethodSpecVO
+import network.bisq.mobile.data.replicated.offer.payment_method.FiatPaymentMethodSpecVO
+import network.bisq.mobile.data.replicated.offer.price.spec.FixPriceSpecVO
+import network.bisq.mobile.data.replicated.trade.TradeRoleEnum
+import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeDto
+import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeModel
+import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradePartyVO
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector.OUT_OF_SYNC_THRESHOLD_MS
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TradeOutOfSyncDetectorTest {
+    private companion object {
+        const val TAKE_OFFER_DATE = 1_000_000L
+    }
+
+    @Test
+    fun `a trade in INIT past the threshold is out of sync`() {
+        val trade = createTradeModel(BisqEasyTradeStateEnum.INIT)
+
+        assertTrue(TradeOutOfSyncDetector.isOutOfSync(trade, nowMs = TAKE_OFFER_DATE + OUT_OF_SYNC_THRESHOLD_MS + 1))
+    }
+
+    @Test
+    fun `a trade in INIT within the threshold is not out of sync`() {
+        val trade = createTradeModel(BisqEasyTradeStateEnum.INIT)
+
+        assertFalse(TradeOutOfSyncDetector.isOutOfSync(trade, nowMs = TAKE_OFFER_DATE + OUT_OF_SYNC_THRESHOLD_MS))
+    }
+
+    @Test
+    fun `a trade past the threshold but out of INIT is not out of sync`() {
+        val trade = createTradeModel(BisqEasyTradeStateEnum.TAKER_SENT_TAKE_OFFER_REQUEST)
+
+        assertFalse(TradeOutOfSyncDetector.isOutOfSync(trade, nowMs = TAKE_OFFER_DATE + OUT_OF_SYNC_THRESHOLD_MS + 1))
+    }
+
+    @Test
+    fun `a stuck trade leaving INIT stops being out of sync`() {
+        val trade = createTradeModel(BisqEasyTradeStateEnum.INIT)
+        val now = TAKE_OFFER_DATE + OUT_OF_SYNC_THRESHOLD_MS + 1
+
+        assertTrue(TradeOutOfSyncDetector.isOutOfSync(trade, nowMs = now))
+
+        trade.setTradeState(BisqEasyTradeStateEnum.REJECTED)
+
+        assertFalse(TradeOutOfSyncDetector.isOutOfSync(trade, nowMs = now))
+    }
+
+    /** Minimal real model, mirroring `createMockTradeItem` in `OpenTradeListItem.kt` — every type in the chain is a plain data class. */
+    private fun createTradeModel(tradeState: BisqEasyTradeStateEnum): BisqEasyTradeModel {
+        val makerProfile = createMockUserProfile("Maker")
+        val takerProfile = createMockUserProfile("Taker")
+        val market = MarketVO("BTC", "EUR", "Bitcoin", "Euro")
+        val priceSpec = FixPriceSpecVO(PriceQuoteVOFactory.fromPrice(50_000L, market))
+        val bitcoinPaymentMethod = BitcoinPaymentMethodSpecVO("MAIN_CHAIN", null)
+        val fiatPaymentMethod = FiatPaymentMethodSpecVO("SEPA", null)
+        val offer =
+            BisqEasyOfferVO(
+                id = "test-offer-1",
+                date = 0L,
+                makerNetworkId = makerProfile.networkId,
+                direction = DirectionEnum.SELL,
+                market = market,
+                amountSpec = QuoteSideFixedAmountSpecVO(500_00),
+                priceSpec = priceSpec,
+                protocolTypes = emptyList(),
+                baseSidePaymentMethodSpecs = listOf(bitcoinPaymentMethod),
+                quoteSidePaymentMethodSpecs = listOf(fiatPaymentMethod),
+                offerOptions = emptyList(),
+                supportedLanguageCodes = listOf("en"),
+            )
+        return BisqEasyTradeModel(
+            BisqEasyTradeDto(
+                contract =
+                    BisqEasyContractVO(
+                        takeOfferDate = TAKE_OFFER_DATE,
+                        offer = offer,
+                        maker = PartyVO(RoleEnum.MAKER, makerProfile.networkId),
+                        taker = PartyVO(RoleEnum.TAKER, takerProfile.networkId),
+                        baseSideAmount = 1_000_000L,
+                        quoteSideAmount = 500_00L,
+                        baseSidePaymentMethodSpec = bitcoinPaymentMethod,
+                        quoteSidePaymentMethodSpec = fiatPaymentMethod,
+                        mediator = null,
+                        priceSpec = priceSpec,
+                        marketPrice = 50_000L,
+                    ),
+                id = "test-trade-1",
+                tradeRole = TradeRoleEnum.BUYER_AS_TAKER,
+                myIdentity = IdentityVO(tag = "test", networkId = takerProfile.networkId),
+                taker = BisqEasyTradePartyVO(takerProfile.networkId),
+                maker = BisqEasyTradePartyVO(makerProfile.networkId),
+                tradeState = tradeState,
+                paymentAccountData = null,
+                bitcoinPaymentData = null,
+                paymentProof = null,
+                interruptTradeInitiator = null,
+                errorMessage = null,
+                errorStackTrace = null,
+                peersErrorMessage = null,
+                peersErrorStackTrace = null,
+            ),
+        )
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/components/OpenTradeListItemUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/components/OpenTradeListItemUiTest.kt
@@ -24,7 +24,10 @@ class OpenTradeListItemUiTest : PresentationKoinComposeTestBase() {
     private var selected = false
     private var peerProfileOpened = false
 
-    private fun renderItem(unreadCount: Int = 0) {
+    private fun renderItem(
+        unreadCount: Int = 0,
+        isOutOfSync: Boolean = false,
+    ) {
         setTestContent {
             OpenTradeListItem(
                 item = item,
@@ -32,6 +35,7 @@ class OpenTradeListItemUiTest : PresentationKoinComposeTestBase() {
                 unreadCount = unreadCount,
                 onSelect = { selected = true },
                 onPeerProfileClick = { peerProfileOpened = true },
+                isOutOfSync = isOutOfSync,
             )
         }
     }
@@ -57,5 +61,19 @@ class OpenTradeListItemUiTest : PresentationKoinComposeTestBase() {
 
         assertTrue(selected)
         assertFalse(peerProfileOpened)
+    }
+
+    @Test
+    fun `an out of sync trade shows the tag`() {
+        renderItem(isOutOfSync = true)
+
+        composeTestRule.onNodeWithText("mobile.bisqEasy.openTrades.outOfSync.listTag".i18n()).assertExists()
+    }
+
+    @Test
+    fun `a healthy trade shows no out of sync tag`() {
+        renderItem(isOutOfSync = false)
+
+        composeTestRule.onNodeWithText("mobile.bisqEasy.openTrades.outOfSync.listTag".i18n()).assertDoesNotExist()
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
@@ -1,0 +1,136 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.foundation.ScrollState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.repository.TradeReadStateRepository
+import network.bisq.mobile.domain.utils.DateUtils
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Uses [runCurrent] instead of [kotlinx.coroutines.test.advanceUntilIdle], and always detaches the
+ * presenter in a finally block: the presenter starts
+ * [network.bisq.mobile.domain.utils.TimeUtils.tickerFlow] for the out-of-sync re-check, and an
+ * un-cancelled ticker keeps the shared virtual-time scheduler busy forever, hanging runTest's
+ * cleanup (same pattern and reasoning as `UserProfilePresenterTest.runPresenterTest`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OpenTradePresenterTest : PresentationKoinTestBase() {
+    private val tradesServiceFacade: TradesServiceFacade = mockk(relaxed = true)
+    private val userProfileServiceFacade: UserProfileServiceFacade = mockk(relaxed = true)
+    private val tradeReadStateRepository: TradeReadStateRepository = mockk(relaxed = true)
+    private val tradeFlowPresenter: TradeFlowPresenter = mockk(relaxed = true)
+    private val mainPresenter: MainPresenter = mockk(relaxed = true)
+
+    private lateinit var presenter: OpenTradePresenter
+    private var scrollScope: CoroutineScope? = null
+
+    override fun onKoinReady() {
+        I18nSupport.initialize("en")
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+    }
+
+    private fun runPresenterTest(block: suspend TestScope.() -> Unit) =
+        runTest {
+            try {
+                block()
+            } finally {
+                // Cancel the delayed scroll-animation task before it can be advanced into —
+                // animateScrollTo would need a MonotonicFrameClock plain presenter tests lack.
+                scrollScope?.cancel()
+                if (::presenter.isInitialized) {
+                    presenter.onViewUnattaching()
+                    // Disposal is launched on Main — run it so the ticker actually cancels.
+                    runCurrent()
+                }
+            }
+        }
+
+    private fun createAndInitializePresenter() {
+        presenter =
+            OpenTradePresenter(
+                mainPresenter,
+                tradeReadStateRepository,
+                tradesServiceFacade,
+                userProfileServiceFacade,
+                tradeFlowPresenter,
+            )
+        val scope = CoroutineScope(testDispatcher + SupervisorJob())
+        scrollScope = scope
+        presenter.initialize("tid", ScrollState(0), scope)
+    }
+
+    @Test
+    fun `a trade stuck in INIT past the threshold is flagged out of sync`() =
+        runPresenterTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            // The harness pins takeOfferDate far in the past, so an INIT trade is stuck right away.
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+
+            createAndInitializePresenter()
+            runCurrent()
+
+            assertTrue(presenter.isTradeOutOfSync.value)
+        }
+
+    @Test
+    fun `a trade in INIT within the threshold is not flagged`() =
+        runPresenterTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            val tradeModel = harness.selectedTrade.value!!.bisqEasyTradeModel
+            every { tradeModel.takeOfferDate } returns DateUtils.now()
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+
+            createAndInitializePresenter()
+            runCurrent()
+
+            assertFalse(presenter.isTradeOutOfSync.value)
+        }
+
+    @Test
+    fun `a stuck trade leaving INIT clears the flag`() =
+        runPresenterTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+
+            createAndInitializePresenter()
+            runCurrent()
+            assertTrue(presenter.isTradeOutOfSync.value)
+
+            harness.tradeStateFlow.value = BisqEasyTradeStateEnum.REJECTED
+            runCurrent()
+
+            assertFalse(presenter.isTradeOutOfSync.value)
+        }
+
+    @Test
+    fun `unattaching the view resets the flag`() =
+        runPresenterTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+
+            createAndInitializePresenter()
+            runCurrent()
+            assertTrue(presenter.isTradeOutOfSync.value)
+
+            presenter.onViewUnattaching()
+            runCurrent()
+
+            assertFalse(presenter.isTradeOutOfSync.value)
+        }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPaneUiTest.kt
@@ -1,0 +1,35 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.ui.test.onNodeWithText
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import kotlin.test.Test
+
+/**
+ * A trade in raw INIT used to render a fully blank step 1 — the "dead box" a user with a stuck
+ * trade stares at. This pins the waiting fallback for that branch.
+ */
+class TradeFlowPaneUiTest : PresentationKoinComposeTestBase() {
+    @Test
+    fun `raw INIT phase renders the waiting fallback instead of a blank step`() {
+        val presenter = mockk<TradeFlowPresenter>(relaxed = true)
+        every { presenter.tradePhaseState } returns MutableStateFlow(TradeFlowPresenter.TradePhaseState.INIT)
+        every { presenter.steps } returns
+            listOf(
+                TradeFlowPresenter.TradeFlowStep.ACCOUNT_DETAILS,
+                TradeFlowPresenter.TradeFlowStep.FIAT_PAYMENT,
+                TradeFlowPresenter.TradeFlowStep.BITCOIN_TRANSFER,
+                TradeFlowPresenter.TradeFlowStep.TRADE_COMPLETED,
+            )
+        every { presenter.presenterForPhase(any()) } returns null
+
+        setTestContent {
+            TradeFlowPane(presenter)
+        }
+
+        composeTestRule.onNodeWithText("mobile.bisqEasy.openTrades.waitingForTradeData".i18n()).assertExists()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
@@ -1,0 +1,60 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import kotlin.test.Test
+
+class TradeOutOfSyncPaneUiTest : PresentationKoinComposeTestBase() {
+    private val headline get() = "mobile.bisqEasy.openTrades.outOfSync.headline".i18n()
+    private val openChat get() = "mobile.bisqEasy.openTrades.outOfSync.openChat".i18n()
+    private val reportToMediator get() = "bisqEasy.openTrades.reportToMediator".i18n()
+
+    private fun renderPane(
+        isTradeOutOfSync: Boolean,
+        isInMediation: Boolean = false,
+    ): Pair<OpenTradePresenter, TradeDetailsHeaderPresenter> {
+        val presenter = mockk<OpenTradePresenter>(relaxed = true)
+        val headerPresenter = mockk<TradeDetailsHeaderPresenter>(relaxed = true)
+        every { presenter.isTradeOutOfSync } returns MutableStateFlow(isTradeOutOfSync)
+        every { presenter.isInMediation } returns MutableStateFlow(isInMediation)
+
+        setTestContent {
+            TradeOutOfSyncPane(presenter = presenter, headerPresenter = headerPresenter)
+        }
+        return presenter to headerPresenter
+    }
+
+    @Test
+    fun `an out of sync trade shows the pane with both actions`() {
+        val (presenter, headerPresenter) = renderPane(isTradeOutOfSync = true)
+
+        composeTestRule.onNodeWithText(headline).assertExists()
+
+        composeTestRule.onNodeWithText(openChat).performClick()
+        verify { presenter.onOpenChat() }
+
+        composeTestRule.onNodeWithText(reportToMediator).performClick()
+        verify { headerPresenter.onOpenMediationConfirmationDialog() }
+    }
+
+    @Test
+    fun `a trade in sync renders nothing`() {
+        renderPane(isTradeOutOfSync = false)
+
+        composeTestRule.onNodeWithText(headline).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the mediator action is hidden once mediation is already active`() {
+        renderPane(isTradeOutOfSync = true, isInMediation = true)
+
+        composeTestRule.onNodeWithText(headline).assertExists()
+        composeTestRule.onNodeWithText(reportToMediator).assertDoesNotExist()
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListPresenter.kt
@@ -22,6 +22,8 @@ import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
 import network.bisq.mobile.domain.usecase.trade.FilterOpenTradesUseCase
+import network.bisq.mobile.domain.utils.TimeUtils
+import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
@@ -44,6 +46,7 @@ class OpenTradeListPresenter(
 ) : BasePresenter(mainPresenter) {
     private companion object {
         const val FILTER_DEBOUNCE_MS = 400L
+        const val OUT_OF_SYNC_RECHECK_MS = 30_000L
     }
 
     private val _uiState = MutableStateFlow(OpenTradeListUiState())
@@ -94,6 +97,21 @@ class OpenTradeListPresenter(
                         )
                     }
                 }
+        }
+
+        presenterScope.launch {
+            // Ticker-driven so a trade that crosses the stuck threshold while the list is open
+            // gets tagged without a data change; a state moving out of INIT clears the tag on
+            // the next tick.
+            tradesServiceFacade.openTradeItems
+                .combine(TimeUtils.tickerFlow(OUT_OF_SYNC_RECHECK_MS)) { items, _ -> items }
+                .map { items ->
+                    items
+                        .filter { TradeOutOfSyncDetector.isOutOfSync(it.bisqEasyTradeModel) }
+                        .map { it.tradeId }
+                        .toSet()
+                }.distinctUntilChanged()
+                .collect { ids -> _uiState.update { it.copy(outOfSyncTradeIds = ids) } }
         }
     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListScreen.kt
@@ -151,6 +151,7 @@ private fun OpenTradeListContent(
 
                     OpenTradeListBody(
                         filteredOpenTrades = uiState.filteredOpenTrades,
+                        outOfSyncTradeIds = uiState.outOfSyncTradeIds,
                         searchQuery = uiState.searchQuery,
                         tradeRulesConfirmed = tradeRulesConfirmed,
                         tradeGuideVisible = uiState.tradeGuideVisible,
@@ -168,6 +169,7 @@ private fun OpenTradeListContent(
 @Composable
 private fun OpenTradeListBody(
     filteredOpenTrades: List<TradeItemPresentationModel>,
+    outOfSyncTradeIds: Set<String>,
     searchQuery: String,
     tradeRulesConfirmed: Boolean,
     tradeGuideVisible: Boolean,
@@ -231,6 +233,7 @@ private fun OpenTradeListBody(
                 trade,
                 unreadCount = tradesWithUnreadMessages.getOrElse(trade.tradeId) { 0 },
                 userProfileIconProvider = userProfileIconProvider,
+                isOutOfSync = trade.tradeId in outOfSyncTradeIds,
                 onSelect = { onAction(OpenTradeListUiAction.OnSelectTrade(trade)) },
                 onPeerProfileClick = {
                     onAction(OpenTradeListUiAction.OnPeerProfileClick(trade.peersUserProfile.id))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/OpenTradeListUiState.kt
@@ -15,6 +15,7 @@ data class OpenTradeListUiState(
     val tradeGuideVisible: Boolean = false,
     val totalCount: Int = 0,
     val filteredOpenTrades: List<TradeItemPresentationModel> = emptyList(),
+    val outOfSyncTradeIds: Set<String> = emptySet(),
 ) {
     val isFilterActive: Boolean
         get() = sortBy != TradeSort.NEWEST_FIRST || roleFilter != TradeRoleFilter.ALL

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/components/OpenTradeListItem.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/tabs/my_trades/open/components/OpenTradeListItem.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -41,6 +42,7 @@ import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.BtcSatsText
 import network.bisq.mobile.presentation.common.ui.components.atoms.debouncedClickable
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.molecules.PaymentMethods
 import network.bisq.mobile.presentation.common.ui.components.molecules.UserProfileRow
@@ -55,6 +57,7 @@ fun OpenTradeListItem(
     unreadCount: Int,
     onSelect: () -> Unit,
     onPeerProfileClick: () -> Unit,
+    isOutOfSync: Boolean = false,
 ) {
     val hasNotifications = unreadCount > 0
 
@@ -98,6 +101,19 @@ fun OpenTradeListItem(
                 }
                 BisqText.SmallLightGrey("${item.formattedDate} ${item.formattedTime}")
                 BisqText.SmallLightGrey("mobile.bisqEasy.openTrades.title".i18n(item.shortTradeId))
+                if (isOutOfSync) {
+                    Row(
+                        modifier = Modifier.padding(top = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        WarningIcon(modifier = Modifier.size(16.dp))
+                        BisqGap.HHalfQuarter()
+                        BisqText.SmallMedium(
+                            text = "mobile.bisqEasy.openTrades.outOfSync.listTag".i18n(),
+                            color = BisqTheme.colors.warning,
+                        )
+                    }
+                }
             }
             Column(
                 horizontalAlignment = Alignment.End,
@@ -253,6 +269,22 @@ private fun OpenTradeListItem_BuyerPreview() {
             unreadCount = 0,
             onSelect = {},
             onPeerProfileClick = {},
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun OpenTradeListItem_OutOfSyncPreview() {
+    BisqTheme.Preview {
+        OpenTradeListItem(
+            item = createMockTradeItem(tradeRole = TradeRoleEnum.BUYER_AS_TAKER),
+            userProfileIconProvider = previewUserProfileIconProvider,
+            unreadCount = 0,
+            onSelect = {},
+            onPeerProfileClick = {},
+            isOutOfSync = true,
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -29,6 +29,8 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.i
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
+import network.bisq.mobile.domain.utils.TimeUtils
+import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
@@ -41,6 +43,10 @@ class OpenTradePresenter(
     private val userProfileServiceFacade: UserProfileServiceFacade,
     val tradeFlowPresenter: TradeFlowPresenter,
 ) : BasePresenter(mainPresenter) {
+    private companion object {
+        const val OUT_OF_SYNC_RECHECK_MS = 30_000L
+    }
+
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
 
@@ -52,6 +58,9 @@ class OpenTradePresenter(
 
     private val _isInMediation: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isInMediation: StateFlow<Boolean> = _isInMediation.asStateFlow()
+
+    private val _isTradeOutOfSync: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isTradeOutOfSync: StateFlow<Boolean> = _isTradeOutOfSync.asStateFlow()
 
     private val _showTradeNotFoundDialog = MutableStateFlow(false)
     val showTradeNotFoundDialog: StateFlow<Boolean> = _showTradeNotFoundDialog.asStateFlow()
@@ -122,6 +131,17 @@ class OpenTradePresenter(
         }
 
         presenterScope.launch {
+            // The ticker keeps re-evaluating while the trade sits in INIT, so a trade that
+            // crosses the threshold with the screen open starts showing the pane without a
+            // state change; a trade stuck for days shows it immediately.
+            currentTrade.bisqEasyTradeModel.tradeState
+                .combine(TimeUtils.tickerFlow(OUT_OF_SYNC_RECHECK_MS)) { state, _ -> state }
+                .collect {
+                    _isTradeOutOfSync.value = TradeOutOfSyncDetector.isOutOfSync(currentTrade.bisqEasyTradeModel)
+                }
+        }
+
+        presenterScope.launch {
             isUserIgnored
                 .combine(currentTrade.bisqEasyOpenTradeChannelModel.chatMessages) { isIgnored, messages ->
                     if (isIgnored) {
@@ -151,6 +171,7 @@ class OpenTradePresenter(
         _tradeAbortedBoxVisible.value = false
         _tradeProcessBoxVisible.value = false
         _isInMediation.value = false
+        _isTradeOutOfSync.value = false
 
         super.onViewUnattaching()
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
@@ -169,6 +169,8 @@ fun OpenTradeScreen(tradeId: String) {
                         MediationBanner()
                     }
 
+                    TradeOutOfSyncPane(presenter = presenter, headerPresenter = headerPresenter)
+
                     if (tradeAbortedBoxVisible) {
                         BisqGap.V2()
                         InterruptedTradePane()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeFlowPane.kt
@@ -97,7 +97,13 @@ fun TradeFlowPane(presenter: TradeFlowPresenter) {
                                             SELLER_STATE1 -> SellerState1(presenterForPhase as SellerState1Presenter)
                                             BUYER_STATE1A -> BuyerState1a(presenterForPhase as BuyerState1aPresenter)
                                             BUYER_STATE1B -> BuyerState1b() // static screen
-                                            else -> {}
+                                            else -> {
+                                                // Raw INIT (and any unmapped phase) used to render a fully
+                                                // blank step, leaving a stuck trade with no feedback at all.
+                                                BisqText.SmallRegularGrey(
+                                                    text = "mobile.bisqEasy.openTrades.waitingForTradeData".i18n(),
+                                                )
+                                            }
                                         }
                                     }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
@@ -1,0 +1,143 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
+import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIcon
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
+import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
+import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+
+/**
+ * Shown when a trade has been sitting in the INIT state past
+ * [network.bisq.mobile.domain.utils.TradeOutOfSyncDetector.OUT_OF_SYNC_THRESHOLD_MS]: the local
+ * trade FSM is desynced from the peer and the step tracker below stays frozen with no actionable
+ * content, while the peer's side is typically healthy. Renders nothing while the trade is in sync.
+ */
+@Composable
+fun TradeOutOfSyncPane(
+    presenter: OpenTradePresenter,
+    headerPresenter: TradeDetailsHeaderPresenter,
+) {
+    val isTradeOutOfSync by presenter.isTradeOutOfSync.collectAsState()
+    val isInMediation by presenter.isInMediation.collectAsState()
+
+    if (!isTradeOutOfSync) return
+
+    BisqGap.V2()
+    TradeOutOfSyncPaneContent(
+        showReportToMediator = !isInMediation,
+        onOpenChat = presenter::onOpenChat,
+        onReportToMediator = headerPresenter::onOpenMediationConfirmationDialog,
+    )
+}
+
+/**
+ * Deliberately calm (no danger styling) and without a reject/cancel action: money may already be
+ * in flight, and promoting cancel here would invite a scared user to abandon a recoverable trade.
+ * The header keeps the reject action for users who deliberately look for it.
+ */
+@Composable
+fun TradeOutOfSyncPaneContent(
+    showReportToMediator: Boolean,
+    onOpenChat: () -> Unit,
+    onReportToMediator: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(shape = RoundedCornerShape(12.dp))
+                .background(color = BisqTheme.colors.dark_grey40)
+                .padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            WarningIcon(modifier = Modifier.size(24.dp))
+            BisqGap.HHalf()
+            BisqText.BaseMedium(
+                text = "mobile.bisqEasy.openTrades.outOfSync.headline".i18n(),
+                color = BisqTheme.colors.warning,
+            )
+        }
+
+        BisqGap.V2()
+
+        BisqText.BaseRegular(
+            text = "mobile.bisqEasy.openTrades.outOfSync.body".i18n(),
+        )
+
+        BisqGap.V2()
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Max),
+            horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPadding),
+        ) {
+            BisqButton(
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+                text = "mobile.bisqEasy.openTrades.outOfSync.openChat".i18n(),
+                onClick = onOpenChat,
+                type = BisqButtonType.Outline,
+                color = BisqTheme.colors.primary,
+                borderColor = BisqTheme.colors.primary,
+            )
+            if (showReportToMediator) {
+                BisqButton(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    text = "bisqEasy.openTrades.reportToMediator".i18n(),
+                    onClick = onReportToMediator,
+                    type = BisqButtonType.WarningOutline,
+                )
+            }
+        }
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun TradeOutOfSyncPaneContent_Preview() {
+    BisqTheme.Preview {
+        TradeOutOfSyncPaneContent(
+            showReportToMediator = true,
+            onOpenChat = {},
+            onReportToMediator = {},
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
+private fun TradeOutOfSyncPaneContent_InMediationPreview() {
+    BisqTheme.Preview {
+        TradeOutOfSyncPaneContent(
+            showReportToMediator = false,
+            onOpenChat = {},
+            onReportToMediator = {},
+        )
+    }
+}


### PR DESCRIPTION
 - UX improvement whilst #1622 long term fixes get worked out
 - improved UX when a trade gets stucked on INIT for the taker (FSM protocol bug) by labelling it as "out of sync" and giving the user options (chat and mediation)
 - improved init open trade UI state by detailing a proper state-UI. Most case it won't show at all but it can become important for these cases.
 - added composable previews
 - added AI generated full PR coverage
 

### Taker with INIT stucked state example (from real life)

<img width="349" height="468" alt="Screenshot 2026-08-30 at 14 59 14" src="https://github.com/user-attachments/assets/c795bd38-6dc5-4cdf-a1e2-3ac14569f8a8" />

### Previews of solution

<img width="1126" height="357" alt="Screenshot 2026-08-30 at 15 58 56" src="https://github.com/user-attachments/assets/a6146850-2db7-4ce9-b42d-af55b3156a4d" />
<img width="821" height="437" alt="Screenshot 2026-08-30 at 16 11 55" src="https://github.com/user-attachments/assets/fea7adda-1a83-465b-9c15-3679df2ae4e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects open trades that remain stuck while waiting to start.
  * Displays an “Out of sync” warning on affected trades.
  * Provides options to open trade chat or report the issue to a mediator.
  * Hides the mediator option when mediation is already active.
  * Shows a waiting message when trade data is unavailable.
* **Tests**
  * Added coverage for detection, list indicators, warning actions, and waiting-state messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->