### PR TITLE
fix: don't wrap caller-cancelled Node facade actions as failures (#1706)

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
@@ -50,6 +50,7 @@ import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.mapping.OfferItemPresentationVOFactory
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -244,10 +245,10 @@ class NodeOffersServiceFacade(
             log.e("Failed to select offerbook market: ${marketListItem.market}", e)
         }
 
-    override suspend fun deleteOffer(offerId: String): Result<Boolean> {
-        try {
+    override suspend fun deleteOffer(offerId: String): Result<Boolean> =
+        resultCatching {
             // significant CPU work and possibly blocking action
-            return withContext(Dispatchers.IO) {
+            withContext(Dispatchers.IO) {
                 val optionalOfferbookMessage: Optional<BisqEasyOfferbookMessage> =
                     bisqEasyOfferbookChannelService.findMessageByOfferId(offerId)
                 check(optionalOfferbookMessage.isPresent) { "Could not find offer for offer ID $offerId" }
@@ -267,12 +268,9 @@ class NodeOffersServiceFacade(
                 if (!broadcastResultNotEmpty) {
                     log.w { "Delete offer message was not broadcast to network. Maybe there are no peers connected." }
                 }
-                Result.success(broadcastResultNotEmpty)
+                broadcastResultNotEmpty
             }
-        } catch (e: Exception) {
-            return Result.failure(e)
         }
-    }
 
     override suspend fun createOffer(
         direction: DirectionEnum,
@@ -283,26 +281,21 @@ class NodeOffersServiceFacade(
         priceSpec: PriceSpecVO,
         supportedLanguageCodes: Set<String>,
     ): Result<String> =
-        try {
+        resultCatching {
             // significant CPU work and possibly blocking action, otherwise Default dispatcher
             // would be a better choice
-            val offerId =
-                withContext(Dispatchers.IO) {
-                    createOffer(
-                        Mappings.DirectionMapping.toBisq2Model(direction),
-                        Mappings.MarketMapping.toBisq2Model(market),
-                        bitcoinPaymentMethods.map { BitcoinPaymentMethodUtil.getPaymentMethod(it) },
-                        fiatPaymentMethods.map { FiatPaymentMethodUtil.getPaymentMethod(it) },
-                        Mappings.AmountSpecMapping.toBisq2Model(amountSpec),
-                        Mappings.PriceSpecMapping.toBisq2Model(priceSpec),
-                        ArrayList<String>(supportedLanguageCodes),
-                    )
-                }
-            Result.success(offerId)
-        } catch (e: Exception) {
-            log.e(e) { "Failed to create offer: ${e.message}" }
-            Result.failure(e)
-        }
+            withContext(Dispatchers.IO) {
+                createOffer(
+                    Mappings.DirectionMapping.toBisq2Model(direction),
+                    Mappings.MarketMapping.toBisq2Model(market),
+                    bitcoinPaymentMethods.map { BitcoinPaymentMethodUtil.getPaymentMethod(it) },
+                    fiatPaymentMethods.map { FiatPaymentMethodUtil.getPaymentMethod(it) },
+                    Mappings.AmountSpecMapping.toBisq2Model(amountSpec),
+                    Mappings.PriceSpecMapping.toBisq2Model(priceSpec),
+                    ArrayList<String>(supportedLanguageCodes),
+                )
+            }
+        }.onFailure { e -> log.e(e) { "Failed to create offer: ${e.message}" } }
 
     // Private
     private suspend fun createOffer(

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -426,7 +426,7 @@ class NodeTradesServiceFacade(
         outcomeFilter: TradeOutcomeFilter,
         roleFilter: TradeRoleFilter,
     ): Result<PaginatedResponse<ClosedTradeListItem>> =
-        try {
+        resultCatching {
             withContext(Dispatchers.IO) {
                 val allClosedTrades = bisqEasyTradeService.closedTrades
                 val items =
@@ -460,20 +460,15 @@ class NodeTradesServiceFacade(
                 // Node runs in-process with bisq2 lib; closed trades already in memory.
                 // Mapping/filter/sort is O(n) regardless, so return everything as a single page.
                 val total = filtered.size
-                Result.success(
-                    PaginatedResponse(
-                        items = filtered,
-                        page = 1,
-                        pageSize = total,
-                        totalItems = total.toLong(),
-                        totalPages = 1,
-                    ),
+                PaginatedResponse(
+                    items = filtered,
+                    page = 1,
+                    pageSize = total,
+                    totalItems = total.toLong(),
+                    totalPages = 1,
                 )
             }
-        } catch (e: Exception) {
-            log.e(e) { "Error getting paginated closed trades" }
-            Result.failure(e)
-        }
+        }.onFailure { e -> log.e(e) { "Error getting paginated closed trades" } }
 
     /**
      * Mirrors server-side ClosedTradesQuery.matches: searches across formatted display

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -28,6 +28,8 @@ import bisq.user.profile.UserProfile
 import bisq.user.profile.UserProfileService
 import bisq.user.reputation.ReputationService
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,6 +51,7 @@ import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
 import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
 import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.mapping.TradeItemPresentationModelFactory
@@ -221,6 +224,7 @@ class NodeTradesServiceFacade(
             return Result.success(tradeId)
         } catch (e: Exception) {
             log.e(e) { "Failed to take offer: ${e.message}" }
+            currentCoroutineContext().ensureActive()
             // Set user-friendly error message only if not already set by doTakeOffer
             if (takeOfferErrorMessage.value == null) {
                 val restriction = TradeRestrictionError.fromMessage(e.message)
@@ -251,15 +255,12 @@ class NodeTradesServiceFacade(
 
     override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> =
         withContext(Dispatchers.Default) {
-            try {
+            resultCatching {
                 val (channel, trade, userName) = getTradeChannelUserNameTriple()
                 val encoded: String =
                     Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName)
                 bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).await()
                 bisqEasyTradeService.rejectTrade(trade)
-                Result.success(Unit)
-            } catch (e: Exception) {
-                Result.failure(e)
             }
         }.onSuccess { trackTrade(AnalyticsEvent.Trade.Rejected(reason)) }
 
@@ -267,37 +268,31 @@ class NodeTradesServiceFacade(
         // Before the request: the cancel transition itself would reset the stall clock to ~zero.
         val stall = selectedTradeStallBucket()
         return withContext(Dispatchers.Default) {
-            try {
+            resultCatching {
                 val (channel, trade, userName) = getTradeChannelUserNameTriple()
                 val encoded: String = Res.encode("bisqEasy.openTrades.tradeLogMessage.cancelled", userName)
                 bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).await()
                 bisqEasyTradeService.cancelTrade(trade)
-                Result.success(Unit)
-            } catch (e: Exception) {
-                Result.failure(e)
             }
         }.onSuccess { trackTrade(AnalyticsEvent.Trade.Cancelled(reason, stall)) }
     }
 
     override suspend fun closeTrade(): Result<Unit> =
         withContext(Dispatchers.Default) {
-            try {
+            resultCatching {
                 val (channel, trade, userName) = getTradeChannelUserNameTriple()
                 val myUserProfile = channel.myUserIdentity.userProfile
                 val peerUserProfile = channel.peer
                 bisqEasyTradeService.closeTrade(trade, myUserProfile, peerUserProfile)
                 leavePrivateChatManager.leaveChannel(channel)
                 _selectedTrade.value = null
-                Result.success(Unit)
-            } catch (e: Exception) {
-                Result.failure(e)
             }
         }
 
     override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.ACCOUNT_DATA) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val encoded =
                         Res.encode(
@@ -307,9 +302,6 @@ class NodeTradesServiceFacade(
                         )
                     bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     bisqEasyTradeService.sellerSendsPaymentAccount(trade, paymentAccountData)
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }
@@ -317,7 +309,7 @@ class NodeTradesServiceFacade(
     override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.BTC_ADDRESS) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val paymentRailName = trade.contract.baseSidePaymentMethodSpec.paymentMethod.paymentRail.name
                     val key = "bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage.$paymentRailName"
@@ -329,9 +321,6 @@ class NodeTradesServiceFacade(
                         )
                     bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     bisqEasyTradeService.buyerSendBitcoinPaymentData(trade, bitcoinPaymentData)
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }
@@ -339,7 +328,7 @@ class NodeTradesServiceFacade(
     override suspend fun sellerConfirmFiatReceipt(): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.FIAT_RECEIPT) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val selectedTradeSnapshot = selectedTrade.value
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val encoded =
@@ -350,9 +339,6 @@ class NodeTradesServiceFacade(
                         )
                     bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     bisqEasyTradeService.sellerConfirmFiatReceipt(trade)
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }
@@ -360,7 +346,7 @@ class NodeTradesServiceFacade(
     override suspend fun buyerConfirmFiatSent(): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.FIAT_SENT) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val selectedTradeSnapshot = selectedTrade.value
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val encoded =
@@ -371,9 +357,6 @@ class NodeTradesServiceFacade(
                         )
                     bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     bisqEasyTradeService.buyerConfirmFiatSent(trade)
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }
@@ -381,7 +364,7 @@ class NodeTradesServiceFacade(
     override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.BTC_SENT) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val encoded: String
                     val paymentMethod = trade.contract.baseSidePaymentMethodSpec.paymentMethod
@@ -404,9 +387,6 @@ class NodeTradesServiceFacade(
 
                     bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     bisqEasyTradeService.sellerConfirmBtcSent(trade, Optional.ofNullable(paymentProof))
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }
@@ -414,7 +394,7 @@ class NodeTradesServiceFacade(
     override suspend fun btcConfirmed(): Result<Unit> =
         trackedAction(AnalyticsEvent.Trade.Step.BTC_RECEIVED) {
             withContext(Dispatchers.Default) {
-                try {
+                resultCatching {
                     val (channel, trade, userName) = getTradeChannelUserNameTriple()
                     val paymentRail = trade.contract.baseSidePaymentMethodSpec.paymentMethod.paymentRail
                     if (paymentRail == BitcoinPaymentRail.LN && trade.isBuyer) {
@@ -426,9 +406,6 @@ class NodeTradesServiceFacade(
                         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel)
                     }
                     bisqEasyTradeService.btcConfirmed(trade)
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
                 }
             }
         }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -25,6 +25,7 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.i
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
 import network.bisq.mobile.node.common.domain.service.cat_hash.AndroidNodeCatHashService
@@ -163,8 +164,8 @@ class NodeUserProfileServiceFacade(
         profileId: String,
         statement: String?,
         terms: String?,
-    ): Result<UserProfileVO> {
-        try {
+    ): Result<UserProfileVO> =
+        resultCatching {
             val userIdentity =
                 userService.userIdentityService.findUserIdentity(profileId).getOrNull()
                     ?: throw IllegalStateException("userIdentity with id `$profileId` not found")
@@ -183,16 +184,8 @@ class NodeUserProfileServiceFacade(
 
             val updatedProfile = getSelectedUserProfile()
             _selectedUserProfile.value = updatedProfile
-            return if (updatedProfile == null) {
-                Result.failure(IllegalStateException("Selected user profile is null after update"))
-            } else {
-                Result.success(updatedProfile)
-            }
-        } catch (e: Exception) {
-            log.e(e) { "Failed to republish user profile: ${e.message}" }
-            return Result.failure(e)
-        }
-    }
+            updatedProfile ?: throw IllegalStateException("Selected user profile is null after update")
+        }.onFailure { e -> log.e(e) { "Failed to republish user profile: ${e.message}" } }
 
     override suspend fun getUserIdentityIds(): List<String> = userService.userIdentityService.userIdentities.map { userIdentity -> userIdentity.id }
 
@@ -313,14 +306,11 @@ class NodeUserProfileServiceFacade(
         if (trimmedMessage.isBlank()) {
             return Result.failure(IllegalArgumentException("Report message cannot be blank"))
         }
-        return try {
+        return resultCatching {
             val userProfile = Mappings.UserProfileMapping.toBisq2Model(accusedUserProfile)
             withContext(Dispatchers.Default) {
                 moderationRequestService.reportUserProfile(userProfile, trimmedMessage)
             }
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -185,7 +185,7 @@ class NodeUserProfileServiceFacade(
             val updatedProfile = getSelectedUserProfile()
             _selectedUserProfile.value = updatedProfile
             updatedProfile ?: throw IllegalStateException("Selected user profile is null after update")
-        }.onFailure { log.e { "Failed to republish user profile" } }
+        }.onFailure { e -> log.e(e) { "Failed to republish user profile" } }
 
     override suspend fun getUserIdentityIds(): List<String> = userService.userIdentityService.userIdentities.map { userIdentity -> userIdentity.id }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -185,7 +185,7 @@ class NodeUserProfileServiceFacade(
             val updatedProfile = getSelectedUserProfile()
             _selectedUserProfile.value = updatedProfile
             updatedProfile ?: throw IllegalStateException("Selected user profile is null after update")
-        }.onFailure { e -> log.e(e) { "Failed to republish user profile: ${e.message}" } }
+        }.onFailure { log.e { "Failed to republish user profile" } }
 
     override suspend fun getUserIdentityIds(): List<String> = userService.userIdentityService.userIdentities.map { userIdentity -> userIdentity.id }
 

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -101,26 +102,81 @@ class TradeAnalyticsTrackerTest {
             val tracker = TradeAnalyticsTracker(analytics, stallTimeout)
             val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
             val gate = CompletableDeferred<Unit>()
+            val started = CompletableDeferred<Unit>()
 
             var outcome: Result<Unit>? = null
+            var propagated: CancellationException? = null
             val child =
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    outcome =
-                        tracker.trackAction(Trade.Step.BTC_RECEIVED, state, scope) {
-                            try {
-                                gate.await()
-                                Result.success(Unit)
-                            } catch (e: CancellationException) {
-                                // Node facade wraps teardown into Result.failure; the tracker must
-                                // still refuse to report it when OUR job is already cancelled.
-                                Result.failure(e)
+                    try {
+                        outcome =
+                            tracker.trackAction(Trade.Step.BTC_RECEIVED, state, scope) {
+                                started.complete(Unit)
+                                try {
+                                    gate.await()
+                                    Result.success(Unit)
+                                } catch (e: CancellationException) {
+                                    // Simulate a wrap-into-Result.failure while OUR job is already
+                                    // cancelled (HttpClientService / an inner catch). The tracker must
+                                    // still refuse to report it.
+                                    Result.failure(e)
+                                }
                             }
-                        }
+                    } catch (e: CancellationException) {
+                        propagated = e
+                        throw e
+                    }
                 }
 
+            started.await()
             child.cancel()
             child.join()
 
+            assertNotNull(propagated)
+            assertTrue(child.isCancelled)
+            assertNull(outcome)
+            verify(exactly = 0) { analytics.track(any()) }
+            verify(exactly = 0) { analytics.captureException(any()) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `non-CE failure is not reported when the caller is already cancelled`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, stallTimeout)
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+            val gate = CompletableDeferred<Unit>()
+            val started = CompletableDeferred<Unit>()
+
+            var outcome: Result<Unit>? = null
+            var propagated: CancellationException? = null
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        outcome =
+                            tracker.trackAction(Trade.Step.BTC_ADDRESS, state, scope) {
+                                started.complete(Unit)
+                                try {
+                                    gate.await()
+                                    Result.success(Unit)
+                                } catch (_: CancellationException) {
+                                    Result.failure(RuntimeException("teardown boom"))
+                                }
+                            }
+                    } catch (e: CancellationException) {
+                        propagated = e
+                        throw e
+                    }
+                }
+
+            started.await()
+            child.cancel()
+            child.join()
+
+            assertNotNull(propagated)
+            assertTrue(child.isCancelled)
             assertNull(outcome)
             verify(exactly = 0) { analytics.track(any()) }
             verify(exactly = 0) { analytics.captureException(any()) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.domain.service.trades
 
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.currentCoroutineContext
@@ -90,9 +89,10 @@ class TradeAnalyticsTracker(
      * value, emitting `CONFIRMED` if it advances within [stallTimeoutMs] or `STALLED` otherwise. The
      * action's [Result] is returned unchanged — the stall watch runs in the background.
      *
-     * A [CancellationException] in [action]'s failure is gated with [ensureActive]: if this coroutine
-     * is already cancelled (navigate-away), the exception is rethrown and not reported. If the caller
-     * is still active (request timeout), it is reported as `FAILED`.
+     * A failure is gated with [ensureActive]: if this coroutine is already cancelled (navigate-away),
+     * the exception is rethrown and not reported — including non-[CancellationException] teardown
+     * failures. If the caller is still active (request timeout or a genuine error), it is reported
+     * as `FAILED`.
      */
     suspend fun trackAction(
         step: AnalyticsEvent.Trade.Step,
@@ -104,9 +104,7 @@ class TradeAnalyticsTracker(
         val result = action()
         result
             .onFailure { e ->
-                if (e is CancellationException) {
-                    currentCoroutineContext().ensureActive()
-                }
+                currentCoroutineContext().ensureActive()
                 analyticsService.track(AnalyticsEvent.Trade.Action(step, AnalyticsEvent.Trade.Outcome.FAILED))
                 analyticsService.captureException(TradeActionException(step, e))
             }.onSuccess {

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
@@ -1,5 +1,7 @@
 package network.bisq.mobile.domain.utils
 
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -16,6 +18,24 @@ import kotlinx.coroutines.flow.merge
 class OperationCancelledException(
     message: String = "Operation cancelled",
 ) : Exception(message)
+
+/**
+ * Like a `try/catch (Exception)` that returns [Result], but does not treat our own job
+ * cancellation as a failure. If this coroutine is already cancelled, [ensureActive] rethrows —
+ * including for a non-[kotlinx.coroutines.CancellationException] thrown during teardown.
+ * A timeout-style [kotlinx.coroutines.CancellationException] while the caller is still
+ * active becomes [Result.failure].
+ *
+ * Use at Node (and similar) `catch (Exception) { Result.failure(e) }` sites so teardown does not
+ * surface as a user-facing error or a failed analytics event.
+ */
+suspend fun <T> resultCatching(block: suspend () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: Exception) {
+        currentCoroutineContext().ensureActive()
+        Result.failure(e)
+    }
 
 private sealed class AwaitResult<T> {
     data class Value<T>(

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
@@ -29,10 +29,13 @@ class OperationCancelledException(
  * Use at Node (and similar) `catch (Exception) { Result.failure(e) }` sites so teardown does not
  * surface as a user-facing error or a failed analytics event.
  */
+private val log = getLogger("resultCatching")
+
 suspend fun <T> resultCatching(block: suspend () -> T): Result<T> =
     try {
         Result.success(block())
     } catch (e: Exception) {
+        log.d(e) { "Caught exception; rethrowing if coroutine is cancelled" }
         currentCoroutineContext().ensureActive()
         Result.failure(e)
     }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/ResultCatchingTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/utils/ResultCatchingTest.kt
@@ -1,0 +1,106 @@
+package network.bisq.mobile.domain.utils
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ResultCatchingTest {
+    @Test
+    fun `success is returned as Result success`() =
+        runTest {
+            val result = resultCatching { "ok" }
+            assertEquals("ok", result.getOrNull())
+        }
+
+    @Test
+    fun `generic exception becomes Result failure`() =
+        runTest {
+            val result = resultCatching { error("boom") }
+            assertTrue(result.isFailure)
+            assertEquals("boom", result.exceptionOrNull()?.message)
+        }
+
+    @Test
+    fun `timeout-style cancellation with an active caller is a failure`() =
+        runTest {
+            val result =
+                resultCatching {
+                    throw CancellationException("request timed out")
+                }
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is CancellationException)
+        }
+
+    @Test
+    fun `genuine caller cancellation is rethrown instead of a failure`() =
+        runTest {
+            val gate = CompletableDeferred<Unit>()
+            val started = CompletableDeferred<Unit>()
+
+            var outcome: Result<Unit>? = null
+            var propagated: CancellationException? = null
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        outcome =
+                            resultCatching {
+                                started.complete(Unit)
+                                gate.await()
+                            }
+                    } catch (e: CancellationException) {
+                        propagated = e
+                        throw e
+                    }
+                }
+
+            started.await()
+            child.cancel()
+            child.join()
+
+            assertNotNull(propagated)
+            assertTrue(child.isCancelled)
+            assertNull(outcome)
+        }
+
+    @Test
+    fun `non-CE failure is rethrown when the caller is already cancelled`() =
+        runTest {
+            val gate = CompletableDeferred<Unit>()
+            val started = CompletableDeferred<Unit>()
+
+            var outcome: Result<Unit>? = null
+            var propagated: CancellationException? = null
+            val child =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        outcome =
+                            resultCatching {
+                                started.complete(Unit)
+                                try {
+                                    gate.await()
+                                } catch (_: CancellationException) {
+                                    throw RuntimeException("teardown boom")
+                                }
+                            }
+                    } catch (e: CancellationException) {
+                        propagated = e
+                        throw e
+                    }
+                }
+
+            started.await()
+            child.cancel()
+            child.join()
+
+            assertNotNull(propagated)
+            assertTrue(child.isCancelled)
+            assertNull(outcome)
+        }
+}


### PR DESCRIPTION
Follow-up of [#1748](https://github.com/bisq-network/bisq-mobile/pull/1748), addressing @rodvar's comments:

> 1. make the gate an unconditional ensureActive() at the top of onFailure (covers non-CE teardown failures too)

Done

> 2. the node facade's catch (Exception) { Result.failure(e) } wrappers are the root cause and also leak "StandaloneCoroutine was cancelled" into user-facing snackbars — a shared gated wrapper there fixes analytics AND UI at once

Shared `resultCatching` wrapper like `try/catch (Exception) { Result.failure(e) }`, but rethrows via `ensureActive()` when the caller's job is already cancelled.

Applied to other Node facade `catch (Exception) { Result.failure(e) }` sites:
  - Trades: `takeOffer`, `getPaginatedClosedTrades`
  - Offers: `createOffer`, `deleteOffer`
  - User profile: `republishUserProfile`, `reportUserProfile`

> 3. the second test can pass vacuously if the UNDISPATCHED start ever gets dropped — add a positive assert that the CE actually propagated, and fix the comment saying the node facade wraps teardown into Result.failure (it doesn't; withContext rethrows at its boundary). Also watch the 1706 reports after next release — they should drop but maybe not to zero until (2).

Done. Will monitor the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failures and cancellations during offer, trade, and profile operations.
  * Prevented normal caller cancellation and shutdown activity from appearing as user-facing failures.
  * Improved trade analytics accuracy by avoiding false failure reports during cancellation or teardown.

* **Reliability**
  * Standardized success and failure reporting across operations.
  * Improved handling of timeouts and exceptional conditions.
  * Added coverage for cancellation, timeout, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->