### PR TITLE
fix: skip GlitchTip capture for expected protocol-validation rejections

### DIFF
--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -228,7 +228,7 @@ class TradeAnalyticsTrackerTest {
         }
 
     @Test
-    fun `observeTrades emits Errored and captures the exception on a local error`() =
+    fun `observeTrades emits Errored and captures unexpected local errors`() =
         runTest {
             val analytics = mockk<AnalyticsService>(relaxed = true)
             val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
@@ -245,7 +245,7 @@ class TradeAnalyticsTrackerTest {
         }
 
     @Test
-    fun `observeTrades emits Errored on a peer-only error even when the local error stays null`() =
+    fun `observeTrades emits Errored on a peer-only unexpected error even when the local error stays null`() =
         runTest {
             val analytics = mockk<AnalyticsService>(relaxed = true)
             val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
@@ -258,6 +258,40 @@ class TradeAnalyticsTrackerTest {
 
             verify(exactly = 1) { analytics.track(Trade.Errored) }
             verify { analytics.captureException(any<TradeProtocolException>()) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `observeTrades does not capture expected protocol-validation rejections`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics)
+            val errorMessage = MutableStateFlow<String?>(null)
+            val openTrades = MutableStateFlow(listOf(fakeTrade(errorMessage = errorMessage)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            errorMessage.value = "Bitcoin address length must not be longer than 62"
+
+            verify(exactly = 1) { analytics.track(Trade.Errored) }
+            verify(exactly = 0) { analytics.captureException(any()) }
+            scope.cancel()
+        }
+
+    @Test
+    fun `observeTrades does not capture expected peer-reported amount rejections`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics)
+            val peersErrorMessage = MutableStateFlow<String?>(null)
+            val openTrades = MutableStateFlow(listOf(fakeTrade(peersErrorMessage = peersErrorMessage)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            peersErrorMessage.value = "Takers (buyers) Bitcoin amount is too high. market mismatch"
+
+            verify(exactly = 1) { analytics.track(Trade.Errored) }
+            verify(exactly = 0) { analytics.captureException(any()) }
             scope.cancel()
         }
 

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejection.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejection.kt
@@ -1,0 +1,22 @@
+package network.bisq.mobile.domain.service.trades
+
+/**
+ * Expected protocol-validation rejections from bisq2 (bad/hostile peer
+ * messages). Mobile only sees the error string, so we match core-authored
+ * prefixes rather than peer-supplied text.
+ */
+object ExpectedTradeProtocolRejection {
+    // Prefix-only so trailing details (max length, offer dump) still match.
+    private val expectedPrefixes =
+        listOf(
+            "Bitcoin address length must not be longer than",
+            "Lightning invoice length must not be longer than",
+            "Bitcoin payment data must not be empty",
+            "Takers (buyers) Bitcoin amount is too high",
+            "Takers (sellers) Bitcoin amount is too low",
+            "Could not find matching offer",
+            "Mediators do not match",
+        )
+
+    fun isExpected(message: String): Boolean = expectedPrefixes.any { message.startsWith(it) }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -34,7 +34,8 @@ import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
  *    counterparty never trips the stall watch.
  *  - **lifecycle** via [track]: `Taken` / `Cancelled` / `Rejected` on the corresponding actions.
  *  - **completion & errors** via [observeTrades]: `Completed` when a trade reaches `BTC_CONFIRMED`,
- *    `Errored` (+ captured exception) when a trade surfaces a protocol/peer error, and
+ *    `Errored` when a trade surfaces a protocol/peer error (expected validation
+ *    rejections stay volume-only; unexpected ones also capture an exception), and
  *    `OutOfSyncDetected` when a trade sits in INIT past the [TradeOutOfSyncDetector] threshold —
  *    the field measurement of the stuck-FSM desync the out-of-sync recovery pane exists for.
  */
@@ -228,7 +229,9 @@ class TradeAnalyticsTracker(
                 }.collect { (id, message, stackTrace) ->
                     if (message != null && errored.add(id)) {
                         analyticsService.track(AnalyticsEvent.Trade.Errored)
-                        analyticsService.captureException(TradeProtocolException(message, stackTrace))
+                        if (!ExpectedTradeProtocolRejection.isExpected(message)) {
+                            analyticsService.captureException(TradeProtocolException(message, stackTrace))
+                        }
                     }
                 }
         }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejectionTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejectionTest.kt
@@ -1,0 +1,44 @@
+package network.bisq.mobile.domain.service.trades
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExpectedTradeProtocolRejectionTest {
+    @Test
+    fun `issue 148 over-length BTC address is expected`() {
+        assertTrue(
+            ExpectedTradeProtocolRejection.isExpected(
+                "Bitcoin address length must not be longer than 62",
+            ),
+        )
+    }
+
+    @Test
+    fun `issue 147 take-offer amount too high is expected`() {
+        assertTrue(
+            ExpectedTradeProtocolRejection.isExpected(
+                "Takers (buyers) Bitcoin amount is too high. " +
+                    "This can be caused by differences in the 2 traders market price or by an attempt by the taker " +
+                    "to manipulate the price.",
+            ),
+        )
+    }
+
+    @Test
+    fun `typed expected failures and the other verify prefixes are expected`() {
+        assertTrue(ExpectedTradeProtocolRejection.isExpected("Lightning invoice length must not be longer than 1000"))
+        assertTrue(ExpectedTradeProtocolRejection.isExpected("Bitcoin payment data must not be empty"))
+        assertTrue(ExpectedTradeProtocolRejection.isExpected("Takers (sellers) Bitcoin amount is too low. more detail"))
+        assertTrue(ExpectedTradeProtocolRejection.isExpected("Could not find matching offer in BisqEasyOfferbookChannel"))
+        assertTrue(ExpectedTradeProtocolRejection.isExpected("Mediators do not match.\nMaker's mediator: x"))
+    }
+
+    @Test
+    fun `unrelated or unexpected FSM text is not expected`() {
+        assertFalse(ExpectedTradeProtocolRejection.isExpected("boom"))
+        assertFalse(ExpectedTradeProtocolRejection.isExpected("peer boom"))
+        assertFalse(ExpectedTradeProtocolRejection.isExpected("IllegalStateException: FSM invariant broken"))
+        assertFalse(ExpectedTradeProtocolRejection.isExpected("basf"))
+    }
+}


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1707
 - Classifies known bisq2 protocol-validation rejections (Better solution should be to have named exceptions in bisq2 and work based on them).
 - Prevents expected peer-message rejections from being captured as GlitchTip exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trade error handling for expected validation rejections.
  - Trade errors continue to be shown and recorded, while known protocol-related rejections are no longer treated as unexpected exceptions.
  - Unexpected trade failures continue to be captured for diagnostics, improving the accuracy of error reporting and analytics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->