### PR TITLE
Feature/trade stall improve analytics data with timestamps

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
@@ -37,7 +37,7 @@ class ClientTradesServiceFacadeTest : ClientKoinIntegrationTestBase() {
         webSocketClientService = mockk(relaxed = true)
         globalUiManager = mockk(relaxed = true)
         analyticsService = mockk(relaxed = true)
-        facade = ClientTradesServiceFacade(apiGateway, webSocketClientService, Json, globalUiManager, analyticsService)
+        facade = ClientTradesServiceFacade(apiGateway, webSocketClientService, Json, globalUiManager, analyticsService, mockk(relaxed = true))
     }
 
     @Test

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -412,6 +412,7 @@ val clientDomainModule =
                 get(),
                 get(),
                 get(), // analyticsService
+                get(), // tradeStallClockRepository
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -26,6 +26,7 @@ import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
 import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
 import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 
@@ -54,7 +55,8 @@ class ClientTradesServiceFacade(
     json: Json,
     private val globalUiManager: GlobalUiManager,
     analyticsService: AnalyticsService,
-) : BaseTradesServiceFacade(analyticsService) {
+    tradeStallClockRepository: TradeStallClockRepository,
+) : BaseTradesServiceFacade(analyticsService, tradeStallClockRepository) {
     companion object {
         private const val MAX_CACHED_TRADE_PROPERTIES = 500
     }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -182,7 +182,7 @@ val androidNodeDomainModule =
 
         single<ExplorerServiceFacade> { NodeExplorerServiceFacade(get()) }
 
-        single<TradesServiceFacade> { NodeTradesServiceFacade(get(), get()) }
+        single<TradesServiceFacade> { NodeTradesServiceFacade(get(), get(), get()) }
 
         single<TradeChatMessagesServiceFacade> {
             NodeTradeChatMessagesServiceFacade(

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -51,6 +51,7 @@ import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
 import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
 import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.node.common.domain.mapping.Mappings
@@ -90,7 +91,8 @@ import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel as Bisq2BisqEasy
 class NodeTradesServiceFacade(
     applicationService: AndroidApplicationService.Provider,
     analyticsService: AnalyticsService,
-) : BaseTradesServiceFacade(analyticsService) {
+    tradeStallClockRepository: TradeStallClockRepository,
+) : BaseTradesServiceFacade(analyticsService, tradeStallClockRepository) {
     // Dependencies
     private val marketPriceService: MarketPriceService by lazy { applicationService.bondedRolesService.get().marketPriceService }
     private val bisqEasyOfferbookChannelService: BisqEasyOfferbookChannelService by lazy {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/TradeStallClockRepositoryImplTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/data/repository/TradeStallClockRepositoryImplTest.kt
@@ -1,0 +1,148 @@
+package network.bisq.mobile.data.repository
+
+import androidx.datastore.core.DataStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.model.TradeStallClockEntry
+import network.bisq.mobile.data.model.TradeStallClockMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TradeStallClockRepositoryImplTest {
+    private val mockDataStore = mockk<DataStore<TradeStallClockMap>>()
+    private val repository = TradeStallClockRepositoryImpl(mockDataStore)
+
+    @Test
+    fun `data flow should return stall clock map from datastore`() =
+        runTest {
+            val expectedMap =
+                TradeStallClockMap(
+                    mapOf(
+                        "trade1" to TradeStallClockEntry("INIT", 1_000L),
+                        "trade2" to TradeStallClockEntry("BTC_CONFIRMED", null),
+                    ),
+                )
+            every { mockDataStore.data } returns flowOf(expectedMap)
+
+            assertEquals(expectedMap, repository.data.first())
+        }
+
+    // Exercises createDefault() via the base class's IOException fallback, like the sibling
+    // TradeReadStateRepositoryImplTest does: a corrupt/unreadable store degrades to an empty map,
+    // which the tracker reads as honest UNKNOWN rather than failing.
+    @Test
+    fun `data flow should emit empty map on IOException`() =
+        runTest {
+            every { mockDataStore.data } returns
+                kotlinx.coroutines.flow.flow {
+                    throw androidx.datastore.core.IOException("Test IO error")
+                }
+
+            assertEquals(TradeStallClockMap(emptyMap()), repository.data.first())
+        }
+
+    @Test
+    fun `fetch should return first item from data flow`() =
+        runTest {
+            val expectedMap = TradeStallClockMap(mapOf("trade1" to TradeStallClockEntry("INIT", 42L)))
+            every { mockDataStore.data } returns flowOf(expectedMap)
+
+            assertEquals(expectedMap, repository.fetch())
+        }
+
+    @Test
+    fun `record should add a new entry and preserve existing ones`() =
+        runTest {
+            val updateSlot = slot<suspend (TradeStallClockMap) -> TradeStallClockMap>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns TradeStallClockMap()
+
+            val originalMap = TradeStallClockMap(mapOf("existing" to TradeStallClockEntry("INIT", 5L)))
+
+            repository.record("new_trade", "TAKER_SENT_TAKE_OFFER_REQUEST", 99L)
+
+            coVerify { mockDataStore.updateData(any()) }
+            val updatedMap = updateSlot.captured(originalMap)
+            assertEquals(TradeStallClockEntry("TAKER_SENT_TAKE_OFFER_REQUEST", 99L), updatedMap.map["new_trade"])
+            assertEquals(TradeStallClockEntry("INIT", 5L), updatedMap.map["existing"]) // preserved
+            assertEquals(2, updatedMap.map.size)
+        }
+
+    @Test
+    fun `record should overwrite an existing entry`() =
+        runTest {
+            val updateSlot = slot<suspend (TradeStallClockMap) -> TradeStallClockMap>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns TradeStallClockMap()
+
+            val originalMap = TradeStallClockMap(mapOf("trade1" to TradeStallClockEntry("INIT", 5L)))
+
+            repository.record("trade1", "BTC_CONFIRMED", 100L)
+
+            val updatedMap = updateSlot.captured(originalMap)
+            assertEquals(TradeStallClockEntry("BTC_CONFIRMED", 100L), updatedMap.map["trade1"])
+            assertEquals(1, updatedMap.map.size)
+        }
+
+    // A first sighting has no witnessed transition, so its time is null by contract.
+    @Test
+    fun `record should accept a null transition time`() =
+        runTest {
+            val updateSlot = slot<suspend (TradeStallClockMap) -> TradeStallClockMap>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns TradeStallClockMap()
+
+            repository.record("trade1", "INIT", null)
+
+            val updatedMap = updateSlot.captured(TradeStallClockMap())
+            assertEquals(TradeStallClockEntry("INIT", null), updatedMap.map["trade1"])
+        }
+
+    @Test
+    fun `record should reject blank tradeId`() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> { repository.record("", "INIT", 1L) }
+            assertFailsWith<IllegalArgumentException> { repository.record("   ", "INIT", 1L) }
+        }
+
+    @Test
+    fun `retainAll should keep only the given trade ids`() =
+        runTest {
+            val updateSlot = slot<suspend (TradeStallClockMap) -> TradeStallClockMap>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns TradeStallClockMap()
+
+            val originalMap =
+                TradeStallClockMap(
+                    mapOf(
+                        "open1" to TradeStallClockEntry("INIT", 1L),
+                        "closed" to TradeStallClockEntry("BTC_CONFIRMED", 2L),
+                        "open2" to TradeStallClockEntry("INIT", null),
+                    ),
+                )
+
+            repository.retainAll(setOf("open1", "open2"))
+
+            val updatedMap = updateSlot.captured(originalMap)
+            assertEquals(setOf("open1", "open2"), updatedMap.map.keys)
+            assertEquals(TradeStallClockEntry("INIT", 1L), updatedMap.map["open1"])
+            assertEquals(TradeStallClockEntry("INIT", null), updatedMap.map["open2"])
+        }
+
+    @Test
+    fun `retainAll with an empty set should clear the map`() =
+        runTest {
+            val updateSlot = slot<suspend (TradeStallClockMap) -> TradeStallClockMap>()
+            coEvery { mockDataStore.updateData(capture(updateSlot)) } returns TradeStallClockMap()
+
+            val originalMap = TradeStallClockMap(mapOf("trade1" to TradeStallClockEntry("INIT", 1L)))
+
+            repository.retainAll(emptySet())
+
+            val updatedMap = updateSlot.captured(originalMap)
+            assertEquals(emptyMap(), updatedMap.map)
+        }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -9,16 +9,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.model.TradeStallClockEntry
+import network.bisq.mobile.data.model.TradeStallClockMap
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.analytics.AnalyticsEvent.Trade
 import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 import kotlin.test.Test
@@ -399,6 +404,119 @@ class TradeAnalyticsTrackerTest {
             scope.cancel()
         }
 
+    @Test
+    fun `stall clock survives a restart when the state did not change`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val repo = FakeTradeStallClockRepository()
+            var nowMs = 0L
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+            // First session witnesses a transition at t=0.
+            val firstScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val firstTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            firstTracker.observeTrades(firstScope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            firstScope.cancel()
+
+            // "Restart": a fresh tracker on the same repository, trade still in the same state.
+            nowMs = 2L * 60 * 60 * 1000
+            val secondScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val secondTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            secondTracker.observeTrades(secondScope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+
+            assertEquals(Trade.StallBucket.H1_TO_24H, secondTracker.stallBucketFor("t1"))
+            secondScope.cancel()
+        }
+
+    @Test
+    fun `state changed while the app was closed re-stamps the clock at reload`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val repo = FakeTradeStallClockRepository()
+            var nowMs = 0L
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+            val firstScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val firstTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            firstTracker.observeTrades(firstScope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            firstScope.cancel()
+
+            // The trade advanced "while the app was closed" — the change is witnessed at reload,
+            // so the clock re-stamps to the reload time instead of keeping the stale timestamp.
+            state.value = BisqEasyTradeStateEnum.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION
+            nowMs = 2L * 60 * 60 * 1000
+            val secondScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val secondTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            secondTracker.observeTrades(secondScope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+
+            nowMs += 30L * 60 * 1000
+            assertEquals(Trade.StallBucket.UNDER_1H, secondTracker.stallBucketFor("t1"))
+            secondScope.cancel()
+        }
+
+    @Test
+    fun `initial empty open list does not wipe persisted clocks`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val repo = FakeTradeStallClockRepository()
+            var nowMs = 0L
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+            val firstScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val firstTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            firstTracker.observeTrades(firstScope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            firstScope.cancel()
+
+            // At startup the open list replays empty while trades load — that must not evict.
+            nowMs = 2L * 60 * 60 * 1000
+            val openTrades = MutableStateFlow(emptyList<TradeItemPresentationModel>())
+            val secondScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val secondTracker = TradeAnalyticsTracker(analytics, clock = { nowMs }, stallClockRepository = repo)
+            secondTracker.observeTrades(secondScope, openTrades) { it.tradeId }
+            openTrades.value = listOf(fakeTrade(tradeState = state))
+
+            assertEquals(Trade.StallBucket.H1_TO_24H, secondTracker.stallBucketFor("t1"))
+            secondScope.cancel()
+        }
+
+    @Test
+    fun `persisted clock is evicted when a trade leaves the open list`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val repo = FakeTradeStallClockRepository()
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, clock = { 0L }, stallClockRepository = repo)
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+            val openTrades = MutableStateFlow(listOf(fakeTrade(tradeState = state)))
+
+            tracker.observeTrades(scope, openTrades) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BUYER_SENT_FIAT_SENT_CONFIRMATION
+            assertTrue(repo.fetch().map.containsKey("t1"))
+
+            openTrades.value = emptyList()
+
+            assertTrue(repo.fetch().map.isEmpty())
+            scope.cancel()
+        }
+
+    @Test
+    fun `persisted state name the enum no longer knows is skipped on seeding`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val repo = FakeTradeStallClockRepository()
+            repo.record("t1", "NO_SUCH_STATE", 0L)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val tracker = TradeAnalyticsTracker(analytics, clock = { 5L * 60 * 1000 }, stallClockRepository = repo)
+
+            tracker.observeTrades(scope, MutableStateFlow(listOf(fakeTrade()))) { it.tradeId }
+
+            assertEquals(Trade.StallBucket.UNKNOWN, tracker.stallBucketFor("t1"))
+            scope.cancel()
+        }
+
     private fun fakeTrade(
         id: String = "t1",
         isSeller: Boolean = false,
@@ -422,5 +540,23 @@ class TradeAnalyticsTrackerTest {
         every { item.bisqEasyTradeModel } returns model
         every { item.tradeId } returns id
         return item
+    }
+
+    private class FakeTradeStallClockRepository : TradeStallClockRepository {
+        private val state = MutableStateFlow(TradeStallClockMap())
+
+        override val data: Flow<TradeStallClockMap> get() = state
+
+        override suspend fun record(
+            tradeId: String,
+            stateName: String,
+            transitionAtMs: Long?,
+        ) {
+            state.update { it.copy(it.map + (tradeId to TradeStallClockEntry(stateName, transitionAtMs))) }
+        }
+
+        override suspend fun retainAll(tradeIds: Set<String>) {
+            state.update { it.copy(it.map.filterKeys(tradeIds::contains)) }
+        }
     }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTrackerTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -517,6 +518,24 @@ class TradeAnalyticsTrackerTest {
             scope.cancel()
         }
 
+    @Test
+    fun `datastore failures degrade to in-memory clocks without killing the observer`() =
+        runTest {
+            val analytics = mockk<AnalyticsService>(relaxed = true)
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            // Seed read, retainAll and record all throw — the collector must keep going and still
+            // emit Completed, and the in-memory clock must still tick.
+            val tracker = TradeAnalyticsTracker(analytics, clock = { 0L }, stallClockRepository = ThrowingTradeStallClockRepository())
+            val state = MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+
+            tracker.observeTrades(scope, MutableStateFlow(listOf(fakeTrade(tradeState = state)))) { it.tradeId }
+            state.value = BisqEasyTradeStateEnum.BTC_CONFIRMED
+
+            verify(exactly = 1) { analytics.track(Trade.Completed) }
+            assertEquals(Trade.StallBucket.UNDER_1H, tracker.stallBucketFor("t1"))
+            scope.cancel()
+        }
+
     private fun fakeTrade(
         id: String = "t1",
         isSeller: Boolean = false,
@@ -558,5 +577,17 @@ class TradeAnalyticsTrackerTest {
         override suspend fun retainAll(tradeIds: Set<String>) {
             state.update { it.copy(it.map.filterKeys(tradeIds::contains)) }
         }
+    }
+
+    private class ThrowingTradeStallClockRepository : TradeStallClockRepository {
+        override val data: Flow<TradeStallClockMap> get() = flow { throw RuntimeException("read boom") }
+
+        override suspend fun record(
+            tradeId: String,
+            stateName: String,
+            transitionAtMs: Long?,
+        ): Unit = throw RuntimeException("write boom")
+
+        override suspend fun retainAll(tradeIds: Set<String>): Unit = throw RuntimeException("write boom")
     }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/TradeStallClockMapSerializer.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/datastore/serializer/TradeStallClockMapSerializer.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import androidx.datastore.core.okio.OkioSerializer
+import network.bisq.mobile.data.model.TradeStallClockMap
+
+object TradeStallClockMapSerializer : OkioSerializer<TradeStallClockMap> by jsonDataStoreSerializer(
+    defaultValue = TradeStallClockMap(),
+    typeName = "TradeStallClockMap",
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/di/DataModule.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/di/DataModule.kt
@@ -7,14 +7,17 @@ import network.bisq.mobile.data.datastore.createDataStore
 import network.bisq.mobile.data.datastore.serializer.OfferbookFilterConfigsSerializer
 import network.bisq.mobile.data.datastore.serializer.SettingsSerializer
 import network.bisq.mobile.data.datastore.serializer.TradeReadStateMapSerializer
+import network.bisq.mobile.data.datastore.serializer.TradeStallClockMapSerializer
 import network.bisq.mobile.data.datastore.serializer.UserSerializer
 import network.bisq.mobile.data.model.Settings
 import network.bisq.mobile.data.model.TradeReadStateMap
+import network.bisq.mobile.data.model.TradeStallClockMap
 import network.bisq.mobile.data.model.User
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfigs
 import network.bisq.mobile.data.repository.OfferbookFilterConfigRepositoryImpl
 import network.bisq.mobile.data.repository.SettingsRepositoryImpl
 import network.bisq.mobile.data.repository.TradeReadStateRepositoryImpl
+import network.bisq.mobile.data.repository.TradeStallClockRepositoryImpl
 import network.bisq.mobile.data.repository.UserRepositoryImpl
 import network.bisq.mobile.data.utils.EnvironmentController
 import network.bisq.mobile.data.utils.getStorageDir
@@ -22,6 +25,7 @@ import network.bisq.mobile.domain.coroutines.DispatcherProvider
 import network.bisq.mobile.domain.repository.OfferbookFilterConfigRepository
 import network.bisq.mobile.domain.repository.SettingsRepository
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.domain.repository.UserRepository
 import network.bisq.mobile.domain.utils.CoroutineExceptionHandlerSetup
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
@@ -61,6 +65,15 @@ val dataModule =
             )
         }
 
+        single<DataStore<TradeStallClockMap>>(named("TradeStallClockMap")) {
+            createDataStore(
+                "TradeStallClockMap",
+                getStorageDir(),
+                TradeStallClockMapSerializer,
+                ReplaceFileCorruptionHandler { TradeStallClockMap() },
+            )
+        }
+
         single<DataStore<OfferbookFilterConfigs>>(named("OfferbookFilterConfigs")) {
             createDataStore(
                 "OfferbookFilterConfigs",
@@ -74,6 +87,7 @@ val dataModule =
         single<SettingsRepository> { SettingsRepositoryImpl(get(named("Settings"))) }
         single<UserRepository> { UserRepositoryImpl(get(named("User"))) }
         single<TradeReadStateRepository> { TradeReadStateRepositoryImpl(get(named("TradeReadStateMap"))) }
+        single<TradeStallClockRepository> { TradeStallClockRepositoryImpl(get(named("TradeStallClockMap"))) }
         // Koin singles are lazy by default. This repository must initialize at app startup so it can
         // load persisted offerbook filter configs into session memory before the user can disable
         // remember-filter-preferences from Settings. Disabling then clears local storage while the

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/TradeStallClockMap.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/model/TradeStallClockMap.kt
@@ -1,0 +1,22 @@
+package network.bisq.mobile.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Persisted stall clocks for open trades: per trade, the last state the app witnessed and when the
+ * last state transition was witnessed. Local-only — read back into `TradeAnalyticsTracker` so
+ * "time since the trade last visibly moved" survives app restarts; only the bounded
+ * `AnalyticsEvent.Trade.StallBucket` ever reaches analytics.
+ */
+@Serializable
+data class TradeStallClockMap(
+    // tradeId to last witnessed state + transition time
+    val map: Map<String, TradeStallClockEntry> = emptyMap(),
+)
+
+@Serializable
+data class TradeStallClockEntry(
+    val stateName: String,
+    // null until a transition is witnessed — a first sighting's age is unknowable
+    val transitionAtMs: Long? = null,
+)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/TradeStallClockRepositoryImpl.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/repository/TradeStallClockRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package network.bisq.mobile.data.repository
+
+import androidx.datastore.core.DataStore
+import network.bisq.mobile.data.model.TradeStallClockEntry
+import network.bisq.mobile.data.model.TradeStallClockMap
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
+
+class TradeStallClockRepositoryImpl(
+    tradeStallClockMapStore: DataStore<TradeStallClockMap>,
+) : DataStoreRepository<TradeStallClockMap>(tradeStallClockMapStore),
+    TradeStallClockRepository {
+    override fun createDefault() = TradeStallClockMap(emptyMap())
+
+    override suspend fun record(
+        tradeId: String,
+        stateName: String,
+        transitionAtMs: Long?,
+    ) {
+        require(tradeId.isNotBlank()) { "tradeId cannot be blank" }
+
+        set { it.copy(it.map + (tradeId to TradeStallClockEntry(stateName, transitionAtMs))) }
+    }
+
+    override suspend fun retainAll(tradeIds: Set<String>) {
+        set { it.copy(it.map.filterKeys(tradeIds::contains)) }
+    }
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.data.service.trades
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.domain.service.trades.TradeAnalyticsTracker
 
 /**
@@ -16,13 +17,16 @@ import network.bisq.mobile.domain.service.trades.TradeAnalyticsTracker
  */
 abstract class BaseTradesServiceFacade(
     protected val analyticsService: AnalyticsService,
+    tradeStallClockRepository: TradeStallClockRepository,
 ) : ServiceFacade(),
     TradesServiceFacade {
     // Scope-free by design: the tracker reads `serviceScope` fresh on every call (see the helpers
     // below), so it always launches on the facade's LIVE scope. `deactivate()` cancels and REPLACES
     // serviceScope, so a tracker that captured it once would silently go dead after the first
     // deactivate/reactivate cycle.
-    private val tradeAnalyticsTracker by lazy { TradeAnalyticsTracker(analyticsService) }
+    private val tradeAnalyticsTracker by lazy {
+        TradeAnalyticsTracker(analyticsService, stallClockRepository = tradeStallClockRepository)
+    }
 
     /** Emit a lifecycle/funnel [AnalyticsEvent.Trade] (Taken/Completed/Cancelled/Rejected/Errored/…). */
     protected fun trackTrade(event: AnalyticsEvent.Trade) = tradeAnalyticsTracker.track(event)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
@@ -121,10 +121,11 @@ sealed class AnalyticsEvent(
          * (never raw durations — bounded names only). A cancel after days without a transition is
          * a desync fingerprint; minutes is a human decision.
          *
-         * [UNKNOWN] keeps the data honest: transition times live in memory only (the trade DTO
-         * carries no per-state timestamps), so a state change the app never saw this session — e.g.
-         * it happened before an app restart — has an unknowable age and MUST NOT masquerade as a
-         * short stall.
+         * [UNKNOWN] keeps the data honest: the trade DTO carries no per-state timestamps, so only
+         * transitions the app itself witnessed can be timed. Witnessed transition times are
+         * persisted (`TradeStallClockRepository`), so the clock survives app restarts — [UNKNOWN]
+         * remains for trades whose state changed entirely outside any session, whose age is
+         * unknowable and MUST NOT masquerade as a short stall.
          */
         enum class StallBucket(
             val slug: String,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/repository/TradeStallClockRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/repository/TradeStallClockRepository.kt
@@ -1,0 +1,19 @@
+package network.bisq.mobile.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import network.bisq.mobile.data.model.TradeStallClockMap
+
+interface TradeStallClockRepository {
+    val data: Flow<TradeStallClockMap>
+
+    suspend fun fetch() = data.first()
+
+    suspend fun record(
+        tradeId: String,
+        stateName: String,
+        transitionAtMs: Long?,
+    )
+
+    suspend fun retainAll(tradeIds: Set<String>)
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -125,6 +125,20 @@ class TradeAnalyticsTracker(
     }
 
     /**
+     * Stall-clock persistence is best-effort: the [observeTrades] collector that writes it also
+     * emits `Completed`, so a datastore failure must degrade to in-memory clocks rather than end
+     * completion tracking for the session. Cancellation still propagates.
+     */
+    private suspend fun persistSafely(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            log.e(e) { "Stall-clock persistence failed — continuing with in-memory clocks only" }
+        }
+    }
+
+    /**
      * Runs a user-driven confirm action and records its outcome. On failure emits `FAILED` and captures
      * the exception; on success watches [tradeState] for the user's own transition away from its current
      * value, emitting `CONFIRMED` if it advances within [stallTimeoutMs] or `STALLED` otherwise. The
@@ -204,7 +218,7 @@ class TradeAnalyticsTracker(
         // whenever the open-trade list changes. The same stream feeds the stall clock — every state
         // change is a witnessed transition, cached in memory and persisted so it survives restarts.
         scope.launch {
-            seedFromPersistedClocks()
+            persistSafely { seedFromPersistedClocks() }
             // Eviction is gated on having seen a non-empty list: the first emission at startup is
             // an empty list while trades load, and evicting on it would wipe the just-seeded
             // persisted clocks. A session that never loads a trade keeps stale entries — bounded
@@ -219,12 +233,12 @@ class TradeAnalyticsTracker(
                         val openIds = trades.mapTo(mutableSetOf()) { tradeId(it) }
                         lastKnownStateByTradeId.keys.retainAll(openIds)
                         lastTransitionAtMsByTradeId.keys.retainAll(openIds)
-                        stallClockRepository?.retainAll(openIds)
+                        persistSafely { stallClockRepository?.retainAll(openIds) }
                     }
                     merge(*trades.map { item -> item.bisqEasyTradeModel.tradeState.map { state -> tradeId(item) to state } }.toTypedArray())
                 }.collect { (id, state) ->
                     if (recordTransition(id, state)) {
-                        stallClockRepository?.record(id, state.name, lastTransitionAtMsByTradeId[id])
+                        persistSafely { stallClockRepository?.record(id, state.name, lastTransitionAtMsByTradeId[id]) }
                     }
                     if (state == BisqEasyTradeStateEnum.BTC_CONFIRMED && completed.add(id)) {
                         analyticsService.track(AnalyticsEvent.Trade.Completed)

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/TradeAnalyticsTracker.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPre
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.domain.repository.TradeStallClockRepository
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.domain.utils.TimeUtils
@@ -44,6 +45,9 @@ class TradeAnalyticsTracker(
     private val analyticsService: AnalyticsService,
     private val stallTimeoutMs: Long = DEFAULT_STALL_TIMEOUT_MS,
     private val clock: () -> Long = { DateUtils.now() },
+    // Optional so tests exercising unrelated signals need no repository; production wiring
+    // (BaseTradesServiceFacade) always passes one.
+    private val stallClockRepository: TradeStallClockRepository? = null,
 ) : Logging {
     companion object {
         // Generous for Tor round-trips. Only the user's OWN local state transition is timed (fast), so
@@ -56,11 +60,13 @@ class TradeAnalyticsTracker(
         const val OUT_OF_SYNC_RECHECK_MS = 60_000L
     }
 
-    // In-memory only, by design: the trade DTO carries no per-state timestamps, so a
-    // transition the app never saw this session has an unknowable age — stallBucketFor reports it
-    // as UNKNOWN rather than fabricating a short stall. Entries are evicted as trades leave the
-    // open list. If UNKNOWN dominates cancel events in the monthly report, the follow-up is
-    // persisting this map, not widening the buckets.
+    // Session cache of the persisted stall clock ([TradeStallClockRepository]): the trade DTO
+    // carries no per-state timestamps, so the app can only time transitions it witnesses itself —
+    // but witnessed transitions are persisted, so the clock survives restarts. A genuinely stuck
+    // trade (state frozen across sessions) now ages into the 1h+/1d+ buckets instead of resetting
+    // to UNKNOWN on every restart (which the first monthly report showed dominating cancel
+    // events). A state that CHANGED while the app was closed is re-stamped at reload — the moment
+    // the change became visible. Entries are evicted as trades leave the open list.
     private val lastKnownStateByTradeId = mutableMapOf<String, BisqEasyTradeStateEnum>()
     private val lastTransitionAtMsByTradeId = mutableMapOf<String, Long>()
 
@@ -82,14 +88,39 @@ class TradeAnalyticsTracker(
      * or a pre-existing one loaded on startup, and only the former's age would be ~zero. StateFlows
      * also replay their current value on every re-subscription (the observers re-subscribe whenever
      * the open-trades list changes), which the same-state check discards.
+     *
+     * Returns whether anything new was witnessed (first sighting or transition) — i.e. whether the
+     * persisted clock is stale and worth rewriting. Replays return false, so the datastore is not
+     * rewritten on every open-list change.
      */
     private fun recordTransition(
         id: String,
         state: BisqEasyTradeStateEnum,
-    ) {
+    ): Boolean {
         val previous = lastKnownStateByTradeId.put(id, state)
         if (previous != null && previous != state) {
             lastTransitionAtMsByTradeId[id] = clock()
+        }
+        return previous != state
+    }
+
+    /**
+     * Restores persisted stall clocks into the session cache before observing. Only ids not already
+     * tracked this session are seeded, so a deactivate/reactivate cycle never overwrites fresher
+     * in-memory data with stale persisted state. A persisted state name the current enum no longer
+     * knows (app update) is skipped — its age is unknowable, which [stallBucketFor] already reports
+     * as UNKNOWN.
+     */
+    private suspend fun seedFromPersistedClocks() {
+        val persisted = stallClockRepository?.fetch()?.map ?: return
+        persisted.forEach { (id, entry) ->
+            if (id !in lastKnownStateByTradeId) {
+                val state =
+                    BisqEasyTradeStateEnum.entries.find { it.name == entry.stateName }
+                        ?: return@forEach
+                lastKnownStateByTradeId[id] = state
+                entry.transitionAtMs?.let { lastTransitionAtMsByTradeId[id] = it }
+            }
         }
     }
 
@@ -171,17 +202,30 @@ class TradeAnalyticsTracker(
 
         // Completion: BTC_CONFIRMED. flatMapLatest re-subscribes to the current trades' state flows
         // whenever the open-trade list changes. The same stream feeds the stall clock — every state
-        // change is a witnessed transition.
+        // change is a witnessed transition, cached in memory and persisted so it survives restarts.
         scope.launch {
+            seedFromPersistedClocks()
+            // Eviction is gated on having seen a non-empty list: the first emission at startup is
+            // an empty list while trades load, and evicting on it would wipe the just-seeded
+            // persisted clocks. A session that never loads a trade keeps stale entries — bounded
+            // (only ever past open trades) and evicted on the next session that does.
+            var sawOpenTrades = false
             openTradeItems
                 .flatMapLatest { trades ->
-                    // Evict stall entries for trades no longer open, so the maps stay bounded.
-                    val openIds = trades.mapTo(mutableSetOf()) { tradeId(it) }
-                    lastKnownStateByTradeId.keys.retainAll(openIds)
-                    lastTransitionAtMsByTradeId.keys.retainAll(openIds)
+                    // Evict stall entries for trades no longer open, so the maps and the persisted
+                    // clocks stay bounded.
+                    if (trades.isNotEmpty()) sawOpenTrades = true
+                    if (sawOpenTrades) {
+                        val openIds = trades.mapTo(mutableSetOf()) { tradeId(it) }
+                        lastKnownStateByTradeId.keys.retainAll(openIds)
+                        lastTransitionAtMsByTradeId.keys.retainAll(openIds)
+                        stallClockRepository?.retainAll(openIds)
+                    }
                     merge(*trades.map { item -> item.bisqEasyTradeModel.tradeState.map { state -> tradeId(item) to state } }.toTypedArray())
                 }.collect { (id, state) ->
-                    recordTransition(id, state)
+                    if (recordTransition(id, state)) {
+                        stallClockRepository?.record(id, state.name, lastTransitionAtMsByTradeId[id])
+                    }
                     if (state == BisqEasyTradeStateEnum.BTC_CONFIRMED && completed.add(id)) {
                         analyticsService.track(AnalyticsEvent.Trade.Completed)
                     }

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeStallClockMapSerializerTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/data/datastore/serializer/TradeStallClockMapSerializerTest.kt
@@ -1,0 +1,57 @@
+package network.bisq.mobile.data.datastore.serializer
+
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.model.TradeStallClockEntry
+import network.bisq.mobile.data.model.TradeStallClockMap
+import network.bisq.mobile.test.datastore.jsonDataStoreSerializerTestSupport
+import kotlin.test.Test
+
+class TradeStallClockMapSerializerTest {
+    private val support =
+        jsonDataStoreSerializerTestSupport(
+            serializer = TradeStallClockMapSerializer,
+            defaultValue = TradeStallClockMap(),
+            sampleValue = ::sampleMap,
+            typeName = "TradeStallClockMap",
+            kSerializer = TradeStallClockMap.serializer(),
+        )
+
+    @Test
+    fun `defaultValue returns empty TradeStallClockMap`() {
+        support.assertDefaultValue()
+    }
+
+    @Test
+    fun `readFrom returns default when source is exhausted`() =
+        runTest {
+            support.assertExhaustedReturnsDefault()
+        }
+
+    @Test
+    fun `readFrom deserializes valid JSON`() =
+        runTest {
+            support.assertDeserializesValidJson()
+        }
+
+    @Test
+    fun `readFrom wraps SerializationException in CorruptionException`() =
+        runTest {
+            support.assertWrapsSerializationExceptionInCorruptionException()
+        }
+
+    @Test
+    fun `writeTo round trips TradeStallClockMap`() =
+        runTest {
+            support.assertRoundTrip()
+        }
+
+    // The null transition time is part of the contract (first sighting), so the round-trip sample
+    // carries both a stamped and an unstamped entry.
+    private fun sampleMap() =
+        TradeStallClockMap(
+            mapOf(
+                "trade-1" to TradeStallClockEntry("INIT", 1_000L),
+                "trade-2" to TradeStallClockEntry("BTC_CONFIRMED", null),
+            ),
+        )
+}


### PR DESCRIPTION
 - track open trades progress persisting timestamps on a new TradeStallRepository
 - used that for analytics to help us understand funnel better and specifically to track what's the actual % impact of the INIT stalled trades problem in Bisq Easy protocol.
 - added substantial PR coverage AI assisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade stall timing information now persists locally across app restarts.
  * Trade analytics can restore previously observed trade states and continue tracking stall durations.
  * Persisted data is cleaned up when trades are no longer active.

* **Tests**
  * Added coverage for persistence, restoration, cleanup, serialization, invalid data, and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->