### PR TITLE
bugfix/community_hub_notifications_badges_issues

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityTopBarActionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/community/CommunityTopBarActionUiTest.kt
@@ -48,6 +48,15 @@ class CommunityTopBarActionUiTest : BisqComposeUiTestBase() {
     }
 
     @Test
+    fun `caps the badge text above 99`() {
+        val presenter = presenterWith(visible = true, unread = 105)
+
+        setTestContent { CommunityTopBarAction(presenter) }
+
+        composeTestRule.onNodeWithText("99+").assertExists()
+    }
+
+    @Test
     fun `tap routes to the presenter`() {
         val presenter = presenterWith(visible = true)
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/animations/AnimatedBadge.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/components/atoms/animations/AnimatedBadge.kt
@@ -21,6 +21,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 @Composable
 fun AnimatedBadge(
     text: String,
+    modifier: Modifier = Modifier,
     contentColor: Color = BisqTheme.colors.white,
     badgeColor: Color = BisqTheme.colors.yellow,
     showAnimation: Boolean = false,
@@ -58,7 +59,7 @@ fun AnimatedBadge(
         containerColor = badgeColor,
         contentColor = contentColor,
         modifier =
-            Modifier
+            modifier
                 .offset(x = xOffset, y = yOffset)
                 .graphicsLayer {
                     scaleX = scale

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityTopBarIcon.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/community/CommunityTopBarIcon.kt
@@ -1,21 +1,25 @@
 package network.bisq.mobile.presentation.community
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.BadgedBox
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.atoms.AutoResizeText
 import network.bisq.mobile.presentation.common.ui.components.atoms.animations.AnimatedBadge
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.ChatIconOutlined
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBarContent
@@ -69,37 +73,41 @@ fun CommunityTopBarIcon(
     // visual weight than stark white. Sized to the avatar so the two centre together and sit
     // close — a default 48dp IconButton adds ~12dp of invisible padding around the 24dp glyph.
     val tint = ColorFilter.tint(BisqTheme.colors.mid_grey20)
-    IconButton(
-        onClick = onClick,
-        modifier =
-            modifier
-                .size(BisqUIConstants.topBarAvatarSize)
-                // Optical alignment using offset as is a post-layout translation — unlike
-                // padding it leaves touch bounds and the badgeanchor untouched.
-                .offset(y = 1.dp)
-                .testTag("community_topbar_icon")
-                .semantics { contentDescription = label },
-    ) {
+    // Optical alignment using offset as is a post-layout translation — unlike padding it
+    // leaves touch bounds untouched.
+    Box(modifier = modifier.offset(y = 1.dp)) {
+        IconButton(
+            onClick = onClick,
+            modifier =
+                Modifier
+                    .size(BisqUIConstants.topBarAvatarSize)
+                    .testTag("community_topbar_icon")
+                    .semantics { contentDescription = label },
+        ) {
+            ChatIconOutlined(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X), colorFilter = tint)
+        }
         val badgeText = formatUnreadBadgeCount(unreadCount)
         if (badgeText != null) {
-            BadgedBox(
-                badge = {
-                    // Near-zero offsets: AnimatedBadge's defaults are tuned for the bottom
-                    // nav's roomy Column; TopAppBar is a fixed-height clipping Surface that
-                    // would cut the pill off with them.
-                    AnimatedBadge(
-                        text = badgeText,
-                        showAnimation = showAnimation,
-                        xOffset = 2.dp,
-                        yOffset = (-2).dp,
-                    )
-                },
-                modifier = Modifier.padding(top = 2.dp, end = 2.dp),
+            // The badge must overlay the IconButton, not live inside it: IconButton clips
+            // its content to a circle, which sliced the pill into a blob (#1809). The width
+            // cap + AutoResizeText keep "99+" from widening the pill across the glyph — the
+            // text shrinks instead. The small offsets hang the pill over the button's
+            // top-end corner: the TopAppBar has vertical headroom there, and horizontally
+            // it may only borrow from the gap to the avatar, never reach it.
+            AnimatedBadge(
+                text = badgeText,
+                showAnimation = showAnimation,
+                xOffset = 4.dp,
+                yOffset = (-2).dp,
+                modifier = Modifier.align(Alignment.TopEnd).widthIn(max = 26.dp),
             ) {
-                ChatIconOutlined(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X), colorFilter = tint)
+                AutoResizeText(
+                    text = badgeText,
+                    textStyle = BisqTheme.typography.xsmallMedium,
+                    textAlign = TextAlign.Center,
+                    minimumFontSize = 9.sp,
+                )
             }
-        } else {
-            ChatIconOutlined(modifier = Modifier.size(BisqUIConstants.ScreenPadding2X), colorFilter = tint)
         }
     }
 }
@@ -133,12 +141,25 @@ private fun CommunityTopBarIcon_SmallUnread_Preview() {
 @ExcludeFromCoverage
 @Preview
 @Composable
+private fun CommunityTopBarIcon_TwoDigitUnread_Preview() {
+    BisqTheme.Preview {
+        TopBarContent(
+            title = "Offerbook",
+            showUserAvatar = true,
+            extraActions = { CommunityTopBarIcon(unreadCount = 56, showAnimation = false, onClick = {}) },
+        )
+    }
+}
+
+@ExcludeFromCoverage
+@Preview
+@Composable
 private fun CommunityTopBarIcon_CappedUnread_Preview() {
     BisqTheme.Preview {
         TopBarContent(
             title = "Offerbook",
             showUserAvatar = true,
-            extraActions = { CommunityTopBarIcon(unreadCount = 120, showAnimation = false, onClick = {}) },
+            extraActions = { CommunityTopBarIcon(unreadCount = 105, showAnimation = false, onClick = {}) },
         )
     }
 }


### PR DESCRIPTION
 - resolves #1809 
 - fixed container background cut off
 - added previews with different scenarios to visualice
 - fixed growth of container with text, cap + AutoResizeText component used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Improved unread-count badge placement and alignment on the community top bar.
  - Enhanced badge text sizing and spacing for clearer display, including multi-digit counts.
  - Unread counts above 99 now display as **“99+”**.

- **Bug Fixes**
  - Improved badge positioning relative to the community icon for more consistent rendering.

- **Tests**
  - Added coverage verifying that unread counts over 99 are capped at **“99+”**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->