### PR TITLE
Prevent malformed WebSocket payloads from terminating client subscription collectors

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacadeTest.kt
@@ -147,7 +147,14 @@ class ClientTradeRestrictingAlertServiceFacadeTest : ClientKoinIntegrationTestBa
             )
             advanceUntilIdle()
 
-            assertNull(facade.alert.value)
+            assertNull(
+                facade.alert.value,
+                "JSON null must clear the alert, not be skipped as a decode failure",
+            )
+
+            observer.setEvent(validAlertEvent(sequenceNumber = 3))
+            advanceUntilIdle()
+            assertEquals("emergency-1", facade.alert.value?.id)
         }
 
     @Test

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacadeTest.kt
@@ -1,0 +1,107 @@
+package network.bisq.mobile.client.common.domain.service.chat.trade
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import org.junit.Test
+
+/**
+ * Covers the TRADE_CHAT_MESSAGES and CHAT_REACTIONS subscription collectors of
+ * [ClientTradeChatMessagesServiceFacade]: both stay gated on the first open trade, then decode
+ * and apply events. Empty-list payloads keep the assertions on the wiring — DTO-to-domain mapping
+ * is pinned by [BisqEasyOpenTradeMessageDtoMappingTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientTradeChatMessagesServiceFacadeTest : ClientKoinIntegrationTestBase() {
+    private val tradesServiceFacade: TradesServiceFacade = mockk(relaxed = true)
+    private val userProfileServiceFacade: UserProfileServiceFacade = mockk(relaxed = true)
+    private val apiGateway: TradeChatMessagesApiGateway = mockk(relaxed = true)
+    private val globalUiManager: GlobalUiManager = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
+    private lateinit var facade: ClientTradeChatMessagesServiceFacade
+
+    override fun onSetup() {
+        every { tradesServiceFacade.openTradeItems } returns openTradeItems
+        every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
+        every { userProfileServiceFacade.selectedUserProfile } returns MutableStateFlow(null)
+        facade =
+            ClientTradeChatMessagesServiceFacade(
+                tradesServiceFacade,
+                userProfileServiceFacade,
+                apiGateway,
+                json,
+                globalUiManager,
+            )
+    }
+
+    @Test
+    fun `trade chats subscription waits for the first open trade and then collects events`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeTradeChats() } returns observer
+
+            facade.activate()
+            advanceUntilIdle()
+            coVerify(exactly = 0) { apiGateway.subscribeTradeChats() }
+
+            openTradeItems.value = listOf(mockk(relaxed = true))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeTradeChats() }
+
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.TRADE_CHAT_MESSAGES,
+                    subscriberId = "trade-chat-test",
+                    deferredPayload = "[]",
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+            advanceUntilIdle()
+
+            facade.deactivate()
+        }
+
+    @Test
+    fun `chat reactions subscription waits for the first open trade and then collects events`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeChatReactions() } returns observer
+
+            facade.activate()
+            advanceUntilIdle()
+            coVerify(exactly = 0) { apiGateway.subscribeChatReactions() }
+
+            openTradeItems.value = listOf(mockk(relaxed = true))
+            advanceUntilIdle()
+            coVerify(exactly = 1) { apiGateway.subscribeChatReactions() }
+
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.CHAT_REACTIONS,
+                    subscriberId = "chat-reactions-test",
+                    deferredPayload = "[]",
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+            advanceUntilIdle()
+
+            facade.deactivate()
+        }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacadeTest.kt
@@ -1,0 +1,68 @@
+package network.bisq.mobile.client.common.domain.service.market
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
+import network.bisq.mobile.test.mocks.SettingsRepositoryMock
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Covers the MARKET_PRICE subscription collector of [ClientMarketPriceServiceFacade]: a valid
+ * event reaches the handler and fires the global price-update trigger.
+ *
+ * The collector launches on the injected `dispatcherProvider.default`, here backed by
+ * [testDispatcher] — the same pattern as `ClientOffersServiceFacadeTest` — so delivery settles
+ * with `advanceUntilIdle()`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientMarketPriceServiceFacadeTest : ClientKoinIntegrationTestBase() {
+    private val apiGateway: MarketPriceApiGateway = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var facade: ClientMarketPriceServiceFacade
+
+    override fun onSetup() {
+        facade =
+            ClientMarketPriceServiceFacade(
+                apiGateway,
+                json,
+                SettingsRepositoryMock(),
+                StandardTestDispatcherProvider(testDispatcher),
+            )
+    }
+
+    @Test
+    fun `market price websocket event triggers global price update`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeMarketPrice() } returns observer
+
+            facade.activate()
+            advanceUntilIdle()
+            assertEquals(0L, facade.globalPriceUpdate.value)
+
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.MARKET_PRICE,
+                    subscriberId = "market-price-test",
+                    deferredPayload = """{}""",
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+            advanceUntilIdle()
+
+            assertNotEquals(0L, facade.globalPriceUpdate.value)
+
+            facade.deactivate()
+        }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacadeTest.kt
@@ -1,0 +1,95 @@
+package network.bisq.mobile.client.common.domain.service.network
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
+import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepositoryMock
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
+import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.data.service.network.KmpTorService
+import network.bisq.mobile.test.coroutines.StandardTestDispatcherProvider
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Covers the NETWORK_INFO subscription collector of [ClientNetworkServiceFacade]: a valid event
+ * updates [ClientNetworkServiceFacade.networkInfo].
+ *
+ * The collector launches on the injected `dispatcherProvider.default`, here backed by
+ * [testDispatcher] — the same pattern as `ClientOffersServiceFacadeTest` — so delivery settles
+ * with `advanceUntilIdle()`. Tor stays disabled (`SensitiveSettingsRepositoryMock` defaults to
+ * `BisqProxyOption.NONE`) so activation skips the Tor bootstrap path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientNetworkServiceFacadeTest : ClientKoinIntegrationTestBase() {
+    private val networkApiGateway: NetworkApiGateway = mockk(relaxed = true)
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val httpClientService: HttpClientService = mockk(relaxed = true)
+    private val kmpTorService: KmpTorService = mockk(relaxed = true)
+    private val applicationBootstrapFacade: ApplicationBootstrapFacade = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var facade: ClientNetworkServiceFacade
+
+    override fun onSetup() {
+        facade =
+            ClientNetworkServiceFacade(
+                SensitiveSettingsRepositoryMock(),
+                httpClientService,
+                webSocketClientService,
+                networkApiGateway,
+                json,
+                kmpTorService,
+                applicationBootstrapFacade,
+                StandardTestDispatcherProvider(testDispatcher),
+            )
+    }
+
+    @Test
+    fun `network info websocket event updates networkInfo`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            coEvery { networkApiGateway.subscribeNetworkInfo() } returns observer
+
+            facade.activate()
+            advanceUntilIdle()
+
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.NETWORK_INFO,
+                    subscriberId = "network-info-test",
+                    deferredPayload =
+                        """
+                        {
+                          "allDataReceived": true,
+                          "torRunning": false,
+                          "myAddress": "abc123.onion:8090",
+                          "keyId": "key-1",
+                          "connections": []
+                        }
+                        """.trimIndent(),
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+            advanceUntilIdle()
+
+            val info = facade.networkInfo.value
+            assertNotNull(info)
+            assertEquals(true, info.allDataReceived)
+            assertEquals(false, info.torRunning)
+            assertEquals("abc123.onion:8090", info.myAddress)
+            assertEquals("key-1", info.keyId)
+            assertEquals(0, info.connections.size)
+
+            facade.deactivate()
+        }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacadeNumProfilesTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacadeNumProfilesTest.kt
@@ -1,0 +1,65 @@
+package network.bisq.mobile.client.common.domain.service.user_profile
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.ConnectionState
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
+import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
+import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
+import network.bisq.mobile.data.utils.PlatformImage
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the NUM_USER_PROFILES subscription collector of [ClientUserProfileServiceFacade]: a
+ * valid event updates [ClientUserProfileServiceFacade.numUserProfiles].
+ *
+ * Separate from [ClientUserProfileServiceFacadeTest] because that class owns the Robolectric +
+ * `TestApplication` exception for real bitmap decoding, while this one drives `serviceScope`
+ * through the Koin integration leaf (the two must never mix in one class — see testing catalog).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClientUserProfileServiceFacadeNumProfilesTest : ClientKoinIntegrationTestBase() {
+    private val apiGateway: UserProfileApiGateway = mockk(relaxed = true)
+    private val clientCatHashService: ClientCatHashService<PlatformImage> = mockk(relaxed = true)
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var facade: ClientUserProfileServiceFacade
+
+    override fun onSetup() {
+        // Never Connected: activate()'s profile-refresh branch stays out of this test's way.
+        every { webSocketClientService.connectionState } returns MutableStateFlow(ConnectionState.Connecting)
+        facade = ClientUserProfileServiceFacade(apiGateway, clientCatHashService, json, webSocketClientService)
+    }
+
+    @Test
+    fun `num user profiles websocket event updates numUserProfiles`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            coEvery { apiGateway.subscribeNumUserProfiles() } returns observer
+
+            facade.activate()
+            advanceUntilIdle()
+
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.NUM_USER_PROFILES,
+                    subscriberId = "num-profiles-test",
+                    deferredPayload = "7",
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(7, facade.numUserProfiles.value)
+        }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/SubscriptionTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/SubscriptionTest.kt
@@ -1,0 +1,62 @@
+package network.bisq.mobile.client.common.domain.websocket.subscription
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.service.trades.TradePropertiesDto
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers [Subscription]: a valid event is decoded and delivered to the result handler with its
+ * [ModificationType].
+ *
+ * Lives in androidUnitTest (not commonTest) because it needs mockk — [WebSocketClientService] is
+ * a concrete class. No Koin/Main setup: [Subscription] hardcodes [Dispatchers.Default], so
+ * delivery is awaited in real time via [runBlocking] + [withTimeout].
+ */
+class SubscriptionTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `subscribe delivers decoded payload and modification type to the result handler`() =
+        runBlocking {
+            val observer = WebSocketEventObserver()
+            val webSocketClientService = mockk<WebSocketClientService>()
+            coEvery { webSocketClientService.subscribe(Topic.TRADE_PROPERTIES, null) } returns observer
+
+            val received = CompletableDeferred<Pair<List<Map<String, TradePropertiesDto>>, ModificationType>>()
+            val subscription =
+                Subscription<Map<String, TradePropertiesDto>>(
+                    webSocketClientService,
+                    json,
+                    Topic.TRADE_PROPERTIES,
+                    resultHandler = { payload, modificationType ->
+                        received.complete(payload to modificationType)
+                    },
+                )
+
+            subscription.subscribe()
+            observer.setEvent(
+                WebSocketEvent(
+                    topic = Topic.TRADE_PROPERTIES,
+                    subscriberId = "subscription-test",
+                    deferredPayload = "[]",
+                    modificationType = ModificationType.REPLACE,
+                    sequenceNumber = 1,
+                ),
+            )
+
+            val (payload, modificationType) = withTimeout(5_000) { received.await() }
+            assertEquals(emptyList(), payload)
+            assertEquals(ModificationType.REPLACE, modificationType)
+
+            subscription.dispose()
+        }
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -370,12 +370,14 @@ val clientDomainModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         } bind NetworkServiceFacade::class
 
         single { MarketPriceApiGateway(get(), get()) }
         single<MarketPriceServiceFacade> {
             ClientMarketPriceServiceFacade(
+                get(),
                 get(),
                 get(),
                 get(),

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
@@ -61,8 +61,9 @@ class ClientAlertNotificationsServiceFacade(
             runCatching {
                 WebSocketEventPayload
                     .from<List<AuthorizedAlertDataDto>>(json, webSocketEvent)
-                    .payload
-                    .mapNotNull(AuthorizedAlertDataDto::toDomainOrNull)
+                    ?.payload
+                    ?.mapNotNull(AuthorizedAlertDataDto::toDomainOrNull)
+                    ?: return@collect
             }.onSuccess { payload ->
                 _alerts.value = payload
             }.onFailure { error ->

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientAlertNotificationsServiceFacade.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.data.mapping.alert.toDomainOrNull
 import network.bisq.mobile.client.common.data.model.alert.AuthorizedAlertDataDto
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.service.alert.AlertNotificationsServiceFacade
 import network.bisq.mobile.domain.model.alert.AuthorizedAlertData
 import network.bisq.mobile.domain.utils.resultCatching
@@ -53,22 +53,8 @@ class ClientAlertNotificationsServiceFacade(
 
     private suspend fun subscribeAlerts() {
         val observer = apiGateway.subscribeAlerts()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-
-            runCatching {
-                WebSocketEventPayload
-                    .from<List<AuthorizedAlertDataDto>>(json, webSocketEvent)
-                    ?.payload
-                    ?.mapNotNull(AuthorizedAlertDataDto::toDomainOrNull)
-                    ?: return@collect
-            }.onSuccess { payload ->
-                _alerts.value = payload
-            }.onFailure { error ->
-                log.e(error) { "Failed to deserialize authorized alert payload; event ignored." }
-            }
+        observer.collectPayloads<List<AuthorizedAlertDataDto>>(json) { payload, _ ->
+            _alerts.value = payload.mapNotNull(AuthorizedAlertDataDto::toDomainOrNull)
         }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
@@ -45,10 +45,10 @@ class ClientTradeRestrictingAlertServiceFacade(
             }
 
             runCatching {
-                WebSocketEventPayload
-                    .from<AuthorizedAlertDataDto?>(json, webSocketEvent)
-                    .payload
-                    ?.toDomainOrNull()
+                val decoded =
+                    WebSocketEventPayload.from<AuthorizedAlertDataDto?>(json, webSocketEvent)
+                        ?: return@collect
+                decoded.payload?.toDomainOrNull()
             }.onSuccess { payload ->
                 _alert.value = payload
             }.onFailure { error ->

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/alert/ClientTradeRestrictingAlertServiceFacade.kt
@@ -38,22 +38,17 @@ class ClientTradeRestrictingAlertServiceFacade(
 
     private suspend fun subscribeAlert() {
         val observer = apiGateway.subscribeAlert()
+        // Not collectPayloads: an event without a payload means "no alert" here, whereas the shared
+        // collector ignores it. A payload that does not decode is skipped and the current alert stays.
         observer.webSocketEvent.collect { webSocketEvent ->
             if (webSocketEvent?.deferredPayload == null) {
                 _alert.value = null
                 return@collect
             }
 
-            runCatching {
-                val decoded =
-                    WebSocketEventPayload.from<AuthorizedAlertDataDto?>(json, webSocketEvent)
-                        ?: return@collect
-                decoded.payload?.toDomainOrNull()
-            }.onSuccess { payload ->
-                _alert.value = payload
-            }.onFailure { error ->
-                log.e(error) { "Failed to deserialize trade restricting alert payload; event ignored." }
-            }
+            val decoded =
+                WebSocketEventPayload.from<AuthorizedAlertDataDto?>(json, webSocketEvent) ?: return@collect
+            _alert.value = decoded.payload?.toDomainOrNull()
         }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/private_chat/ClientPrivateChatServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/private_chat/ClientPrivateChatServiceFacade.kt
@@ -217,7 +217,7 @@ class ClientPrivateChatServiceFacade(
                 return@collect
             }
             val payload: WebSocketEventPayload<List<TwoPartyPrivateChatChannelDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent)
+                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
             stateMutex.withLock {
                 when (webSocketEvent.modificationType) {
                     // REMOVED is a channel that was left — here or on another client of the same node.
@@ -252,7 +252,7 @@ class ClientPrivateChatServiceFacade(
                 return@collect
             }
             val payload: WebSocketEventPayload<List<TwoPartyPrivateChatMessageDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent)
+                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
             stateMutex.withLock {
                 // No REPLACE branch, unlike channels and reactions: a private chat message is never
                 // removed on the node (PrivateChatMessagesWebSocketService), so a snapshot can only add.
@@ -274,7 +274,7 @@ class ClientPrivateChatServiceFacade(
                 return@collect
             }
             val payload: WebSocketEventPayload<List<TwoPartyPrivateChatMessageReactionDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent)
+                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
             stateMutex.withLock {
                 if (webSocketEvent.modificationType == ModificationType.REPLACE) {
                     // Same reasoning as subscribeChannels: the snapshot carries every live reaction —

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/private_chat/ClientPrivateChatServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/private_chat/ClientPrivateChatServiceFacade.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.util.notifyIfDemoModeRestricted
 import network.bisq.mobile.client.common.domain.websocket.api_proxy.WebSocketRestApiException
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.data.replicated.chat.two_party.TwoPartyPrivateChatChannel
@@ -212,17 +212,12 @@ class ClientPrivateChatServiceFacade(
 
     private suspend fun subscribeChannels() {
         val observer = apiGateway.subscribeChannels()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            val payload: WebSocketEventPayload<List<TwoPartyPrivateChatChannelDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
+        observer.collectPayloads<List<TwoPartyPrivateChatChannelDto>>(json) { payload, webSocketEvent ->
             stateMutex.withLock {
                 when (webSocketEvent.modificationType) {
                     // REMOVED is a channel that was left — here or on another client of the same node.
                     // Treating it as an upsert like the other types would resurrect it.
-                    ModificationType.REMOVED -> payload.payload.forEach { forgetChannel(it.id) }
+                    ModificationType.REMOVED -> payload.forEach { forgetChannel(it.id) }
 
                     // REPLACE never comes from the node, which only ever sends ADDED/REMOVED here: it
                     // is the (re)subscription snapshot the client synthesises from the node's full
@@ -230,15 +225,15 @@ class ClientPrivateChatServiceFacade(
                     // channel that was left on another client while this one was offline alive for the
                     // rest of the session — openable, with every write against it failing.
                     ModificationType.REPLACE -> {
-                        val incomingIds = payload.payload.mapTo(mutableSetOf()) { it.id }
+                        val incomingIds = payload.mapTo(mutableSetOf()) { it.id }
                         channelModelsById.keys
                             .filterNot { it in incomingIds }
                             .toList()
                             .forEach { forgetChannel(it) }
-                        payload.payload.forEach { upsertChannel(it) }
+                        payload.forEach { upsertChannel(it) }
                     }
 
-                    else -> payload.payload.forEach { upsertChannel(it) }
+                    else -> payload.forEach { upsertChannel(it) }
                 }
                 publishChannels()
             }
@@ -247,19 +242,14 @@ class ClientPrivateChatServiceFacade(
 
     private suspend fun subscribeMessages() {
         val observer = apiGateway.subscribeMessages()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            val payload: WebSocketEventPayload<List<TwoPartyPrivateChatMessageDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
+        observer.collectPayloads<List<TwoPartyPrivateChatMessageDto>>(json) { payload, _ ->
             stateMutex.withLock {
                 // No REPLACE branch, unlike channels and reactions: a private chat message is never
                 // removed on the node (PrivateChatMessagesWebSocketService), so a snapshot can only add.
                 // The one way a message disappears is its channel being left, and forgetChannel drops
                 // the messages along with it.
-                payload.payload.forEach { messageDtosById[it.messageId] = it }
-                payload.payload
+                payload.forEach { messageDtosById[it.messageId] = it }
+                payload
                     .map { it.channelId }
                     .toSet()
                     .forEach { rebuildMessages(it) }
@@ -269,25 +259,20 @@ class ClientPrivateChatServiceFacade(
 
     private suspend fun subscribeReactions() {
         val observer = apiGateway.subscribeReactions()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            val payload: WebSocketEventPayload<List<TwoPartyPrivateChatMessageReactionDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
+        observer.collectPayloads<List<TwoPartyPrivateChatMessageReactionDto>>(json) { payload, webSocketEvent ->
             stateMutex.withLock {
                 if (webSocketEvent.modificationType == ModificationType.REPLACE) {
                     // Same reasoning as subscribeChannels: the snapshot carries every live reaction —
                     // the node filters removed ones out of it — so a reaction withdrawn while this
                     // client was offline is simply absent, and merging would leave it on screen.
                     reactionDtos.clear()
-                    reactionDtos.addAll(payload.payload.filterNot { it.isRemoved })
+                    reactionDtos.addAll(payload.filterNot { it.isRemoved })
                     // Every known channel, not just those named in the payload: the channels that lost
                     // a reaction are exactly the ones the snapshot no longer mentions.
                     channelModelsById.keys.toList().forEach { rebuildMessages(it) }
                 } else {
-                    payload.payload.forEach { applyReaction(it) }
-                    payload.payload
+                    payload.forEach { applyReaction(it) }
+                    payload
                         .mapNotNull { messageDtosById[it.chatMessageId]?.channelId }
                         .toSet()
                         .forEach { rebuildMessages(it) }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.util.notifyIfDemoModeRestricted
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
@@ -75,13 +75,7 @@ class ClientTradeChatMessagesServiceFacade(
         // wait for first open trade to start subscribing so that updateChatMessages works properly
         tradesServiceFacade.openTradeItems.first { it.isNotEmpty() }
         val observer = apiGateway.subscribeTradeChats()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            val webSocketEventPayload: WebSocketEventPayload<List<BisqEasyOpenTradeMessageDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
-            val payload = webSocketEventPayload.payload
+        observer.collectPayloads<List<BisqEasyOpenTradeMessageDto>>(json) { payload, _ ->
             allBisqEasyOpenTradeMessages.update { it + payload }
             // To update bisqEasyOpenTradeChannelModel of the trades
             val updatedTradeIds = payload.map { it.tradeId }.toSet()
@@ -95,13 +89,7 @@ class ClientTradeChatMessagesServiceFacade(
         // wait for first open trade to start subscribing so that updateChatMessages works properly
         tradesServiceFacade.openTradeItems.first { it.isNotEmpty() }
         val observer = apiGateway.subscribeChatReactions()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            val webSocketEventPayload: WebSocketEventPayload<List<BisqEasyOpenTradeMessageReaction>> =
-                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
-            val payload = webSocketEventPayload.payload
+        observer.collectPayloads<List<BisqEasyOpenTradeMessageReaction>>(json) { payload, _ ->
             payload.forEach { reaction ->
                 // We cannot just remove it from the set as the removed reaction has a difference id.
                 // We lookup instead the matching reaction and remove that.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -80,7 +80,7 @@ class ClientTradeChatMessagesServiceFacade(
                 return@collect
             }
             val webSocketEventPayload: WebSocketEventPayload<List<BisqEasyOpenTradeMessageDto>> =
-                WebSocketEventPayload.from(json, webSocketEvent)
+                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
             val payload = webSocketEventPayload.payload
             allBisqEasyOpenTradeMessages.update { it + payload }
             // To update bisqEasyOpenTradeChannelModel of the trades
@@ -100,7 +100,7 @@ class ClientTradeChatMessagesServiceFacade(
                 return@collect
             }
             val webSocketEventPayload: WebSocketEventPayload<List<BisqEasyOpenTradeMessageReaction>> =
-                WebSocketEventPayload.from(json, webSocketEvent)
+                WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
             val payload = webSocketEventPayload.payload
             payload.forEach { reaction ->
                 // We cannot just remove it from the set as the removed reaction has a difference id.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.market
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -44,6 +45,8 @@ class ClientMarketPriceServiceFacade(
                     }
                     updateMarketPriceItem()
                     triggerGlobalPriceUpdate()
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     log.e(e.toString(), e)
                 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
@@ -41,7 +41,7 @@ class ClientMarketPriceServiceFacade(
                         return@collect
                     }
                     val webSocketEventPayload: WebSocketEventPayload<Map<String, network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO>> =
-                        WebSocketEventPayload.from(json, webSocketEvent)
+                        WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
                     val marketPriceMap = webSocketEventPayload.payload
                     log.d { "Client received price data for ${marketPriceMap.size} market price map markets: ${marketPriceMap.keys.take(10)}" }
                     quotesMutex.withLock {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.client.common.domain.service.market
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -11,6 +10,7 @@ import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVOFactory
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
 import network.bisq.mobile.domain.formatters.MarketPriceFormatter
 import network.bisq.mobile.domain.repository.SettingsRepository
 
@@ -18,6 +18,7 @@ class ClientMarketPriceServiceFacade(
     private val apiGateway: MarketPriceApiGateway,
     private val json: Json,
     settingsRepository: SettingsRepository,
+    private val dispatcherProvider: DispatcherProvider,
 ) : MarketPriceServiceFacade(settingsRepository) {
     // Misc
     private val quotes: MutableMap<String, network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO> = mutableMapOf()
@@ -33,7 +34,7 @@ class ClientMarketPriceServiceFacade(
             updateMarketPriceItem()
         }
 
-        serviceScope.launch(Dispatchers.Default) {
+        serviceScope.launch(dispatcherProvider.default) {
             val observer = apiGateway.subscribeMarketPrice()
             observer.collectPayloads<Map<String, network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO>>(json) { marketPriceMap, _ ->
                 try {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/market/ClientMarketPriceServiceFacade.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVOFactory
@@ -35,14 +35,8 @@ class ClientMarketPriceServiceFacade(
 
         serviceScope.launch(Dispatchers.Default) {
             val observer = apiGateway.subscribeMarketPrice()
-            observer.webSocketEvent.collect { webSocketEvent ->
+            observer.collectPayloads<Map<String, network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO>>(json) { marketPriceMap, _ ->
                 try {
-                    if (webSocketEvent?.deferredPayload == null) {
-                        return@collect
-                    }
-                    val webSocketEventPayload: WebSocketEventPayload<Map<String, network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO>> =
-                        WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
-                    val marketPriceMap = webSocketEventPayload.payload
                     log.d { "Client received price data for ${marketPriceMap.size} market price map markets: ${marketPriceMap.keys.take(10)}" }
                     quotesMutex.withLock {
                         quotes.putAll(marketPriceMap)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
@@ -14,7 +14,7 @@ import network.bisq.mobile.client.common.domain.httpclient.HttpClientService
 import network.bisq.mobile.client.common.domain.sensitive_settings.SensitiveSettingsRepository
 import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
@@ -62,22 +62,12 @@ class ClientNetworkServiceFacade(
     private fun subscribeNetworkInfo() {
         serviceScope.launch(Dispatchers.Default) {
             val observer = networkApiGateway.subscribeNetworkInfo()
-            observer.webSocketEvent.collect { event ->
-                try {
-                    if (event?.deferredPayload == null) {
-                        return@collect
-                    }
-                    val payload: WebSocketEventPayload<NetworkInfoDto> =
-                        WebSocketEventPayload.from(json, event) ?: return@collect
-                    val info = payload.payload
-                    _networkInfo.value = info
-                    log.i {
-                        "NETWORK_INFO received: torRunning=${info.torRunning}, " +
-                            "allDataReceived=${info.allDataReceived}, myAddress=${info.myAddress}, keyId=${info.keyId}, " +
-                            "connections=${info.connections.size}"
-                    }
-                } catch (e: Exception) {
-                    log.e(e) { "Failed to parse NETWORK_INFO payload" }
+            observer.collectPayloads<NetworkInfoDto>(json) { info, _ ->
+                _networkInfo.value = info
+                log.i {
+                    "NETWORK_INFO received: torRunning=${info.torRunning}, " +
+                        "allDataReceived=${info.allDataReceived}, myAddress=${info.myAddress}, keyId=${info.keyId}, " +
+                        "connections=${info.connections.size}"
                 }
             }
         }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
@@ -67,7 +67,8 @@ class ClientNetworkServiceFacade(
                     if (event?.deferredPayload == null) {
                         return@collect
                     }
-                    val payload: WebSocketEventPayload<NetworkInfoDto> = WebSocketEventPayload.from(json, event)
+                    val payload: WebSocketEventPayload<NetworkInfoDto> =
+                        WebSocketEventPayload.from(json, event) ?: return@collect
                     val info = payload.payload
                     _networkInfo.value = info
                     log.i {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
@@ -1,6 +1,5 @@
 package network.bisq.mobile.client.common.domain.service.network
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +17,7 @@ import network.bisq.mobile.client.common.domain.websocket.subscription.collectPa
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.network.KmpTorService
 import network.bisq.mobile.data.service.network.NetworkServiceFacade
+import network.bisq.mobile.domain.coroutines.DispatcherProvider
 
 class ClientNetworkServiceFacade(
     private val sensitiveSettingsRepository: SensitiveSettingsRepository,
@@ -27,6 +27,7 @@ class ClientNetworkServiceFacade(
     private val json: Json,
     kmpTorService: KmpTorService,
     applicationBootstrapFacade: ApplicationBootstrapFacade,
+    private val dispatcherProvider: DispatcherProvider,
 ) : NetworkServiceFacade(kmpTorService, applicationBootstrapFacade) {
     override val numConnections: StateFlow<Int> =
         webSocketClientService.connectionState
@@ -60,7 +61,7 @@ class ClientNetworkServiceFacade(
     }
 
     private fun subscribeNetworkInfo() {
-        serviceScope.launch(Dispatchers.Default) {
+        serviceScope.launch(dispatcherProvider.default) {
             val observer = networkApiGateway.subscribeNetworkInfo()
             observer.collectPayloads<NetworkInfoDto>(json) { info, _ ->
                 _networkInfo.value = info

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/network/ClientNetworkServiceFacade.kt
@@ -67,8 +67,7 @@ class ClientNetworkServiceFacade(
                 _networkInfo.value = info
                 log.i {
                     "NETWORK_INFO received: torRunning=${info.torRunning}, " +
-                        "allDataReceived=${info.allDataReceived}, myAddress=${info.myAddress}, keyId=${info.keyId}, " +
-                        "connections=${info.connections.size}"
+                        "allDataReceived=${info.allDataReceived}, connections=${info.connections.size}"
                 }
             }
         }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -15,7 +15,7 @@ import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.model.offerbook.MarketListItem
 import network.bisq.mobile.data.model.offerbook.OfferbookMarket
 import network.bisq.mobile.data.replicated.offer.DirectionEnum
@@ -299,43 +299,24 @@ class ClientOffersServiceFacade(
     }
 
     private suspend fun collectOffers(observer: WebSocketEventObserver) {
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-
-            val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
-                WebSocketEventPayload.from(
-                    json,
-                    webSocketEvent,
-                ) ?: return@collect
+        observer.collectPayloads<List<OfferItemPresentationDto>>(json) { payload, webSocketEvent ->
             resultCatching {
-                val payload: List<OfferItemPresentationDto> = webSocketEventPayload.payload
                 log.d { "WebSocket offer update - Type: ${webSocketEvent.modificationType}, Count: ${payload.size}" }
                 updateOffersByMarket(webSocketEvent, payload)
                 applyOffersToSelectedMarket()
             }.onFailure { e ->
-                // Log and skip: one malformed event must not tear down the subscription for all
-                // markets. Genuine collector failures reset via the catch in
-                // [startOffersSubscription] so the next market select can re-subscribe.
+                // Log and skip: one event that fails to apply must not tear down the subscription
+                // for all markets (undecodable events are already skipped by collectPayloads).
+                // Genuine collector failures reset via the catch in [startOffersSubscription] so
+                // the next market select can re-subscribe.
                 log.e(e) { "Error processing offers WebSocket event (seq=${webSocketEvent.sequenceNumber}); skipping event" }
             }
         }
     }
 
     private suspend fun collectNumOffers(observer: WebSocketEventObserver) {
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-
+        observer.collectPayloads<Map<String, Int>>(json) { numOffersByMarketCode, _ ->
             try {
-                val webSocketEventPayload: WebSocketEventPayload<Map<String, Int>> =
-                    WebSocketEventPayload.from(
-                        json,
-                        webSocketEvent,
-                    ) ?: return@collect
-                val numOffersByMarketCode = webSocketEventPayload.payload
                 // Cached raw, as the node reported it: the count-aware loading check asks whether
                 // the *node* considers the market empty, not whether it is empty for this device.
                 cachedNumOffersByMarketCode = numOffersByMarketCode

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -248,6 +248,8 @@ class ClientOffersServiceFacade(
         serviceScope.launch {
             try {
                 collectNumOffers(apiGateway.subscribeNumOffers())
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.e(e) { "Failed to subscribe to numOffers" }
             }
@@ -265,6 +267,8 @@ class ClientOffersServiceFacade(
         serviceScope.launch {
             try {
                 startOffersSubscription("activate")
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.e(e) { "Failed to subscribe to offers at activate" }
             }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/offers/ClientOffersServiceFacade.kt
@@ -304,12 +304,12 @@ class ClientOffersServiceFacade(
                 return@collect
             }
 
+            val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
+                WebSocketEventPayload.from(
+                    json,
+                    webSocketEvent,
+                ) ?: return@collect
             resultCatching {
-                val webSocketEventPayload: WebSocketEventPayload<List<OfferItemPresentationDto>> =
-                    WebSocketEventPayload.from(
-                        json,
-                        webSocketEvent,
-                    )
                 val payload: List<OfferItemPresentationDto> = webSocketEventPayload.payload
                 log.d { "WebSocket offer update - Type: ${webSocketEvent.modificationType}, Count: ${payload.size}" }
                 updateOffersByMarket(webSocketEvent, payload)
@@ -334,7 +334,7 @@ class ClientOffersServiceFacade(
                     WebSocketEventPayload.from(
                         json,
                         webSocketEvent,
-                    )
+                    ) ?: return@collect
                 val numOffersByMarketCode = webSocketEventPayload.payload
                 // Cached raw, as the node reported it: the count-aware loading check asks whether
                 // the *node* considers the market empty, not whether it is empty for this device.

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.client.shared.BuildConfig
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.ServiceFacade
@@ -69,19 +69,9 @@ class ClientReputationServiceFacade(
     // Private
     private suspend fun subscribeReputation() {
         val observer = apiGateway.subscribeUserReputation()
-        observer.webSocketEvent.collect { webSocketEvent ->
-            if (webSocketEvent?.deferredPayload == null) {
-                return@collect
-            }
-            runCatching {
-                WebSocketEventPayload.from<Map<String, ReputationScoreVO>>(json, webSocketEvent)?.payload
-                    ?: return@collect
-            }.onSuccess { payload ->
-                reputationByUserProfileId.value = payload
-                _scoreByUserProfileId.value = payload.mapValues { (_, v) -> v.totalScore }
-            }.onFailure { t ->
-                log.e(t) { "Failed to deserialize reputation payload; event ignored." }
-            }
+        observer.collectPayloads<Map<String, ReputationScoreVO>>(json) { payload, _ ->
+            reputationByUserProfileId.value = payload
+            _scoreByUserProfileId.value = payload.mapValues { (_, v) -> v.totalScore }
         }
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/reputation/ClientReputationServiceFacade.kt
@@ -74,7 +74,8 @@ class ClientReputationServiceFacade(
                 return@collect
             }
             runCatching {
-                WebSocketEventPayload.from<Map<String, ReputationScoreVO>>(json, webSocketEvent).payload
+                WebSocketEventPayload.from<Map<String, ReputationScoreVO>>(json, webSocketEvent)?.payload
+                    ?: return@collect
             }.onSuccess { payload ->
                 reputationByUserProfileId.value = payload
                 _scoreByUserProfileId.value = payload.mapValues { (_, v) -> v.totalScore }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -435,7 +435,7 @@ class ClientUserProfileServiceFacade(
                     }
 
                     val webSocketEventPayload: WebSocketEventPayload<Int> =
-                        WebSocketEventPayload.from(json, webSocketEvent)
+                        WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
                     _numUserProfiles.value = webSocketEventPayload.payload
                 }
             } catch (e: Exception) {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.ConnectionState
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
-import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventPayload
+import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.service.ServiceFacade
@@ -429,14 +429,8 @@ class ClientUserProfileServiceFacade(
         serviceScope.launch {
             try {
                 val observer = apiGateway.subscribeNumUserProfiles()
-                observer.webSocketEvent.collect { webSocketEvent ->
-                    if (webSocketEvent?.deferredPayload == null) {
-                        return@collect
-                    }
-
-                    val webSocketEventPayload: WebSocketEventPayload<Int> =
-                        WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
-                    _numUserProfiles.value = webSocketEventPayload.payload
+                observer.collectPayloads<Int>(json) { numUserProfiles, _ ->
+                    _numUserProfiles.value = numUserProfiles
                 }
             } catch (e: Exception) {
                 log.e(e) { "Failed to subscribe to numUserProfiles" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/user_profile/ClientUserProfileServiceFacade.kt
@@ -432,6 +432,8 @@ class ClientUserProfileServiceFacade(
                 observer.collectPayloads<Int>(json) { numUserProfiles, _ ->
                     _numUserProfiles.value = numUserProfiles
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.e(e) { "Failed to subscribe to numUserProfiles" }
             }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/CollectPayloads.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/CollectPayloads.kt
@@ -1,0 +1,31 @@
+package network.bisq.mobile.client.common.domain.websocket.subscription
+
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+
+/**
+ * Collects [WebSocketEventObserver.webSocketEvent], decodes each event's payload with the
+ * serializer of its [Topic] and hands the result to [handler].
+ *
+ * This is the shared recovery path for client subscription collectors:
+ * - an event without a payload is ignored;
+ * - an event whose payload does not decode is logged by [WebSocketEventPayload.from] (topic and
+ *   cause only, never the payload) and skipped, so that one malformed or version-incompatible
+ *   event does not end the collector for the rest of the session;
+ * - whatever [handler] throws propagates unchanged, including cancellation. Recovery is scoped to
+ *   deserialization on purpose: a bug in the handler should surface, not be filed as a bad event.
+ *
+ * Like [kotlinx.coroutines.flow.StateFlow.collect], this never returns normally.
+ */
+suspend fun <T> WebSocketEventObserver.collectPayloads(
+    json: Json,
+    handler: suspend (payload: T, event: WebSocketEvent) -> Unit,
+) {
+    webSocketEvent.collect { event ->
+        if (event?.deferredPayload == null) {
+            return@collect
+        }
+        val decoded = WebSocketEventPayload.from<T>(json, event) ?: return@collect
+        handler(decoded.payload, event)
+    }
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
@@ -30,7 +30,7 @@ class Subscription<T>(
                         }
                         log.d { "deferredPayload = ${webSocketEvent.deferredPayload}" }
                         val webSocketEventPayload: WebSocketEventPayload<List<T>> =
-                            WebSocketEventPayload.from(json, webSocketEvent)
+                            WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
                         log.d { "webSocketEventPayload = $webSocketEventPayload" }
 
                         val payload: List<T> = webSocketEventPayload.payload

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
@@ -23,18 +23,9 @@ class Subscription<T>(
             CoroutineScope(Dispatchers.Default).launch {
                 // subscribe blocks until we get a response
                 val observer = webSocketClientService.subscribe(topic, parameter)
-                observer.webSocketEvent.collect { webSocketEvent ->
+                observer.collectPayloads<List<T>>(json) { payload, webSocketEvent ->
+                    log.d { "webSocketEvent topic=$topic type=${webSocketEvent.modificationType} size=${payload.size}" }
                     try {
-                        if (webSocketEvent?.deferredPayload == null) {
-                            return@collect
-                        }
-                        log.d { "deferredPayload = ${webSocketEvent.deferredPayload}" }
-                        val webSocketEventPayload: WebSocketEventPayload<List<T>> =
-                            WebSocketEventPayload.from(json, webSocketEvent) ?: return@collect
-                        log.d { "webSocketEventPayload = $webSocketEventPayload" }
-
-                        val payload: List<T> = webSocketEventPayload.payload
-                        log.d { "payload = $payload" }
                         resultHandler(payload, webSocketEvent.modificationType)
                     } catch (e: Exception) {
                         log.e { "Error at processing webSocketEvent ${e.message}" }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
@@ -1,17 +1,31 @@
 package network.bisq.mobile.client.common.domain.websocket.subscription
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.domain.utils.getLogger
-import kotlin.coroutines.cancellation.CancellationException
 
 data class WebSocketEventPayload<T>(
     val payload: T,
 ) {
     companion object {
         val log = getLogger("WebSocketEventPayload")
+
+        /**
+         * Returns null when the event carries no payload, or when the payload cannot be decoded:
+         * malformed JSON, a shape this build does not know (version skew with the node), or a DTO
+         * that rejects the values. The caller is expected to skip such an event so that one bad
+         * event does not end its collector for the rest of the session.
+         *
+         * A payload that decodes to JSON `null` (e.g. [Topic.TRADE_RESTRICTING_ALERT]) is a
+         * success: the returned wrapper is non-null and [payload] is null.
+         *
+         * [CancellationException] is never swallowed. The failure log names the topic and the
+         * exception class only: kotlinx quotes the JSON input in its messages, and the payload may
+         * carry user data.
+         */
         inline fun <reified T> from(
             json: Json,
             webSocketEvent: WebSocketEvent,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
@@ -11,13 +11,16 @@ data class WebSocketEventPayload<T>(
     val payload: T,
 ) {
     companion object {
-        val log = getLogger("WebSocketEventPayload")
+        // var so tests can substitute a capturing logger: the release logger's config is an
+        // immutable StaticConfig, so its writers cannot be swapped in place.
+        internal var log = getLogger("WebSocketEventPayload")
 
         /**
          * Returns null when the event carries no payload, or when the payload cannot be decoded:
          * malformed JSON, a shape this build does not know (version skew with the node), or a DTO
          * that rejects the values. The caller is expected to skip such an event so that one bad
          * event does not end its collector for the rest of the session.
+         * for the shared collector that does exactly that.
          *
          * A payload that decodes to JSON `null` (e.g. [Topic.TRADE_RESTRICTING_ALERT]) is a
          * success: the returned wrapper is non-null and [payload] is null.
@@ -26,7 +29,7 @@ data class WebSocketEventPayload<T>(
          * exception class only: kotlinx quotes the JSON input in its messages, and the payload may
          * carry user data.
          */
-        inline fun <reified T> from(
+        fun <T> from(
             json: Json,
             webSocketEvent: WebSocketEvent,
         ): WebSocketEventPayload<T>? {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayload.kt
@@ -5,28 +5,29 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.domain.utils.getLogger
+import kotlin.coroutines.cancellation.CancellationException
 
 data class WebSocketEventPayload<T>(
     val payload: T,
 ) {
     companion object {
+        val log = getLogger("WebSocketEventPayload")
         inline fun <reified T> from(
             json: Json,
             webSocketEvent: WebSocketEvent,
-        ): WebSocketEventPayload<T> {
+        ): WebSocketEventPayload<T>? {
             val topic = webSocketEvent.topic
-            val deferredPayload = webSocketEvent.deferredPayload!!
-            try {
+            val deferredPayload = webSocketEvent.deferredPayload ?: return null
+            return try {
                 @Suppress("UNCHECKED_CAST")
                 val serializer: KSerializer<T> = serializer(topic.typeOf) as KSerializer<T>
                 val payload: T = json.decodeFromString(serializer, deferredPayload)
-                return WebSocketEventPayload(payload)
-            } catch (e: Exception) {
-                getLogger(WebSocketEventPayload::class.simpleName!!).e(
-                    "Deserializing payloadJson failed. topic=$topic; payloadJson=$deferredPayload",
-                    e,
-                )
+                WebSocketEventPayload(payload)
+            } catch (e: CancellationException) {
                 throw e
+            } catch (e: Exception) {
+                log.e { "Skipping undecodable event; topic=$topic; cause=${e::class.simpleName}" }
+                null
             }
         }
     }

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/CollectPayloadsTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/CollectPayloadsTest.kt
@@ -1,0 +1,144 @@
+package network.bisq.mobile.client.common.domain.websocket.subscription
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Collector-level contract of [collectPayloads], the shared recovery path for client
+ * subscriptions: a malformed event is skipped and the collector stays alive, while cancellation
+ * and handler failures propagate. Decode details live in [WebSocketEventPayloadTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectPayloadsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `malformed event is skipped and a later valid event is delivered`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            val received = mutableListOf<Pair<Int, Int>>()
+            val job =
+                launch {
+                    observer.collectPayloads<Int>(json) { payload, event ->
+                        received += payload to event.sequenceNumber
+                    }
+                }
+            runCurrent()
+
+            observer.setEvent(event("not-json", sequenceNumber = 1))
+            runCurrent()
+            observer.setEvent(event("42", sequenceNumber = 2))
+            runCurrent()
+
+            assertTrue(job.isActive, "Collector must survive a malformed event")
+            assertEquals(listOf(42 to 2), received)
+            job.cancel()
+        }
+
+    @Test
+    fun `event without payload is ignored`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            var handlerCalls = 0
+            val job =
+                launch {
+                    observer.collectPayloads<Int>(json) { _, _ -> handlerCalls++ }
+                }
+            runCurrent()
+
+            observer.setEvent(event(deferredPayload = null, sequenceNumber = 1))
+            runCurrent()
+
+            assertTrue(job.isActive)
+            assertEquals(0, handlerCalls)
+            job.cancel()
+        }
+
+    @Test
+    fun `cancelling the collector stops delivery`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            val received = mutableListOf<Int>()
+            val job =
+                launch {
+                    observer.collectPayloads<Int>(json) { payload, _ -> received += payload }
+                }
+            runCurrent()
+
+            job.cancel()
+            runCurrent()
+            observer.setEvent(event("42", sequenceNumber = 1))
+            runCurrent()
+
+            assertTrue(job.isCancelled)
+            assertEquals(emptyList(), received)
+        }
+
+    @Test
+    fun `cancellation thrown by the handler is not swallowed`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+            val received = mutableListOf<Int>()
+            val job =
+                launch {
+                    observer.collectPayloads<Int>(json) { payload, _ ->
+                        received += payload
+                        throw CancellationException("cancelled while handling")
+                    }
+                }
+            runCurrent()
+
+            observer.setEvent(event("1", sequenceNumber = 1))
+            runCurrent()
+            observer.setEvent(event("2", sequenceNumber = 2))
+            runCurrent()
+
+            assertTrue(job.isCancelled, "CancellationException must end the collector, not be filed as a bad event")
+            assertFalse(job.isActive)
+            assertEquals(listOf(1), received)
+        }
+
+    @Test
+    fun `exception thrown by the handler propagates`() =
+        runTest {
+            val observer = WebSocketEventObserver()
+
+            supervisorScope {
+                val collector =
+                    async {
+                        observer.collectPayloads<Int>(json) { _, _ -> throw IllegalStateException("handler bug") }
+                    }
+                testScheduler.runCurrent()
+
+                observer.setEvent(event("42", sequenceNumber = 1))
+                testScheduler.runCurrent()
+
+                assertTrue(collector.isCompleted, "Handler failure must end the collector")
+                val error = assertFailsWith<IllegalStateException> { collector.await() }
+                assertEquals("handler bug", error.message)
+            }
+        }
+
+    private fun event(
+        deferredPayload: String?,
+        sequenceNumber: Int,
+    ) = WebSocketEvent(
+        topic = Topic.NUM_USER_PROFILES,
+        subscriberId = "test-subscriber",
+        deferredPayload = deferredPayload,
+        modificationType = ModificationType.REPLACE,
+        sequenceNumber = sequenceNumber,
+    )
+}

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayloadTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayloadTest.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.common.domain.websocket.subscription
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
+import co.touchlab.kermit.loggerConfigInit
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.data.model.alert.AuthorizedAlertDataDto
 import network.bisq.mobile.client.common.domain.service.network.NetworkInfoDto
@@ -26,7 +27,7 @@ class WebSocketEventPayloadTest {
     private val json = Json { ignoreUnknownKeys = true }
     private val capturedLogs = mutableListOf<String>()
     private val capturedSeverities = mutableListOf<Severity>()
-    private lateinit var originalWriters: List<LogWriter>
+    private lateinit var originalLogger: Logger
 
     @BeforeTest
     fun captureLogs() {
@@ -48,13 +49,13 @@ class WebSocketEventPayloadTest {
                     throwable?.let { capturedLogs += it.toString() }
                 }
             }
-        originalWriters = Logger.config.logWriterList.toList()
-        Logger.setLogWriters(testWriter)
+        originalLogger = WebSocketEventPayload.log
+        WebSocketEventPayload.log = Logger(loggerConfigInit(testWriter), tag = "WebSocketEventPayload")
     }
 
     @AfterTest
     fun restoreLogs() {
-        Logger.setLogWriters(*originalWriters.toTypedArray())
+        WebSocketEventPayload.log = originalLogger
     }
 
     // Valid payloads

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayloadTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/WebSocketEventPayloadTest.kt
@@ -1,0 +1,235 @@
+package network.bisq.mobile.client.common.domain.websocket.subscription
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.data.model.alert.AuthorizedAlertDataDto
+import network.bisq.mobile.client.common.domain.service.network.NetworkInfoDto
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
+import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationDto
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Decode-level contract of [WebSocketEventPayload.from]: what decodes, what is reported as
+ * undecodable (null), and what the failure log may contain. The collector-level skip-and-continue
+ * behaviour is covered by [CollectPayloadsTest].
+ */
+class WebSocketEventPayloadTest {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val capturedLogs = mutableListOf<String>()
+    private val capturedSeverities = mutableListOf<Severity>()
+    private lateinit var originalWriters: List<LogWriter>
+
+    @BeforeTest
+    fun captureLogs() {
+        capturedLogs.clear()
+        capturedSeverities.clear()
+        val testWriter =
+            object : LogWriter() {
+                override fun log(
+                    severity: Severity,
+                    message: String,
+                    tag: String,
+                    throwable: Throwable?,
+                ) {
+                    capturedSeverities += severity
+                    capturedLogs += message
+                    // kotlinx quotes the JSON input in its exception messages, so a logged
+                    // throwable is as much of a leak as a logged payload.
+                    throwable?.message?.let { capturedLogs += it }
+                    throwable?.let { capturedLogs += it.toString() }
+                }
+            }
+        originalWriters = Logger.config.logWriterList.toList()
+        Logger.setLogWriters(testWriter)
+    }
+
+    @AfterTest
+    fun restoreLogs() {
+        Logger.setLogWriters(*originalWriters.toTypedArray())
+    }
+
+    // Valid payloads
+
+    @Test
+    fun `valid payload is decoded`() {
+        val decoded = WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, "42"))
+
+        assertEquals(42, decoded?.payload)
+    }
+
+    @Test
+    fun `json null trade restricting alert is a successful null payload`() {
+        val decoded =
+            WebSocketEventPayload.from<AuthorizedAlertDataDto?>(
+                json,
+                event(Topic.TRADE_RESTRICTING_ALERT, "null"),
+            )
+
+        assertNotNull(decoded, "JSON null is a value, not a decode failure")
+        assertNull(decoded.payload)
+    }
+
+    @Test
+    fun `valid empty list payload is decoded`() {
+        val decoded =
+            WebSocketEventPayload.from<List<OfferItemPresentationDto>>(
+                json,
+                event(Topic.OFFERS, "[]"),
+            )
+
+        assertEquals(emptyList(), decoded?.payload)
+    }
+
+    @Test
+    fun `valid empty map payload is decoded`() {
+        val decoded =
+            WebSocketEventPayload.from<Map<String, Int>>(
+                json,
+                event(Topic.NUM_OFFERS, "{}"),
+            )
+
+        assertEquals(emptyMap(), decoded?.payload)
+    }
+
+    // Undecodable payloads
+
+    @Test
+    fun `event without payload returns null`() {
+        assertNull(WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, deferredPayload = null)))
+    }
+
+    @Test
+    fun `unparseable payloads return null without throwing`() {
+        for (payload in listOf("not-json", "", "{")) {
+            assertNull(
+                WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, payload)),
+                payload,
+            )
+        }
+    }
+
+    @Test
+    fun `version incompatible json returns null without throwing`() {
+        for (payload in listOf("{}", "[]")) {
+            assertNull(
+                WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, payload)),
+                payload,
+            )
+        }
+    }
+
+    @Test
+    fun `dto missing required fields returns null`() {
+        assertNull(
+            WebSocketEventPayload.from<NetworkInfoDto>(json, event(Topic.NETWORK_INFO, "{}")),
+        )
+    }
+
+    @Test
+    fun `collection with one undecodable element is skipped as a whole`() {
+        // No partial delivery: the caller sees either the complete collection or nothing.
+        assertNull(
+            WebSocketEventPayload.from<Map<String, Int>>(
+                json,
+                event(Topic.NUM_OFFERS, """{"BTC/USD":3,"BTC/EUR":"three"}"""),
+            ),
+            "map with one bad value",
+        )
+        assertNull(
+            WebSocketEventPayload.from<List<OfferItemPresentationDto>>(
+                json,
+                event(Topic.OFFERS, "[{}]"),
+            ),
+            "list with one bad element",
+        )
+    }
+
+    @Test
+    fun `incompatible payload is skipped and the next valid event is decoded`() {
+        val received = mutableListOf<Int>()
+        for (event in listOf(event(Topic.NUM_USER_PROFILES, "{}", 1), event(Topic.NUM_USER_PROFILES, "42", 2))) {
+            val decoded = WebSocketEventPayload.from<Int>(json, event) ?: continue
+            received += decoded.payload
+        }
+
+        assertEquals(listOf(42), received)
+    }
+
+    // Failure logging
+
+    @Test
+    fun `failure is logged as an error naming the topic`() {
+        WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, "not-json"))
+
+        // Positive control for the leak tests below: if nothing is captured, they pass vacuously.
+        assertTrue(capturedSeverities.isNotEmpty(), "Decode failure was not logged")
+        assertTrue(capturedSeverities.all { it == Severity.Error }, "Expected error severity, got $capturedSeverities")
+        assertTrue(
+            capturedLogs.any { it.contains(Topic.NUM_USER_PROFILES.name) },
+            "Failure log should name the topic: $capturedLogs",
+        )
+    }
+
+    @Test
+    fun `failure logs do not include payload contents`() {
+        val canary = "SECRET_PAYLOAD_CANARY_7f3a"
+
+        val decoded =
+            WebSocketEventPayload.from<Int>(
+                json,
+                event(Topic.NUM_USER_PROFILES, """{"secret":"$canary"}"""),
+            )
+
+        assertNull(decoded)
+        assertTrue(capturedLogs.isNotEmpty(), "Decode failure was not logged")
+        assertFalse(
+            capturedLogs.any { it.contains(canary) },
+            "Logs leaked payload contents: $capturedLogs",
+        )
+    }
+
+    @Test
+    fun `failure logs do not include the subscriber id`() {
+        val subscriberId = "session-CANARY-9c1e"
+
+        WebSocketEventPayload.from<Int>(
+            json,
+            event(Topic.NUM_USER_PROFILES, "not-json", subscriberId = subscriberId),
+        )
+
+        assertTrue(capturedLogs.isNotEmpty(), "Decode failure was not logged")
+        assertFalse(
+            capturedLogs.any { it.contains(subscriberId) },
+            "Logs leaked the subscriber id: $capturedLogs",
+        )
+    }
+
+    @Test
+    fun `successful decode logs nothing`() {
+        WebSocketEventPayload.from<Int>(json, event(Topic.NUM_USER_PROFILES, "42"))
+
+        assertTrue(capturedLogs.isEmpty(), "Unexpected logs on success: $capturedLogs")
+    }
+
+    private fun event(
+        topic: Topic,
+        deferredPayload: String?,
+        sequenceNumber: Int = 1,
+        subscriberId: String = "test-subscriber",
+    ) = WebSocketEvent(
+        topic = topic,
+        subscriberId = subscriberId,
+        deferredPayload = deferredPayload,
+        modificationType = ModificationType.REPLACE,
+        sequenceNumber = sequenceNumber,
+    )
+}

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejection.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/service/trades/ExpectedTradeProtocolRejection.kt
@@ -3,7 +3,8 @@ package network.bisq.mobile.domain.service.trades
 /**
  * Expected protocol-validation rejections from bisq2 (bad/hostile peer
  * messages). Mobile only sees the error string, so we match core-authored
- * prefixes rather than peer-supplied text.
+ * prefixes. peersErrorMessage arrives over the wire; a mismatch fails open
+ * to captureException.
  */
 object ExpectedTradeProtocolRejection {
     // Prefix-only so trailing details (max length, offer dump) still match.


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1753

 - `WebSocketEventPayload.from` - returns `null` on decode failure instead of throwing. logs the failure with topic and modification type only. `CancellationException` propagation is preserved.
 - CollectPayloads.kt - shared `WebSocketEventObserver.collectPayloads` helper implementing the skip-and-continue recovery path: null events and undecodable payloads are skipped, valid events are delivered to the handler.
- Migrated all affected client collectors to the helper: private chat, trade chat (messages + reactions), offers, reputation, market price, user profile, network info, alert notifications, trade-restricting alerts, and the shared Subscription` path.
- DispatcherProvider injection into `ClientNetworkServiceFacade` and `ClientMarketPriceServiceFacade` (same pattern as `ClientOffersServiceFacade` / `NodeNetworkServiceFacade`) so their collectors are testable on the virtual-time scheduler.

Nit from https://github.com/bisq-network/bisq-mobile/pull/1800
- KDoc clarification in `ExpectedTradeProtocolRejection` (fail-open on mismatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * WebSocket event payloads are now handled consistently across alerts, chats, offers, market data, network information, reputation, and user profiles.
  * Events without payloads or with invalid data are safely skipped, while valid updates continue processing.
  * Market-price and network updates now use consistent background processing.

* **Bug Fixes**
  * Empty alert events correctly clear alerts, and subsequent valid events restore them.

* **Tests**
  * Added coverage for WebSocket decoding, cancellation, malformed events, subscriptions, and service state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->