### PR TITLE
build: move app packaging to AGP 9 APIs and enable ABI splits

### DIFF
--- a/apps/clientApp/build.gradle.kts
+++ b/apps/clientApp/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     // `SentryMechanismMeta declared twice`. See [[project_analytics_phase0_plan]].
     alias(libs.plugins.sentry.kotlin.multiplatform)
     alias(libs.plugins.kover)
+    id("network.bisq.mobile.app-artifacts")
     // google-services plugin is applied conditionally below when
     // google-services.json is present (gitignored — provisioned per
     // environment: prod LLC project for releases, dev project for end-to-end
@@ -306,6 +307,11 @@ val releaseKeystoreFile: File? = extra["releaseKeystoreFile"] as File?
 val optionalSigningProp = extra["optionalSigningProp"] as (String) -> String
 extra["requiredCompanionProps"] = listOf("KEYSTORE_PASSWORD", "CLI_KEY_ALIAS", "CLI_KEY_PASSWORD")
 
+// -------------------- App artifact naming / packaging --------------------
+appArtifacts {
+    productName.set(appName)
+}
+
 // -------------------- Android Configuration --------------------
 android {
     namespace = "network.bisq.mobile.client"
@@ -340,6 +346,19 @@ android {
 
         buildConfigField("String", "APP_VERSION", "\"${version}\"")
         buildConfigField("String", "SHARED_VERSION", "\"${sharedVersion}\"")
+    }
+
+    // ABI splits: one APK per architecture instead of one carrying all four copies of
+    // libtor.so. The universal APK stays for sideloading, and AppArtifactsPlugin gives each output
+    // its own version code. That plugin also switches this off for bundle builds, which AGP
+    // cannot produce while splits are on.
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            isUniversalApk = true
+        }
     }
 
     // Enable resources for Robolectric unit tests
@@ -419,16 +438,6 @@ android {
         }
     }
 
-    applicationVariants.all {
-        val variant = this
-        outputs.all {
-            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
-            val version = variant.versionName
-            val fileName = "${appName.replace(" ", "_")}-$version.apk"
-            output.outputFileName = fileName
-        }
-    }
-
     buildFeatures {
         buildConfig = true
     }
@@ -437,9 +446,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-
-    // Needed for aab files renaming
-    setProperty("archivesBaseName", getArtifactName(defaultConfig))
 }
 
 // -------------------- Build Tasks Configuration --------------------
@@ -508,9 +514,6 @@ tasks.register("syncIosVersion") {
 tasks.matching { it.name == "podInstall" }.configureEach {
     dependsOn("syncIosVersion")
 }
-
-// -------------------- Helper Functions --------------------
-fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String = "${appName.replace(" ", "")}-${defaultConfig.versionName}_${defaultConfig.versionCode}"
 
 // -------------------- Swift Bridge Configuration --------------------
 // Ensure Swift bridge objects are built before linking iOS frameworks. SDK-specific aggregates

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -211,6 +211,13 @@ android {
             excludes.add("META-INF/INDEX.LIST")
             excludes.add("META-INF/NOTICE.markdown")
 
+            // bisq2's JVM tor stack contributes a desktop tor bundle as a jar resource. It only
+            // materializes when the build host is macOS, which is how the published APKs are
+            // produced: Bisq_Easy-0.12.0.apk carries an 18.6 MB tor.zip of Mach-O binaries
+            // (tor, libevent dylib, lyrebird, conjure-client) that cannot execute on Android.
+            // Android drives tor through kmp-tor's lib/<abi>/libtor.so instead, so drop it.
+            excludes.add("tor.zip")
+
             pickFirsts.add("**/protobuf/**/*.class")
             pickFirsts +=
                 listOf(

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.protobuf)
     alias(libs.plugins.kover)
+    id("network.bisq.mobile.app-artifacts")
 }
 
 // -------------------- Version Configuration --------------------
@@ -98,6 +99,11 @@ val releaseKeystoreFile: File? = extra["releaseKeystoreFile"] as File?
 @Suppress("UNCHECKED_CAST")
 val optionalSigningProp = extra["optionalSigningProp"] as (String) -> String
 extra["requiredCompanionProps"] = listOf("KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD")
+
+// -------------------- App artifact naming / packaging --------------------
+appArtifacts {
+    productName.set(appName)
+}
 
 // -------------------- Android Configuration --------------------
 android {
@@ -181,10 +187,16 @@ android {
         }
     }
 
-    // Disable ABI splits to avoid packaging conflicts with kmp-tor
+    // ABI splits: one APK per architecture instead of one carrying all four copies of
+    // libtor.so. The universal APK stays for sideloading, and AppArtifactsPlugin gives each output
+    // its own version code. That plugin also switches this off for bundle builds, which AGP
+    // cannot produce while splits are on.
     splits {
         abi {
-            isEnable = false
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            isUniversalApk = true
         }
     }
 
@@ -275,15 +287,6 @@ android {
             matchingFallbacks += listOf("release")
         }
     }
-    applicationVariants.all {
-        val variant = this
-        outputs.all {
-            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
-            val version = variant.versionName
-            val fileName = "${appName.replace(" ", "_")}-$version.apk"
-            output.outputFileName = fileName
-        }
-    }
     buildFeatures {
         buildConfig = true
     }
@@ -297,9 +300,6 @@ android {
     testOptions {
         unitTests.isIncludeAndroidResources = true
     }
-
-    // Needed for aab files renaming
-    setProperty("archivesBaseName", getArtifactName(defaultConfig))
 }
 
 // -------------------- Protobuf Configuration --------------------
@@ -518,6 +518,3 @@ afterEvaluate {
             }
     }
 }
-
-// -------------------- Helper Functions --------------------
-fun getArtifactName(defaultConfig: com.android.build.gradle.internal.dsl.DefaultConfig): String = "${appName.replace(" ", "")}-${defaultConfig.versionName}_${defaultConfig.versionCode}"

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -218,12 +218,14 @@ android {
             // Android drives tor through kmp-tor's lib/<abi>/libtor.so instead, so drop it.
             excludes.add("tor.zip")
 
-            // grpc-netty-shaded ships its tcnative binaries as jar resources for every desktop
-            // OS. Windows .dll and macOS .jnilib cannot be loaded on Android by any code path,
-            // and no Linux or Android tcnative build is present, so netty already falls back to
-            // the JDK TLS stack here. 9.6 MB of formats the platform cannot read.
-            excludes.add("META-INF/native/*.dll")
-            excludes.add("META-INF/native/*.jnilib")
+            // grpc-netty-shaded ships tcnative and epoll binaries as jar resources for every
+            // desktop OS: Windows .dll, macOS .jnilib and glibc-linked Linux .so. None can be
+            // loaded on Android. AGP's java-resource merger already drops the .so on its own, so
+            // only the .dll and .jnilib (9.6 MB) actually reached the APK, but excluding the whole
+            // directory covers all of them and does not rot if that merger behaviour changes.
+            // Nothing under META-INF/native/ is loadable here: Android takes native code from
+            // lib/<abi>/ only, so netty stays on the JDK TLS stack and NIO transport either way.
+            excludes.add("META-INF/native/**")
 
             pickFirsts.add("**/protobuf/**/*.class")
             pickFirsts +=

--- a/apps/nodeApp/build.gradle.kts
+++ b/apps/nodeApp/build.gradle.kts
@@ -218,6 +218,13 @@ android {
             // Android drives tor through kmp-tor's lib/<abi>/libtor.so instead, so drop it.
             excludes.add("tor.zip")
 
+            // grpc-netty-shaded ships its tcnative binaries as jar resources for every desktop
+            // OS. Windows .dll and macOS .jnilib cannot be loaded on Android by any code path,
+            // and no Linux or Android tcnative build is present, so netty already falls back to
+            // the JDK TLS stack here. 9.6 MB of formats the platform cannot read.
+            excludes.add("META-INF/native/*.dll")
+            excludes.add("META-INF/native/*.jnilib")
+
             pickFirsts.add("**/protobuf/**/*.class")
             pickFirsts +=
                 listOf(

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    `kotlin-dsl`
+    alias(libs.plugins.ktlint)
+}
+
+// Mirrors the root build's ktlint setup so the plugin sources are held to the same style.
+// build-logic is a separate build, so the root ktlintCheck/ktlintFormat tasks delegate here
+// (see the root build.gradle.kts).
+ktlint {
+    version.set(
+        libs.versions.ktlint.cli
+            .get(),
+    )
+    verbose.set(true)
+    outputToConsole.set(true)
+    outputColorName.set("RED")
+    ignoreFailures.set(false)
+}
+
+dependencies {
+    // compileOnly: AGP is already on the consuming build's classpath, and a second copy here
+    // would load the Variant API through a different classloader.
+    compileOnly("com.android.tools.build:gradle-api:${libs.versions.agp.get()}")
+}
+
+gradlePlugin {
+    plugins {
+        create("appArtifacts") {
+            id = "network.bisq.mobile.app-artifacts"
+            implementationClass = "network.bisq.gradle.AppArtifactsPlugin"
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,20 @@
+dependencyResolutionManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
+++ b/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
@@ -1,0 +1,187 @@
+package network.bisq.gradle
+
+import com.android.build.api.artifact.ArtifactTransformationRequest
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.FilterConfiguration.FilterType
+import com.android.build.gradle.AppPlugin
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.plugins.BasePluginExtension
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+/**
+ * Shared packaging rules for the two Bisq apps.
+ *
+ * Names the release artifacts from one product name:
+ *  - APKs as `<Product_Name>-<versionName>-<abi>-<versionCode>.apk`
+ *  - the AAB (through `archivesName`) as `<ProductName>-<versionName>_<versionCode>`
+ *
+ * gives every ABI split of one build its own version code, and turns ABI splits off for bundle
+ * builds, which cannot be produced while they are on.
+ *
+ * Naming replaces the legacy `applicationVariants.all { outputs.all { outputFileName = ... } }`
+ * block, which AGP 9 removes along with `BaseVariantOutputImpl`. Public APIs only, so it compiles
+ * the same on AGP 8.13 and 9.x. It needs two halves because the new `VariantOutput` carries a
+ * version code but no file name: `onVariants` for the codes, an APK artifact transform for the
+ * names.
+ */
+class AppArtifactsPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("appArtifacts", AppArtifactsExtension::class.java)
+
+        project.plugins.withType(AppPlugin::class.java) {
+            val androidComponents =
+                project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
+
+            // archivesName is read when AGP creates the variants, so it has to be set before that.
+            androidComponents.finalizeDsl { dsl ->
+                val versionName = dsl.defaultConfig.versionName.orEmpty()
+                val versionCode = abiVersionCode(dsl.defaultConfig.versionCode ?: 0, null)
+                project.extensions.getByType(BasePluginExtension::class.java).archivesName.set(
+                    "${extension.productName.get().replace(" ", "")}-${versionName}_$versionCode",
+                )
+
+                // An AAB already carries every ABI and Play splits it server side, so per-ABI APKs
+                // are redundant there. AGP does not merely ignore them: with resource shrinking on,
+                // buildPreBundle fails with "Multiple shrunk-resources files found"
+                // (https://issuetracker.google.com/402800800). Requesting a bundle therefore drops
+                // the splits rather than the shrinker.
+                if (dsl.splits.abi.isEnable && project.isBundleRequested()) {
+                    dsl.splits.abi.isEnable = false
+                    project.logger.lifecycle(
+                        "ABI splits disabled for ${project.path}: incompatible with bundle tasks.",
+                    )
+                }
+            }
+
+            androidComponents.onVariants { variant ->
+                val baseVersionCode =
+                    variant.outputs
+                        .firstOrNull()
+                        ?.versionCode
+                        ?.orNull
+                if (baseVersionCode != null) {
+                    variant.outputs.forEach { output ->
+                        val abi = output.filters.firstOrNull { it.filterType == FilterType.ABI }?.identifier
+                        output.versionCode.set(abiVersionCode(baseVersionCode, abi))
+                    }
+                }
+
+                val suffix = variant.name.replaceFirstChar { it.uppercase() }
+                val renameTask =
+                    project.tasks.register<RenameApksTask>("renameApksFor$suffix") {
+                        baseName.set(extension.productName.map { it.replace(" ", "_") })
+                    }
+
+                val transformationRequest =
+                    variant.artifacts
+                        .use(renameTask)
+                        .wiredWithDirectories(RenameApksTask::apkFolder, RenameApksTask::renamedApkFolder)
+                        .toTransformMany(SingleArtifact.APK)
+
+                renameTask.configure { this.transformationRequest.set(transformationRequest) }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Leaves three digits of room under each release for per-ABI codes. Bumping a release
+         * therefore still outranks every ABI of the release before it.
+         */
+        private const val ABI_VERSION_CODE_MULTIPLIER = 1000
+
+        /**
+         * Ordinals are permanent: changing one rewrites the version code of an already published
+         * ABI. 0 stays reserved for the universal APK so the store always prefers an ABI-specific
+         * one when both match a device.
+         */
+        private val ABI_ORDINALS =
+            mapOf(
+                "armeabi-v7a" to 1,
+                "arm64-v8a" to 2,
+                "x86" to 3,
+                "x86_64" to 4,
+            )
+
+        private fun abiVersionCode(
+            baseVersionCode: Int,
+            abi: String?,
+        ): Int = baseVersionCode * ABI_VERSION_CODE_MULTIPLIER + (ABI_ORDINALS[abi] ?: 0)
+    }
+}
+
+// Splits are a DSL flag, decided long before the task graph exists, so the requested task names
+// are the only signal available. Gradle keys configuration cache entries on them, so branching
+// here stays cache-correct.
+private fun Project.isBundleRequested(): Boolean =
+    gradle.startParameter.taskNames.any {
+        it.substringAfterLast(':').startsWith("bundle", ignoreCase = true)
+    }
+
+interface AppArtifactsExtension {
+    /** Product name as written for humans, e.g. `Bisq Easy`. Spaces are stripped per artifact type. */
+    val productName: Property<String>
+}
+
+abstract class RenameApksTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val apkFolder: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val renamedApkFolder: DirectoryProperty
+
+    @get:Input
+    abstract val baseName: Property<String>
+
+    @get:Internal
+    abstract val transformationRequest: Property<ArtifactTransformationRequest<RenameApksTask>>
+
+    @TaskAction
+    fun rename() {
+        val outputDir = renamedApkFolder.get().asFile
+        val inputDir = apkFolder.get().asFile
+        outputDir.mkdirs()
+        // A version bump changes the file name, so the previous build's APKs would linger here.
+        // Guarded: AGP is free to hand this task the directory it also reads from.
+        if (outputDir.canonicalFile != inputDir.canonicalFile) {
+            outputDir.listFiles { file -> file.extension == "apk" }?.forEach { it.delete() }
+        }
+
+        transformationRequest.get().submit(this) { builtArtifact ->
+            val abi =
+                builtArtifact.filters
+                    .firstOrNull { it.filterType == FilterType.ABI }
+                    ?.identifier
+                    ?: UNIVERSAL_ABI
+            val name =
+                listOfNotNull(
+                    baseName.get(),
+                    builtArtifact.versionName?.takeIf { it.isNotBlank() },
+                    abi,
+                    builtArtifact.versionCode?.toString(),
+                ).joinToString("-", postfix = ".apk")
+
+            File(outputDir, name).also { target ->
+                File(builtArtifact.outputFile).copyTo(target, overwrite = true)
+            }
+        }
+    }
+
+    private companion object {
+        const val UNIVERSAL_ABI = "universal"
+    }
+}

--- a/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
+++ b/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
@@ -2,10 +2,12 @@ package network.bisq.gradle
 
 import com.android.build.api.artifact.ArtifactTransformationRequest
 import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.FilterConfiguration.FilterType
 import com.android.build.gradle.AppPlugin
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -20,6 +22,8 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.register
 import java.io.File
+import java.io.IOException
+import java.nio.file.Files
 
 /**
  * Shared packaging rules for the two Bisq apps.
@@ -28,8 +32,8 @@ import java.io.File
  *  - APKs as `<Product_Name>-<versionName>-<abi>-<versionCode>.apk`
  *  - the AAB (through `archivesName`) as `<ProductName>-<versionName>_<versionCode>`
  *
- * gives every ABI split of one build its own version code, and turns ABI splits off for bundle
- * builds, which cannot be produced while they are on.
+ * gives every ABI split of one build its own version code, and decides when per-ABI APKs are built
+ * at all (see [configureAbiSplits]).
  *
  * Naming replaces the legacy `applicationVariants.all { outputs.all { outputFileName = ... } }`
  * block, which AGP 9 removes along with `BaseVariantOutputImpl`. Public APIs only, so it compiles
@@ -53,17 +57,7 @@ class AppArtifactsPlugin : Plugin<Project> {
                     "${extension.productName.get().replace(" ", "")}-${versionName}_$versionCode",
                 )
 
-                // An AAB already carries every ABI and Play splits it server side, so per-ABI APKs
-                // are redundant there. AGP does not merely ignore them: with resource shrinking on,
-                // buildPreBundle fails with "Multiple shrunk-resources files found"
-                // (https://issuetracker.google.com/402800800). Requesting a bundle therefore drops
-                // the splits rather than the shrinker.
-                if (dsl.splits.abi.isEnable && project.isBundleRequested()) {
-                    dsl.splits.abi.isEnable = false
-                    project.logger.lifecycle(
-                        "ABI splits disabled for ${project.path}: incompatible with bundle tasks.",
-                    )
-                }
+                configureAbiSplits(project, dsl)
             }
 
             androidComponents.onVariants { variant ->
@@ -123,13 +117,112 @@ class AppArtifactsPlugin : Plugin<Project> {
     }
 }
 
-// Splits are a DSL flag, decided long before the task graph exists, so the requested task names
-// are the only signal available. Gradle keys configuration cache entries on them, so branching
-// here stays cache-correct.
-private fun Project.isBundleRequested(): Boolean =
-    gradle.startParameter.taskNames.any {
-        it.substringAfterLast(':').startsWith("bundle", ignoreCase = true)
+/**
+ * Decides whether this build produces per-ABI APKs.
+ *
+ * Splits multiply packaging work, so they are only earned by the artifacts that ship:
+ *  - `-PabiSplits=true|false` forces them on or off.
+ *  - Otherwise they are on only when the build packages a non-debug APK, so a plain
+ *    `assembleDebug` keeps the single universal APK it produced before this plugin existed.
+ *  - `-Pabi=arm64-v8a[,x86_64]` narrows the set and drops the universal APK, for when one
+ *    architecture is all you need.
+ *
+ * Bundles are a hard conflict rather than a preference: with resource shrinking on, asking for
+ * splits and a bundle in the same build fails inside AGP with "Multiple shrunk-resources files
+ * found" (https://issuetracker.google.com/402800800). Rather than silently dropping the per-ABI
+ * APKs from a release run, that combination stops the build and says how to split it in two.
+ */
+private fun configureAbiSplits(
+    project: Project,
+    dsl: ApplicationExtension,
+) {
+    val abi = dsl.splits.abi
+    if (!abi.isEnable) return
+
+    val forced =
+        project
+            .findProperty(ABI_SPLITS_PROPERTY)
+            ?.toString()
+            ?.toBooleanStrictOrNull()
+    val wanted = forced ?: project.packagesShippableApk()
+
+    if (!wanted) {
+        abi.isEnable = false
+        return
     }
+
+    val bundleTasks = project.requestedTasks().filter { it.startsWith("bundle", ignoreCase = true) }
+    if (bundleTasks.isNotEmpty()) {
+        throw GradleException(
+            "ABI splits and app bundles cannot be built in one invocation (AGP fails with " +
+                "\"Multiple shrunk-resources files found\", https://issuetracker.google.com/402800800).\n" +
+                "Run them separately, for ${project.path}:\n" +
+                "  ./gradlew ${project.path}:${bundleTasks.first()}\n" +
+                "  ./gradlew ${project.path}:assembleRelease\n" +
+                "or pass -P$ABI_SPLITS_PROPERTY=false to build both at once with a single universal APK.",
+        )
+    }
+
+    val requestedAbis =
+        project
+            .findProperty(ABI_PROPERTY)
+            ?.toString()
+            ?.split(',')
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
+    if (requestedAbis.isEmpty()) return
+
+    val unknown = requestedAbis - SUPPORTED_ABIS
+    if (unknown.isNotEmpty()) {
+        throw GradleException(
+            "Unknown ABI(s) in -P$ABI_PROPERTY: ${unknown.joinToString()}. " +
+                "Supported: ${SUPPORTED_ABIS.joinToString()}",
+        )
+    }
+    abi.reset()
+    abi.include(*requestedAbis.toTypedArray())
+    // One architecture was asked for, so the all-ABI fallback would just double the work.
+    abi.isUniversalApk = false
+    // Without a universal APK, AGP rejects any non-empty ndk abiFilters alongside split filters,
+    // even an identical set (ApplicationVariantFactory.checkSplitsConflicts). The split include
+    // list already restricts what is packaged, so hand that job over to it entirely.
+    dsl.defaultConfig.ndk.abiFilters
+        .clear()
+}
+
+/**
+ * Requested task names that apply to this project: either unqualified, so every project runs them,
+ * or explicitly addressed to this one. Without the path check, asking for
+ * `:apps:nodeApp:bundleRelease` would also reconfigure clientApp and report errors against it.
+ *
+ * Splits are a DSL flag, decided long before the task graph exists, so the requested task names are
+ * the only signal available. Gradle keys configuration cache entries on them, so branching here
+ * stays cache-correct.
+ */
+private fun Project.requestedTasks(): List<String> =
+    gradle.startParameter.taskNames.mapNotNull { requested ->
+        val separator = requested.lastIndexOf(':')
+        if (separator < 0) {
+            requested
+        } else {
+            val target = requested.take(separator).let { if (it.startsWith(":")) it else ":$it" }
+            requested.substring(separator + 1).takeIf { target == path }
+        }
+    }
+
+/** True when the build packages an APK that ships, i.e. an assemble/install of a non-debug variant. */
+private fun Project.packagesShippableApk(): Boolean =
+    requestedTasks().any { name ->
+        PACKAGING_TASK_PREFIXES.any { prefix -> name.startsWith(prefix, ignoreCase = true) } &&
+            !name.contains("debug", ignoreCase = true) &&
+            !name.contains("test", ignoreCase = true)
+    }
+
+private const val ABI_SPLITS_PROPERTY = "abiSplits"
+private const val ABI_PROPERTY = "abi"
+private val PACKAGING_TASK_PREFIXES = listOf("assemble", "package", "install")
+private val SUPPORTED_ABIS = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 
 interface AppArtifactsExtension {
     /** Product name as written for humans, e.g. `Bisq Easy`. Spaces are stripped per artifact type. */
@@ -176,8 +269,31 @@ abstract class RenameApksTask : DefaultTask() {
                 ).joinToString("-", postfix = ".apk")
 
             File(outputDir, name).also { target ->
-                File(builtArtifact.outputFile).copyTo(target, overwrite = true)
+                link(File(builtArtifact.outputFile), target)
             }
+        }
+    }
+
+    /**
+     * Hard link rather than copy. AGP has already written the packaged APK, and a release
+     * universal APK is ~100 MB, so copying every output again doubles the packaging IO for no
+     * gain. AGP replaces intermediates by rename rather than editing in place, so the link cannot
+     * be mutated behind the artifact. Falls back to a copy where links are unavailable, such as a
+     * build directory spanning filesystems or a filesystem without them.
+     */
+    private fun link(
+        source: File,
+        target: File,
+    ) {
+        target.delete()
+        try {
+            Files.createLink(target.toPath(), source.toPath())
+        } catch (e: IOException) {
+            logger.info("Hard link failed for ${target.name}, copying instead: ${e.message}")
+            source.copyTo(target, overwrite = true)
+        } catch (e: UnsupportedOperationException) {
+            logger.info("Hard links unsupported here, copying ${target.name} instead: ${e.message}")
+            source.copyTo(target, overwrite = true)
         }
     }
 

--- a/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
+++ b/build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt
@@ -125,7 +125,8 @@ class AppArtifactsPlugin : Plugin<Project> {
  *  - Otherwise they are on only when the build packages a non-debug APK, so a plain
  *    `assembleDebug` keeps the single universal APK it produced before this plugin existed.
  *  - `-Pabi=arm64-v8a[,x86_64]` narrows the set and drops the universal APK, for when one
- *    architecture is all you need.
+ *    architecture is all you need. Naming an ABI enables splits by itself, so it works on a debug
+ *    build too, unless `-PabiSplits=false` says otherwise.
  *
  * Bundles are a hard conflict rather than a preference: with resource shrinking on, asking for
  * splits and a bundle in the same build fails inside AGP with "Multiple shrunk-resources files
@@ -139,12 +140,30 @@ private fun configureAbiSplits(
     val abi = dsl.splits.abi
     if (!abi.isEnable) return
 
+    val requestedAbis =
+        project
+            .findProperty(ABI_PROPERTY)
+            ?.toString()
+            ?.split(',')
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
+    val unknown = requestedAbis - SUPPORTED_ABIS
+    if (unknown.isNotEmpty()) {
+        throw GradleException(
+            "Unknown ABI(s) in -P$ABI_PROPERTY: ${unknown.joinToString()}. " +
+                "Supported: ${SUPPORTED_ABIS.joinToString()}",
+        )
+    }
+
     val forced =
         project
             .findProperty(ABI_SPLITS_PROPERTY)
             ?.toString()
             ?.toBooleanStrictOrNull()
-    val wanted = forced ?: project.packagesShippableApk()
+    // Naming an ABI is itself a request for per-ABI APKs, so it enables splits on its own rather
+    // than being dropped on the floor by a debug build. An explicit -PabiSplits still wins.
+    val wanted = forced ?: (requestedAbis.isNotEmpty() || project.packagesShippableApk())
 
     if (!wanted) {
         abi.isEnable = false
@@ -163,23 +182,8 @@ private fun configureAbiSplits(
         )
     }
 
-    val requestedAbis =
-        project
-            .findProperty(ABI_PROPERTY)
-            ?.toString()
-            ?.split(',')
-            ?.map { it.trim() }
-            ?.filter { it.isNotEmpty() }
-            .orEmpty()
     if (requestedAbis.isEmpty()) return
 
-    val unknown = requestedAbis - SUPPORTED_ABIS
-    if (unknown.isNotEmpty()) {
-        throw GradleException(
-            "Unknown ABI(s) in -P$ABI_PROPERTY: ${unknown.joinToString()}. " +
-                "Supported: ${SUPPORTED_ABIS.joinToString()}",
-        )
-    }
     abi.reset()
     abi.include(*requestedAbis.toTypedArray())
     // One architecture was asked for, so the all-ABI fallback would just double the work.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,9 @@ buildscript {
     }
 }
 
-// ktlint version constant
-val ktlintVersion = "1.7.1"
+val ktlintVersion =
+    libs.versions.ktlint.cli
+        .get()
 
 // Convert ktlint version to IDE plugin format (e.g., "1.7.1" -> "V1_7_1")
 fun String.toKtlintIdeVersion(): String = "V${this.replace(".", "_")}"
@@ -392,6 +393,14 @@ tasks.register<VerifyKtlintIdePluginTask>("verifyKtlintIdePlugin") {
         ktlintPluginFile.set(pluginFile)
     }
     expectedVersion.set(ktlintVersion.toKtlintIdeVersion())
+}
+
+// build-logic is an included build, so its ktlint tasks are not picked up by a root
+// `./gradlew ktlintCheck`. Delegate explicitly, keeping CI and the pre-push hook honest.
+listOf("ktlintCheck", "ktlintFormat").forEach { taskName ->
+    tasks.named(taskName) {
+        dependsOn(gradle.includedBuild("build-logic").task(":$taskName"))
+    }
 }
 
 tasks.register<Exec>("ktlintFormatAndCheck") {

--- a/docs/android.md
+++ b/docs/android.md
@@ -43,7 +43,7 @@ To audit a build:
 
 ```bash
 ./gradlew :apps:clientApp:assembleDebug
-cd $(mktemp -d) && unzip -q <path-to>/Bisq_Connect-*-debug.apk 'classes*.dex'
+cd $(mktemp -d) && unzip -q <path-to>/Bisq_Connect-*-debug-universal-*.apk 'classes*.dex'
 grep -al 'java/time' classes*.dex   # then disassemble with build-tools/dexdump to find the owner
 ```
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -5,6 +5,27 @@ a dependency or an API call that assumes a modern JDK.
 
 ---
 
+## Release packaging
+
+ABI splits are enabled for release APKs ([build-logic/AppArtifactsPlugin](../build-logic/src/main/kotlin/network/bisq/gradle/AppArtifactsPlugin.kt)), and AGP cannot build split APKs and an app bundle in one invocation, so a release is two Gradle runs per app (`[type]` = `clientApp` | `nodeApp`):
+
+```bash
+./gradlew apps:[type]:clean apps:[type]:bundleRelease --info && ./gradlew apps:[type]:assembleRelease --info
+```
+
+`clean` belongs only to the first run — the second reuses the compiled code and just packages the APKs. Combining `bundleRelease` and `assembleRelease` in one invocation fails at configuration time with a message repeating the two commands above.
+
+Outputs:
+
+- `apps/[type]/build/outputs/bundle/release/` — one AAB for Google Play, carrying all four ABIs (Play derives per-device splits itself).
+- `apps/[type]/build/outputs/apk/release/` — five APKs for the GitHub release: `universal` plus one per ABI. All five are uploaded; the universal stays the sideloading default.
+
+Version codes are `base × 1000 + ABI ordinal` (universal = 0, then armeabi-v7a/arm64-v8a/x86/x86_64 = 1–4), where `base` is the app's version code from [gradle.properties](../gradle.properties). The ordinals are permanent — changing one would rewrite the version code of an already published ABI — and the scheme itself is one-way on Google Play, which only accepts increasing version codes.
+
+Escape hatches: `-PabiSplits=false` restores the previous single-universal-APK behaviour (and lets one invocation build APK + AAB together again); `-Pabi=arm64-v8a` builds just that split, debug builds included.
+
+---
+
 ## API floor per app
 
 | App | `minSdk` | Core library desugaring |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,9 @@ protobuf = "0.9.4"
 protob = "4.28.2"
 process-phoenix = "3.0.0"
 ktlint = "14.2.0"
+# ktlint CLI, distinct from the Gradle plugin above. Keep in sync with the IDE plugin
+# (Settings > Tools > ktlint); verifyKtlintIdePlugin checks that.
+ktlint-cli = "1.7.1"
 compose-rules = "0.4.28"
 
 # -------------------- Bisq Core Transitive Dependencies --------------------

--- a/scripts/keystore-matrix/run-all.sh
+++ b/scripts/keystore-matrix/run-all.sh
@@ -198,9 +198,25 @@ find_newest() {
   fi
 }
 
-find_apk() {
-  local app="$1" variant="$2"
-  find_newest "$ROOT/apps/${app}/build/outputs/apk/${variant}" "*.apk"
+# Every APK of one app/variant, sorted for a stable order. ABI splits make assemble*
+# emit one APK per ABI plus the universal, and all of them ship, so signing checks
+# have to cover all of them rather than whichever one happens to be newest.
+find_apks() {
+  local app="$1" variant="$2" dir
+  dir="$ROOT/apps/${app}/build/outputs/apk/${variant}"
+  [[ -d "$dir" ]] || return 0
+  find "$dir" -name "*.apk" -type f 2>/dev/null | sort
+}
+
+# bash 3.2 has neither mapfile nor namerefs, so results land in this shared array.
+# Read APKS straight after the call, before anything else can overwrite it.
+APKS=()
+collect_apks() {
+  local line
+  APKS=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && APKS+=("$line")
+  done < <(find_apks "$1" "$2")
 }
 
 find_aab() {
@@ -221,6 +237,18 @@ wipe_packaging_outputs() {
 cert_cn() {
   local apk="$1"
   "$APKSIGNER" verify --print-certs "$apk" 2>/dev/null | grep -m1 "DN:" || true
+}
+
+# Distinct signer DNs across the given APKs. Fails outright if any APK has no
+# readable DN, so a caller cannot mistake a partial read for a clean result.
+cert_cns() {
+  local apk dn out=""
+  for apk in "$@"; do
+    dn="$(cert_cn "$apk")"
+    [[ -n "$dn" ]] || return 1
+    out+="${dn}"$'\n'
+  done
+  printf '%s' "$out" | sort -u
 }
 
 SIGNING_FAIL_RE='Failed to read key|Keystore was tampered|Cannot recover key|No key with alias|password was incorrect|given final block not properly padded'
@@ -293,12 +321,12 @@ judge() {
       if [[ $exitc -ne 0 ]]; then
         verdict=FAIL
       else
-        local apk cn=""
-        apk="$(find_apk nodeApp profile)"
-        [[ -n "$apk" ]] && cn="$(cert_cn "$apk")"
-        if [[ -z "$apk" || -z "$cn" ]]; then
+        # No split may carry the release cert: profile has to fall back to debug.
+        local cns
+        collect_apks nodeApp profile
+        if [[ ${#APKS[@]} -eq 0 ]] || ! cns="$(cert_cns "${APKS[@]}")"; then
           verdict=FAIL
-        elif echo "$cn" | grep -q "CN=PR1747 Review"; then
+        elif echo "$cns" | grep -q "CN=PR1747 Review"; then
           verdict=FAIL
         else
           verdict=PASS
@@ -309,14 +337,15 @@ judge() {
       if [[ $exitc -ne 0 ]]; then
         verdict=FAIL
       else
-        local apk
-        apk="$(find_apk nodeApp profile)"
-        if [[ -z "$apk" ]]; then
+        # Mirror image: every split has to carry the release cert, not just one.
+        local cns
+        collect_apks nodeApp profile
+        if [[ ${#APKS[@]} -eq 0 ]] || ! cns="$(cert_cns "${APKS[@]}")"; then
           verdict=FAIL
-        elif echo "$(cert_cn "$apk")" | grep -q "CN=PR1747 Review"; then
-          verdict=PASS
+        elif echo "$cns" | grep -qv "CN=PR1747 Review"; then
+          verdict=FAIL
         else
-          verdict=FAIL
+          verdict=PASS
         fi
       fi
       ;;
@@ -414,9 +443,12 @@ run_case() {
   notes="${notes};${err:0:350}"
 
   if [[ "$expected" == success-debug-signed || "$expected" == success-release-signed ]]; then
-    local apk
-    apk="$(find_apk nodeApp profile)"
-    notes="${notes};apk=${apk:-none};cn=$(cert_cn "${apk:-/dev/null}" | tr '\n' ' ')"
+    local cns=""
+    collect_apks nodeApp profile
+    if [[ ${#APKS[@]} -gt 0 ]]; then
+      cns="$(cert_cns "${APKS[@]}" || true)"
+    fi
+    notes="${notes};apks=${#APKS[@]};cn=$(printf '%s' "$cns" | tr '\n' ' ')"
   fi
 
   local verdict
@@ -466,13 +498,27 @@ verify_signed() {
   local log="$LOGDIR/${id}.log"
   local artifact="" cn="" verdict=FAIL notes="" verc=""
   if [[ "$kind" == apk ]]; then
-    artifact="$(find_apk "$app" release)"
-    if [[ -n "$artifact" ]]; then
-      "$APKSIGNER" verify --print-certs "$artifact" >"$log" 2>&1
-      verc=$?
+    collect_apks "$app" release
+    if [[ ${#APKS[@]} -gt 0 ]]; then
+      # Each ABI split is packaged separately, so each is verified separately and
+      # all of them have to pass. The log keeps the per-APK output.
+      local apk out rc ok=0
+      : >"$log"
+      for apk in "${APKS[@]}"; do
+        out="$("$APKSIGNER" verify --print-certs "$apk" 2>&1)"
+        rc=$?
+        printf '== %s (exit %s)\n%s\n' "$apk" "$rc" "$out" >>"$log"
+        if [[ $rc -eq 0 ]] && printf '%s' "$out" | grep -q "DN:.*CN=PR1747 Review"; then
+          ok=$((ok + 1))
+        fi
+      done
+      artifact="${ok}/${#APKS[@]} apk"
       cn=$(grep -m1 "DN:" "$log" || true)
-      if [[ $verc -eq 0 ]] && echo "$cn" | grep -q "CN=PR1747 Review"; then
+      if [[ $ok -eq ${#APKS[@]} ]]; then
+        verc=0
         verdict=PASS
+      else
+        verc=1
       fi
     else
       echo "no apk" >"$log"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {


### PR DESCRIPTION
closes https://github.com/bisq-network/bisq-mobile/issues/569

Size effect on release: Bisq Connect drops from 40.0 MB universal to 22.1 MB for arm64-v8a; Bisq Easy from 96.9 MB to 79.0 MB (smaller proportional win, since the bisq2 dex dominates there).

a surprise that I discovered during this investigation: Official node app release is bundling a macOS specific tor artifact, adding 18.6 MB unnecessarily to the package
I have applied a fix on this PR for it too, but it needs checking on mac builds. this is why the official release is 114MB and not the 96.9 MB reported here

notes:
- From next release after this PR, the version codes will jump from 32 and 50 to 32000 and 50000 for example, because the abi splitting needs predictable and dedicated version codes for clean distribution (32000 being universal and 32001, 32002, 32003, 32004 being the split apks)
- I included the connect app, because the numbers show it is significant enough that splitting is worth it in my opinion
- Also during the same investigation for MacOS binaries, found out that the apk includes netty native binaries for desktop OS, which is around 9.6MB uncompresed, the PR includes that fix too (~3.3 MB compressed, so Bisq Easy down to ~ 75 MB)
- I intentionally tried to avoid deprecated APIs that are removed in AGP 9, because a migration is in sight (#1682), hence the introduction of build-logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android builds now provide separate APKs for supported CPU architectures, along with a universal APK.
  * APK naming and versioning are standardized across app variants.
  * Release signing checks now verify every generated APK split.

* **Bug Fixes**
  * Android packages no longer include desktop-only or unsupported native binaries.

* **Documentation**
  * Updated Android packaging and verification instructions for split and universal APKs.

* **Chores**
  * Improved build formatting checks and centralized ktlint version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->