### PR TITLE
refactor: preserve coroutine cancellation in facade Result handling

### DIFF
--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/accounts/user_defined/ClientUserDefinedAccountsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/accounts/user_defined/ClientUserDefinedAccountsServiceFacade.kt
@@ -5,22 +5,23 @@ import network.bisq.mobile.client.payment_accounts.data.mapping.fiat.toDto
 import network.bisq.mobile.data.service.accounts.UserDefinedAccountsServiceFacade
 import network.bisq.mobile.domain.model.account.create.fiat.CreateUserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
+import network.bisq.mobile.domain.utils.resultCatching
 
 class ClientUserDefinedAccountsServiceFacade(
     private val apiGateway: UserDefinedPaymentAccountsApiGateway,
 ) : UserDefinedAccountsServiceFacade() {
     override suspend fun executeGetAccounts(): Result<List<UserDefinedFiatAccount>> =
-        runCatching {
+        resultCatching {
             apiGateway.getPaymentAccounts().getOrThrow().map { it.toDomain() }
         }
 
     override suspend fun executeGetSelectedAccount(): Result<UserDefinedFiatAccount?> =
-        runCatching {
+        resultCatching {
             apiGateway.getSelectedAccount().getOrThrow()?.toDomain()
         }
 
     override suspend fun executeAddAccount(account: CreateUserDefinedFiatAccount): Result<UserDefinedFiatAccount> =
-        runCatching {
+        resultCatching {
             apiGateway.addAccount(account.toDto()).getOrThrow().toDomain()
         }
 
@@ -28,17 +29,17 @@ class ClientUserDefinedAccountsServiceFacade(
         accountName: String,
         account: CreateUserDefinedFiatAccount,
     ): Result<UserDefinedFiatAccount> =
-        runCatching {
+        resultCatching {
             apiGateway.saveAccount(accountName, account.toDto()).getOrThrow().toDomain()
         }
 
     override suspend fun executeDeleteAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             apiGateway.deleteAccount(accountName).getOrThrow()
         }
 
     override suspend fun executeSetSelectedAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             apiGateway.setSelectedAccount(accountName).getOrThrow()
         }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
@@ -11,6 +11,7 @@ import network.bisq.mobile.client.common.data.model.alert.AuthorizedAlertDataDto
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
+import network.bisq.mobile.domain.utils.resultCatching
 
 class ClientAlertNotificationsServiceFacade(
     private val apiGateway: AlertNotificationsApiGateway,
@@ -23,7 +24,7 @@ class ClientAlertNotificationsServiceFacade(
         super.activate()
 
         serviceScope.launch {
-            runCatching {
+            resultCatching {
                 subscribeAlerts()
             }.onFailure {
                 log.w { "Failed to subscribe to authorized alerts" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.client.common.data.model.alert.AuthorizedAlertDataDto
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
+import network.bisq.mobile.domain.utils.resultCatching
 
 class ClientTradeRestrictingAlertServiceFacade(
     private val apiGateway: TradeRestrictingAlertApiGateway,
@@ -22,7 +23,7 @@ class ClientTradeRestrictingAlertServiceFacade(
         super.activate()
 
         serviceScope.launch {
-            runCatching {
+            resultCatching {
                 subscribeAlert()
             }.onFailure {
                 log.w { "Failed to subscribe to trade restricting alert" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/config/ClientConfigServiceFacade.kt
@@ -18,6 +18,7 @@ import network.bisq.mobile.data.replicated.config.TradeAmountLimitsVO
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.domain.service.capabilities.Feature
+import network.bisq.mobile.domain.utils.resultCatching
 
 /**
  * Client implementation of [ConfigServiceFacade].
@@ -72,7 +73,7 @@ class ClientConfigServiceFacade(
                 .distinctUntilChanged()
                 .collectLatest {
                     if (startedUp) {
-                        runCatching { configCacheRepository.clear() }
+                        resultCatching { configCacheRepository.clear() }
                     }
                     startedUp = true
                     loadConfig()
@@ -83,13 +84,13 @@ class ClientConfigServiceFacade(
     private suspend fun loadConfig() {
         val hostHash = parseUrl(sensitiveSettingsRepository.fetch().bisqApiUrl)?.host?.let { hashTrustedNodeHost(it) }
 
-        val cached = runCatching { configCacheRepository.get() }.getOrNull()
+        val cached = resultCatching { configCacheRepository.get() }.getOrNull()
         // A cache from a different node is invalid: drop it from disk and don't serve it, so we never
         // show one node's config against another.
         val validCached = cached?.takeIf { it.trustedNodeHostHash == hostHash }
         if (cached != null && validCached == null) {
             log.d { "Config: cached entry belongs to a different node; invalidating" }
-            runCatching { configCacheRepository.clear() }
+            resultCatching { configCacheRepository.clear() }
         }
         // Stale-while-revalidate: show the current node's last good values instantly.
         validCached?.let {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/mediation/ClientMediationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/mediation/ClientMediationServiceFacade.kt
@@ -6,6 +6,7 @@ import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPre
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.mediation.MediationServiceFacade
 import network.bisq.mobile.data.service.offers.MediatorNotAvailableException
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 
 class ClientMediationServiceFacade(
@@ -23,22 +24,13 @@ class ClientMediationServiceFacade(
 
     override suspend fun reportToMediator(value: TradeItemPresentationModel): Result<Unit> {
         if (globalUiManager.notifyIfDemoModeRestricted()) return Result.success(Unit)
-        return try {
-            val result = apiGateway.reportToMediator(value.tradeId)
-            result.fold(
-                onSuccess = { Result.success(it) },
-                onFailure = { exception ->
-                    when {
-                        exception is WebSocketRestApiException && exception.httpStatusCode.value == 409 -> {
-                            Result.failure(MediatorNotAvailableException())
-                        }
-
-                        else -> Result.failure(exception)
-                    }
-                },
-            )
-        } catch (e: Exception) {
-            Result.failure(e)
+        return resultCatching {
+            apiGateway.reportToMediator(value.tradeId).getOrThrow()
+        }.recoverCatching { exception ->
+            if (exception is WebSocketRestApiException && exception.httpStatusCode.value == 409) {
+                throw MediatorNotAvailableException()
+            }
+            throw exception
         }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -28,6 +28,7 @@ import network.bisq.mobile.data.service.offers.OfferFormattingUtil
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.coroutines.DispatcherProvider
+import network.bisq.mobile.domain.utils.resultCatching
 import kotlin.concurrent.Volatile
 
 class ClientOffersServiceFacade(
@@ -229,7 +230,7 @@ class ClientOffersServiceFacade(
 
     private fun observeMarketPrice() {
         serviceScope.launch {
-            runCatching {
+            resultCatching {
                 marketPriceServiceFacade.selectedMarketPriceItem.collectLatest { marketPriceItem ->
                     if (marketPriceItem != null) {
                         _selectedOfferbookMarket.value.setFormattedPrice(marketPriceItem.formattedPrice)
@@ -303,7 +304,7 @@ class ClientOffersServiceFacade(
                 return@collect
             }
 
-            runCatching {
+            resultCatching {
                 val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
                     WebSocketEventPayload.from(
                         json,
@@ -359,7 +360,7 @@ class ClientOffersServiceFacade(
         replaceExisting: Boolean = false,
     ) {
         serviceScope.launch {
-            runCatching { apiGateway.getOffers(code).getOrThrow() }
+            resultCatching { apiGateway.getOffers(code).getOrThrow() }
                 .onSuccess { offers -> applyRestPrefetchedOffers(code, offers, replaceExisting) }
                 .onFailure { e -> log.w(e) { "REST offers prefetch failed for $code; relying on the OFFERS subscription" } }
         }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 
 class ClientReputationServiceFacade(
     val apiGateway: ReputationApiGateway,
@@ -35,7 +36,7 @@ class ClientReputationServiceFacade(
     override suspend fun activate() {
         super<ServiceFacade>.activate()
         serviceScope.launch {
-            runCatching {
+            resultCatching {
                 subscribeReputation()
             }.onFailure {
                 log.w { "Failed to activate client reputation service" }
@@ -48,12 +49,9 @@ class ClientReputationServiceFacade(
     }
 
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> =
-        try {
-            apiGateway.getProfileAge(userProfileId)
-        } catch (e: Exception) {
-            log.e(e) { "Failed to get profile age for userId=$userProfileId" }
-            Result.failure(e)
-        }
+        resultCatching {
+            apiGateway.getProfileAge(userProfileId).getOrThrow()
+        }.onFailure { e -> log.e(e) { "Failed to get profile age for userId=$userProfileId" } }
 
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
@@ -51,7 +51,7 @@ class ClientReputationServiceFacade(
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> =
         resultCatching {
             apiGateway.getProfileAge(userProfileId).getOrThrow()
-        }.onFailure { e -> log.e(e) { "Failed to get profile age for userId=$userProfileId" } }
+        }.onFailure { e -> log.e(e) { "Failed to get profile age" } }
 
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> {
@@ -63,7 +63,7 @@ class ClientReputationServiceFacade(
             return apiGateway.getReputationScore(userProfileId)
         }
         return reputationByUserProfileId.value[userProfileId]?.let { Result.success(it) }
-            ?: Result.failure(NoSuchElementException("Reputation for userId=$userProfileId not found"))
+            ?: Result.failure(NoSuchElementException("Reputation not found"))
     }
 
     // Private

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/settings/ClientSettingsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/settings/ClientSettingsServiceFacade.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.data.service.settings.DEFAULT_DIFFICULTY_ADJUSTMENT_F
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.i18n.I18nSupport
 
 class ClientSettingsServiceFacade(
@@ -33,22 +34,13 @@ class ClientSettingsServiceFacade(
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
     override val languageCode: StateFlow<String> = _languageCode.asStateFlow()
 
-    override suspend fun setLanguageCode(value: String): Result<Unit> {
-        try {
+    override suspend fun setLanguageCode(value: String): Result<Unit> =
+        resultCatching {
             log.i { "Client attempting to set language code to: $value" }
-            val result = apiGateway.setLanguageCode(value)
-            if (result.isSuccess) {
-                updateLanguage(value)
-                log.i { "Client successfully set language code to: $value (via API)" }
-            } else {
-                log.e { "Client API call failed for language code: $value" }
-            }
-            return result
-        } catch (e: Exception) {
-            log.e(e) { "Client failed to set language code to: $value" }
-            return Result.failure(e)
-        }
-    }
+            apiGateway.setLanguageCode(value).getOrThrow()
+            updateLanguage(value)
+            log.i { "Client successfully set language code to: $value (via API)" }
+        }.onFailure { e -> log.e(e) { "Client failed to set language code to: $value" } }
 
     override suspend fun setSupportedLanguageCodes(value: Set<String>): Result<Unit> = apiGateway.setSupportedLanguageCodes(value)
 
@@ -92,14 +84,14 @@ class ClientSettingsServiceFacade(
     override val showWebLinkConfirmation: StateFlow<Boolean> = _showWebLinkConfirmation.asStateFlow()
 
     override suspend fun setWebLinkDontShowAgain(): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsRepository.setDontShowAgainHyperlinksOpenInBrowser(true)
         }.onSuccess {
             _showWebLinkConfirmation.value = false
         }
 
     override suspend fun resetAllDontShowAgainFlags(): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsRepository.setDontShowAgainHyperlinksOpenInBrowser(false)
         }.onSuccess {
             _showWebLinkConfirmation.value = true
@@ -109,7 +101,7 @@ class ClientSettingsServiceFacade(
     override val permitOpeningBrowser: StateFlow<Boolean> = _permitOpeningBrowser.asStateFlow()
 
     override suspend fun setPermitOpeningBrowser(value: Boolean): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsRepository.setPermitOpeningBrowser(value)
         }.onSuccess {
             _permitOpeningBrowser.value = value

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -28,6 +28,7 @@ import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.data.utils.createEmptyImage
 import network.bisq.mobile.domain.utils.hexToByteArray
+import network.bisq.mobile.domain.utils.resultCatching
 import kotlin.concurrent.Volatile
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -201,33 +202,25 @@ class ClientUserProfileServiceFacade(
         profileId: String,
         statement: String?,
         terms: String?,
-    ): Result<UserProfileVO> {
-        try {
-            val apiResult =
-                apiGateway.updateUserProfile(
-                    profileId,
-                    statement
-                        ?: "",
-                    terms
-                        ?: "",
-                )
-            if (apiResult.isFailure) {
-                throw apiResult.exceptionOrNull()!!
-            }
-
-            val response: CreateUserIdentityResponse = apiResult.getOrThrow()
+    ): Result<UserProfileVO> =
+        resultCatching {
+            val response: CreateUserIdentityResponse =
+                apiGateway
+                    .updateUserProfile(
+                        profileId,
+                        statement
+                            ?: "",
+                        terms
+                            ?: "",
+                    ).getOrThrow()
             this.keyMaterialResponse = null
             log.i {
                 "Call to updateAndPublishUserProfile successful. new statement = ${response.userProfile.statement}, " + "new terms = ${response.userProfile.terms}"
             }
 
             _selectedUserProfile.value = response.userProfile
-            return Result.success(response.userProfile)
-        } catch (e: Exception) {
-            log.e(e) { "Failed to update and publish user profile: ${e.message}" }
-            return Result.failure(e)
-        }
-    }
+            response.userProfile
+        }.onFailure { e -> log.e(e) { "Failed to update and publish user profile: ${e.message}" } }
 
     override suspend fun getUserIdentityIds(): List<String> {
         val apiResult = apiGateway.getUserIdentityIds()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/data/service/ClientPaymentAccountsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/data/service/ClientPaymentAccountsServiceFacade.kt
@@ -14,18 +14,19 @@ import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccount
 import network.bisq.mobile.client.payment_accounts.domain.service.PaymentAccountsServiceFacade
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.create.CreatePaymentAccount
+import network.bisq.mobile.domain.utils.resultCatching
 
 class ClientPaymentAccountsServiceFacade(
     private val apiGateway: PaymentAccountsApiGateway,
     private val bankAccountCountryDetailsRepository: BankAccountCountryDetailsRepository,
 ) : PaymentAccountsServiceFacade() {
     override suspend fun executeGetAccounts(): Result<List<PaymentAccount>> =
-        runCatching {
+        resultCatching {
             apiGateway.getPaymentAccounts().getOrThrow().map { it.toDomain() }
         }
 
     override suspend fun executeAddAccount(account: CreatePaymentAccount): Result<PaymentAccount> =
-        runCatching {
+        resultCatching {
             apiGateway.addAccount(account.toDto()).getOrThrow().toDomain()
         }.recoverCatching { exception ->
             if (exception is WebSocketRestApiException && exception.httpStatusCode == HttpStatusCode.Conflict) {
@@ -35,22 +36,22 @@ class ClientPaymentAccountsServiceFacade(
         }
 
     override suspend fun executeDeleteAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             apiGateway.deleteAccount(accountName).getOrThrow()
         }
 
     override suspend fun executeGetFiatPaymentMethods(): Result<List<FiatPaymentMethod>> =
-        runCatching {
+        resultCatching {
             apiGateway.getFiatPaymentMethods().getOrThrow().map { it.toDomain() }
         }
 
     override suspend fun executeGetCryptoPaymentMethods(): Result<List<CryptoPaymentMethod>> =
-        runCatching {
+        resultCatching {
             apiGateway.getCryptoPaymentMethods().getOrThrow().map { it.toDomain() }
         }
 
     override suspend fun executeGetBankAccountCountryDetails(countryCode: String): Result<BankAccountCountryDetails> =
-        runCatching {
+        resultCatching {
             bankAccountCountryDetailsRepository
                 .get(countryCode) {
                     apiGateway.getBankAccountCountryDetails().getOrThrow()

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/domain/service/PaymentAccountsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/payment_accounts/domain/service/PaymentAccountsServiceFacade.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.client.payment_accounts.domain.model.fiat.common.bank
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.domain.model.account.PaymentAccount
 import network.bisq.mobile.domain.model.account.create.CreatePaymentAccount
+import network.bisq.mobile.domain.utils.resultCatching
 
 abstract class PaymentAccountsServiceFacade : ServiceFacade() {
     private val _accountsByName = MutableStateFlow<Map<String, PaymentAccount>>(emptyMap())
@@ -31,7 +32,7 @@ abstract class PaymentAccountsServiceFacade : ServiceFacade() {
 
     // Concrete implementations with shared business logic
     suspend fun getAccounts(): Result<Unit> =
-        runCatching {
+        resultCatching {
             val accounts =
                 executeGetAccounts()
                     .getOrThrow()
@@ -39,7 +40,7 @@ abstract class PaymentAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun addAccount(account: CreatePaymentAccount): Result<Unit> =
-        runCatching {
+        resultCatching {
             val addedAccount =
                 executeAddAccount(account)
                     .getOrThrow()
@@ -49,7 +50,7 @@ abstract class PaymentAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun deleteAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             executeDeleteAccount(accountName).getOrThrow()
             _accountsByName.update { current ->
                 getAccountsByName(current.values.filter { it.accountName != accountName })
@@ -57,17 +58,17 @@ abstract class PaymentAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun getFiatPaymentMethods(): Result<List<FiatPaymentMethod>> =
-        runCatching {
+        resultCatching {
             executeGetFiatPaymentMethods().getOrThrow()
         }
 
     suspend fun getCryptoPaymentMethods(): Result<List<CryptoPaymentMethod>> =
-        runCatching {
+        resultCatching {
             executeGetCryptoPaymentMethods().getOrThrow()
         }
 
     suspend fun getBankAccountCountryDetails(countryCode: String): Result<BankAccountCountryDetails> =
-        runCatching {
+        resultCatching {
             executeGetBankAccountCountryDetails(countryCode).getOrThrow()
         }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/accounts/NodeUserDefinedAccountsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/accounts/NodeUserDefinedAccountsServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.node.common.domain.service.accounts
 import bisq.account.AccountService
 import bisq.account.accounts.fiat.UserDefinedFiatAccount
 import network.bisq.mobile.data.service.accounts.UserDefinedAccountsServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.toBisq2
 import network.bisq.mobile.node.common.domain.mapping.toDomain
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -15,7 +16,7 @@ class NodeUserDefinedAccountsServiceFacade(
     private val accountService: AccountService by lazy { applicationService.accountService.get() }
 
     override suspend fun executeGetAccounts(): Result<List<DomainUserDefinedFiatAccount>> =
-        runCatching {
+        resultCatching {
             accountService
                 .accountByNameMap
                 .values
@@ -24,7 +25,7 @@ class NodeUserDefinedAccountsServiceFacade(
         }
 
     override suspend fun executeGetSelectedAccount(): Result<DomainUserDefinedFiatAccount?> =
-        runCatching {
+        resultCatching {
             val optionalAccount = accountService.findSelectedAccount()
             if (optionalAccount.isPresent) {
                 val bisq2Account = optionalAccount.get()
@@ -38,7 +39,7 @@ class NodeUserDefinedAccountsServiceFacade(
         }
 
     override suspend fun executeAddAccount(account: DomainCreateUserDefinedFiatAccount): Result<DomainUserDefinedFiatAccount> =
-        runCatching {
+        resultCatching {
             val bisq2Account = account.toBisq2()
             check(accountService.addPaymentAccount(bisq2Account)) {
                 "Account already exists: ${bisq2Account.accountName}"
@@ -50,14 +51,14 @@ class NodeUserDefinedAccountsServiceFacade(
         accountName: String,
         account: DomainCreateUserDefinedFiatAccount,
     ): Result<DomainUserDefinedFiatAccount> =
-        runCatching {
+        resultCatching {
             val savedAccount = account.toBisq2()
             accountService.updatePaymentAccount(accountName, savedAccount)
             savedAccount.toDomain()
         }
 
     override suspend fun executeDeleteAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             val existingAccount =
                 accountService.accountByNameMap[accountName]
                     ?: throw IllegalStateException("Account not found: $accountName")
@@ -66,7 +67,7 @@ class NodeUserDefinedAccountsServiceFacade(
         }
 
     override suspend fun executeSetSelectedAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             val account =
                 accountService
                     .findAccount(accountName)

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/private_chat/NodePrivateChatServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/private_chat/NodePrivateChatServiceFacade.kt
@@ -14,8 +14,6 @@ import bisq.user.identity.UserIdentityService
 import bisq.user.profile.UserProfile
 import bisq.user.profile.UserProfileService
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,6 +30,7 @@ import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.chat.private_chat.PrivateChatSendRefusedException
 import network.bisq.mobile.data.service.chat.private_chat.PrivateChatSendRejection
 import network.bisq.mobile.data.service.chat.private_chat.PrivateChatServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.mapping.chat.toDomain
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -133,7 +132,7 @@ class NodePrivateChatServiceFacade(
 
     override suspend fun findOrCreateChannel(peerProfileId: String): Result<String> =
         withContext(Dispatchers.Default) {
-            runCatching {
+            resultCatching {
                 // No id in any message below: these become the `Result.failure` cause, and
                 // `BasePresenter.handleError` logs `exception.message` verbatim. A two-party channel
                 // id is derived from both profile ids, so logging one records who is talking to whom,
@@ -155,17 +154,17 @@ class NodePrivateChatServiceFacade(
         citation: Citation?,
     ): Result<Unit> =
         withContext(Dispatchers.Default) {
-            // The onFailure below is not decoration: this is the only runCatching in the file wrapping
-            // a real suspension point, so the only one that can catch a cancellation. Leaving the
-            // screen mid-send would otherwise come back as an ordinary Result.failure and raise a
+            // resultCatching is load-bearing here: this is the only wrapper in the file around a real
+            // suspension point, so the only one that can catch a cancellation. Leaving the screen
+            // mid-send would otherwise come back as an ordinary Result.failure and raise a
             // "could not send" snackbar for a send nobody is waiting on any more.
             //
-            // ensureActive rather than rethrowing every CancellationException, because two different
-            // things arrive as one type here: `await` also throws it when the *future* is cancelled
-            // while this coroutine is perfectly alive, and rethrowing that would cancel the caller
-            // silently instead of reporting a send that did fail. Same distinction, and the same
-            // reasoning, as WebSocketApiClient.kt:159.
-            runCatching {
+            // Its ensureActive check, rather than rethrowing every CancellationException, is what this
+            // site needs: two different things arrive as one type here, since `await` also throws it
+            // when the *future* is cancelled while this coroutine is perfectly alive, and rethrowing
+            // that would cancel the caller silently instead of reporting a send that did fail. Same
+            // distinction, and the same reasoning, as WebSocketApiClient.kt:159.
+            resultCatching {
                 val channel = requireChannel(channelId)
                 val bisq2Citation = Optional.ofNullable(citation?.let { Mappings.CitationMapping.toBisq2Model(it) })
                 // trySendTextMessage rather than sendTextMessage: the node decides locally, before
@@ -181,7 +180,7 @@ class NodePrivateChatServiceFacade(
                 // See addOrRemoveChatMessageReaction for why the reaction's future is not awaited.
                 outcome.delivery.await()
                 Unit
-            }.onFailure { currentCoroutineContext().ensureActive() }
+            }
         }
 
     override suspend fun addChatMessageReaction(
@@ -197,7 +196,7 @@ class NodePrivateChatServiceFacade(
     ): Result<Boolean> =
         withContext(Dispatchers.Default) {
             // Resolved here rather than inline at the call below: as an argument it would be evaluated
-            // outside addOrRemoveChatMessageReaction's runCatching, so a reaction id this build does
+            // outside addOrRemoveChatMessageReaction's resultCatching, so a reaction id this build does
             // not know would throw out of the facade instead of returning a failure.
             val reactionEnum =
                 ReactionEnum.entries.getOrNull(reaction.reactionId)
@@ -214,7 +213,7 @@ class NodePrivateChatServiceFacade(
 
     override suspend fun leaveChannel(channelId: String): Result<Unit> =
         withContext(Dispatchers.Default) {
-            runCatching {
+            resultCatching {
                 val channel = requireChannel(channelId)
                 // Not channelService.leaveChannel: the manager consumes the departed channel's
                 // notifications and, only if that channel was the selected one, re-selects the
@@ -233,7 +232,7 @@ class NodePrivateChatServiceFacade(
 
     private fun findChannel(channelId: String): Bisq2TwoPartyPrivateChatChannel? = channelService.findChannel(channelId).getOrNull()
 
-    /** Call from inside a `runCatching`, where the failure becomes a `Result.failure`. */
+    /** Call from inside a `resultCatching`, where the failure becomes a `Result.failure`. */
     private fun requireChannel(channelId: String): Bisq2TwoPartyPrivateChatChannel = findChannel(channelId) ?: error("No private chat channel found")
 
     private fun handleChannelAdded(channel: Bisq2TwoPartyPrivateChatChannel) {
@@ -395,7 +394,7 @@ class NodePrivateChatServiceFacade(
         isRemoved: Boolean,
     ): Result<Unit> =
         withContext(Dispatchers.Default) {
-            runCatching {
+            resultCatching {
                 val channel = requireChannel(channelId)
                 val message =
                     channel.chatMessages.find { it.id == messageId }
@@ -405,7 +404,7 @@ class NodePrivateChatServiceFacade(
                 // and drops the future of its `sendTextMessageReaction` in exactly the same way.
                 //
                 // What still reaches the caller: a missing channel or message, both raised above inside
-                // this runCatching, and a refusal for a banned profile, which trySendTextMessageReaction
+                // this resultCatching, and a refusal for a banned profile, which trySendTextMessageReaction
                 // reports on the outcome before anything is stored — the same thing the REST API
                 // answers 409 for. Only delivery is left unobserved.
                 val outcome =
@@ -419,7 +418,7 @@ class NodePrivateChatServiceFacade(
             }
         }
 
-    /** Call from inside a `runCatching`, where the throw becomes the `Result.failure` the presenter reads. */
+    /** Call from inside a `resultCatching`, where the throw becomes the `Result.failure` the presenter reads. */
     private fun throwIfRefused(outcome: SendOutcome) {
         val rejection = outcome.rejection.getOrNull() ?: return
         throw PrivateChatSendRefusedException(rejection.toDomain())

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
@@ -23,6 +23,7 @@ import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.mapping.chat.toDomain
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -111,7 +112,7 @@ class NodeTradeChatMessagesServiceFacade(
             // Bisq2 hands back a CompletableFuture; dropping it would report every send as delivered.
             // The client facade propagates the dispatch failure, and the delivery-status UI only
             // covers what happens after dispatch, so this is the only place the node mode can.
-            runCatching { bisqEasyOpenTradeChannelService.sendTextMessage(text, bisq2Citation, channel).await() }
+            resultCatching { bisqEasyOpenTradeChannelService.sendTextMessage(text, bisq2Citation, channel).await() }
                 .map { }
         }
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/contacts/NodeContactsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/contacts/NodeContactsServiceFacade.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.data.replicated.user.contact_list.ContactListEntryVO
 import network.bisq.mobile.data.replicated.user.contact_list.ContactReasonEnum
 import network.bisq.mobile.data.service.contacts.ContactsServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
 import kotlin.jvm.optionals.getOrNull
@@ -47,7 +48,7 @@ class NodeContactsServiceFacade(
         userProfileId: String,
         reason: ContactReasonEnum,
     ): Result<Boolean> =
-        runCatching {
+        resultCatching {
             val peer =
                 userProfileService.findUserProfile(userProfileId).getOrNull()
                     ?: error("No user profile found")
@@ -58,7 +59,7 @@ class NodeContactsServiceFacade(
     // A missing entry is `false`, not an error (see the base-class contract): a stale remove
     // means the peer is already gone, which is exactly the state the user asked for.
     override suspend fun removeContact(userProfileId: String): Result<Boolean> =
-        runCatching {
+        resultCatching {
             val entry = contactListService.contactListEntries.firstOrNull { it.userProfile.id == userProfileId }
             entry != null && contactListService.removeContactListEntry(entry)
         }
@@ -70,7 +71,7 @@ class NodeContactsServiceFacade(
         userProfileId: String,
         tag: String,
     ): Result<Unit> =
-        runCatching {
+        resultCatching {
             contactListService.setTag(requireEntry(userProfileId), tag)
             refreshContacts()
         }
@@ -79,7 +80,7 @@ class NodeContactsServiceFacade(
         userProfileId: String,
         notes: String,
     ): Result<Unit> =
-        runCatching {
+        resultCatching {
             contactListService.setNotes(requireEntry(userProfileId), notes)
             refreshContacts()
         }
@@ -88,7 +89,7 @@ class NodeContactsServiceFacade(
         userProfileId: String,
         trustScore: Double,
     ): Result<Unit> =
-        runCatching {
+        resultCatching {
             contactListService.setTrustScore(requireEntry(userProfileId), trustScore)
             refreshContacts()
         }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/offers/NodeOffersServiceFacade.kt
@@ -114,7 +114,7 @@ class NodeOffersServiceFacade(
 
     private suspend fun restoreAndSelectChannel() {
         var marketSelectionRestored = false
-        runCatching {
+        resultCatching {
             val settings = settingsRepository.fetch()
             val marketCode = settings.selectedMarketCode
 

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/reputation/NodeReputationServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/reputation/NodeReputationServiceFacade.kt
@@ -49,12 +49,16 @@ class NodeReputationServiceFacade(
     }
 
     // API
+    // No profile id or profile age in any message below, same reasoning as
+    // NodePrivateChatServiceFacade.findOrCreateChannel: these are lookups of the peers this device
+    // viewed, the exception message becomes the Result.failure cause that BasePresenter.handleError
+    // logs verbatim, and device logs travel in bug reports. The caller already has the id it passed.
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> =
         withContext(Dispatchers.Default) {
             resultCatching {
                 val score: ReputationScore = reputationService.getReputationScore(userProfileId)
                 Mappings.ReputationScoreMapping.fromBisq2Model(score)
-            }.onFailure { e -> log.e(e) { "Failed to get reputation for userId=$userProfileId" } }
+            }.onFailure { e -> log.e(e) { "Failed to get reputation" } }
         }
 
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> =
@@ -63,17 +67,17 @@ class NodeReputationServiceFacade(
                 val userService = applicationService.userService.get()
                 val userProfile = userService.userProfileService.findUserProfile(userProfileId)
                 if (!userProfile.isPresent) {
-                    throw NoSuchElementException("UserProfile for userId=$userProfileId not found")
+                    throw NoSuchElementException("UserProfile not found")
                 }
                 val profileAge = reputationService.profileAgeService.getProfileAge(userProfile.get())
 
                 if (profileAge.isPresent) {
-                    log.d { "Profile age from ProfileAgeService: ${profileAge.get()} for userId=$userProfileId" }
+                    log.d { "Profile age resolved from ProfileAgeService" }
                     profileAge.get()
                 } else {
-                    log.d { "No profile age data available from ProfileAgeService for userId=$userProfileId" }
+                    log.d { "No profile age data available from ProfileAgeService" }
                     null
                 }
-            }.onFailure { e -> log.e(e) { "Failed to get profile age for userId=$userProfileId" } }
+            }.onFailure { e -> log.e(e) { "Failed to get profile age" } }
         }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/reputation/NodeReputationServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/reputation/NodeReputationServiceFacade.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
 
@@ -50,38 +51,29 @@ class NodeReputationServiceFacade(
     // API
     override suspend fun getReputation(userProfileId: String): Result<ReputationScoreVO> =
         withContext(Dispatchers.Default) {
-            try {
+            resultCatching {
                 val score: ReputationScore = reputationService.getReputationScore(userProfileId)
-                val scoreVO = Mappings.ReputationScoreMapping.fromBisq2Model(score)
-                Result.success(scoreVO)
-            } catch (e: Exception) {
-                log.e(e) { "Failed to get reputation for userId=$userProfileId" }
-                Result.failure(e)
-            }
+                Mappings.ReputationScoreMapping.fromBisq2Model(score)
+            }.onFailure { e -> log.e(e) { "Failed to get reputation for userId=$userProfileId" } }
         }
 
     override suspend fun getProfileAge(userProfileId: String): Result<Long?> =
         withContext(Dispatchers.Default) {
-            try {
+            resultCatching {
                 val userService = applicationService.userService.get()
                 val userProfile = userService.userProfileService.findUserProfile(userProfileId)
-                if (userProfile.isPresent) {
-                    val profile = userProfile.get()
-                    val profileAge = reputationService.profileAgeService.getProfileAge(profile)
-
-                    if (profileAge.isPresent) {
-                        log.d { "Profile age from ProfileAgeService: ${profileAge.get()} for userId=$userProfileId" }
-                        Result.success(profileAge.get())
-                    } else {
-                        log.d { "No profile age data available from ProfileAgeService for userId=$userProfileId" }
-                        Result.success(null)
-                    }
-                } else {
-                    Result.failure(NoSuchElementException("UserProfile for userId=$userProfileId not found"))
+                if (!userProfile.isPresent) {
+                    throw NoSuchElementException("UserProfile for userId=$userProfileId not found")
                 }
-            } catch (e: Exception) {
-                log.e(e) { "Failed to get profile age for userId=$userProfileId" }
-                Result.failure(e)
-            }
+                val profileAge = reputationService.profileAgeService.getProfileAge(userProfile.get())
+
+                if (profileAge.isPresent) {
+                    log.d { "Profile age from ProfileAgeService: ${profileAge.get()} for userId=$userProfileId" }
+                    profileAge.get()
+                } else {
+                    log.d { "No profile age data available from ProfileAgeService for userId=$userProfileId" }
+                    null
+                }
+            }.onFailure { e -> log.e(e) { "Failed to get profile age for userId=$userProfileId" } }
         }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/settings/NodeSettingsServiceFacade.kt
@@ -16,6 +16,7 @@ import network.bisq.mobile.data.service.settings.DEFAULT_DIFFICULTY_ADJUSTMENT_F
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.utils.locale
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.node.common.domain.mapping.Mappings
 import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
@@ -82,29 +83,29 @@ class NodeSettingsServiceFacade(
 
     // Properties
 
-    override suspend fun confirmTacAccepted(value: Boolean): Result<Unit> = runCatching { settingsService.setIsTacAccepted(value) }
+    override suspend fun confirmTacAccepted(value: Boolean): Result<Unit> = resultCatching { settingsService.setIsTacAccepted(value) }
 
     private val _tradeRulesConfirmed = MutableStateFlow(false)
     override val tradeRulesConfirmed: StateFlow<Boolean> = _tradeRulesConfirmed.asStateFlow()
 
-    override suspend fun confirmTradeRules(value: Boolean): Result<Unit> = runCatching { settingsService.setBisqEasyTradeRulesConfirmed(value) }
+    override suspend fun confirmTradeRules(value: Boolean): Result<Unit> = resultCatching { settingsService.setBisqEasyTradeRulesConfirmed(value) }
 
     private val _languageCode: MutableStateFlow<String> = MutableStateFlow("")
     override val languageCode: StateFlow<String> = _languageCode.asStateFlow()
 
     override suspend fun setLanguageCode(value: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             log.i { "Attempting to set language code to: $value" }
             settingsService.setLanguageTag(value)
             updateLanguage(value)
             log.i { "Successfully set language code to: $value (via Bisq2 core)" }
         }
 
-    override suspend fun setSupportedLanguageCodes(value: Set<String>): Result<Unit> = runCatching { settingsService.supportedLanguageTags.setAll(value) }
+    override suspend fun setSupportedLanguageCodes(value: Set<String>): Result<Unit> = resultCatching { settingsService.supportedLanguageTags.setAll(value) }
 
-    override suspend fun setCloseMyOfferWhenTaken(value: Boolean): Result<Unit> = runCatching { settingsService.setCloseMyOfferWhenTaken(value) }
+    override suspend fun setCloseMyOfferWhenTaken(value: Boolean): Result<Unit> = resultCatching { settingsService.setCloseMyOfferWhenTaken(value) }
 
-    override suspend fun setMaxTradePriceDeviation(value: Double): Result<Unit> = runCatching { settingsService.setMaxTradePriceDeviation(value) }
+    override suspend fun setMaxTradePriceDeviation(value: Double): Result<Unit> = resultCatching { settingsService.setMaxTradePriceDeviation(value) }
 
     private val _useAnimations: MutableStateFlow<Boolean> = MutableStateFlow(true)
     override val useAnimations: StateFlow<Boolean> = _useAnimations.asStateFlow()
@@ -115,13 +116,13 @@ class NodeSettingsServiceFacade(
     override val autoAddTradePeersToContacts: StateFlow<Boolean> = _autoAddTradePeersToContacts.asStateFlow()
 
     override suspend fun setAutoAddTradePeersToContacts(value: Boolean): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsService.setAutoAddToContactsList(value)
             _autoAddTradePeersToContacts.value = value
         }
 
     override suspend fun setUseAnimations(value: Boolean): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsService.setUseAnimations(value)
             _useAnimations.value = value
         }
@@ -129,20 +130,20 @@ class NodeSettingsServiceFacade(
     private val _difficultyAdjustmentFactor: MutableStateFlow<Double> = MutableStateFlow(DEFAULT_DIFFICULTY_ADJUSTMENT_FACTOR)
     override val difficultyAdjustmentFactor: StateFlow<Double> = _difficultyAdjustmentFactor.asStateFlow()
 
-    override suspend fun setDifficultyAdjustmentFactor(value: Double): Result<Unit> = runCatching { settingsService.setDifficultyAdjustmentFactor(value) }
+    override suspend fun setDifficultyAdjustmentFactor(value: Double): Result<Unit> = resultCatching { settingsService.setDifficultyAdjustmentFactor(value) }
 
-    override suspend fun setNumDaysAfterRedactingTradeData(days: Int): Result<Unit> = runCatching { settingsService.setNumDaysAfterRedactingTradeData(days) }
+    override suspend fun setNumDaysAfterRedactingTradeData(days: Int): Result<Unit> = resultCatching { settingsService.setNumDaysAfterRedactingTradeData(days) }
 
     private val _ignoreDiffAdjustmentFromSecManager: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val ignoreDiffAdjustmentFromSecManager: StateFlow<Boolean> = _ignoreDiffAdjustmentFromSecManager.asStateFlow()
 
-    override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean): Result<Unit> = runCatching { settingsService.setIgnoreDiffAdjustmentFromSecManager(value) }
+    override suspend fun setIgnoreDiffAdjustmentFromSecManager(value: Boolean): Result<Unit> = resultCatching { settingsService.setIgnoreDiffAdjustmentFromSecManager(value) }
 
     private val _showWebLinkConfirmation: MutableStateFlow<Boolean> = MutableStateFlow(true)
     override val showWebLinkConfirmation: StateFlow<Boolean> = _showWebLinkConfirmation.asStateFlow()
 
     override suspend fun setWebLinkDontShowAgain(): Result<Unit> =
-        runCatching {
+        resultCatching {
             log.i { "Attempting to set 'Web link' Don't Show again" }
             dontShowAgainService.dontShowAgain(DontShowAgainKey.HYPERLINKS_OPEN_IN_BROWSER)
             check(persistWithRetry()) { "Failed to persist 'Web link' Don't Show again after retries" }
@@ -151,7 +152,7 @@ class NodeSettingsServiceFacade(
         }
 
     override suspend fun resetAllDontShowAgainFlags(): Result<Unit> =
-        runCatching {
+        resultCatching {
             dontShowAgainService.resetDontShowAgain()
             check(persistWithRetry()) { "Failed to persist reset of all 'Don't Show again' flags after retries" }
             _showWebLinkConfirmation.value = true
@@ -161,7 +162,7 @@ class NodeSettingsServiceFacade(
     override val permitOpeningBrowser: StateFlow<Boolean> = _permitOpeningBrowser.asStateFlow()
 
     override suspend fun setPermitOpeningBrowser(value: Boolean): Result<Unit> =
-        runCatching {
+        resultCatching {
             settingsService.setCookie(CookieKey.PERMIT_OPENING_BROWSER, value)
         }
 
@@ -252,11 +253,9 @@ class NodeSettingsServiceFacade(
 
     // API
     override suspend fun getSettings(): Result<SettingsVO> =
-        try {
+        resultCatching {
             val settings = Mappings.SettingsMapping.from(settingsService)
             updateLanguage(settings.languageCode)
-            Result.success(settings)
-        } catch (e: Exception) {
-            Result.failure(e)
+            settings
         }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/user_profile/NodeUserProfileServiceFacade.kt
@@ -325,7 +325,7 @@ class NodeUserProfileServiceFacade(
 
     override suspend fun selectUserProfile(id: String): Result<UserProfileVO> =
         withContext(Dispatchers.IO) {
-            runCatching {
+            resultCatching {
                 val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
                 if (identity != null) {
                     userService.userIdentityService.selectChatUserIdentity(identity)
@@ -340,7 +340,7 @@ class NodeUserProfileServiceFacade(
 
     override suspend fun deleteUserProfile(id: String): Result<UserProfileVO> =
         withContext(Dispatchers.IO) {
-            runCatching {
+            resultCatching {
                 val identity = userService.userIdentityService.findUserIdentity(id).getOrNull()
                 if (identity != null) {
                     userService.userIdentityService.deleteUserIdentity(identity).await()

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/accounts/UserDefinedAccountsServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/accounts/UserDefinedAccountsServiceFacade.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.update
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.domain.model.account.create.fiat.CreateUserDefinedFiatAccount
 import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
+import network.bisq.mobile.domain.utils.resultCatching
 
 abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
     private val _accountState = MutableStateFlow(AccountsState())
@@ -32,7 +33,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
 
     // Concrete implementations with shared business logic
     suspend fun getAccounts(): Result<List<UserDefinedFiatAccount>> =
-        runCatching {
+        resultCatching {
             val accounts =
                 executeGetAccounts()
                     .getOrThrow()
@@ -44,7 +45,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun getSelectedAccount(): Result<Unit> =
-        runCatching {
+        resultCatching {
             val account = executeGetSelectedAccount().getOrThrow()
             _accountState.update { state ->
                 state.copy(
@@ -58,7 +59,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun addAccount(account: CreateUserDefinedFiatAccount): Result<Unit> =
-        runCatching {
+        resultCatching {
             val createdAccount = executeAddAccount(account).getOrThrow()
             val accounts = _accountState.value.accounts
             val sortedAccounts = getSortedAccounts(accounts + createdAccount)
@@ -73,7 +74,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun saveAccount(account: CreateUserDefinedFiatAccount): Result<Unit> =
-        runCatching {
+        resultCatching {
             val accountName = getCurrentSelectedAccount()?.accountName
             if (accountName == null) throw IllegalStateException("No account selected")
             val savedAccount = executeSaveAccount(accountName, account).getOrThrow()
@@ -89,7 +90,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun deleteAccount(accountName: String): Result<Unit> =
-        runCatching {
+        resultCatching {
             val selectedAccount = getCurrentSelectedAccount()
             executeDeleteAccount(accountName).getOrThrow()
             val accountList = getAccountsExcluding(accountName)
@@ -109,7 +110,7 @@ abstract class UserDefinedAccountsServiceFacade : ServiceFacade() {
         }
 
     suspend fun setSelectedAccountIndex(accountIndex: Int): Result<Unit> =
-        runCatching {
+        resultCatching {
             val currentSelectedIndex = _accountState.value.selectedAccountIndex
             if (currentSelectedIndex != accountIndex) {
                 _accountState.update { it.copy(selectedAccountIndex = accountIndex) }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/utils/CoroutineUtils.kt
@@ -35,7 +35,7 @@ suspend fun <T> resultCatching(block: suspend () -> T): Result<T> =
     try {
         Result.success(block())
     } catch (e: Exception) {
-        log.d(e) { "Caught exception; rethrowing if coroutine is cancelled" }
+        log.v(e) { "Caught exception; rethrowing if coroutine is cancelled" }
         currentCoroutineContext().ensureActive()
         Result.failure(e)
     }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/service/accounts/UserDefinedAccountsServiceFacadeCancellationTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/service/accounts/UserDefinedAccountsServiceFacadeCancellationTest.kt
@@ -1,0 +1,82 @@
+package network.bisq.mobile.data.service.accounts
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.domain.model.account.create.fiat.CreateUserDefinedFiatAccount
+import network.bisq.mobile.domain.model.account.fiat.UserDefinedFiatAccount
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the facade-layer contract that `runCatching` used to break: a backend call cancelled with
+ * its caller must not come back as an ordinary `Result.failure` the presenter reports as an error.
+ */
+class UserDefinedAccountsServiceFacadeCancellationTest {
+    private class TestFacade(
+        private val onGetAccounts: suspend () -> Result<List<UserDefinedFiatAccount>>,
+    ) : UserDefinedAccountsServiceFacade() {
+        override suspend fun executeGetAccounts(): Result<List<UserDefinedFiatAccount>> = onGetAccounts()
+
+        override suspend fun executeGetSelectedAccount(): Result<UserDefinedFiatAccount?> = Result.success(null)
+
+        override suspend fun executeAddAccount(account: CreateUserDefinedFiatAccount): Result<UserDefinedFiatAccount> = Result.failure(NotImplementedError())
+
+        override suspend fun executeSaveAccount(
+            accountName: String,
+            account: CreateUserDefinedFiatAccount,
+        ): Result<UserDefinedFiatAccount> = Result.failure(NotImplementedError())
+
+        override suspend fun executeDeleteAccount(accountName: String): Result<Unit> = Result.success(Unit)
+
+        override suspend fun executeSetSelectedAccount(accountName: String): Result<Unit> = Result.success(Unit)
+    }
+
+    @Test
+    fun `caller cancellation propagates instead of becoming a failed Result`() =
+        runTest {
+            val started = CompletableDeferred<Unit>()
+            val gate = CompletableDeferred<Unit>()
+            val facade =
+                TestFacade {
+                    started.complete(Unit)
+                    gate.await()
+                    Result.success(emptyList())
+                }
+
+            var outcome: Result<List<UserDefinedFiatAccount>>? = null
+            var propagated: CancellationException? = null
+            val caller =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        outcome = facade.getAccounts()
+                    } catch (e: CancellationException) {
+                        propagated = e
+                        throw e
+                    }
+                }
+
+            started.await()
+            caller.cancel()
+            caller.join()
+
+            assertNotNull(propagated)
+            assertNull(outcome)
+        }
+
+    @Test
+    fun `backend failure becomes a failed Result`() =
+        runTest {
+            val facade = TestFacade { Result.failure(IllegalStateException("boom")) }
+
+            val result = facade.getAccounts()
+
+            assertTrue(result.isFailure)
+            assertEquals("boom", result.exceptionOrNull()?.message)
+        }
+}


### PR DESCRIPTION
Closes #1783

## Change

The shared helper already exists: `resultCatching` in
`shared/domain/.../domain/utils/CoroutineUtils.kt`, added in #1788. This PR does the migration the issue asks for.

Every facade-layer `runCatching` that sits inside a `suspend` function now uses `resultCatching`, which rethrows when the caller's job is cancelled and converts every other failure to `Result.failure`. That is 71 call sites across 17 files, covering Node facades, Client facades and the shared facade base classes.

Six longhand `try { ... } catch (e: Exception) { Result.failure(e) }` sites had the same bug and are converted too: `NodeSettingsServiceFacade.getSettings`, 
`NodeReputationServiceFacade.getReputation` and `.getProfileAge`,
`ClientUserProfileServiceFacade.updateAndPublishUserProfile`,
`ClientMediationServiceFacade.reportToMediator`,
`ClientReputationServiceFacade.getProfileAge` and
`ClientSettingsServiceFacade.setLanguageCode`.

In `NodePrivateChatServiceFacade.sendChatMessage` the manual `.onFailure { currentCoroutineContext().ensureActive() }` is now redundant, since the helper does exactly that, so it is removed along with its two imports.

## What is deliberately left alone

Nine `runCatching` calls in facade files stay as they are, because no cancellation can reach them:

- Four in non-suspend functions (`selectMarket` and `selectOfferbookMarket` in both the Node and Client flavours).
- `ClientPrivateChatServiceFacade.parseRejection`, also non-suspend.
- Three blocks that only wrap synchronous payload deserialization inside a WebSocket collector.
- The non-suspend `onMarketRestored` callback in `MarketPriceServiceFacade`.

The rule applied throughout is "the block sits in a suspend function or wraps a suspension point". `resultCatching` is itself a suspend function, so the non-suspend sites could not call it anyway.

## On the first acceptance criterion

The issue says "a `CancellationException` from a wrapped operation reaches the caller". `resultCatching` rethrows only when the caller's own job is cancelled. A timeout-style `CancellationException` raised while the caller is still alive stays a
`Result.failure`, and that is on purpose.

Two sites `await()` a bisq2 `CompletableFuture`, and on the JVM `kotlinx.coroutines.CancellationException` is a typealias for
`java.util.concurrent.CancellationException`. A cancelled future on a perfectly healthy coroutine therefore arrives as a `CancellationException`. Rethrowing it unconditionally would cancel the caller silently, so a failed send would show the
user nothing at all. `WebSocketApiClient` draws the same distinction for the same reason.

The `ensureActive()` form also catches a case a plain type check cannot: cancellation often surfaces as something other than a `CancellationException` (a closed socket, a closed channel, a service already torn down). Those must not be reported as real failures either.

## Behaviour changes worth a look during review

1. `runCatching` catches `Throwable`, `resultCatching` catches `Exception`. An  `Error` now escapes the four `serviceScope.launch { ... }` subscription sites and  reaches `GenericErrorHandler`, which forwards to analytics and shows the error panel, where it used to be swallowed into a warning log. Failing loud looks right here, but it is a user-visible difference.
2. A backend call that returns `Result.failure` rather than throwing now also hits the error log in `ClientReputationServiceFacade.getProfileAge` and `ClientSettingsServiceFacade.setLanguageCode`. The `Result` handed to callers carries the identical exception instance in every case.
3. In `NodeReputationServiceFacade.getProfileAge`, the "UserProfile not found" case now produces an error log where it produced none before. Same `NoSuchElementException`, same failed `Result`.

## Tests

New: `UserDefinedAccountsServiceFacadeCancellationTest` in `shared/domain` `commonTest`. A fake backend proves that cancelling the caller propagates the `CancellationException` out of `getAccounts()` instead of returning a failed `Result`, and that an ordinary backend failure still becomes `Result.failure`.

The helper's own behaviour is already covered by `ResultCatchingTest` from #1788.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling consistency across account, profile, settings, offers, chat, contacts, reputation, mediation, and payment-account operations.
  * Caller cancellation is now propagated correctly instead of being reported as a regular failed operation.
  * Preserved existing fallback behavior and specific error reporting, including unavailable mediation and duplicate payment-account errors.
  * Error messages and logs no longer expose user profile identifiers.

* **Reliability**
  * Improved failure logging and result handling for asynchronous operations without changing existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->