### PR TITLE
Release/anode 0.13.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.12.1
+node.android.version=0.13.0
 
 client.name=Bisq Connect
 client.android.version=0.8.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ android.enableJetifier=false
 shared.version=0.20.1
 
 node.name=Bisq Easy
-node.android.version=0.13.0
+node.android.version=0.13.1
 
 client.name=Bisq Connect
 client.android.version=0.8.3
@@ -44,7 +44,7 @@ client.ios.version=0.8.3
 ## Bump up after uploading to store for each build, and same with versioning above
 client.ios.version.code=50
 client.android.version.code=32
-node.android.version.code=50
+node.android.version.code=51
 
 # Logging
 


### PR DESCRIPTION
 - contribs to #1818 
 - bumped versions marking release for tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android Node component to version 0.13.1.
  * Incremented the Android Node version code to 51.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->