### PR TITLE
feat(publicChat): add the Support channel to the Community Hub and the Help screen

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
@@ -1,0 +1,119 @@
+package network.bisq.mobile.client.common.presentation.support
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.client.common.test_utils.ClientInjectComposeUiTestBase
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.presentation.settings.support.SupportPresenter
+import network.bisq.mobile.test.fixtures.testCommunityHubService
+import org.junit.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Connect keeps its own copy of the Help screen, so the shared screen's coverage says nothing about
+ * this one. What rots here is the copy falling behind: the entry point #1746 asks for has to be on
+ * both, and Connect is where it will one day matter most.
+ */
+class ClientSupportScreenUiTest : ClientInjectComposeUiTestBase() {
+    private lateinit var mainPresenter: MainPresenter
+    private lateinit var clientPresenter: ClientSupportPresenter
+    private var enabledSegments: Set<CommunitySegment> = emptySet()
+
+    private val openChannelLabel = "mobile.community.support.openChannel".i18n()
+
+    private companion object {
+        const val DEBUG_PANEL_HEADLINE = "Push Notifications (Debug)"
+    }
+
+    override fun onBeforeKoinStart() {
+        mainPresenter = mockk(relaxed = true)
+        clientPresenter = mockk(relaxed = true)
+        // The debug panel branches on these. A relaxed mock hands back an erased Object for a
+        // StateFlow<Boolean>, which only blows up where the value is actually read — so leaving them
+        // unstubbed is a ClassCastException that fires in the debug build and nowhere else.
+        every { clientPresenter.deviceToken } returns MutableStateFlow(null)
+        every { clientPresenter.isDeviceRegistered } returns MutableStateFlow(false)
+        every { clientPresenter.tokenRequestInProgress } returns MutableStateFlow(false)
+    }
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                factory { clientPresenter }
+                factory {
+                    SupportPresenter(
+                        mainPresenter,
+                        mockk<VersionProvider>(relaxed = true),
+                        mockk<DeviceInfoProvider>(relaxed = true),
+                        // This base shares no TestCoroutineScheduler, so there is nothing to hand
+                        // the fixture; its own default test dispatcher is what keeps the service's
+                        // stateIn scope off Dispatchers.Default.
+                        testCommunityHubService(
+                            enabled = enabledSegments,
+                            // The rollout flag is the axis under test; see SupportScreenUiTest.
+                            requiredFeatures = emptyMap(),
+                        ),
+                    )
+                }
+            },
+        )
+
+    private fun setClientSupportScreen(isDebug: Boolean = false) =
+        setInjectTestContent {
+            CompositionLocalProvider(LocalExternalUrlOpener provides ExternalUrlOpener { true }) {
+                ClientSupportScreen(isDebug = isDebug)
+            }
+        }
+
+    @Test
+    fun `the support channel entry is offered when discussions is live`() {
+        enabledSegments = setOf(CommunitySegment.DISCUSSIONS)
+
+        setClientSupportScreen()
+
+        composeTestRule.onNodeWithText(openChannelLabel).assertIsDisplayed()
+    }
+
+    /**
+     * `BuildConfig.IS_DEBUG` is a const whose value follows the gradle invocation, so whichever way
+     * it lands one of the two branches is dead code for the whole run — under `testDebugUnitTest` it
+     * is the release one. The `isDebug` seam is what lets both be covered anyway, and these two are
+     * what say it is wired the way round it claims: a release build must not ship a device-token
+     * dump.
+     */
+    @Test
+    fun `the push notification debug panel is shown in a debug build`() {
+        setClientSupportScreen(isDebug = true)
+
+        composeTestRule.onNodeWithText(DEBUG_PANEL_HEADLINE).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `the push notification debug panel is absent in a release build`() {
+        setClientSupportScreen(isDebug = false)
+
+        composeTestRule.onNodeWithText(DEBUG_PANEL_HEADLINE).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the support channel entry is withheld when discussions is not live`() {
+        enabledSegments = emptySet()
+
+        setClientSupportScreen()
+
+        composeTestRule.onNodeWithText(openChannelLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.support.matrix".i18n()).assertIsDisplayed()
+    }
+}

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
@@ -84,6 +84,7 @@ class ClientSupportScreenUiTest : ClientInjectComposeUiTestBase() {
         setClientSupportScreen()
 
         composeTestRule.onNodeWithText(openChannelLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.support.communityChannels".i18n()).assertIsDisplayed()
     }
 
     /**
@@ -114,6 +115,7 @@ class ClientSupportScreenUiTest : ClientInjectComposeUiTestBase() {
         setClientSupportScreen()
 
         composeTestRule.onNodeWithText(openChannelLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.support.communityChannels".i18n()).assertIsDisplayed()
         composeTestRule.onNodeWithText("mobile.support.matrix".i18n()).assertIsDisplayed()
     }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientPresentationModule.kt
@@ -104,7 +104,9 @@ val clientPresentationModule =
         factory<FaqPresenter> { FaqClientPresenter(get()) }
         factory { CommunityHubPresenter(get(), get()) }
         factory { ContactsPresenter(get(), get(), get()) }
-        factory { PublicChatPresenter(get(), get(), get(), get()) }
+        // Parameterized: the chat domain is a construction parameter, so the presenter's screen-view
+        // analytics event is settled before the view attaches.
+        factory { params -> PublicChatPresenter(get(), get(), get(), get(), params.get()) }
 
         factory<ClientSupportPresenter> {
             ClientSupportPresenter(

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -40,18 +40,8 @@ import org.koin.compose.koinInject
 @ExcludeFromCoverage
 @Composable
 fun ClientSupportScreen(
-    // Seam for tests. BuildConfig.IS_DEBUG is a compile-time const that Kotlin inlines at the call
-    // site, and which value it takes depends on the gradle invocation, not on the source set: any
-    // requested task name containing "debug" makes it true (shared/domain/build.gradle.kts:66), so
-    // testDebugUnitTest gets `true` and koverXmlReport gets `false`. Either way one branch is dead
-    // code for that whole run, so a bare read leaves it unreachable. Same seam, same reason, as
-    // ClientReputationServiceFacade.kt:18-20; the rule is docs/TESTING.md "Rules".
-    //
-    // Known limit of that seam: every ClientSupportScreenUiTest case passes this parameter, so the
-    // default expression is the one part no test evaluates. What the tests prove is that the panel
-    // is gated on this flag, not that the flag is the build's — hard-code the default either way and
-    // the suite stays green. A release build is what verifies the wiring, so keep the default a bare
-    // read of the const and nothing else.
+    // Test seam: IS_DEBUG is a compile-time const whose value follows the gradle invocation, so a
+    // bare read leaves one branch untestable per run. Same seam as ClientReputationServiceFacade.
     isDebug: Boolean = BuildConfig.IS_DEBUG,
 ) {
     // Use the standard SupportPresenter for base functionality

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -81,10 +81,15 @@ fun ClientSupportScreen(
             text = "mobile.support.intro".i18n(),
             color = BisqTheme.colors.light_grey50,
         )
+        if (isSupportChannelAvailable) {
+            BisqGap.V2()
+            SupportChannelLink(onClick = { supportPresenter.onOpenSupportChannel() })
+        }
+        BisqGap.V2()
+        // Caption so the external links read as one named, secondary group — with or without the
+        // in-app button above them.
+        BisqText.SmallRegularGrey("mobile.support.communityChannels".i18n())
         Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.Zero)) {
-            if (isSupportChannelAvailable) {
-                SupportChannelLink(onClick = { supportPresenter.onOpenSupportChannel() })
-            }
             SupportWeblink(
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -30,15 +30,30 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.settings.support.SupportChannelLink
 import network.bisq.mobile.presentation.settings.support.SupportPresenter
 import network.bisq.mobile.presentation.settings.support.SupportWeblink
 import org.koin.compose.koinInject
 
-// TODO: Coverage exclusion rationale - Compose UI screen cannot be unit tested.
-// Requires Compose UI testing framework for proper coverage.
+// Coverage exclusion: a screen of static links and a debug panel. ClientSupportScreenUiTest
+// covers the one conditional part, the in-app Support entry.
 @ExcludeFromCoverage
 @Composable
-fun ClientSupportScreen() {
+fun ClientSupportScreen(
+    // Seam for tests. BuildConfig.IS_DEBUG is a compile-time const that Kotlin inlines at the call
+    // site, and which value it takes depends on the gradle invocation, not on the source set: any
+    // requested task name containing "debug" makes it true (shared/domain/build.gradle.kts:66), so
+    // testDebugUnitTest gets `true` and koverXmlReport gets `false`. Either way one branch is dead
+    // code for that whole run, so a bare read leaves it unreachable. Same seam, same reason, as
+    // ClientReputationServiceFacade.kt:18-20; the rule is docs/TESTING.md "Rules".
+    //
+    // Known limit of that seam: every ClientSupportScreenUiTest case passes this parameter, so the
+    // default expression is the one part no test evaluates. What the tests prove is that the panel
+    // is gated on this flag, not that the flag is the build's — hard-code the default either way and
+    // the suite stays green. A release build is what verifies the wiring, so keep the default a bare
+    // read of the const and nothing else.
+    isDebug: Boolean = BuildConfig.IS_DEBUG,
+) {
     // Use the standard SupportPresenter for base functionality
     val supportPresenter: SupportPresenter = koinInject()
     val clientPresenter: ClientSupportPresenter = koinInject()
@@ -47,6 +62,7 @@ fun ClientSupportScreen() {
     RememberPresenterLifecycle(clientPresenter)
 
     val reportUrl by supportPresenter.reportUrl.collectAsState()
+    val isSupportChannelAvailable by supportPresenter.isSupportChannelAvailable.collectAsState()
 
     // Client-specific push notification state
     val deviceToken by clientPresenter.deviceToken.collectAsState()
@@ -66,6 +82,9 @@ fun ClientSupportScreen() {
             color = BisqTheme.colors.light_grey50,
         )
         Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.Zero)) {
+            if (isSupportChannelAvailable) {
+                SupportChannelLink(onClick = { supportPresenter.onOpenSupportChannel() })
+            }
             SupportWeblink(
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
@@ -114,7 +133,7 @@ fun ClientSupportScreen() {
         )
 
         // Push Notifications Debug Section (only in debug builds)
-        if (BuildConfig.IS_DEBUG) {
+        if (isDebug) {
             BisqHDivider(modifier = Modifier.padding(top = BisqUIConstants.ScreenPadding2X, bottom = BisqUIConstants.ScreenPadding3X))
 
             BisqText.H3Light("Push Notifications (Debug)")

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodePresentationModule.kt
@@ -80,7 +80,9 @@ val androidNodePresentationModule =
         factory<FaqPresenter> { FaqNodePresenter(get()) }
         factory { CommunityHubPresenter(get(), get()) }
         factory { ContactsPresenter(get(), get(), get()) }
-        factory { PublicChatPresenter(get(), get(), get(), get()) }
+        // Parameterized: the chat domain is a construction parameter, so the presenter's screen-view
+        // analytics event is settled before the view attaches.
+        factory { params -> PublicChatPresenter(get(), get(), get(), get(), params.get()) }
 
         factory { NodeNetworkOverviewPresenter(get(), get(), get()) }
 

--- a/docs/testing/catalog.md
+++ b/docs/testing/catalog.md
@@ -46,6 +46,8 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `MutableAlertNotificationsServiceFacade` | `shared/presentation/src/androidUnitTest/kotlin/.../common/test_utils/MutableAlertNotificationsServiceFacade.kt` |
 | `FakeTradeReadStateRepository` | `shared/presentation/src/androidUnitTest/kotlin/.../common/test_utils/FakeTradeReadStateRepository.kt` |
 | `TestApplicationLifecycleService` | `shared/presentation/src/androidUnitTest/kotlin/.../common/test_utils/TestApplicationLifecycleService.kt` |
+| `testCommunityHubService(...)` | `shared/test-utils/src/commonMain/kotlin/.../test/fixtures/CommunityHubServiceTestFactory.kt` |
+| `testPublicChatChannel(...)`, `DISCUSSION_MESSAGE_TEXT`, `SUPPORT_MESSAGE_TEXT` | `shared/test-utils/src/commonMain/kotlin/.../test/fixtures/PublicChatChannelTestFactory.kt` |
 | `SettingsRepositoryMock(initial, fetchException)` | `shared/test-utils/src/commonMain/kotlin/.../test/mocks/SettingsRepositoryMock.kt` |
 | `SensitiveSettingsRepositoryMock` | `apps/clientApp/src/androidUnitTest/kotlin/.../common/domain/sensitive_settings/SensitiveSettingsRepositoryMock.kt` |
 | `UserRepositoryMock` | `shared/test-utils/src/commonMain/kotlin/.../test/mocks/UserRepositoryMock.kt` |
@@ -54,6 +56,25 @@ Do **not** extend `CoroutineTestBase` or `KoinIntegrationTestBase` directly.
 | `UnconfinedTestDispatcherProvider` | `shared/test-utils/src/commonMain/kotlin/.../test/coroutines/UnconfinedTestDispatcherProvider.kt` |
 | `jsonDataStoreSerializerTestSupport(...)` | `shared/test-utils/src/commonMain/kotlin/.../test/datastore/JsonDataStoreSerializerTestSupport.kt` |
 | `WebLinkDialogTestSupport` | `shared/presentation/src/androidUnitTest/kotlin/.../dialog/WebLinkDialogTestSupport.kt` |
+
+`testCommunityHubService(...)` builds a real `CommunityHubService` on a test dispatcher — never
+hand-roll the constructor plus an anonymous `BackendCapabilitiesService` again. Pass `capabilities`
+a `MutableStateFlow` to move the backend manifest mid-test, and `dispatcher =
+UnconfinedTestDispatcher(testScheduler)` from inside `runTest` so `advanceUntilIdle()` drives the
+service's own scope. `requiredFeatures` defaults to production's own map and `capabilities` to the
+fail-closed manifest, which is deliberate — a test asserting a segment is live goes red on the day
+that segment starts requiring a backend feature, which is exactly what you want to be told. Default
+it to `emptyMap()` instead and that test would keep quietly passing. So a test about anything other
+than the capability gate has to pass `requiredFeatures = emptyMap()` itself; omitting it makes the
+test's fate depend on a map it never mentions.
+
+`testPublicChatChannel(...)` builds a `CommonPublicChatChannel` holding one message, for seeding a
+mocked `PublicChatServiceFacade.channels`. Use `DISCUSSION_MESSAGE_TEXT` and `SUPPORT_MESSAGE_TEXT`
+as its text when a test has to tell the two channels apart: the facade serves every domain from one
+flow, so a thread on the wrong domain renders a plausible conversation instead of failing, and the
+assertion that catches it is "this text is displayed and that one is not". Build the channel list at
+the call site — which channel comes first decides whether a thread that ignores its domain is caught
+there or only by a sibling test.
 
 `SettingsRepositoryMock` is the **only** hand-rolled `SettingsRepository` fake — do not invent another
 class. Prefer it when you need mutable settings state. `mockk<SettingsRepository>()` is fine when the

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEvent.kt
@@ -413,6 +413,7 @@ sealed class AnalyticsEvent(
                     CommunityHub,
                     CommunityContacts,
                     CommunityDiscussions,
+                    CommunitySupport,
                 )
             }
         }
@@ -458,8 +459,11 @@ sealed class AnalyticsEvent(
 
         data object CommunityContacts : ScreenOpened("screen.community_contacts_opened")
 
-        /** The Discussions tab of the hub; Support gets its own once #1746 wires an entry point. */
+        /** The Discussions tab of the hub. Both come from `PublicChatPresenter`, one per chat domain. */
         data object CommunityDiscussions : ScreenOpened("screen.community_discussions_opened")
+
+        /** The Support channel, pushed from the hub's pinned quick access or More → Help, not a tab. */
+        data object CommunitySupport : ScreenOpened("screen.community_support_opened")
     }
 
     /**

--- a/shared/domain/src/commonMain/resources/mobile/mobile.properties
+++ b/shared/domain/src/commonMain/resources/mobile/mobile.properties
@@ -520,6 +520,7 @@ mobile.reputation.bond.howTo=- Requirements: Bisq 1 desktop application and some
 mobile.support.headline=Need help?
 mobile.support.intro=If you’re having issues with an open trade, you can request mediation inside the trade process or chat with your trade peer.\n\n\
   For other issues or questions, you can reach out to the Bisq community through various channels:
+mobile.support.communityChannels=Community channels
 mobile.support.matrix=Get support on Matrix
 mobile.support.forum=Discuss at the Bisq Forum
 mobile.support.telegram=Join Bisq on Telegram

--- a/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEventContractTest.kt
+++ b/shared/domain/src/commonTest/kotlin/network/bisq/mobile/domain/analytics/AnalyticsEventContractTest.kt
@@ -142,7 +142,7 @@ class AnalyticsEventContractTest {
         // asserting the count matches what we expect from compile-time review.
         // When you add a new ScreenViewed `data object`, update BOTH this
         // count AND the .all list — the same code review.
-        val expectedCount = 20
+        val expectedCount = 21
         assertEquals(
             expectedCount,
             AnalyticsEvent.ScreenOpened.all.size,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
@@ -76,6 +77,11 @@ import kotlin.test.assertEquals
  *  2. Add the override to the presenter (`override fun analyticsScreenEvent() = NewScreen`).
  *  3. Add a `"NewPresenter" to NewScreen` entry to [expectedCoverage].
  *  4. Add a `@Test` below that attaches the presenter and asserts the emission.
+ *
+ * A presenter that serves more than one screen (`PublicChatPresenter`, one per chat domain) gets one
+ * row per event, its name suffixed with what distinguishes them — [expectedCoverage] asserts both
+ * halves of every pair are unique. Such a presenter's event depends on state, so its emission test
+ * has to put it in that state before attaching.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
@@ -93,6 +99,11 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
     /**
      * The expected mapping from presenter class to its screen-view event.
      * Must stay in sync with [AnalyticsEvent.ScreenOpened.all].
+     *
+     * Both halves are checked: the event half for set equality against `ScreenOpened.all` and for
+     * uniqueness, the name half for uniqueness too. Only the name half is free-form, which is what
+     * lets a parameterized presenter carry its domain in the string — and having to keep that string
+     * unique is exactly what forces the domain suffix.
      */
     private val expectedCoverage: List<Pair<String, AnalyticsEvent.ScreenOpened>> =
         listOf(
@@ -118,7 +129,10 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
             // Tier C — community
             "CommunityHubPresenter" to AnalyticsEvent.ScreenOpened.CommunityHub,
             "ContactsPresenter" to AnalyticsEvent.ScreenOpened.CommunityContacts,
-            "PublicChatPresenter" to AnalyticsEvent.ScreenOpened.CommunityDiscussions,
+            // One presenter, two screens: PublicChatPresenter is parameterized by chat domain, so the
+            // name carries the domain to keep this list's one-row-per-event contract.
+            "PublicChatPresenter (DISCUSSION)" to AnalyticsEvent.ScreenOpened.CommunityDiscussions,
+            "PublicChatPresenter (SUPPORT)" to AnalyticsEvent.ScreenOpened.CommunitySupport,
         )
 
     // ============== Contract test ====================================
@@ -274,14 +288,12 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
 
     @Test
     fun `PublicChatPresenter emits ScreenOpened_CommunityDiscussions`() {
-        val presenter =
-            PublicChatPresenter(
-                mainPresenter = mainPresenter,
-                publicChatServiceFacade = mockk(relaxed = true),
-                userProfileServiceFacade = mockk(relaxed = true),
-                settingsRepository = SettingsRepositoryMock(),
-            )
-        assertEmitsOnAttach(presenter, AnalyticsEvent.ScreenOpened.CommunityDiscussions)
+        assertEmitsOnAttach(publicChatPresenter(ChatChannelDomainEnum.DISCUSSION), AnalyticsEvent.ScreenOpened.CommunityDiscussions)
+    }
+
+    @Test
+    fun `PublicChatPresenter emits ScreenOpened_CommunitySupport`() {
+        assertEmitsOnAttach(publicChatPresenter(ChatChannelDomainEnum.SUPPORT), AnalyticsEvent.ScreenOpened.CommunitySupport)
     }
 
     @Test
@@ -412,6 +424,18 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
         verify(exactly = 0) { analyticsService.track(any()) }
     }
 
+    /**
+     * `PublicChatPresenter` answers per domain and only two of the five have a screen here. A third
+     * has to report none: falling through to the Discussions event would file every one of those
+     * views under a screen the user never opened.
+     */
+    @Test
+    fun `PublicChatPresenter emits nothing on a domain it does not serve`() {
+        publicChatPresenter(ChatChannelDomainEnum.BISQ_EASY_OPEN_TRADES).onViewAttached()
+
+        verify(exactly = 0) { analyticsService.track(ofType<AnalyticsEvent.ScreenOpened>()) }
+    }
+
     // ============== Helpers ==========================================
 
     /**
@@ -429,6 +453,15 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
         verify(exactly = 1) { analyticsService.track(expected) }
         verify(exactly = 1) { analyticsService.track(ofType<AnalyticsEvent.ScreenOpened>()) }
     }
+
+    private fun publicChatPresenter(chatChannelDomain: ChatChannelDomainEnum) =
+        PublicChatPresenter(
+            mainPresenter = mainPresenter,
+            publicChatServiceFacade = mockk(relaxed = true),
+            userProfileServiceFacade = mockk(relaxed = true),
+            settingsRepository = SettingsRepositoryMock(),
+            chatChannelDomain = chatChannelDomain,
+        )
 
     private val marketPriceServiceFacade = FakeMarketPriceServiceFacade(SettingsRepositoryMock())
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraphTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraphTest.kt
@@ -1,0 +1,44 @@
+package network.bisq.mobile.presentation.common.ui.navigation.graph
+
+import android.app.Application
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertNotNull
+
+/**
+ * Guards the registration of [NavRoute.SupportChannel] in [addCommonAppRoutes]. Both entry points
+ * to the in-app Support channel — the hub's "Need help?" row and More → Help — push that one route,
+ * so a missing registration breaks both at once, and breaks them silently: `NavigationManagerImpl`
+ * wraps the push in `runCatching { … }.onFailure { log.e(…) }`, which turns an unregistered route
+ * into a log line and a dead tap, with nothing on screen to say so.
+ *
+ * No leaf base and no Koin, because building the graph only registers destinations — it never
+ * invokes the `composable` content lambdas, so no screen is constructed and nothing needs injecting.
+ * It sits in `androidUnitTest` rather than beside its `commonMain` subject because `NavHostController`
+ * takes a `Context` on the Android target, so there is no portable version to write.
+ *
+ * Deliberately narrow, and [addCommonAppRoutes] keeps its `@ExcludeFromCoverage`: this pins the one
+ * route a feature hangs off, it is not a bid to cover the graph.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CommonNavGraphTest {
+    @Test
+    fun `the support channel route is registered`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val navController = NavHostController(context)
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+
+        val graph =
+            navController.createGraph(startDestination = NavRoute.Support) {
+                addCommonAppRoutes { true }
+            }
+
+        assertNotNull(graph.findNode<NavRoute.SupportChannel>())
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenterTest.kt
@@ -1,17 +1,17 @@
 package network.bisq.mobile.presentation.community
 
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
-import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
-import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.testCommunityHubService
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,13 +32,10 @@ class CommunityHubPresenterTest : PresentationKoinTestBase() {
         requiredFeatures: Map<CommunitySegment, Feature> = emptyMap(),
     ): CommunityHubPresenter {
         val hubService =
-            CommunityHubService(
-                backendCapabilitiesService =
-                    object : BackendCapabilitiesService {
-                        override val capabilities: StateFlow<BackendCapabilities> = capabilitiesFlow
-                    },
-                enabledSegments = enabled,
+            testCommunityHubService(
+                enabled = enabled,
                 requiredFeatures = requiredFeatures,
+                capabilities = capabilitiesFlow,
                 dispatcher = UnconfinedTestDispatcher(testScheduler),
             )
         val presenter = CommunityHubPresenter(mainPresenter, hubService)
@@ -110,14 +107,19 @@ class CommunityHubPresenterTest : PresentationKoinTestBase() {
             assertNull(presenter.uiState.value.selectedSegment)
         }
 
+    /**
+     * Support is pushed as its own screen rather than selected as a segment: it is not one, and the
+     * hub keeps the segment it was on so backing out lands where the user left.
+     */
     @Test
-    fun `support quick access action is a safe no-op for now`() =
+    fun `the support quick access pushes the support channel and keeps the segment`() =
         runTest {
             val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
 
             presenter.onAction(CommunityHubUiAction.OnOpenSupportChannel)
             advanceUntilIdle()
 
+            verify { navigationManager.navigate(NavRoute.SupportChannel, any(), any()) }
             assertEquals(CommunitySegment.DISCUSSIONS, presenter.uiState.value.selectedSegment)
         }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenSegmentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenSegmentUiTest.kt
@@ -1,0 +1,168 @@
+package network.bisq.mobile.presentation.community
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import network.bisq.mobile.data.model.Settings
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.chat.common.CommonPublicChatChannel
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.service.chat.public_chat.PublicChatServiceFacade
+import network.bisq.mobile.data.service.contacts.ContactsServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.PreviewTopBarPresenter
+import network.bisq.mobile.presentation.community.contacts.ContactsPresenter
+import network.bisq.mobile.presentation.community.public_chat.PublicChatPresenter
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.DISCUSSION_MESSAGE_TEXT
+import network.bisq.mobile.test.fixtures.SUPPORT_MESSAGE_TEXT
+import network.bisq.mobile.test.fixtures.testCommunityHubService
+import network.bisq.mobile.test.fixtures.testPublicChatChannel
+import network.bisq.mobile.test.mocks.SettingsRepositoryMock
+import network.bisq.mobile.test.presentation.compose.PresentationInjectComposeUiTestBase
+import org.junit.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * The hub's segment behaviour as the real screen wires it: which domain Discussions is mounted on,
+ * and which segment survives a trip forward and back. `CommunityHubScreenUiTest` drives the
+ * stateless content with a stand-in body and no presenter, so neither is observable there.
+ *
+ * The domain half mirrors `SupportChannelScreenUiTest` from the other side: the facade serves both
+ * channels, so the wrong domain renders a plausible thread of the wrong conversation under the
+ * Discussions label — no error, no spinner.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommunityHubScreenSegmentUiTest : PresentationInjectComposeUiTestBase() {
+    private lateinit var publicChatServiceFacade: PublicChatServiceFacade
+    private lateinit var userProfileServiceFacade: UserProfileServiceFacade
+    private lateinit var contactsServiceFacade: ContactsServiceFacade
+    private lateinit var mainPresenter: MainPresenter
+
+    private val alice: UserProfileVO = createMockUserProfile("alice")
+    private val channels = MutableStateFlow<List<CommonPublicChatChannel>>(emptyList())
+    private val screenMounted = mutableStateOf(true)
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<ITopBarPresenter> { PreviewTopBarPresenter() }
+                factory {
+                    CommunityHubPresenter(
+                        mainPresenter,
+                        testCommunityHubService(
+                            enabled = setOf(CommunitySegment.DISCUSSIONS, CommunitySegment.CONTACTS),
+                            // Both segments have to be live for this class to say anything about
+                            // segment bodies, and the fixture's default requirements come from
+                            // production — so the day DISCUSSIONS declares one, every test here
+                            // would go red on the capability gate instead.
+                            requiredFeatures = emptyMap(),
+                            dispatcher = UnconfinedTestDispatcher(testDispatcher.scheduler),
+                        ),
+                    )
+                }
+                factory { ContactsPresenter(mainPresenter, contactsServiceFacade, userProfileServiceFacade) }
+                factory { params ->
+                    PublicChatPresenter(
+                        mainPresenter,
+                        publicChatServiceFacade,
+                        userProfileServiceFacade,
+                        // The chat-rules warn box seeded away — the state of anyone who has tapped
+                        // "Don't show again". Not cosmetic here: Robolectric's default viewport is
+                        // ~320x470dp, and the hub already stacks a top bar, a tab row, the Support
+                        // row and the search field above the thread, so with the box on top of those
+                        // the message list is laid out at zero height and nothing is displayed.
+                        SettingsRepositoryMock(Settings(showChatRulesWarnBox = false)),
+                        params.get(),
+                    )
+                }
+            },
+        )
+
+    override fun onKoinReady() {
+        super.onKoinReady()
+        publicChatServiceFacade = mockk(relaxed = true)
+        userProfileServiceFacade = mockk(relaxed = true)
+        contactsServiceFacade = mockk(relaxed = true)
+        mainPresenter = mockk(relaxed = true)
+
+        every { contactsServiceFacade.contacts } returns MutableStateFlow(emptyList())
+
+        every { publicChatServiceFacade.channels } returns channels
+        every { publicChatServiceFacade.isSupported } returns flowOf(true)
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+        coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(alice)
+
+        channels.value =
+            listOf(
+                // Support first, so dropping the domain predicate in `awaitChannel` reddens this
+                // test on its own rather than leaning on its Support-side twin, which seeds the
+                // other order.
+                testPublicChatChannel(ChatChannelDomainEnum.SUPPORT, SUPPORT_MESSAGE_TEXT, alice),
+                testPublicChatChannel(ChatChannelDomainEnum.DISCUSSION, DISCUSSION_MESSAGE_TEXT, alice),
+            )
+    }
+
+    /** The thread renders link text, which asks the composition for an opener it cannot default. */
+    private fun setCommunityHubScreen(initialSegment: CommunitySegment? = null) =
+        setInjectTestContent {
+            CompositionLocalProvider(LocalExternalUrlOpener provides ExternalUrlOpener { true }) {
+                if (screenMounted.value) CommunityHubScreen(initialSegment = initialSegment)
+            }
+        }
+
+    /**
+     * What navigating forward and back does to this screen: the destination leaves composition while
+     * its `NavBackStackEntry` — and so the [viewModelStore] the presenter is cached in — stays alive.
+     * The presenter that comes back is the same instance; every `remember` slot around it is new.
+     */
+    private fun navigateAwayAndBack() {
+        screenMounted.value = false
+        composeTestRule.waitForIdle()
+        screenMounted.value = true
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `the discussions segment renders the discussion thread and not the support one`() {
+        setCommunityHubScreen()
+
+        composeTestRule.onNodeWithText(DISCUSSION_MESSAGE_TEXT).assertIsDisplayed()
+        composeTestRule.onNodeWithText(SUPPORT_MESSAGE_TEXT).assertDoesNotExist()
+    }
+
+    /**
+     * A deep link picks the segment the hub opens on; it must not keep picking it. More → My Contacts
+     * pushes `CommunityHub(initialSegment = CONTACTS)`, and the route argument outlives every
+     * composition of that back-stack entry — so without a once-only guard, coming back from the
+     * Support screen drops the user on Contacts instead of the Discussions tab they left.
+     */
+    @Test
+    fun `a deep-linked segment is not re-applied when the screen comes back`() {
+        setCommunityHubScreen(initialSegment = CommunitySegment.CONTACTS)
+
+        composeTestRule.onNodeWithText("mobile.community.tab.discussions".i18n()).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(DISCUSSION_MESSAGE_TEXT).assertIsDisplayed()
+
+        navigateAwayAndBack()
+
+        composeTestRule.onNodeWithText(DISCUSSION_MESSAGE_TEXT).assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreenUiTest.kt
@@ -70,11 +70,47 @@ class CommunityHubScreenUiTest : BisqComposeUiTestBase() {
         assertEquals(listOf<CommunityHubUiAction>(CommunityHubUiAction.OnOpenSupportChannel), actions)
     }
 
+    /**
+     * The row navigates as of #1746, and `NavigationManagerImpl.navigate` applies no `launchSingleTop`,
+     * so an undebounced double tap leaves two Support screens on the stack and two backs to get out.
+     *
+     * The one real-time dependency in this class: `rememberDebouncedClick` reads `Clock.System.now()`,
+     * not the test clock, so the two taps have to land within the 300 ms window in wall time. There is
+     * no virtual clock to advance instead — if this ever flakes red on a stalled CI box, that is why.
+     */
+    @Test
+    fun `a double tap on the support row opens the channel once`() {
+        setContent(
+            CommunityHubUiState(
+                liveSegments = listOf(CommunitySegment.DISCUSSIONS),
+                selectedSegment = CommunitySegment.DISCUSSIONS,
+            ),
+        )
+
+        val supportRow = composeTestRule.onNodeWithText(tabLabel("mobile.community.support.needHelp"))
+        supportRow.performClick()
+        supportRow.performClick()
+
+        assertEquals(listOf<CommunityHubUiAction>(CommunityHubUiAction.OnOpenSupportChannel), actions)
+    }
+
     @Test
     fun `no live segments renders the bare coming soon state`() {
         setContent(CommunityHubUiState())
 
         composeTestRule.onNodeWithText("mobile.community.comingSoon".i18n()).assertIsDisplayed()
+    }
+
+    /**
+     * The row now navigates, so offering it with no segment live would push a public chat thread in a
+     * build that serves none. Hard to reach in practice — `TabContainerPresenter` hides the hub icon
+     * while `liveSegments` is empty — but the state is representable, so the gate stays.
+     */
+    @Test
+    fun `support row is hidden when no segment is live`() {
+        setContent(CommunityHubUiState())
+
+        composeTestRule.onNodeWithText(tabLabel("mobile.community.support.needHelp")).assertDoesNotExist()
     }
 
     /** The pinned Support row is Discussions-context only — directory/inbox segments drop it. */

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatPresenterTest.kt
@@ -78,6 +78,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                 publicChatServiceFacade,
                 userProfileServiceFacade,
                 settingsRepository,
+                ChatChannelDomainEnum.DISCUSSION,
             )
     }
 
@@ -86,7 +87,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
     fun `the channel is resolved by domain out of the two the facade serves`() =
         runTest {
             channels.value = listOf(supportChannel(), discussionChannel())
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             assertEquals("discussion.bisq", presenter.uiState.value.channelId)
@@ -100,7 +101,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
     @Test
     fun `no elapsed time alone reports the channel as missing`() =
         runTest {
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceTimeBy(60_000)
 
             assertTrue(presenter.uiState.value.isLoading, "waiting must never turn into a terminal state")
@@ -120,7 +121,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             channel.setUnreadCount(3)
             channels.value = listOf(channel)
 
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             assertEquals(2, presenter.uiState.value.readCount)
@@ -130,7 +131,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
     @Test
     fun `sending is disabled until the channel resolves`() =
         runTest {
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             assertFalse(presenter.isSendChatMessageEnabled.value)
@@ -163,7 +164,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                             ),
                     ),
                 )
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             assertEquals(
@@ -192,7 +193,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                             ),
                     ),
                 )
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnSearchQueryChange("settle"))
@@ -218,7 +219,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                         messages = listOf(message("m1", alice, date = 1), message("m2", bob, date = 2)),
                     ),
                 )
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             ignoredProfileIds.value = setOf(bob.id)
@@ -241,7 +242,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                         messages = listOf(message("m1", alice, date = 1), message("m2", bob, date = 2)),
                     ),
                 )
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnIgnoreUserClick(bob.id))
@@ -257,7 +258,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
         runTest {
             val fromBob = message("m2", bob, date = 2)
             channels.value = listOf(discussionChannel(messages = listOf(message("m1", alice, date = 1), fromBob)))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnReportUserClick(fromBob))
@@ -271,7 +272,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             val mine = message("m1", me, date = 1, isMyMessage = true)
             channels.value = listOf(discussionChannel(messages = listOf(mine)))
             coEvery { publicChatServiceFacade.deleteChatMessage(any(), any()) } returns Result.success(Unit)
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnDeleteMessageClick(mine))
@@ -289,7 +290,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             channels.value = listOf(discussionChannel())
             coEvery { publicChatServiceFacade.sendChatMessage(any(), any(), any()) } returns
                 Result.failure(IllegalStateException("no connection"))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnSendMessage("hello"))
@@ -305,7 +306,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             val mine = message("m1", me, date = 1, text = "original", isMyMessage = true)
             channels.value = listOf(discussionChannel(messages = listOf(mine)))
             coEvery { publicChatServiceFacade.editChatMessage(any(), any(), any()) } returns Result.success(Unit)
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnEditMessage(mine))
@@ -321,15 +322,14 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
 
     /**
      * The hub mounts this tab with `RememberPresenterLifecycle`, which cancels `presenterScope` on
-     * detach and recreates it on re-attach — so the collectors have to be restarted. `initialize` is
-     * idempotent on the domain and would short-circuit, leaving a tab that renders a frozen list and
-     * never sends again.
+     * detach and recreates it on re-attach — so the collectors have to be restarted. A guard that
+     * only asked whether the job had ever been started would short-circuit here, leaving a tab that
+     * renders a frozen list and never sends again.
      */
     @Test
     fun `re-attaching the tab restarts the channel collectors`() =
         runTest {
             channels.value = listOf(discussionChannel(messages = listOf(message("m1", alice, date = 1))))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
             presenter.onViewAttached()
             advanceUntilIdle()
             assertEquals(
@@ -342,7 +342,6 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             advanceUntilIdle()
 
             presenter.onViewAttached()
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
             advanceUntilIdle()
 
             // A message arriving AFTER the re-attach: asserting on what is already in the state would
@@ -376,7 +375,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
                     PublicChatRemovalRejectedException("message") to "mobile.community.chat.removalRejected",
                 )
             channels.value = listOf(discussionChannel())
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             cases.forEach { (exception, key) ->
@@ -396,7 +395,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             channels.value = listOf(discussionChannel())
             coEvery { publicChatServiceFacade.sendChatMessage(any(), any(), any()) } returns
                 Result.failure(PublicChatSendRefusedException(PublicChatSendRejection.UNKNOWN))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnSendMessage("hello"))
@@ -412,7 +411,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             channels.value = listOf(discussionChannel(messages = listOf(peers)))
             coEvery { publicChatServiceFacade.addChatMessageReaction(any(), any(), any()) } returns Result.success(Unit)
             coEvery { publicChatServiceFacade.removeChatMessageReaction(any(), any(), any()) } returns Result.success(Unit)
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
             val reaction = reaction(peers)
 
@@ -432,7 +431,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
             channels.value = listOf(discussionChannel(messages = listOf(peers)))
             coEvery { publicChatServiceFacade.addChatMessageReaction(any(), any(), any()) } returns
                 Result.failure(PublicChatSendRefusedException(PublicChatSendRejection.RATE_LIMIT_EXCEEDED))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnAddReaction(peers, ReactionEnum.THUMBS_UP))
@@ -446,7 +445,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
         runTest {
             val peers = message("m1", alice, date = 1)
             channels.value = listOf(discussionChannel(messages = listOf(peers)))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
 
             presenter.onAction(PublicChatUiAction.OnUndoIgnoreUserClick(alice.id))
@@ -466,7 +465,7 @@ class PublicChatPresenterTest : PresentationKoinTestBase() {
     fun `a burst of scrolls consumes the channel once`() =
         runTest {
             channels.value = listOf(discussionChannel(messages = listOf(message("m1", alice, date = 1))))
-            presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
+            presenter.onViewAttached()
             advanceUntilIdle()
             // Opening the thread consumes once on its own; what the scrolling adds is what is under test.
             clearMocks(publicChatServiceFacade, answers = false)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThreadContentUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThreadContentUiTest.kt
@@ -18,8 +18,9 @@ import kotlin.test.assertEquals
 /**
  * The thread body is a layout, not a scaffold: the hub mounts it inside its own `BisqScaffold` —
  * which already carries `imePadding()` — so a nested scaffold would apply the window insets twice
- * and reserve a bottom-bar height inside a weighted box. #1746's pushed Support screen wraps this in
- * `ChatScaffold` instead, which already owns the top bar and the input padding contract.
+ * and reserve a bottom-bar height inside a weighted box. `SupportChannelScreen` supplies the chrome
+ * from the other side with a `BisqScaffold` carrying only a top bar — not `ChatScaffold`, which owns a
+ * `ChatInputBottomBar` and would give the screen a second composer.
  */
 class PublicChatThreadContentUiTest : BisqComposeUiTestBase() {
     private val me: UserProfileVO = createMockUserProfile("me")

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/SupportChannelScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/public_chat/SupportChannelScreenUiTest.kt
@@ -1,0 +1,124 @@
+package network.bisq.mobile.presentation.community.public_chat
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.chat.common.CommonPublicChatChannel
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.service.chat.public_chat.PublicChatServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
+import network.bisq.mobile.domain.analytics.AnalyticsService
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.PreviewTopBarPresenter
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.DISCUSSION_MESSAGE_TEXT
+import network.bisq.mobile.test.fixtures.SUPPORT_MESSAGE_TEXT
+import network.bisq.mobile.test.fixtures.testPublicChatChannel
+import network.bisq.mobile.test.mocks.SettingsRepositoryMock
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import org.junit.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * The Support screen shares every moving part with the Discussions tab except the domain it is
+ * mounted on, so that domain is what this covers: the facade serves both channels, and picking the
+ * wrong one renders a plausible thread of the wrong conversation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SupportChannelScreenUiTest : PresentationKoinComposeTestBase() {
+    private lateinit var publicChatServiceFacade: PublicChatServiceFacade
+    private lateinit var userProfileServiceFacade: UserProfileServiceFacade
+    private lateinit var mainPresenter: MainPresenter
+
+    private val alice: UserProfileVO = createMockUserProfile("alice")
+    private val analyticsService: AnalyticsService = mockk(relaxed = true)
+    private val channels = MutableStateFlow<List<CommonPublicChatChannel>>(emptyList())
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<ITopBarPresenter> { PreviewTopBarPresenter() }
+                single<AnalyticsService> { analyticsService }
+                factory { params ->
+                    PublicChatPresenter(
+                        mainPresenter,
+                        publicChatServiceFacade,
+                        userProfileServiceFacade,
+                        SettingsRepositoryMock(),
+                        params.get(),
+                    )
+                }
+            },
+        )
+
+    override fun onKoinReady() {
+        super.onKoinReady()
+        publicChatServiceFacade = mockk(relaxed = true)
+        userProfileServiceFacade = mockk(relaxed = true)
+        mainPresenter = mockk(relaxed = true)
+
+        every { publicChatServiceFacade.channels } returns channels
+        every { publicChatServiceFacade.isSupported } returns flowOf(true)
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+        coEvery { userProfileServiceFacade.findUserProfiles(any()) } returns listOf(alice)
+
+        channels.value =
+            listOf(
+                // Discussion first, so a thread that takes the first channel instead of the one
+                // matching its domain reddens this test rather than leaning on its hub-side twin,
+                // which seeds the other order.
+                testPublicChatChannel(ChatChannelDomainEnum.DISCUSSION, DISCUSSION_MESSAGE_TEXT, alice),
+                testPublicChatChannel(ChatChannelDomainEnum.SUPPORT, SUPPORT_MESSAGE_TEXT, alice),
+            )
+    }
+
+    /** The thread renders link text, which asks the composition for an opener it cannot default. */
+    private fun setSupportChannelScreen() =
+        setTestContent {
+            CompositionLocalProvider(LocalExternalUrlOpener provides ExternalUrlOpener { true }) {
+                SupportChannelScreen()
+            }
+        }
+
+    @Test
+    fun `the screen renders the support thread and not the discussion one`() {
+        setSupportChannelScreen()
+
+        composeTestRule.onNodeWithText(SUPPORT_MESSAGE_TEXT).assertIsDisplayed()
+        composeTestRule.onNodeWithText(DISCUSSION_MESSAGE_TEXT).assertDoesNotExist()
+    }
+
+    /**
+     * The screen event is read off the presenter's domain, so it exists only once the screen has set
+     * one. Nothing else in this diff renders the screen with an analytics service bound, which makes
+     * this the only place the order between setting the domain and attaching the view is observable.
+     */
+    @Test
+    fun `the screen reports itself as the support screen`() {
+        setSupportChannelScreen()
+
+        verify { analyticsService.track(AnalyticsEvent.ScreenOpened.CommunitySupport) }
+    }
+
+    /** Pushed as its own screen, so it carries the chrome the hub supplies for the Discussions tab. */
+    @Test
+    fun `the screen carries the support channel title`() {
+        setSupportChannelScreen()
+
+        composeTestRule.onNodeWithText("chat.channelDomain.SUPPORT".i18n()).assertIsDisplayed()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenterTest.kt
@@ -1,0 +1,138 @@
+package network.bisq.mobile.presentation.settings.support
+
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
+import network.bisq.mobile.domain.service.capabilities.Feature
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.testCommunityHubService
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Help screen's in-app Support entry. The external links it lists always work; the in-app one
+ * only does in a build that serves public chat, so availability is the part worth covering.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SupportPresenterTest : PresentationKoinTestBase() {
+    private lateinit var mainPresenter: MainPresenter
+    private val capabilities = MutableStateFlow(BackendCapabilities.UNAVAILABLE)
+
+    override fun onKoinReady() {
+        // onViewAttached resolves the GitHub issue body, and PresentationKoinTestBase does not set
+        // up i18n the way the Compose bases do.
+        I18nSupport.setLanguage()
+        mainPresenter = mockk(relaxed = true)
+    }
+
+    private fun TestScope.createPresenter(
+        enabled: Set<CommunitySegment>,
+        requiredFeatures: Map<CommunitySegment, Feature> = emptyMap(),
+    ): SupportPresenter {
+        val hubService =
+            testCommunityHubService(
+                enabled = enabled,
+                requiredFeatures = requiredFeatures,
+                capabilities = capabilities,
+                dispatcher = UnconfinedTestDispatcher(testScheduler),
+            )
+        return SupportPresenter(
+            mainPresenter,
+            mockk<VersionProvider>(relaxed = true),
+            mockk<DeviceInfoProvider>(relaxed = true),
+            hubService,
+        )
+    }
+
+    private fun TestScope.createAttachedPresenter(
+        enabled: Set<CommunitySegment>,
+        requiredFeatures: Map<CommunitySegment, Feature> = emptyMap(),
+    ): SupportPresenter =
+        createPresenter(enabled, requiredFeatures).also {
+            it.onViewAttached()
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `the support channel is offered when discussions is live`() =
+        runTest {
+            val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
+
+            assertTrue(presenter.isSupportChannelAvailable.value)
+        }
+
+    /**
+     * Availability has to be right on the first frame, not one recomposition later. `SupportPresenter`
+     * is a Koin `factory` behind `RememberPresenterLifecycle`, so the Help screen builds a fresh one
+     * every time it enters composition — every return from the Support channel included. A flag that
+     * only fills in `onViewAttached` makes the entry pop in after the list has already been laid out
+     * without it. `liveSegments` is `stateIn(Eagerly)` and has a value at construction, so there is
+     * nothing to wait for.
+     */
+    @Test
+    fun `the support channel is offered before the view attaches`() =
+        runTest {
+            val presenter = createPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
+
+            assertTrue(presenter.isSupportChannelAvailable.value)
+        }
+
+    /**
+     * Discussions carries the public chat rollout, so without it the link would push a thread the
+     * app cannot fill — a spinner, not an error.
+     */
+    @Test
+    fun `the support channel is withheld when discussions is not live`() =
+        runTest {
+            val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.CONTACTS))
+
+            assertFalse(presenter.isSupportChannelAvailable.value)
+        }
+
+    /**
+     * The flag has to follow the flow, not sample it once. `isSupportChannelAvailable` starts false,
+     * so the withheld case alone would pass just as well on a presenter that never collected —
+     * dropping the segment out from under an attached one is what separates the two.
+     */
+    @Test
+    fun `the support channel is withdrawn when discussions stops being live`() =
+        runTest {
+            capabilities.value = BackendCapabilities(setOf(Feature.PRIVATE_CHAT.key))
+            val presenter =
+                createAttachedPresenter(
+                    enabled = setOf(CommunitySegment.DISCUSSIONS),
+                    // Any feature does here: what is under test is that the flag tracks liveSegments, and
+                    // a backend requirement is the only thing that moves that set after construction.
+                    requiredFeatures = mapOf(CommunitySegment.DISCUSSIONS to Feature.PRIVATE_CHAT),
+                )
+            assertTrue(presenter.isSupportChannelAvailable.value)
+
+            capabilities.value = BackendCapabilities.UNAVAILABLE
+            advanceUntilIdle()
+
+            assertFalse(presenter.isSupportChannelAvailable.value)
+        }
+
+    @Test
+    fun `opening the support channel navigates to it`() =
+        runTest {
+            val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
+
+            presenter.onOpenSupportChannel()
+            advanceUntilIdle()
+
+            verify { navigationManager.navigate(NavRoute.SupportChannel, any(), any()) }
+        }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreenUiTest.kt
@@ -1,0 +1,113 @@
+package network.bisq.mobile.presentation.settings.support
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import network.bisq.mobile.domain.service.community.CommunitySegment
+import network.bisq.mobile.domain.utils.DeviceInfoProvider
+import network.bisq.mobile.domain.utils.VersionProvider
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.context.ExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.context.LocalExternalUrlOpener
+import network.bisq.mobile.presentation.common.ui.components.molecules.ITopBarPresenter
+import network.bisq.mobile.presentation.common.ui.components.molecules.PreviewTopBarPresenter
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.testCommunityHubService
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import org.junit.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * #1746 asks for the Support chat to be reachable from the Help screen as well as the hub, and the
+ * Help screen is the entry that has to withhold it: it is reachable on every build, including the
+ * ones that serve no public chat.
+ *
+ * The issue also asks for back navigation to be correct from both entry paths, and the hub path is
+ * covered (`CommunityHubScreenSegmentUiTest`) because the hub has a segment selection to preserve.
+ * This path has nothing: `SupportPresenter` is a Koin `factory` behind `RememberPresenterLifecycle`,
+ * so returning from the channel builds a fresh presenter that seeds availability from the hub
+ * service, and there is no state a return could arrive stale with. A remount test here was written
+ * and dropped — neither reverting the synchronous seeding nor rebinding the presenter as a `single`
+ * reddened it, so it asserted nothing the mount tests do not already assert. Correct by
+ * construction; re-test the path the day this presenter starts carrying state across a visit.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SupportScreenUiTest : PresentationKoinComposeTestBase() {
+    private lateinit var mainPresenter: MainPresenter
+    private var enabledSegments: Set<CommunitySegment> = emptySet()
+
+    private val openChannelLabel = "mobile.community.support.openChannel".i18n()
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                single<ITopBarPresenter> { PreviewTopBarPresenter() }
+                factory {
+                    SupportPresenter(
+                        mainPresenter,
+                        mockk<VersionProvider>(relaxed = true),
+                        mockk<DeviceInfoProvider>(relaxed = true),
+                        testCommunityHubService(
+                            enabled = enabledSegments,
+                            // What is under test is the rollout flag, not the capability gate, and
+                            // the fixture's default requirements come from production — so the day
+                            // DISCUSSIONS declares one, this would withhold the entry for a reason
+                            // it is not about.
+                            requiredFeatures = emptyMap(),
+                            dispatcher = UnconfinedTestDispatcher(testDispatcher.scheduler),
+                        ),
+                    )
+                }
+            },
+        )
+
+    override fun onKoinReady() {
+        mainPresenter = mockk(relaxed = true)
+    }
+
+    /** The screen is a wall of external links, and every one of them reads the opener. */
+    private fun setSupportScreen() =
+        setTestContent {
+            CompositionLocalProvider(LocalExternalUrlOpener provides ExternalUrlOpener { true }) {
+                SupportScreen()
+            }
+        }
+
+    @Test
+    fun `the support channel entry is offered when discussions is live`() {
+        enabledSegments = setOf(CommunitySegment.DISCUSSIONS)
+
+        setSupportScreen()
+
+        composeTestRule.onNodeWithText(openChannelLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the support channel entry is withheld when discussions is not live`() {
+        enabledSegments = emptySet()
+
+        setSupportScreen()
+
+        composeTestRule.onNodeWithText(openChannelLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.support.matrix".i18n()).assertIsDisplayed()
+    }
+
+    /** The same destination the hub row pushes, so both entry points land on one channel. */
+    @Test
+    fun `tapping the support channel entry pushes the channel`() {
+        enabledSegments = setOf(CommunitySegment.DISCUSSIONS)
+        setSupportScreen()
+
+        composeTestRule.onNodeWithText(openChannelLabel).performClick()
+        composeTestRule.waitForIdle()
+
+        verify { navigationManager.navigate(NavRoute.SupportChannel, any(), any()) }
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreenUiTest.kt
@@ -87,6 +87,7 @@ class SupportScreenUiTest : PresentationKoinComposeTestBase() {
         setSupportScreen()
 
         composeTestRule.onNodeWithText(openChannelLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("mobile.support.communityChannels".i18n()).assertIsDisplayed()
     }
 
     @Test
@@ -96,6 +97,7 @@ class SupportScreenUiTest : PresentationKoinComposeTestBase() {
         setSupportScreen()
 
         composeTestRule.onNodeWithText(openChannelLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithText("mobile.support.communityChannels".i18n()).assertIsDisplayed()
         composeTestRule.onNodeWithText("mobile.support.matrix".i18n()).assertIsDisplayed()
     }
 

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterCommunityIconTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/tabs/tab/TabContainerPresenterCommunityIconTest.kt
@@ -5,13 +5,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import network.bisq.mobile.data.service.alert.TradeRestrictingAlertServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
-import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
 import network.bisq.mobile.domain.service.capabilities.Feature
 import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.service.community.CommunitySegment
@@ -22,6 +20,7 @@ import network.bisq.mobile.presentation.common.ui.animation.AnimationSettings
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
+import network.bisq.mobile.test.fixtures.testCommunityHubService
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,13 +51,10 @@ class TabContainerPresenterCommunityIconTest : PlatformPresentationKoinTestBase(
         val tradeRestrictingAlertServiceFacade = mockk<TradeRestrictingAlertServiceFacade>(relaxed = true)
         every { tradeRestrictingAlertServiceFacade.alert } returns MutableStateFlow(null)
         val communityHubService =
-            CommunityHubService(
-                backendCapabilitiesService =
-                    object : BackendCapabilitiesService {
-                        override val capabilities: StateFlow<BackendCapabilities> = capabilitiesFlow
-                    },
-                enabledSegments = enabled,
+            testCommunityHubService(
+                enabled = enabled,
                 requiredFeatures = requiredFeatures,
+                capabilities = capabilitiesFlow,
                 dispatcher = UnconfinedTestDispatcher(testScheduler),
             )
         val mainPresenter =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -94,7 +94,7 @@ val presentationModule =
 
         factory<ReputationPresenter> { ReputationPresenter(get(), get()) }
 
-        factory<SupportPresenter> { SupportPresenter(get(), get(), get()) }
+        factory<SupportPresenter> { SupportPresenter(get(), get(), get(), get()) }
 
         factory<ResourcesPresenter> { ResourcesPresenter(get(), get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/NavRoute.kt
@@ -146,6 +146,10 @@ interface NavRoute {
     @Serializable
     data object Support : NavRoute
 
+    /** The in-app Support chat channel, distinct from [Support], which lists external help links. */
+    @Serializable
+    data object SupportChannel : NavRoute
+
     @Serializable
     data object Faqs : NavRoute
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/graph/CommonNavGraph.kt
@@ -20,6 +20,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.NavUtils.getDeepLinkBasePath
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.community.CommunityHubScreen
+import network.bisq.mobile.presentation.community.public_chat.SupportChannelScreen
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideOverview
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideProcess
 import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideSecurity
@@ -62,7 +63,12 @@ import kotlin.reflect.KType
 
 const val NAV_ANIM_MS = 300
 
-@ExcludeFromCoverage // declarative nav wiring (like the DI modules); not unit-testable in isolation
+// Declarative nav wiring, excluded from coverage the way the DI modules are: forty routes, and
+// asserting each one is registered would mostly restate this file back at itself. It is not
+// untestable, though — CommonNavGraphTest builds this graph with no Koin and no Compose runtime,
+// and pins NavRoute.SupportChannel there because two entry points share it and an unregistered
+// route fails silently. Pin any other route whose absence would be a dead tap rather than a crash.
+@ExcludeFromCoverage
 fun NavGraphBuilder.addCommonAppRoutes(animationsEnabled: () -> Boolean) {
     addScreen<NavRoute.UserAgreement>(animationsEnabled = animationsEnabled) { UserAgreementScreen() }
     addScreen<NavRoute.Onboarding>(animationsEnabled = animationsEnabled) { OnboardingScreen() }
@@ -134,6 +140,7 @@ fun NavGraphBuilder.addCommonAppRoutes(animationsEnabled: () -> Boolean) {
     addScreen<NavRoute.ChatRules>(animationsEnabled = animationsEnabled) { ChatRulesScreen() }
     addScreen<NavRoute.Settings>(animationsEnabled = animationsEnabled) { SettingsScreen() }
     addScreen<NavRoute.Support>(animationsEnabled = animationsEnabled) { SupportScreen() }
+    addScreen<NavRoute.SupportChannel>(animationsEnabled = animationsEnabled) { SupportChannelScreen() }
     addScreen<NavRoute.Faqs>(animationsEnabled = animationsEnabled) { FaqScreen() }
     addScreen<NavRoute.CommunityHub>(animationsEnabled = animationsEnabled) { backStackEntry ->
         val route: NavRoute.CommunityHub = backStackEntry.toRoute()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubPresenter.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class CommunityHubPresenter(
@@ -32,7 +33,15 @@ class CommunityHubPresenter(
     // then cleared — later liveSegments updates must not yank the user's own selection back.
     private var pendingInitialSegment: CommunitySegment? = null
 
+    // The route argument outlives every composition of its back-stack entry, so the screen asks
+    // again on each one: after a trip to the Support screen, after a rotation. Only the first ask
+    // is a deep link; the rest would overwrite whatever the user picked in between. Never reset —
+    // a genuinely new deep link arrives on a new back-stack entry, and so on a new presenter.
+    private var initialSegmentAsked = false
+
     fun selectInitialSegment(segment: CommunitySegment) {
+        if (initialSegmentAsked) return
+        initialSegmentAsked = true
         pendingInitialSegment = segment
         _uiState.update { state ->
             if (segment in state.liveSegments) {
@@ -67,10 +76,9 @@ class CommunityHubPresenter(
                 _uiState.update { state ->
                     if (action.segment in state.liveSegments) state.copy(selectedSegment = action.segment) else state
                 }
-            CommunityHubUiAction.OnOpenSupportChannel -> {
-                // TODO push the in-app Support chat screen once it exists
-                log.i { "Support channel requested from the Community hub; screen not available yet" }
-            }
+            // Pushed rather than selected: Support is not a segment, so the hub keeps the segment it
+            // was on and backing out lands where the user left.
+            CommunityHubUiAction.OnOpenSupportChannel -> navigateTo(NavRoute.SupportChannel)
         }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityHubScreen.kt
@@ -19,11 +19,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
 import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
+import network.bisq.mobile.presentation.common.ui.components.atoms.debouncedClickable
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ArrowRightIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.QuestionIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
@@ -35,7 +38,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycleBackStackAware
 import network.bisq.mobile.presentation.community.contacts.ContactsTabContent
-import network.bisq.mobile.presentation.community.discussions.DiscussionsTabContent
+import network.bisq.mobile.presentation.community.public_chat.PublicChatThread
 
 @ExcludeFromCoverage
 @Composable
@@ -44,7 +47,9 @@ fun CommunityHubScreen(initialSegment: CommunitySegment? = null) {
 
     // remember (not LaunchedEffect) so the deep-linked segment is selected DURING the first
     // composition — with LaunchedEffect the default segment (and its Support banner) renders
-    // for one frame before the switch. Idempotent: selectInitialSegment is honored once.
+    // for one frame before the switch. This slot is gone and rebuilt every time the screen leaves
+    // and re-enters composition, so it asks again on the way back from Support and on rotation;
+    // the presenter is what makes the second ask a no-op.
     remember(initialSegment) {
         initialSegment?.let { presenter.selectInitialSegment(it) }
     }
@@ -58,7 +63,7 @@ fun CommunityHubScreen(initialSegment: CommunitySegment? = null) {
         segmentContent = { segment ->
             when (segment) {
                 CommunitySegment.DISCUSSIONS -> {
-                    { DiscussionsTabContent() }
+                    { PublicChatThread(ChatChannelDomainEnum.DISCUSSION) }
                 }
                 CommunitySegment.CONTACTS -> {
                     { ContactsTabContent() }
@@ -100,8 +105,11 @@ fun CommunityHubScreenContent(
             // hub-side above the thread rather than moving inside it as CommunityHubScreenDesign.kt
             // specs: this gate puts it in the same place on screen, and it keeps the segment body a
             // plain thread that the Support screen can reuse unchanged. Directory/inbox segments
-            // don't carry it.
-            if (uiState.selectedSegment == null || uiState.selectedSegment == CommunitySegment.DISCUSSIONS) {
+            // don't carry it, and neither does the no-segment state: the row pushes a public chat
+            // thread, and Discussions being live is what says this build serves one. That last arm is
+            // hard to reach — TabContainerPresenter hides the hub icon while liveSegments is empty —
+            // but the state is representable, so the gate stays.
+            if (uiState.selectedSegment == CommunitySegment.DISCUSSIONS) {
                 SupportQuickAccessRow(onClick = { onAction(CommunityHubUiAction.OnOpenSupportChannel) })
             }
 
@@ -167,13 +175,18 @@ private fun CommunitySegmentTabRow(
     }
 }
 
+/**
+ * Debounced because it navigates and [network.bisq.mobile.presentation.common.ui.navigation.manager.NavigationManagerImpl]
+ * pushes without `launchSingleTop`: a double tap would otherwise leave two Support screens on the
+ * stack, and two backs to get out of them.
+ */
 @Composable
 private fun SupportQuickAccessRow(onClick: () -> Unit) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .debouncedClickable(role = Role.Button, onClick = onClick)
                 .background(BisqTheme.colors.dark_grey40)
                 .padding(horizontal = BisqUIConstants.ScreenPadding, vertical = BisqUIConstants.ScreenPadding),
         horizontalArrangement = Arrangement.spacedBy(BisqUIConstants.ScreenPaddingHalf),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatPresenter.kt
@@ -37,8 +37,8 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 
 /**
- * A public chat thread, parameterized by domain so the same screen serves Discussions and — once
- * #1746 wires its entry points — Support.
+ * A public chat thread, parameterized by domain so the same screen serves the hub's Discussions
+ * segment and the pushed Support screen.
  *
  * Two things separate it from `PrivateChatPresenter`, and both are places a copy would misbehave in
  * silence: the channel is resolved by DOMAIN rather than by position or by a literal id, because the
@@ -51,6 +51,7 @@ class PublicChatPresenter(
     private val publicChatServiceFacade: PublicChatServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val settingsRepository: SettingsRepository,
+    private val chatChannelDomain: ChatChannelDomainEnum,
 ) : BasePresenter(mainPresenter) {
     private companion object {
         /** Coalesces the scroll-driven read updates into one node round-trip. */
@@ -74,7 +75,6 @@ class PublicChatPresenter(
     val userProfileIconProvider: suspend (UserProfileVO) -> PlatformImage
         get() = userProfileServiceFacade::getUserProfileIcon
 
-    private var initializedDomain: ChatChannelDomainEnum? = null
     private var channelJob: Job? = null
 
     /** Extra buffer + DROP_OLDEST so the non-suspending [onUpdateReadCount] can never block or lose the latest. */
@@ -90,44 +90,34 @@ class PublicChatPresenter(
 
     private val searchQuery = MutableStateFlow("")
 
-    override fun analyticsScreenEvent() = AnalyticsEvent.ScreenOpened.CommunityDiscussions
-
     /**
-     * Idempotent on the domain, because the mounting composable re-runs whenever the tab is revealed —
-     * but only while the job it started is still alive. The hub mounts this tab with
-     * `RememberPresenterLifecycle`, which disposes `presenterScope` on detach, so a tab coming back
-     * would otherwise short-circuit here and render a frozen list forever.
+     * One presenter, two screens, and three chat domains it is never mounted on — the last of which
+     * is why this is nullable. The domain arrives at construction, so the answer is settled before
+     * the view can attach and ask.
      */
-    fun initialize(chatChannelDomain: ChatChannelDomainEnum) {
-        if (initializedDomain == chatChannelDomain) {
-            if (channelJob?.isActive != true) startChannelJob(chatChannelDomain)
-            return
+    override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened? =
+        when (chatChannelDomain) {
+            ChatChannelDomainEnum.DISCUSSION -> AnalyticsEvent.ScreenOpened.CommunityDiscussions
+            ChatChannelDomainEnum.SUPPORT -> AnalyticsEvent.ScreenOpened.CommunitySupport
+            else -> null
         }
-        initializedDomain = chatChannelDomain
-        _uiState.value = PublicChatUiState()
-        reportedReadCount.value = null
-        searchQuery.value = ""
-        startChannelJob(chatChannelDomain)
-    }
 
     /**
-     * The other half of the same problem: on a re-attach the scope is recreated here, before the
-     * composable's `initialize` runs. Restarting from both ends is harmless — whichever runs first
-     * leaves an active job and the other returns.
+     * The only place the collectors start. `presenterScope` is cancelled on detach and recreated on
+     * the next attach, so a tab or screen coming back needs a fresh job; [startChannelJob] cancels
+     * whatever was there first, which is all an attach has to do.
      */
     override fun onViewAttached() {
         super.onViewAttached()
-        initializedDomain?.let { domain ->
-            if (channelJob?.isActive != true) startChannelJob(domain)
-        }
+        startChannelJob()
     }
 
-    private fun startChannelJob(chatChannelDomain: ChatChannelDomainEnum) {
+    private fun startChannelJob() {
         channelJob?.cancel()
         channelJob =
             presenterScope.launch {
-                // Children of the channel's job, so re-initialising on another domain takes them down
-                // with everything else the first one started.
+                // Children of the channel's job, so a restart on re-attach takes them down with
+                // everything else the previous one started.
                 launch {
                     settingsRepository.data.collect { settings ->
                         _uiState.update { it.copy(showChatRulesWarnBox = settings.showChatRulesWarnBox) }
@@ -143,7 +133,7 @@ class PublicChatPresenter(
                 // branch, and it clears its text the moment it hands the message over — so an early
                 // send costs the user what they wrote rather than just failing.
                 _isSendChatMessageEnabled.value = false
-                val channel = awaitChannel(chatChannelDomain)
+                val channel = awaitChannel()
                 _isSendChatMessageEnabled.value = true
                 // Read before consuming, because consuming zeroes it — synchronously on the node,
                 // where bisq2 publishes changedNotification from inside consume(). Reading afterwards
@@ -253,7 +243,7 @@ class PublicChatPresenter(
      * "the channel could not be loaded" against a healthy node. The terminal states are
      * [PublicChatUiState.isSupported] and an explicit facade failure, never a clock.
      */
-    private suspend fun awaitChannel(chatChannelDomain: ChatChannelDomainEnum): CommonPublicChatChannel =
+    private suspend fun awaitChannel(): CommonPublicChatChannel =
         publicChatServiceFacade.channels
             .mapNotNull { channels -> channels.firstOrNull { it.chatChannelDomain == chatChannelDomain } }
             .first()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThread.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThread.kt
@@ -1,35 +1,34 @@
-package network.bisq.mobile.presentation.community.discussions
+package network.bisq.mobile.presentation.community.public_chat
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
-import network.bisq.mobile.presentation.community.public_chat.PublicChatPresenter
-import network.bisq.mobile.presentation.community.public_chat.PublicChatThreadContent
-import network.bisq.mobile.presentation.community.public_chat.PublicChatUiAction
 import network.bisq.mobile.presentation.report_user.ReportUserDialog
 import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
 
 /**
- * The Discussions segment's body inside the Community hub shell — #1744's glue between the facade and
- * the hub. Owns its presenter, like `ContactsTabContent`, so the hub screen stays presenter-agnostic
- * about segment content and its previews keep rendering without Koin.
+ * A public chat thread with its own presenter — the glue between the facade and whoever mounts it:
+ * the hub's Discussions segment and the pushed Support screen. Owns the presenter, like
+ * `ContactsTabContent`, so the hub screen stays presenter-agnostic about segment content and its
+ * previews keep rendering without Koin.
  *
- * No top bar: the hub already has one, and `PublicChatThreadContent` is a layout rather than a
- * scaffold. #1746's pushed Support screen supplies the chrome from its own side.
+ * No chrome. `PublicChatThreadContent` is a layout rather than a scaffold, so whoever mounts this
+ * supplies the top bar: the hub already has one, and the Support screen brings its own.
+ *
+ * The domain goes in at construction rather than through a post-construction call, because the
+ * presenter's screen-view analytics event is chosen by it and is emitted on attach. Nothing here
+ * starts work during composition: the presenter's collectors start in `onViewAttached`, which
+ * `RememberPresenterLifecycle` runs from an effect and unwinds on dispose.
  */
 @ExcludeFromCoverage
 @Composable
-fun DiscussionsTabContent() {
-    val presenter: PublicChatPresenter = koinInject()
+fun PublicChatThread(chatChannelDomain: ChatChannelDomainEnum) {
+    val presenter: PublicChatPresenter = koinInject { parametersOf(chatChannelDomain) }
     RememberPresenterLifecycle(presenter)
-
-    LaunchedEffect(presenter) {
-        presenter.initialize(ChatChannelDomainEnum.DISCUSSION)
-    }
 
     val uiState by presenter.uiState.collectAsState()
     val isSendChatMessageEnabled by presenter.isSendChatMessageEnabled.collectAsState()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThreadContent.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatThreadContent.kt
@@ -36,15 +36,16 @@ import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.toClipEntry
 
 /**
- * A public chat thread, parameterized by domain through its presenter — Discussions today, Support
- * once #1746 wires an entry point.
+ * A public chat thread, parameterized by domain through its presenter — Discussions in the hub's
+ * segment, Support in its own pushed screen.
  *
  * **A layout, not a scaffold, and it owns no top bar.** The hub mounts a segment body inside its own
  * `BisqScaffold` → `Column` → `Box(weight(1f))`, and that scaffold already carries `imePadding()`; a
  * nested scaffold here would apply the window insets and the ime padding twice and reserve a
- * bottom-bar height inside a weighted box. Whoever mounts this owns the chrome: `DiscussionsTabContent`
- * mounts it bare, and a pushed Support screen wraps it in `ChatScaffold`, which already takes a
- * nullable `topBar` and owns the input/content padding contract.
+ * bottom-bar height inside a weighted box. Whoever mounts this owns the chrome: the hub mounts it
+ * bare, and `SupportChannelScreen` gives it a `BisqScaffold` with only a top bar — not `ChatScaffold`,
+ * which owns a `ChatInputBottomBar` and would leave the screen with two composers, since the
+ * `ChatInputField` below is this layout's own.
  *
  * @param reportDialog a slot rather than rendered here, since `ReportUserDialog` injects its own
  *   presenter — same reason `PrivateChatScreen` does it.
@@ -217,8 +218,8 @@ private fun ColumnScope.CenteredHint(text: String) {
 }
 
 /**
- * Rendered against SUPPORT rather than Discussions on purpose: the parameterization #1745 asked for is
- * the thing worth proving before #1746 wires an entry point to it.
+ * Rendered against SUPPORT rather than Discussions on purpose: the domain is what `SupportChannelScreen`
+ * varies, and a preview of the default would not exercise it.
  */
 @ExcludeFromCoverage
 @Preview(heightDp = 700)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/PublicChatUiState.kt
@@ -4,7 +4,7 @@ import network.bisq.mobile.data.replicated.chat.common.CommonPublicChatMessage
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 
 /**
- * State of a public chat thread — Discussions here, Support once #1746 wires its entry points.
+ * State of a public chat thread — the hub's Discussions segment and the pushed Support screen.
  *
  * [messages] holds domain models rather than flattened rows, for the reason `PrivateChatUiState`
  * documents: `ChatMessageList` subscribes to a `StateFlow` on each message for its reactions, so

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/SupportChannelScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/public_chat/SupportChannelScreen.kt
@@ -1,0 +1,38 @@
+package network.bisq.mobile.presentation.community.public_chat
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.layout.BisqScaffold
+import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
+
+/**
+ * The in-app Support channel. It is the shared destination of the two entry points #1746 asks to
+ * coexist: the Community hub's pinned "Need help?" quick access, and More → Help. The same thread
+ * the Discussions segment renders, on the other domain bisq2 serves through the same channel type —
+ * desktop does the same, varying only `chatChannelDomain`
+ * (`CommonChatTabController`/`CommonChatTabView`).
+ *
+ * Support is deliberately not a hub segment: bisq 2 keeps official support institutionally separate
+ * from casual chat, so this is a screen of its own with its own back button rather than a tab.
+ *
+ * `BisqScaffold` rather than `ChatScaffold`, which owns a `ChatInputBottomBar`:
+ * [PublicChatThreadContent] renders its own composer, so that scaffold would give the screen two.
+ *
+ * The title comes from the domain's own i18n key rather than the channel's `channelTitle` — the
+ * screen serves one fixed domain, and the channel need not have loaded for the chrome to be right.
+ */
+@Composable
+fun SupportChannelScreen() {
+    BisqScaffold(
+        topBar = { TopBar("chat.channelDomain.SUPPORT".i18n(), showUserAvatar = false) },
+    ) { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            PublicChatThread(ChatChannelDomainEnum.SUPPORT)
+        }
+    }
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/CommunityHubScreenDesign.kt
@@ -1,14 +1,18 @@
 /**
  * CommunityHubScreenDesign.kt — Design PoC (Milestone 11 "Bisq community")
  *
- * STATUS: PARTIALLY IMPLEMENTED. The hub SHELL — gated segments, tab row, entry icon,
- * navigation, dev override — is production code now:
+ * STATUS: IMPLEMENTED. The hub SHELL — gated segments, tab row, entry icon,
+ * navigation, dev override — and the Discussions body are production code now:
  *   - gating: `domain/service/community/CommunityHubService` (liveSegments =
  *     enabled ∩ capabilities, fail closed; enabled = the feature.communityHubSegments rollout config)
  *   - screen shell + segmented tab row: `presentation/community/CommunityHubScreen.kt`
  *     (including the Contacts muted-tab treatment and the shell previews)
  *   - entry icon + badge: `presentation/community/CommunityTopBarIcon.kt`
- * What REMAINS design spec in this file is the SEGMENT CONTENT that has not shipped yet:
+ *   - the Discussions body specced below as [DiscussionsTabContent]:
+ *     `presentation/community/public_chat/PublicChatThread.kt`, which the Support screen
+ *     reuses unchanged on `ChatChannelDomainEnum.SUPPORT`
+ * Both sections below have now shipped, so read them as the spec the production code was
+ * built from and as the record of where it deviated, not as pending work:
  *
  * ======================================================================================
  * DISCUSSIONS TAB CONTENT — spec for the Discussions wiring
@@ -37,8 +41,8 @@
  * thread composable as Discussions, parameterized (see `DiscussionsChannelScreenDesign.kt`
  * "REUSED FOR THE SUPPORT CHANNEL").
  *
- * The previews render the milestone-11 main-screen composition (what the icon opens once
- * the Discussions wiring ships): TopBar, pinned Support reference, embedded thread.
+ * The previews render the milestone-11 main-screen composition as it was specced: TopBar,
+ * pinned Support reference, embedded thread.
  */
 package network.bisq.mobile.presentation.design.community
 
@@ -70,15 +74,15 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 
 // ============================================================================================
-// Content — DISCUSSIONS TAB (the milestone-11 hub body, not yet implemented)
+// Content — DISCUSSIONS TAB (the milestone-11 hub body, shipped as PublicChatThread.kt)
 // ============================================================================================
 
 /**
  * The Discussions segment's content: pinned Support reference, then the embedded channel
- * thread. This is the composition that replaces the production shell's placeholder body
- * when the Discussions wiring ships. If bisq2 ever ships a second live Discussion channel,
- * this is the reinsertion point for a channel picker (see
- * `DiscussionsChannelScreenDesign.kt` "REINTRODUCING A CHANNEL PICKER").
+ * thread. This is the composition that replaced the production shell's placeholder body.
+ * If bisq2 ever ships a second live Discussion channel, this is the reinsertion point for
+ * a channel picker (see `DiscussionsChannelScreenDesign.kt` "REINTRODUCING A CHANNEL
+ * PICKER").
  */
 @Composable
 internal fun DiscussionsTabContent(
@@ -134,7 +138,7 @@ private fun SupportChannelPinnedReference(onClick: () -> Unit) {
 private fun discussionsPreviewState() = DiscussionsChannelUiState(channelName = "Discussion", memberCount = 1284, messages = simulatedMessages())
 
 // ============================================================================================
-// Previews — the milestone-11 main-screen composition once the Discussions wiring ships
+// Previews — the milestone-11 main-screen composition as it was specced
 // (TopBar + pinned Support reference + embedded thread; no tab row with one live segment)
 // ============================================================================================
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/design/community/DiscussionsChannelScreenDesign.kt
@@ -48,6 +48,14 @@
  * ======================================================================================
  * REUSED FOR THE SUPPORT CHANNEL
  * ======================================================================================
+ * This section has shipped: read it as the spec production was built from and as the
+ * record of where it deviated, not as pending work. The deviation is the top bar. There
+ * is no `showTopBar` parameter — the thread that shipped
+ * (`presentation/community/public_chat/PublicChatThread.kt`) owns no chrome of its own,
+ * so `presentation/community/public_chat/SupportChannelScreen.kt` wraps it in a
+ * `BisqScaffold(topBar = TopBar(...))` instead, and the domain arrives by constructor
+ * rather than as channel data. Both entry points below shipped together.
+ *
  * `CommunityHubScreenDesign.kt`'s pinned "Need help?" reference in the Discussions tab
  * (see that file's "SUPPORT — HUB-SIDE REFERENCE" section) pushes to THIS SAME
  * `DiscussionsChannelScreenContent`, parameterized with the Support channel's data
@@ -249,7 +257,8 @@ internal sealed interface DiscussionsChannelUiAction {
  *   owns ONE shared TopBar for all tabs — see that file's "LAYOUT" section. The
  *   search-toggle icon relocates accordingly; see file KDoc "SEARCH-IN-CHANNEL".
  * @param modifier applied to the root `Column`, in addition to `fillMaxSize()`. Lets a
- *   caller such as `DiscussionsTabContent` constrain this composable to a `weight(1f)`
+ *   caller such as `CommunityHubScreenDesign.kt`'s `DiscussionsTabContent` (production:
+ *   `community/public_chat/PublicChatThread.kt`) constrain this composable to a `weight(1f)`
  *   slice of a taller `Column` (e.g. below the pinned Support reference row) instead of
  *   claiming the full available height unconditionally.
  */

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
@@ -31,22 +31,10 @@ class SupportPresenter(
         MutableStateFlow(CommunitySegment.DISCUSSIONS in communityHubService.liveSegments.value)
 
     /**
-     * Whether to offer the in-app Support channel alongside the external ones. Keyed on DISCUSSIONS
-     * being live because that segment carries the public chat rollout — the closest thing to a
-     * rollout switch the Help screen can read, and the precondition the Community hub's Support row
-     * is itself gated behind (that row additionally requires the segment to be *selected*).
-     *
-     * Not that the ungated entry would be unsafe to tap: a build with no public chat reports
-     * `isSupported == false`, and the thread renders that as a terminal "not available" hint. The
-     * gate is about the Help screen, which ships on every build — a permanently dead entry there is
-     * worse than no entry.
-     *
-     * This is a proxy, not the source of truth, and it holds only while [CommunityHubService.REQUIRED_FEATURES]
-     * carries no DISCUSSIONS entry to make it exact. Register that entry as part of shipping public
-     * chat on Connect: without it, flipping `feature.communityHubSegments.client` on offers the
-     * channel from every Connect build, including ones whose trusted node cannot serve it — the dead
-     * entry this gate exists to prevent. The exact predicate is `PublicChatServiceFacade.isSupported`,
-     * which the thread already collects; fold it in here if the two ever have to come apart.
+     * Offers the in-app Support channel when DISCUSSIONS is live — a proxy for public chat being
+     * served, exact only once [CommunityHubService.REQUIRED_FEATURES] carries a DISCUSSIONS entry.
+     * Register that entry when shipping public chat on Connect, or every Connect build offers a
+     * channel its node may not serve. Exact predicate: `PublicChatServiceFacade.isSupported`.
      */
     val isSupportChannelAvailable: StateFlow<Boolean> = _isSupportChannelAvailable.asStateFlow()
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
@@ -3,11 +3,16 @@ package network.bisq.mobile.presentation.settings.support
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import network.bisq.mobile.domain.service.community.CommunityHubService
+import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
 import network.bisq.mobile.domain.utils.StringUtils.urlEncode
 import network.bisq.mobile.domain.utils.VersionProvider
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.main.MainPresenter
 
@@ -15,18 +20,55 @@ class SupportPresenter(
     mainPresenter: MainPresenter,
     private val versionProvider: VersionProvider,
     private val deviceInfoProvider: DeviceInfoProvider,
+    private val communityHubService: CommunityHubService,
 ) : BasePresenter(mainPresenter) {
+    // Seeded synchronously from the service's current value (stateIn Eagerly), the way
+    // CommunityHubPresenter seeds its own state: this presenter is a Koin factory behind
+    // RememberPresenterLifecycle, so the Help screen builds a fresh one every time it enters
+    // composition, and a flag that only fills in onViewAttached pops the entry in a frame late on
+    // every return from the Support channel.
+    private val _isSupportChannelAvailable =
+        MutableStateFlow(CommunitySegment.DISCUSSIONS in communityHubService.liveSegments.value)
+
+    /**
+     * Whether to offer the in-app Support channel alongside the external ones. Keyed on DISCUSSIONS
+     * being live because that segment carries the public chat rollout — the closest thing to a
+     * rollout switch the Help screen can read, and the precondition the Community hub's Support row
+     * is itself gated behind (that row additionally requires the segment to be *selected*).
+     *
+     * Not that the ungated entry would be unsafe to tap: a build with no public chat reports
+     * `isSupported == false`, and the thread renders that as a terminal "not available" hint. The
+     * gate is about the Help screen, which ships on every build — a permanently dead entry there is
+     * worse than no entry.
+     *
+     * This is a proxy, not the source of truth, and it holds only while [CommunityHubService.REQUIRED_FEATURES]
+     * carries no DISCUSSIONS entry to make it exact. Register that entry as part of shipping public
+     * chat on Connect: without it, flipping `feature.communityHubSegments.client` on offers the
+     * channel from every Connect build, including ones whose trusted node cannot serve it — the dead
+     * entry this gate exists to prevent. The exact predicate is `PublicChatServiceFacade.isSupported`,
+     * which the thread already collects; fold it in here if the two ever have to come apart.
+     */
+    val isSupportChannelAvailable: StateFlow<Boolean> = _isSupportChannelAvailable.asStateFlow()
+
     protected val _reportUrl: MutableStateFlow<String> = MutableStateFlow("")
     val reportUrl: StateFlow<String> = _reportUrl.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
 
+        communityHubService.liveSegments
+            .onEach { _isSupportChannelAvailable.value = CommunitySegment.DISCUSSIONS in it }
+            .launchIn(presenterScope)
+
         val versionInfo = versionProvider.getVersionInfo(isDemo(), isIOS())
         val deviceInfo = deviceInfoProvider.getDeviceInfo()
 
         val body = "mobile.support.troubleShooting.github.body".i18n(versionInfo, deviceInfo)
         _reportUrl.value = BisqLinks.BISQ_MOBILE_GH_ISSUES + "/new?body=" + body.urlEncode()
+    }
+
+    fun onOpenSupportChannel() {
+        navigateTo(NavRoute.SupportChannel)
     }
 
     fun onRestartApp() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -19,6 +19,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
+import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ChatIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WebLinkIcon
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqHDivider
@@ -36,6 +37,7 @@ fun SupportScreen() {
     RememberPresenterLifecycle(presenter)
 
     val reportUrl by presenter.reportUrl.collectAsState()
+    val isSupportChannelAvailable by presenter.isSupportChannelAvailable.collectAsState()
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.more.support".i18n(), showUserAvatar = false) },
@@ -50,6 +52,9 @@ fun SupportScreen() {
             color = BisqTheme.colors.light_grey50,
         )
         Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.Zero)) {
+            if (isSupportChannelAvailable) {
+                SupportChannelLink(onClick = { presenter.onOpenSupportChannel() })
+            }
             SupportWeblink(
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
@@ -149,6 +154,27 @@ fun SupportScreen() {
             }
         }
     }
+}
+
+/**
+ * The in-app Support channel, listed with the community channels because that is what it is to the
+ * reader: one more way to reach the community, and the only one that stays in the app. Not a
+ * [SupportWeblink] — there is no URL to open, so there is no leaving-the-app confirmation to show.
+ */
+@Composable
+fun SupportChannelLink(onClick: () -> Unit) {
+    BisqButton(
+        text = "mobile.community.support.openChannel".i18n(),
+        onClick = onClick,
+        type = BisqButtonType.Underline,
+        color = BisqTheme.colors.mid_grey20,
+        leftIcon = { ChatIcon(modifier = Modifier.size(16.dp).alpha(0.5f)) },
+        padding =
+            PaddingValues(
+                horizontal = BisqUIConstants.ScreenPaddingHalf,
+                vertical = BisqUIConstants.Zero,
+            ),
+    )
 }
 
 @Composable

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -51,10 +51,15 @@ fun SupportScreen() {
             text = "mobile.support.intro".i18n(),
             color = BisqTheme.colors.light_grey50,
         )
+        if (isSupportChannelAvailable) {
+            BisqGap.V2()
+            SupportChannelLink(onClick = { presenter.onOpenSupportChannel() })
+        }
+        BisqGap.V2()
+        // Caption so the external links read as one named, secondary group — with or without the
+        // in-app button above them.
+        BisqText.SmallRegularGrey("mobile.support.communityChannels".i18n())
         Column(verticalArrangement = Arrangement.spacedBy(BisqUIConstants.Zero)) {
-            if (isSupportChannelAvailable) {
-                SupportChannelLink(onClick = { presenter.onOpenSupportChannel() })
-            }
             SupportWeblink(
                 text = "mobile.support.matrix".i18n(),
                 link = BisqLinks.MATRIX,
@@ -157,8 +162,9 @@ fun SupportScreen() {
 }
 
 /**
- * The in-app Support channel, listed with the community channels because that is what it is to the
- * reader: one more way to reach the community, and the only one that stays in the app. Not a
+ * The in-app Support channel — the one route that stays in the app, so it gets button affordance
+ * the external links deliberately lack: `Outline` is what this screen already uses for real actions
+ * (Restart/Shutdown), while grey underline is its vocabulary for passive links. Not a
  * [SupportWeblink] — there is no URL to open, so there is no leaving-the-app confirmation to show.
  */
 @Composable
@@ -166,14 +172,9 @@ fun SupportChannelLink(onClick: () -> Unit) {
     BisqButton(
         text = "mobile.community.support.openChannel".i18n(),
         onClick = onClick,
-        type = BisqButtonType.Underline,
-        color = BisqTheme.colors.mid_grey20,
-        leftIcon = { ChatIcon(modifier = Modifier.size(16.dp).alpha(0.5f)) },
-        padding =
-            PaddingValues(
-                horizontal = BisqUIConstants.ScreenPaddingHalf,
-                vertical = BisqUIConstants.Zero,
-            ),
+        type = BisqButtonType.Outline,
+        fullWidth = true,
+        leftIcon = { ChatIcon(modifier = Modifier.size(16.dp)) },
     )
 }
 

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/fixtures/CommunityHubServiceTestFactory.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/fixtures/CommunityHubServiceTestFactory.kt
@@ -1,0 +1,47 @@
+package network.bisq.mobile.test.fixtures
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilities
+import network.bisq.mobile.domain.service.capabilities.BackendCapabilitiesService
+import network.bisq.mobile.domain.service.capabilities.Feature
+import network.bisq.mobile.domain.service.community.CommunityHubService
+import network.bisq.mobile.domain.service.community.CommunitySegment
+
+/**
+ * A real [CommunityHubService] on a test dispatcher — the service is cheap and its whole point is
+ * the `enabled ∩ capabilities` arithmetic, so tests exercise it rather than mock it.
+ *
+ * Every argument is defaulted to the inert value, which is what makes this worth sharing: a caller
+ * names only the axis it is about, and a new constructor parameter lands in one place instead of
+ * every test that happens to need a hub service.
+ *
+ * @param capabilities pass a `MutableStateFlow` to move the backend manifest mid-test; the default
+ *   is the fail-closed one, so any segment that does declare a requirement starts withheld.
+ * @param requiredFeatures defaults to production's own [CommunityHubService.REQUIRED_FEATURES], so
+ *   a test that wants no capability gate has to say `requiredFeatures = emptyMap()` and mean it. The
+ *   other way round, a test asserting a segment is live would keep passing on the day that segment
+ *   starts requiring a backend feature production would gate it on.
+ * @param dispatcher pass `UnconfinedTestDispatcher(testScheduler)` from a `runTest` block so
+ *   `advanceUntilIdle()` drives the service's own `stateIn` scope. The default keeps that scope off
+ *   `Dispatchers.Default` for tests that have no scheduler to share.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun testCommunityHubService(
+    enabled: Set<CommunitySegment> = emptySet(),
+    requiredFeatures: Map<CommunitySegment, Feature> = CommunityHubService.REQUIRED_FEATURES,
+    capabilities: StateFlow<BackendCapabilities> = MutableStateFlow(BackendCapabilities.UNAVAILABLE),
+    dispatcher: CoroutineDispatcher = UnconfinedTestDispatcher(),
+): CommunityHubService =
+    CommunityHubService(
+        backendCapabilitiesService =
+            object : BackendCapabilitiesService {
+                override val capabilities: StateFlow<BackendCapabilities> = capabilities
+            },
+        enabledSegments = enabled,
+        requiredFeatures = requiredFeatures,
+        dispatcher = dispatcher,
+    )

--- a/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/fixtures/PublicChatChannelTestFactory.kt
+++ b/shared/test-utils/src/commonMain/kotlin/network/bisq/mobile/test/fixtures/PublicChatChannelTestFactory.kt
@@ -1,0 +1,53 @@
+package network.bisq.mobile.test.fixtures
+
+import network.bisq.mobile.data.replicated.chat.ChatChannelDomainEnum
+import network.bisq.mobile.data.replicated.chat.common.CommonPublicChatChannel
+import network.bisq.mobile.data.replicated.chat.common.createMockCommonPublicChatMessage
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+
+/**
+ * The one message the Discussions channel carries in a test that seeds both channels, and the one
+ * the Support channel carries. They exist as a pair: a `PublicChatServiceFacade` serves every domain
+ * from one `channels` flow, so a thread mounted on the wrong domain does not fail — it renders a
+ * plausible conversation. Asserting one text is displayed *and the other is not* is what separates
+ * the two, and it only reads that way if both texts are obviously from different conversations.
+ */
+const val DISCUSSION_MESSAGE_TEXT = "what do you all think of the new fee model"
+const val SUPPORT_MESSAGE_TEXT = "how do I reopen a dispute"
+
+/**
+ * A [CommonPublicChatChannel] on [domain] holding a single message with [text], sent by [author].
+ *
+ * [myUserProfile] defaults to someone other than [author], so the message renders as a peer's —
+ * which is what a public thread mostly holds, and what the peer affordances (report, ignore, sender
+ * name, avatar) need. Pass `myUserProfile = author` for one of the reader's own.
+ *
+ * Seed a list of these into a mocked `PublicChatServiceFacade.channels` to give a public chat thread
+ * something to resolve. The order of that list is usually load-bearing — a thread that picks the
+ * first channel instead of the one matching its domain still renders — so build the list at the call
+ * site, with a comment saying which order it is proving, rather than defaulting it here.
+ */
+fun testPublicChatChannel(
+    domain: ChatChannelDomainEnum,
+    text: String,
+    author: UserProfileVO,
+    myUserProfile: UserProfileVO = createMockUserProfile("someone-else"),
+    id: String = "${domain.name.lowercase()}.channel",
+): CommonPublicChatChannel =
+    CommonPublicChatChannel(
+        id = id,
+        chatChannelDomain = domain,
+        channelTitle = domain.name.lowercase(),
+    ).apply {
+        setAllChatMessages(
+            setOf(
+                createMockCommonPublicChatMessage(
+                    id = "msg-$id",
+                    text = text,
+                    senderUserProfile = author,
+                    myUserProfile = myUserProfile,
+                ),
+            ),
+        )
+    }


### PR DESCRIPTION
 - resolves #1746 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an in-app Support chat channel accessible from the Support screen and Community hub.
- Support chat availability reflects whether Discussions is live; external help links remain available otherwise.
- Discussions now displays the public chat thread directly.
- Added dedicated navigation and layout for Support conversations.
- Added a “Community channels” section heading.

## Bug Fixes
- Prevented repeated taps on the Support entry from triggering duplicate navigation.
- Preserved the selected Community segment when returning to the hub.

## Analytics
- Added tracking for Support chat channel views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->