### PR TITLE
fix: hold cold-start deep links until the app reaches the main screen

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacadeTest.kt
@@ -4,20 +4,27 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.serialization.json.Json
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketEvent
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
 import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Covers the TRADE_CHAT_MESSAGES and CHAT_REACTIONS subscription collectors of
@@ -31,14 +38,22 @@ class ClientTradeChatMessagesServiceFacadeTest : ClientKoinIntegrationTestBase()
     private val userProfileServiceFacade: UserProfileServiceFacade = mockk(relaxed = true)
     private val apiGateway: TradeChatMessagesApiGateway = mockk(relaxed = true)
     private val globalUiManager: GlobalUiManager = mockk(relaxed = true)
+    private val webSocketClientService: WebSocketClientService = mockk(relaxed = true)
+    private val failedSubscriptionTopics = MutableStateFlow<Set<Topic>>(emptySet())
     private val json = Json { ignoreUnknownKeys = true }
     private val openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
+    private val selectedUserProfile = MutableStateFlow<UserProfileVO?>(null)
+    private val tradeChatsObserver = WebSocketEventObserver()
+    private val chatReactionsObserver = WebSocketEventObserver()
     private lateinit var facade: ClientTradeChatMessagesServiceFacade
 
     override fun onSetup() {
         every { tradesServiceFacade.openTradeItems } returns openTradeItems
         every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
-        every { userProfileServiceFacade.selectedUserProfile } returns MutableStateFlow(null)
+        every { userProfileServiceFacade.selectedUserProfile } returns selectedUserProfile
+        every { webSocketClientService.failedSubscriptionTopics } returns failedSubscriptionTopics
+        coEvery { apiGateway.subscribeTradeChats() } returns tradeChatsObserver
+        coEvery { apiGateway.subscribeChatReactions() } returns chatReactionsObserver
         facade =
             ClientTradeChatMessagesServiceFacade(
                 tradesServiceFacade,
@@ -46,15 +61,95 @@ class ClientTradeChatMessagesServiceFacadeTest : ClientKoinIntegrationTestBase()
                 apiGateway,
                 json,
                 globalUiManager,
+                webSocketClientService,
             )
     }
+
+    /** A subscribe that failed is only retried on the next reconnect, so a wait on the sync has to be told. */
+    @Test
+    fun `a failed chat subscription is reported until a reconnect clears it`() =
+        runTest {
+            facade.activate()
+            advanceUntilIdle()
+            assertFalse(facade.chatMessagesSyncFailed.value)
+
+            failedSubscriptionTopics.value = setOf(Topic.TRADE_CHAT_MESSAGES)
+            advanceUntilIdle()
+            assertTrue(facade.chatMessagesSyncFailed.value)
+
+            failedSubscriptionTopics.value = emptySet()
+            advanceUntilIdle()
+            assertFalse(facade.chatMessagesSyncFailed.value)
+
+            facade.deactivate()
+        }
+
+    private var dispatchersMocked = false
+
+    /**
+     * Routes the profile collector, which runs on Dispatchers.Default in production, onto the test
+     * dispatcher so the synced flag it drives can be asserted on. Base already set Main. Only for
+     * the tests that need it, and after every coEvery/coVerify of the test: a suspend recording made
+     * while Dispatchers is mocked picks up the Dispatchers.Default read its coroutine runner makes.
+     */
+    private fun routeDefaultDispatcherOntoTestDispatcher() {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.Default } returns testDispatcher
+        dispatchersMocked = true
+    }
+
+    override fun onTearDown() {
+        try {
+            if (dispatchersMocked) unmockkStatic(Dispatchers::class)
+        } finally {
+            super.onTearDown()
+        }
+    }
+
+    /**
+     * On a cold start over Tor the snapshot can land before the user profile, and without the profile
+     * it cannot be applied to any channel, so an empty channel still says nothing until both are in.
+     */
+    @Test
+    fun `chat messages sync once both the snapshot and the user profile are in`() =
+        runTest {
+            routeDefaultDispatcherOntoTestDispatcher()
+            facade.activate()
+            openTradeItems.value = listOf(mockk(relaxed = true))
+            advanceUntilIdle()
+
+            tradeChatsObserver.setEvent(tradeChatSnapshot())
+            advanceUntilIdle()
+            assertFalse(facade.chatMessagesSynced.value, "The snapshot could not be applied without the profile")
+
+            selectedUserProfile.value = mockk()
+            advanceUntilIdle()
+            assertTrue(facade.chatMessagesSynced.value)
+
+            facade.deactivate()
+            assertFalse(facade.chatMessagesSynced.value)
+        }
+
+    @Test
+    fun `chat messages sync when the snapshot lands after the user profile`() =
+        runTest {
+            selectedUserProfile.value = mockk()
+            routeDefaultDispatcherOntoTestDispatcher()
+            facade.activate()
+            openTradeItems.value = listOf(mockk(relaxed = true))
+            advanceUntilIdle()
+            assertFalse(facade.chatMessagesSynced.value, "Nothing has been delivered yet")
+
+            tradeChatsObserver.setEvent(tradeChatSnapshot())
+            advanceUntilIdle()
+
+            assertTrue(facade.chatMessagesSynced.value)
+            facade.deactivate()
+        }
 
     @Test
     fun `trade chats subscription waits for the first open trade and then collects events`() =
         runTest {
-            val observer = WebSocketEventObserver()
-            coEvery { apiGateway.subscribeTradeChats() } returns observer
-
             facade.activate()
             advanceUntilIdle()
             coVerify(exactly = 0) { apiGateway.subscribeTradeChats() }
@@ -63,26 +158,24 @@ class ClientTradeChatMessagesServiceFacadeTest : ClientKoinIntegrationTestBase()
             advanceUntilIdle()
             coVerify(exactly = 1) { apiGateway.subscribeTradeChats() }
 
-            observer.setEvent(
-                WebSocketEvent(
-                    topic = Topic.TRADE_CHAT_MESSAGES,
-                    subscriberId = "trade-chat-test",
-                    deferredPayload = "[]",
-                    modificationType = ModificationType.REPLACE,
-                    sequenceNumber = 1,
-                ),
-            )
+            tradeChatsObserver.setEvent(tradeChatSnapshot())
             advanceUntilIdle()
 
             facade.deactivate()
         }
 
+    private fun tradeChatSnapshot() =
+        WebSocketEvent(
+            topic = Topic.TRADE_CHAT_MESSAGES,
+            subscriberId = "trade-chat-test",
+            deferredPayload = "[]",
+            modificationType = ModificationType.REPLACE,
+            sequenceNumber = 1,
+        )
+
     @Test
     fun `chat reactions subscription waits for the first open trade and then collects events`() =
         runTest {
-            val observer = WebSocketEventObserver()
-            coEvery { apiGateway.subscribeChatReactions() } returns observer
-
             facade.activate()
             advanceUntilIdle()
             coVerify(exactly = 0) { apiGateway.subscribeChatReactions() }
@@ -91,7 +184,7 @@ class ClientTradeChatMessagesServiceFacadeTest : ClientKoinIntegrationTestBase()
             advanceUntilIdle()
             coVerify(exactly = 1) { apiGateway.subscribeChatReactions() }
 
-            observer.setEvent(
+            chatReactionsObserver.setEvent(
                 WebSocketEvent(
                     topic = Topic.CHAT_REACTIONS,
                     subscriberId = "chat-reactions-test",

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
@@ -17,6 +18,7 @@ import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -39,6 +41,25 @@ class ClientTradesServiceFacadeTest : ClientKoinIntegrationTestBase() {
         analyticsService = mockk(relaxed = true)
         facade = ClientTradesServiceFacade(apiGateway, webSocketClientService, Json, globalUiManager, analyticsService, mockk(relaxed = true))
     }
+
+    @Test
+    fun `a trades snapshot marks the open trades as synced`() =
+        runTest {
+            assertFalse(facade.openTradesSynced.value, "Nothing has been delivered yet")
+
+            // The snapshot the node sends on subscribe, empty here because only the flag is under test.
+            facade.handleTradeItemPresentationChange(emptyList(), ModificationType.REPLACE)
+
+            assertTrue(facade.openTradesSynced.value)
+        }
+
+    @Test
+    fun `an incremental trades update does not mark the open trades as synced`() =
+        runTest {
+            facade.handleTradeItemPresentationChange(emptyList(), ModificationType.ADDED)
+
+            assertFalse(facade.openTradesSynced.value, "Only the snapshot is authoritative about absence")
+        }
 
     @Test
     fun `takeOffer success tracks Taken`() =

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacadeTest.kt
@@ -1,22 +1,28 @@
 package network.bisq.mobile.client.common.domain.service.trades
 
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.client.common.domain.websocket.subscription.ModificationType
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.domain.websocket.subscription.WebSocketEventObserver
 import network.bisq.mobile.client.common.test_utils.ClientKoinIntegrationTestBase
 import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
 import network.bisq.mobile.i18n.I18nSupport
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -59,6 +65,50 @@ class ClientTradesServiceFacadeTest : ClientKoinIntegrationTestBase() {
             facade.handleTradeItemPresentationChange(emptyList(), ModificationType.ADDED)
 
             assertFalse(facade.openTradesSynced.value, "Only the snapshot is authoritative about absence")
+        }
+
+    /** A subscribe that failed is only retried on the next reconnect, so a wait on the sync has to be told. */
+    @Test
+    fun `a failed trades subscription is reported until a reconnect clears it`() =
+        runTest {
+            val failedTopics = MutableStateFlow<Set<Topic>>(emptySet())
+            every { webSocketClientService.failedSubscriptionTopics } returns failedTopics
+            coEvery { webSocketClientService.subscribe(any(), any()) } returns WebSocketEventObserver()
+            facade.activate()
+            runCurrent()
+            assertFalse(facade.openTradesSyncFailed.value)
+
+            failedTopics.value = setOf(Topic.TRADES)
+            runCurrent()
+            assertTrue(facade.openTradesSyncFailed.value)
+
+            failedTopics.value = emptySet()
+            runCurrent()
+            assertFalse(facade.openTradesSyncFailed.value)
+
+            facade.deactivate()
+        }
+
+    /** After re-pairing, a deep link must resolve against the new session, not the previous one's trades. */
+    @Test
+    fun `deactivate drops the open trades together with the synced flag`() =
+        runTest {
+            mockkStatic(TRADE_ITEM_PRESENTATION_DTO_MAPPING_CLASS)
+            try {
+                val trade = mockk<TradeItemPresentationModel>(relaxed = true)
+                every { trade.tradeId } returns "trade-1"
+                every { any<TradeItemPresentationDto>().toDomain() } returns trade
+                facade.handleTradeItemPresentationChange(listOf(mockk()), ModificationType.REPLACE)
+                assertEquals(listOf("trade-1"), facade.openTradeItems.value.map { it.tradeId })
+                assertTrue(facade.openTradesSynced.value)
+
+                facade.deactivate()
+
+                assertTrue(facade.openTradeItems.value.isEmpty())
+                assertFalse(facade.openTradesSynced.value)
+            } finally {
+                unmockkStatic(TRADE_ITEM_PRESENTATION_DTO_MAPPING_CLASS)
+            }
         }
 
     @Test
@@ -214,4 +264,10 @@ class ClientTradesServiceFacadeTest : ClientKoinIntegrationTestBase() {
             assertFailsWith<IllegalArgumentException> { facade.rejectTrade() }
             assertFailsWith<IllegalArgumentException> { facade.cancelTrade() }
         }
+
+    private companion object {
+        /** JVM file class holding the `TradeItemPresentationDto.toDomain` extension. */
+        const val TRADE_ITEM_PRESENTATION_DTO_MAPPING_CLASS =
+            "network.bisq.mobile.client.common.domain.service.trades.TradeItemPresentationDtoMappingKt"
+    }
 }

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.kt
@@ -420,6 +420,7 @@ val clientDomainModule =
                 get(),
                 get(),
                 get(),
+                get(), // webSocketClientService
             )
         }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -40,6 +41,9 @@ class ClientTradeChatMessagesServiceFacade(
     private val allChatReactions: MutableStateFlow<Set<BisqEasyOpenTradeMessageReaction>> =
         MutableStateFlow(emptySet())
 
+    private val _chatMessagesSynced = MutableStateFlow(false)
+    override val chatMessagesSynced: StateFlow<Boolean> = _chatMessagesSynced.asStateFlow()
+
     // Misc
     override suspend fun activate() {
         super<ServiceFacade>.activate()
@@ -68,6 +72,7 @@ class ClientTradeChatMessagesServiceFacade(
     }
 
     override suspend fun deactivate() {
+        _chatMessagesSynced.value = false
         super<ServiceFacade>.deactivate()
     }
 
@@ -82,6 +87,9 @@ class ClientTradeChatMessagesServiceFacade(
             updatedTradeIds.forEach { tradeId ->
                 updateChatMessages(tradeId)
             }
+            // Set after the channels are updated: the first payload is the node's snapshot, so from
+            // here a channel with no messages is empty rather than still loading.
+            _chatMessagesSynced.value = true
         }
     }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/chat/trade/ClientTradeChatMessagesServiceFacade.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.client.common.domain.service.chat.trade
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.util.notifyIfDemoModeRestricted
+import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
+import network.bisq.mobile.client.common.domain.websocket.subscription.Topic
 import network.bisq.mobile.client.common.domain.websocket.subscription.collectPayloads
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
@@ -22,6 +26,7 @@ import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacad
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import kotlin.concurrent.Volatile
 
 class ClientTradeChatMessagesServiceFacade(
     private val tradesServiceFacade: TradesServiceFacade,
@@ -29,6 +34,7 @@ class ClientTradeChatMessagesServiceFacade(
     private val apiGateway: TradeChatMessagesApiGateway,
     private val json: Json,
     private val globalUiManager: GlobalUiManager,
+    private val webSocketClientService: WebSocketClientService,
 ) : ServiceFacade(),
     TradeChatMessagesServiceFacade {
     // Properties
@@ -41,8 +47,19 @@ class ClientTradeChatMessagesServiceFacade(
     private val allChatReactions: MutableStateFlow<Set<BisqEasyOpenTradeMessageReaction>> =
         MutableStateFlow(emptySet())
 
+    // The first TRADE_CHAT_MESSAGES payload is the node's snapshot, but applying it needs the user
+    // profile as well: updateChatMessages skips every channel until the profile lands, which on a cold
+    // start over Tor can be after the snapshot. Synced is the two together, re-evaluated by whichever
+    // arrives second.
+    @Volatile
+    private var chatMessagesSnapshotReceived = false
     private val _chatMessagesSynced = MutableStateFlow(false)
     override val chatMessagesSynced: StateFlow<Boolean> = _chatMessagesSynced.asStateFlow()
+
+    private val _chatMessagesSyncFailed = MutableStateFlow(false)
+    override val chatMessagesSyncFailed: StateFlow<Boolean> = _chatMessagesSyncFailed.asStateFlow()
+
+    private var tradeChatsJob: Job? = null
 
     // Misc
     override suspend fun activate() {
@@ -61,19 +78,34 @@ class ClientTradeChatMessagesServiceFacade(
                 if (tradeId != null) {
                     updateChatMessages(tradeId = tradeId)
                 }
+                updateChatMessagesSynced()
             }
         }
-        serviceScope.launch {
-            subscribeTradeChats()
-        }
+        tradeChatsJob =
+            serviceScope.launch {
+                subscribeTradeChats()
+            }
         serviceScope.launch {
             subscribeChatReactions()
+        }
+        // A subscribe that failed is only retried on the next reconnect, so until then the snapshot is
+        // not coming and a wait on it has to be told rather than left spinning.
+        serviceScope.launch {
+            webSocketClientService.failedSubscriptionTopics.collect { failed ->
+                _chatMessagesSyncFailed.value = Topic.TRADE_CHAT_MESSAGES in failed
+            }
         }
     }
 
     override suspend fun deactivate() {
+        // Joined, not just cancelled: a payload the collector is still applying would otherwise flip
+        // the flags back after the reset, on a facade that is gone.
+        tradeChatsJob?.cancelAndJoin()
+        tradeChatsJob = null
+        chatMessagesSnapshotReceived = false
         _chatMessagesSynced.value = false
         super<ServiceFacade>.deactivate()
+        _chatMessagesSyncFailed.value = false
     }
 
     private suspend fun subscribeTradeChats() {
@@ -87,10 +119,15 @@ class ClientTradeChatMessagesServiceFacade(
             updatedTradeIds.forEach { tradeId ->
                 updateChatMessages(tradeId)
             }
-            // Set after the channels are updated: the first payload is the node's snapshot, so from
-            // here a channel with no messages is empty rather than still loading.
-            _chatMessagesSynced.value = true
+            // After the channels are updated, so a channel with no messages is empty rather than still
+            // loading by the time synced reads true.
+            chatMessagesSnapshotReceived = true
+            updateChatMessagesSynced()
         }
+    }
+
+    private fun updateChatMessagesSynced() {
+        _chatMessagesSynced.value = chatMessagesSnapshotReceived && selectedUserProfileId.value != null
     }
 
     private suspend fun subscribeChatReactions() {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.service.trades
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -106,6 +107,7 @@ class ClientTradesServiceFacade(
     }
 
     override suspend fun deactivate() {
+        setOpenTradesSynced(false)
         openTradesSubscription.dispose()
         closedTradesSubscription.dispose()
         tradePropertiesSubscription.dispose()
@@ -255,7 +257,10 @@ class ClientTradesServiceFacade(
             }
 
     // Private
-    private fun handleTradeItemPresentationChange(
+
+    /** internal (not private) to expose the snapshot/increment handling as a same-module unit-test seam. */
+    @VisibleForTesting
+    internal fun handleTradeItemPresentationChange(
         payload: List<TradeItemPresentationDto>,
         modificationType: ModificationType,
     ) {
@@ -267,6 +272,8 @@ class ClientTradesServiceFacade(
                     applyPendingTradeProperties(tradeModel)
                 }
                 _openTradeItems.value = newTrades
+                // The snapshot is the whole truth, so from here a missing trade is a trade that is gone.
+                setOpenTradesSynced(true)
             }
 
             ModificationType.ADDED -> {

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/service/trades/ClientTradesServiceFacade.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.data.mapping.trade.toClosedTradeListItem
 import network.bisq.mobile.client.common.domain.util.notifyIfDemoModeRestricted
@@ -52,7 +53,7 @@ import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
  */
 class ClientTradesServiceFacade(
     private val apiGateway: TradesApiGateway,
-    webSocketClientService: WebSocketClientService,
+    private val webSocketClientService: WebSocketClientService,
     json: Json,
     private val globalUiManager: GlobalUiManager,
     analyticsService: AnalyticsService,
@@ -103,16 +104,31 @@ class ClientTradesServiceFacade(
         closedTradesSubscription.subscribe()
         tradePropertiesSubscription.subscribe()
 
+        // A TRADES subscribe that failed is only retried on the next reconnect, so until then the
+        // snapshot is not coming and a wait on it has to be told rather than left spinning.
+        serviceScope.launch {
+            webSocketClientService.failedSubscriptionTopics.collect { failed ->
+                setOpenTradesSyncFailed(Topic.TRADES in failed)
+            }
+        }
+
         observeTradesForAnalytics()
     }
 
     override suspend fun deactivate() {
-        setOpenTradesSynced(false)
+        // Subscriptions first: dispose() joins their collectors, so no snapshot can land after the reset
+        // below and flip synced back on a facade that is gone. The session state is cleared like the
+        // node does, or a deep link after re-pairing would resolve against the previous session's trades.
         openTradesSubscription.dispose()
         closedTradesSubscription.dispose()
         tradePropertiesSubscription.dispose()
+        setOpenTradesSynced(false)
+        _openTradeItems.value = emptyList()
+        _selectedTrade.value = null
+        pendingTradeProperties.clear()
 
         super.deactivate()
+        setOpenTradesSyncFailed(false)
     }
 
     // API

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/websocket/subscription/Subscription.kt
@@ -3,7 +3,10 @@ package network.bisq.mobile.client.common.domain.websocket.subscription
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.common.domain.websocket.WebSocketClientService
 import network.bisq.mobile.domain.utils.Logging
@@ -35,8 +38,16 @@ class Subscription<T>(
             }
     }
 
-    fun dispose() {
-        job?.cancel()
+    /**
+     * Cancels the collector and waits for it: the handler runs on Dispatchers.Default, so a payload it is
+     * still applying would otherwise land after the owner has reset the state it feeds. The wait is not
+     * cancellable so a deactivation that is itself cancelled still leaves the owner fully disposed; it is
+     * short, since every suspension point in the collector answers the cancel at once.
+     */
+    suspend fun dispose() {
+        withContext(NonCancellable) {
+            job?.cancelAndJoin()
+        }
         job = null
     }
 }

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
@@ -9,7 +9,9 @@ import bisq.user.profile.UserProfile
 import bisq.user.profile.UserProfileService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -55,6 +57,9 @@ class NodeTradeChatMessagesServiceFacade(
     private val selectedTrade: StateFlow<TradeItemPresentationModel?> get() = tradesServiceFacade.selectedTrade
     private val openTradeItems: StateFlow<List<TradeItemPresentationModel>> get() = tradesServiceFacade.openTradeItems
 
+    private val _chatMessagesSynced = MutableStateFlow(false)
+    override val chatMessagesSynced: StateFlow<Boolean> = _chatMessagesSynced.asStateFlow()
+
     // Misc
     private var channelsPin: Pin? = null
     private val reactionsPinByMessageId: MutableMap<String, Pin> = mutableMapOf()
@@ -81,9 +86,14 @@ class NodeTradeChatMessagesServiceFacade(
                     }
                 },
             )
+
+        // The observer replays the existing channels while binding, and their messages come from the
+        // embedded node's own store, so there is nothing left in flight once activate() returns.
+        _chatMessagesSynced.value = true
     }
 
     override suspend fun deactivate() {
+        _chatMessagesSynced.value = false
         channelsPin?.unbind()
 
         unbindAllReactionsPins()

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacade.kt
@@ -60,6 +60,9 @@ class NodeTradeChatMessagesServiceFacade(
     private val _chatMessagesSynced = MutableStateFlow(false)
     override val chatMessagesSynced: StateFlow<Boolean> = _chatMessagesSynced.asStateFlow()
 
+    // The embedded node's own store never fails to deliver.
+    override val chatMessagesSyncFailed: StateFlow<Boolean> = MutableStateFlow(false)
+
     // Misc
     private var channelsPin: Pin? = null
     private val reactionsPinByMessageId: MutableMap<String, Pin> = mutableMapOf()

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacade.kt
@@ -180,9 +180,14 @@ class NodeTradesServiceFacade(
                     }
                 },
             )
+
+        // Both observers replay the existing collection while binding, so the open trades are complete
+        // by the time activate() returns.
+        setOpenTradesSynced(true)
     }
 
     override suspend fun deactivate() {
+        setOpenTradesSynced(false)
         channelsPin?.unbind()
         tradesPin?.unbind()
 

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacadeTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/chat/trade/NodeTradeChatMessagesServiceFacadeTest.kt
@@ -54,6 +54,7 @@ import org.junit.Test
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel as Bisq2BisqEasyOpenTradeChannel
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage as Bisq2BisqEasyOpenTradeMessage
@@ -140,6 +141,22 @@ class NodeTradeChatMessagesServiceFacadeTest : NodeKoinIntegrationTestBase() {
             super.onTearDown()
         }
     }
+
+    /**
+     * The trade chat screen's spinner waits on this flag. It rests on the channel observer replaying
+     * the existing channels while binding; the replay itself is pinned by `NodeTradesServiceFacadeTest`.
+     */
+    @Test
+    fun `chat messages are marked synced once activate returns`() =
+        runTest {
+            assertFalse(facade.chatMessagesSynced.value, "Nothing has been delivered yet")
+
+            facade.activate()
+            assertTrue(facade.chatMessagesSynced.value)
+
+            facade.deactivate()
+            assertFalse(facade.chatMessagesSynced.value)
+        }
 
     @Test
     fun `onAllAdded loads visible messages and skips TAKE_BISQ_EASY_OFFER`() =

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacadeTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/trades/NodeTradesServiceFacadeTest.kt
@@ -1,0 +1,100 @@
+package network.bisq.mobile.node.common.domain.service.trades
+
+import bisq.chat.ChatService
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService
+import bisq.common.observable.collection.ObservableSet
+import bisq.trade.TradeService
+import bisq.trade.bisq_easy.BisqEasyTrade
+import bisq.trade.bisq_easy.BisqEasyTradeService
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.node.common.domain.mapping.TradeItemPresentationModelFactory
+import network.bisq.mobile.node.common.domain.service.AndroidApplicationService
+import network.bisq.mobile.node.common.test_utils.NodeKoinIntegrationTestBase
+import org.junit.Test
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel as Bisq2BisqEasyOpenTradeChannel
+
+/**
+ * Pins the contract [NodeTradesServiceFacade.activate] rests on: Bisq 2 collection observers replay the
+ * existing elements synchronously while binding, so the open trades are complete, and can be marked
+ * synced, by the time activate() returns. A real [ObservableSet] stands in for the node's trades so an
+ * upstream change to that replay fails here instead of quietly reviving the cold-start race.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NodeTradesServiceFacadeTest : NodeKoinIntegrationTestBase() {
+    private val trades = ObservableSet<BisqEasyTrade>()
+    private val channelService: BisqEasyOpenTradeChannelService = mockk(relaxed = true)
+    private lateinit var facade: NodeTradesServiceFacade
+
+    override fun onSetup() {
+        val bisqEasyTradeService = mockk<BisqEasyTradeService>(relaxed = true)
+        every { bisqEasyTradeService.trades } returns trades
+        val tradeService = mockk<TradeService>()
+        every { tradeService.bisqEasyTradeService } returns bisqEasyTradeService
+        val chatService = mockk<ChatService>()
+        every { chatService.bisqEasyOpenTradeChannelService } returns channelService
+
+        val applicationService = mockk<AndroidApplicationService>(relaxed = true)
+        every { applicationService.tradeService } returns tradeService
+        every { applicationService.chatService } returns chatService
+        val provider = AndroidApplicationService.Provider()
+        provider.applicationService = applicationService
+
+        mockkObject(TradeItemPresentationModelFactory)
+        facade = NodeTradesServiceFacade(provider, mockk(relaxed = true), mockk(relaxed = true))
+    }
+
+    override fun onTearDown() {
+        try {
+            unmockkObject(TradeItemPresentationModelFactory)
+        } finally {
+            super.onTearDown()
+        }
+    }
+
+    @Test
+    fun `open trades the node already holds are complete and marked synced once activate returns`() =
+        runTest {
+            // A trade the node holds before the facade binds, as on every restart.
+            trades.add(givenOpenTrade(TRADE_ID))
+            assertFalse(facade.openTradesSynced.value, "Nothing has been delivered yet")
+
+            facade.activate()
+
+            assertEquals(listOf(TRADE_ID), facade.openTradeItems.value.map { it.tradeId })
+            assertTrue(facade.openTradesSynced.value)
+
+            // runCurrent, not advanceUntilIdle: activation starts the analytics out-of-sync recheck
+            // ticker, and an infinite ticker keeps the virtual-time scheduler busy forever.
+            runCurrent()
+            facade.deactivate()
+            assertFalse(facade.openTradesSynced.value)
+        }
+
+    private fun givenOpenTrade(tradeId: String): BisqEasyTrade {
+        val trade = mockk<BisqEasyTrade>(relaxed = true)
+        every { trade.id } returns tradeId
+        every { trade.tradeState } returns BisqEasyTradeState.INIT
+        val channel = mockk<Bisq2BisqEasyOpenTradeChannel>(relaxed = true)
+        every { channel.tradeId } returns tradeId
+        every { channelService.findChannelByTradeId(tradeId) } returns Optional.of(channel)
+        val item = mockk<TradeItemPresentationModel>(relaxed = true)
+        every { item.tradeId } returns tradeId
+        every { TradeItemPresentationModelFactory.create(trade, channel, any(), any()) } returns item
+        return trade
+    }
+
+    private companion object {
+        const val TRADE_ID = "trade-1"
+    }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/trades/SelectOpenTradeWhenSyncedTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/trades/SelectOpenTradeWhenSyncedTest.kt
@@ -1,0 +1,89 @@
+package network.bisq.mobile.data.service.trades
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SelectOpenTradeWhenSyncedTest {
+    private val tradeId = "tid"
+
+    /** Mimics a facade whose lookup only succeeds once the trade is in the open trades list. */
+    private fun facadeSyncing(
+        openTradeItems: MutableStateFlow<List<TradeItemPresentationModel>>,
+        openTradesSynced: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    ): TradesServiceFacade {
+        val selected = MutableStateFlow<TradeItemPresentationModel?>(null)
+        val facade = mockk<TradesServiceFacade>(relaxed = true)
+        every { facade.openTradeItems } returns openTradeItems
+        every { facade.openTradesSynced } returns openTradesSynced
+        every { facade.selectedTrade } returns selected
+        every { facade.selectOpenTrade(tradeId) } answers {
+            selected.value = openTradeItems.value.find { it.tradeId == tradeId }
+        }
+        return facade
+    }
+
+    private fun tradeItem(): TradeItemPresentationModel {
+        val trade = mockk<TradeItemPresentationModel>()
+        every { trade.tradeId } returns tradeId
+        return trade
+    }
+
+    @Test
+    fun `a trade already in the list resolves without waiting`() =
+        runTest {
+            val item = tradeItem()
+            val facade = facadeSyncing(MutableStateFlow(listOf(item)))
+
+            assertEquals(item, facade.selectOpenTradeWhenSynced(tradeId))
+        }
+
+    @Test
+    fun `a trade that arrives with a later sync update still resolves`() =
+        runTest {
+            val openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
+            val facade = facadeSyncing(openTradeItems)
+
+            val result = async { facade.selectOpenTradeWhenSynced(tradeId) }
+            runCurrent()
+
+            val item = tradeItem()
+            openTradeItems.value = listOf(item)
+
+            assertEquals(item, result.await())
+        }
+
+    @Test
+    fun `a trade missing from a synced list is reported as absent`() =
+        runTest {
+            val facade = facadeSyncing(MutableStateFlow(emptyList()), MutableStateFlow(true))
+
+            assertNull(facade.selectOpenTradeWhenSynced(tradeId))
+        }
+
+    @Test
+    fun `a trade missing while the list is still syncing is not reported as absent`() =
+        runTest {
+            val openTradesSynced = MutableStateFlow(false)
+            val facade = facadeSyncing(MutableStateFlow(emptyList()), openTradesSynced)
+
+            val result = async { facade.selectOpenTradeWhenSynced(tradeId) }
+            runCurrent()
+
+            assertTrue(result.isActive, "Still waiting for the open trades to sync")
+
+            openTradesSynced.value = true
+
+            assertNull(result.await())
+        }
+}

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/trades/SelectOpenTradeWhenSyncedTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/service/trades/SelectOpenTradeWhenSyncedTest.kt
@@ -2,6 +2,7 @@ package network.bisq.mobile.data.service.trades
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,35 +18,32 @@ import kotlin.test.assertTrue
 class SelectOpenTradeWhenSyncedTest {
     private val tradeId = "tid"
 
-    /** Mimics a facade whose lookup only succeeds once the trade is in the open trades list. */
     private fun facadeSyncing(
         openTradeItems: MutableStateFlow<List<TradeItemPresentationModel>>,
         openTradesSynced: MutableStateFlow<Boolean> = MutableStateFlow(false),
+        openTradesSyncFailed: MutableStateFlow<Boolean> = MutableStateFlow(false),
     ): TradesServiceFacade {
-        val selected = MutableStateFlow<TradeItemPresentationModel?>(null)
         val facade = mockk<TradesServiceFacade>(relaxed = true)
         every { facade.openTradeItems } returns openTradeItems
         every { facade.openTradesSynced } returns openTradesSynced
-        every { facade.selectedTrade } returns selected
-        every { facade.selectOpenTrade(tradeId) } answers {
-            selected.value = openTradeItems.value.find { it.tradeId == tradeId }
-        }
+        every { facade.openTradesSyncFailed } returns openTradesSyncFailed
         return facade
     }
 
-    private fun tradeItem(): TradeItemPresentationModel {
+    private fun tradeItem(id: String = tradeId): TradeItemPresentationModel {
         val trade = mockk<TradeItemPresentationModel>()
-        every { trade.tradeId } returns tradeId
+        every { trade.tradeId } returns id
         return trade
     }
 
     @Test
-    fun `a trade already in the list resolves without waiting`() =
+    fun `a trade already in the list resolves without waiting and is selected once`() =
         runTest {
             val item = tradeItem()
             val facade = facadeSyncing(MutableStateFlow(listOf(item)))
 
             assertEquals(item, facade.selectOpenTradeWhenSynced(tradeId))
+            verify(exactly = 1) { facade.selectOpenTrade(tradeId) }
         }
 
     @Test
@@ -63,12 +61,34 @@ class SelectOpenTradeWhenSyncedTest {
             assertEquals(item, result.await())
         }
 
+    /**
+     * Two screens can wait on different trades at once (a deep link and a chat notification). Selecting
+     * on every emission would have them overwrite each other's shared selection with null on every miss,
+     * and the trade actions all read that selection.
+     */
     @Test
-    fun `a trade missing from a synced list is reported as absent`() =
+    fun `waiting does not touch the shared selection`() =
+        runTest {
+            val openTradeItems = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
+            val facade = facadeSyncing(openTradeItems)
+
+            val result = async { facade.selectOpenTradeWhenSynced(tradeId) }
+            runCurrent()
+            openTradeItems.value = listOf(tradeItem(id = "other"))
+            runCurrent()
+
+            assertTrue(result.isActive, "Still waiting for the trade")
+            verify(exactly = 0) { facade.selectOpenTrade(any()) }
+            result.cancel()
+        }
+
+    @Test
+    fun `a trade missing from a synced list is reported as absent and never selected`() =
         runTest {
             val facade = facadeSyncing(MutableStateFlow(emptyList()), MutableStateFlow(true))
 
             assertNull(facade.selectOpenTradeWhenSynced(tradeId))
+            verify(exactly = 0) { facade.selectOpenTrade(any()) }
         }
 
     @Test
@@ -85,5 +105,22 @@ class SelectOpenTradeWhenSyncedTest {
             openTradesSynced.value = true
 
             assertNull(result.await())
+        }
+
+    /** On the client a subscribe that fails once is only retried on the next reconnect. */
+    @Test
+    fun `a sync that failed is reported as absent rather than waited on`() =
+        runTest {
+            val openTradesSyncFailed = MutableStateFlow(false)
+            val facade = facadeSyncing(MutableStateFlow(emptyList()), openTradesSyncFailed = openTradesSyncFailed)
+
+            val result = async { facade.selectOpenTradeWhenSynced(tradeId) }
+            runCurrent()
+            assertTrue(result.isActive, "Still waiting for the open trades to sync")
+
+            openTradesSyncFailed.value = true
+
+            assertNull(result.await())
+            verify(exactly = 0) { facade.selectOpenTrade(any()) }
         }
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/chat/trade/TradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/chat/trade/TradeChatMessagesServiceFacade.kt
@@ -1,11 +1,19 @@
 package network.bisq.mobile.data.service.chat.trade
 
+import kotlinx.coroutines.flow.StateFlow
 import network.bisq.mobile.data.replicated.chat.Citation
 import network.bisq.mobile.data.replicated.chat.reactions.BisqEasyOpenTradeMessageReaction
 import network.bisq.mobile.data.replicated.chat.reactions.ReactionEnum
 import network.bisq.mobile.data.service.LifeCycleAware
 
 interface TradeChatMessagesServiceFacade : LifeCycleAware {
+    /**
+     * True once the node has delivered the trade chat messages, so a channel with no messages is an
+     * empty channel rather than one whose messages are still on their way. Until then an empty channel
+     * says nothing, which is what the trade chat screen waits on before it stops showing its spinner.
+     */
+    val chatMessagesSynced: StateFlow<Boolean>
+
     suspend fun sendChatMessage(
         text: String,
         citation: Citation?,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/chat/trade/TradeChatMessagesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/chat/trade/TradeChatMessagesServiceFacade.kt
@@ -14,6 +14,14 @@ interface TradeChatMessagesServiceFacade : LifeCycleAware {
      */
     val chatMessagesSynced: StateFlow<Boolean>
 
+    /**
+     * True while the trade chat messages cannot be delivered at all: on the client, a subscribe that
+     * failed, which is only retried on the next reconnect. [chatMessagesSynced] will not turn true until
+     * this clears, so the trade chat screen stops waiting and renders what it has. Never true on the
+     * node, whose messages come from its own store.
+     */
+    val chatMessagesSyncFailed: StateFlow<Boolean>
+
     suspend fun sendChatMessage(
         text: String,
         citation: Citation?,

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
@@ -1,5 +1,8 @@
 package network.bisq.mobile.data.service.trades
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.bisq.mobile.data.service.ServiceFacade
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
 import network.bisq.mobile.domain.analytics.AnalyticsService
@@ -20,6 +23,14 @@ abstract class BaseTradesServiceFacade(
     tradeStallClockRepository: TradeStallClockRepository,
 ) : ServiceFacade(),
     TradesServiceFacade {
+    private val _openTradesSynced = MutableStateFlow(false)
+    override val openTradesSynced: StateFlow<Boolean> = _openTradesSynced.asStateFlow()
+
+    /** Call once the node has delivered the open trades, and again with false when they are dropped. */
+    protected fun setOpenTradesSynced(synced: Boolean) {
+        _openTradesSynced.value = synced
+    }
+
     // Scope-free by design: the tracker reads `serviceScope` fresh on every call (see the helpers
     // below), so it always launches on the facade's LIVE scope. `deactivate()` cancels and REPLACES
     // serviceScope, so a tracker that captured it once would silently go dead after the first

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/BaseTradesServiceFacade.kt
@@ -31,6 +31,14 @@ abstract class BaseTradesServiceFacade(
         _openTradesSynced.value = synced
     }
 
+    private val _openTradesSyncFailed = MutableStateFlow(false)
+    override val openTradesSyncFailed: StateFlow<Boolean> = _openTradesSyncFailed.asStateFlow()
+
+    /** Call while the node cannot deliver the open trades at all, and again with false once it can. */
+    protected fun setOpenTradesSyncFailed(failed: Boolean) {
+        _openTradesSyncFailed.value = failed
+    }
+
     // Scope-free by design: the tracker reads `serviceScope` fresh on every call (see the helpers
     // below), so it always launches on the facade's LIVE scope. `deactivate()` cancels and REPLACES
     // serviceScope, so a tracker that captured it once would silently go dead after the first

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
@@ -2,6 +2,8 @@ package network.bisq.mobile.data.service.trades
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
@@ -17,6 +19,13 @@ import network.bisq.mobile.domain.model.trade.TradeSort
 interface TradesServiceFacade : LifeCycleAware {
     val selectedTrade: StateFlow<TradeItemPresentationModel?>
     val openTradeItems: StateFlow<List<TradeItemPresentationModel>>
+
+    /**
+     * True once the open trades have been delivered at least once, so an [openTradeItems] that does not
+     * hold a trade means the trade is gone rather than still on its way. Until then an empty list says
+     * nothing, which is what [selectOpenTradeWhenSynced] waits on.
+     */
+    val openTradesSynced: StateFlow<Boolean>
 
     /**
      * Change signal for closed trades. Increments whenever the server pushes a closed-trades update
@@ -72,4 +81,27 @@ interface TradesServiceFacade : LifeCycleAware {
         outcomeFilter: TradeOutcomeFilter = TradeOutcomeFilter.ALL,
         roleFilter: TradeRoleFilter = TradeRoleFilter.ALL,
     ): Result<PaginatedResponse<ClosedTradeListItem>>
+}
+
+/**
+ * Selects [tradeId] and returns it, retrying while the open trades sync in. A deep link or a
+ * notification tap opens a trade right after the app connects, when the list can still be arriving,
+ * so a plain snapshot read reports a trade that does exist as missing. Returns null once the trades
+ * have synced without it, which means genuinely absent and is what the callers' not-found dialog is
+ * for.
+ */
+suspend fun TradesServiceFacade.selectOpenTradeWhenSynced(tradeId: String): TradeItemPresentationModel? {
+    var trade: TradeItemPresentationModel? = null
+    // Both flows replay their current value, so a trade already in the list resolves without waiting.
+    // The lookup goes through the facade rather than a local find because the facade owns the id
+    // matching (the client also accepts a short id), and it runs in the collector, not the transform,
+    // since combine may call the transform for values that never reach the predicate.
+    openTradeItems
+        .combine(openTradesSynced) { _, synced -> synced }
+        .first { synced ->
+            selectOpenTrade(tradeId)
+            trade = selectedTrade.value
+            trade != null || synced
+        }
+    return trade
 }

--- a/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
+++ b/shared/domain/src/commonMain/kotlin/network/bisq/mobile/data/service/trades/TradesServiceFacade.kt
@@ -28,6 +28,14 @@ interface TradesServiceFacade : LifeCycleAware {
     val openTradesSynced: StateFlow<Boolean>
 
     /**
+     * True while the open trades cannot be delivered at all: on the client, a TRADES subscribe that
+     * failed, which is only retried on the next reconnect. [openTradesSynced] will not turn true until
+     * this clears, so a wait on it gives up instead and the trade reads as absent. Never true on the
+     * node, whose trades come from its own store.
+     */
+    val openTradesSyncFailed: StateFlow<Boolean>
+
+    /**
      * Change signal for closed trades. Increments whenever the server pushes a closed-trades update
      * or the local closed-trades collection mutates. Consumers should use this to trigger re-fetching
      * paginated closed-trade history.
@@ -84,24 +92,26 @@ interface TradesServiceFacade : LifeCycleAware {
 }
 
 /**
- * Selects [tradeId] and returns it, retrying while the open trades sync in. A deep link or a
+ * Selects [tradeId] and returns it, waiting while the open trades sync in. A deep link or a
  * notification tap opens a trade right after the app connects, when the list can still be arriving,
  * so a plain snapshot read reports a trade that does exist as missing. Returns null once the trades
- * have synced without it, which means genuinely absent and is what the callers' not-found dialog is
- * for.
+ * have synced without it, which means genuinely absent, or once the sync has failed and is not coming;
+ * both are what the callers' not-found dialog is for. The wait has no bound: the data layer knows
+ * when the trades have arrived and when they are not going to, and a duration would only be wrong in
+ * one of the two directions.
+ *
+ * The lookup is local and the selection happens once, at the end: selecting on every emission would
+ * write the shared [TradesServiceFacade.selectedTrade] for every waiter, and two screens waiting on
+ * different trades (a deep link and a chat notification) would overwrite each other's selection while
+ * the trade actions all read that one global.
  */
 suspend fun TradesServiceFacade.selectOpenTradeWhenSynced(tradeId: String): TradeItemPresentationModel? {
-    var trade: TradeItemPresentationModel? = null
-    // Both flows replay their current value, so a trade already in the list resolves without waiting.
-    // The lookup goes through the facade rather than a local find because the facade owns the id
-    // matching (the client also accepts a short id), and it runs in the collector, not the transform,
-    // since combine may call the transform for values that never reach the predicate.
-    openTradeItems
-        .combine(openTradesSynced) { _, synced -> synced }
-        .first { synced ->
-            selectOpenTrade(tradeId)
-            trade = selectedTrade.value
-            trade != null || synced
-        }
+    // Every flow replays its current value, so a trade already in the list resolves without waiting.
+    val trade =
+        combine(openTradeItems, openTradesSynced, openTradesSyncFailed) { items, synced, failed ->
+            items.find { it.tradeId == tradeId } to (synced || failed)
+        }.first { (found, settled) -> found != null || settled }
+            .first ?: return null
+    selectOpenTrade(trade.tradeId)
     return trade
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeTradesServiceFacade.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeTradesServiceFacade.kt
@@ -1,0 +1,72 @@
+package network.bisq.mobile.presentation.common.test_utils
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.service.trades.TakeOfferStatus
+import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.analytics.AnalyticsEvent
+import network.bisq.mobile.domain.core.pagination.PaginatedResponse
+import network.bisq.mobile.domain.core.pagination.PaginationParams
+import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
+import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
+import network.bisq.mobile.domain.model.trade.TradeRoleFilter
+import network.bisq.mobile.domain.model.trade.TradeSort
+
+/**
+ * No-op [TradesServiceFacade] for presenters that need one injected but do not exercise it. Only
+ * [takeOffer] varies between call sites, so it is a constructor parameter; override anything else in
+ * a subclass rather than growing this one.
+ */
+internal open class FakeTradesServiceFacade(
+    private val takeOfferResult: Result<String> = Result.success("trade-1"),
+) : TradesServiceFacade {
+    override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
+    override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
+    override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
+    override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun getClosedTradesPaginated(
+        params: PaginationParams,
+        search: String?,
+        sortBy: TradeSort?,
+        outcomeFilter: TradeOutcomeFilter,
+        roleFilter: TradeRoleFilter,
+    ): Result<PaginatedResponse<ClosedTradeListItem>> = Result.success(PaginatedResponse(emptyList(), params.page, params.pageSize, 0L, 0))
+
+    override suspend fun takeOffer(
+        bisqEasyOffer: BisqEasyOfferVO,
+        takersBaseSideAmount: MonetaryVO,
+        takersQuoteSideAmount: MonetaryVO,
+        bitcoinPaymentMethod: String,
+        fiatPaymentMethod: String,
+        takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
+        takeOfferErrorMessage: MutableStateFlow<String?>,
+    ): Result<String> = takeOfferResult
+
+    override fun selectOpenTrade(tradeId: String) {}
+
+    override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
+
+    override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
+
+    override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
+
+    override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> = Result.success(Unit)
+
+    override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> = Result.success(Unit)
+
+    override suspend fun sellerConfirmFiatReceipt(): Result<Unit> = Result.success(Unit)
+
+    override suspend fun buyerConfirmFiatSent(): Result<Unit> = Result.success(Unit)
+
+    override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> = Result.success(Unit)
+
+    override suspend fun btcConfirmed(): Result<Unit> = Result.success(Unit)
+
+    override suspend fun exportTradeDate(): Result<Unit> = Result.success(Unit)
+
+    override fun resetSelectedTradeToNull() {}
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeTradesServiceFacade.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/test_utils/FakeTradesServiceFacade.kt
@@ -27,6 +27,7 @@ internal open class FakeTradesServiceFacade(
     override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
     override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
     override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
+    override val openTradesSyncFailed: StateFlow<Boolean> = MutableStateFlow(false)
 
     override suspend fun getClosedTradesPaginated(
         params: PaginationParams,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -1,6 +1,8 @@
 package network.bisq.mobile.presentation.common.ui.navigation.manager
 
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
@@ -12,15 +14,18 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.loggerConfigInit
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
@@ -612,6 +617,125 @@ class NavigationManagerImplTest {
             verify(exactly = 1) { mockController.navigate(mockNavUri, any<NavOptions>()) }
         }
 
+    // ========== Cold Start Deep Link Tests ==========
+
+    @Test
+    fun `when deep link arrives on splash then navigation waits for the main screen`() =
+        runTest(testDispatcher) {
+            // Given - root graph handles the deep link, app still bootstrapping on the splash
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController)
+            val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("https://bisq.network/test")
+            runCurrent()
+
+            // Then - nothing is stacked on top of the splash
+            verify(exactly = 0) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+
+            // When - startup lands on the main screen
+            destinations.settleOn(destinationOf<NavRoute.TabContainer>())
+            runCurrent()
+
+            // Then
+            verify(exactly = 1) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when startup lands on onboarding then deep link is discarded`() =
+        runTest(testDispatcher) {
+            // Given
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController)
+            val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When - startup routes to onboarding instead of the main screen
+            navigationManager.navigateFromUri("https://bisq.network/test")
+            runCurrent()
+            destinations.settleOn(destinationOf<NavRoute.Onboarding>())
+            runCurrent()
+
+            // Then
+            verify(exactly = 0) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when startup never leaves the splash then the deep link does not fire`() =
+        runTest(testDispatcher) {
+            // Given
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController)
+            mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("https://bisq.network/test")
+            advanceUntilIdle()
+
+            // Then
+            verify(exactly = 0) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when several deep links arrive on splash then only the last one navigates`() =
+        runTest(testDispatcher) {
+            // Given
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController)
+            val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("https://bisq.network/first")
+            navigationManager.navigateFromUri("https://bisq.network/second")
+            runCurrent()
+            destinations.settleOn(destinationOf<NavRoute.TabContainer>())
+            runCurrent()
+
+            // Then
+            verify(exactly = 1) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when splash state cannot be determined then deep link is dropped`() =
+        runTest(testDispatcher) {
+            // Given - the controller cannot report where startup is
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController)
+            every { mockController.currentBackStackEntry } throws IllegalStateException("Graph not ready")
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("https://bisq.network/test")
+            advanceUntilIdle()
+
+            // Then - nothing is navigated blind
+            verify(exactly = 0) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
     // ========== NavigateBack Tests ==========
 
     @Test
@@ -698,5 +822,58 @@ class NavigationManagerImplTest {
         every { spy.log } returns testLogger
         every { spy.isAtMainScreen() } returns true
         return spy
+    }
+
+    /**
+     * Stubs [controller] so its root graph resolves any deep link, and returns the [NavUri] the
+     * manager will build from the uri string.
+     */
+    private fun mockRootDeepLink(controller: NavHostController): NavUri {
+        val mockGraph = mockk<NavGraph>(relaxed = true)
+        val mockNavUri = mockk<NavUri>(relaxed = true)
+        mockkStatic(::NavUri)
+        every { NavUri(any<String>()) } returns mockNavUri
+        every { controller.graph } returns mockGraph
+        every { mockGraph.hasDeepLink(mockNavUri) } returns true
+        return mockNavUri
+    }
+
+    /**
+     * Drives what [controller] reports as its current destination, starting at [initial]. Mirrors the
+     * real controller: the replayed flow emits the current entry, and [DestinationDriver.settleOn]
+     * moves to the destination startup routed to.
+     */
+    private fun mockCurrentDestinations(
+        controller: NavHostController,
+        initial: NavDestination,
+    ): DestinationDriver {
+        val entries = MutableSharedFlow<NavBackStackEntry>(replay = 1)
+        val driver = DestinationDriver(controller, entries)
+        driver.settleOn(initial)
+        every { controller.currentBackStackEntryFlow } returns entries
+        return driver
+    }
+
+    private class DestinationDriver(
+        private val controller: NavHostController,
+        private val entries: MutableSharedFlow<NavBackStackEntry>,
+    ) {
+        fun settleOn(destination: NavDestination) {
+            val entry = mockk<NavBackStackEntry>(relaxed = true)
+            every { entry.destination } returns destination
+            every { controller.currentBackStackEntry } returns entry
+            entries.tryEmit(entry)
+        }
+    }
+
+    /**
+     * A destination that answers `hasRoute<T>()` with true. Unstubbed routes fall through to the real
+     * implementation, which reports false for a mock.
+     */
+    private inline fun <reified T : Any> destinationOf(): NavDestination {
+        mockkObject(NavDestination.Companion)
+        val destination = mockk<NavDestination>(relaxed = true)
+        every { with(NavDestination.Companion) { destination.hasRoute(T::class) } } returns true
+        return destination
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -626,7 +626,7 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController)
+            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
@@ -654,7 +654,7 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController)
+            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
@@ -677,7 +677,7 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController)
+            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
             mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
@@ -698,7 +698,8 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController)
+            val (firstNavUri, secondNavUri) =
+                mockRootDeepLinks(mockController, "https://bisq.network/first", "https://bisq.network/second")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
@@ -711,8 +712,9 @@ class NavigationManagerImplTest {
             destinations.settleOn(destinationOf<NavRoute.TabContainer>())
             runCurrent()
 
-            // Then
-            verify(exactly = 1) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+            // Then - the superseded link is dropped, not merely counted once
+            verify(exactly = 0) { mockController.navigate(firstNavUri, any<NavOptions>()) }
+            verify(exactly = 1) { mockController.navigate(secondNavUri, any<NavOptions>()) }
         }
 
     @Test
@@ -722,7 +724,7 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController)
+            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
             every { mockController.currentBackStackEntry } throws IllegalStateException("Graph not ready")
 
             navigationManager.setRootNavController(mockController)
@@ -825,18 +827,28 @@ class NavigationManagerImplTest {
     }
 
     /**
-     * Stubs [controller] so its root graph resolves any deep link, and returns the [NavUri] the
-     * manager will build from the uri string.
+     * Stubs [controller] so its root graph resolves each of [uris], and returns the [NavUri] the
+     * manager will build from each one. Distinct per uri, so a test can tell which link navigated.
      */
-    private fun mockRootDeepLink(controller: NavHostController): NavUri {
+    private fun mockRootDeepLinks(
+        controller: NavHostController,
+        vararg uris: String,
+    ): List<NavUri> {
         val mockGraph = mockk<NavGraph>(relaxed = true)
-        val mockNavUri = mockk<NavUri>(relaxed = true)
-        mockkStatic(::NavUri)
-        every { NavUri(any<String>()) } returns mockNavUri
         every { controller.graph } returns mockGraph
-        every { mockGraph.hasDeepLink(mockNavUri) } returns true
-        return mockNavUri
+        mockkStatic(::NavUri)
+        return uris.map { uri ->
+            val mockNavUri = mockk<NavUri>(relaxed = true)
+            every { NavUri(uri) } returns mockNavUri
+            every { mockGraph.hasDeepLink(mockNavUri) } returns true
+            mockNavUri
+        }
     }
+
+    private fun mockRootDeepLink(
+        controller: NavHostController,
+        uri: String,
+    ): NavUri = mockRootDeepLinks(controller, uri).single()
 
     /**
      * Drives what [controller] reports as its current destination, starting at [initial]. Mirrors the

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -718,6 +718,46 @@ class NavigationManagerImplTest {
         }
 
     @Test
+    fun `when a link opens right after the splash settles then a held one does not navigate on top`() =
+        runTest(testDispatcher) {
+            // Given - a held tab link, which waits for the tab controller that composes after the root settles
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockTabController = mockk<NavHostController>(relaxed = true)
+            val mockRootGraph = mockk<NavGraph>(relaxed = true)
+            val mockTabGraph = mockk<NavGraph>(relaxed = true)
+            val heldNavUri = mockk<NavUri>(relaxed = true)
+            val laterNavUri = mockk<NavUri>(relaxed = true)
+            mockkStatic(::NavUri)
+            every { NavUri("https://bisq.network/held") } returns heldNavUri
+            every { NavUri("https://bisq.network/later") } returns laterNavUri
+            // The held link is one only the tab graph declares, the way the trades tab is
+            every { mockController.graph } returns mockRootGraph
+            every { mockRootGraph.hasDeepLink(laterNavUri) } returns true
+            every { mockTabController.graph } returns mockTabGraph
+            every { mockTabGraph.hasDeepLink(heldNavUri) } returns true
+            val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When - the held link waits, startup settles, and a newer link opens before the tab is up
+            navigationManager.navigateFromUri("https://bisq.network/held")
+            runCurrent()
+            destinations.settleOn(destinationOf<NavRoute.TabContainer>())
+            runCurrent()
+            navigationManager.navigateFromUri("https://bisq.network/later")
+            runCurrent()
+            navigationManager.setTabNavController(mockTabController)
+            runCurrent()
+
+            // Then - the newer link is what the user sees, with nothing stacked on top of it
+            verify(exactly = 1) { mockController.navigate(laterNavUri, any<NavOptions>()) }
+            verify(exactly = 0) { mockTabController.navigate(heldNavUri, any<NavOptions>()) }
+        }
+
+    @Test
     fun `when splash state cannot be determined then deep link is dropped`() =
         runTest(testDispatcher) {
             // Given - the controller cannot report where startup is

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -102,6 +102,7 @@ class CreateOfferPricePresenterTest : PlatformPresentationKoinTestBase() {
         override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
         override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
         override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
+        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
 
         override suspend fun getClosedTradesPaginated(
             params: PaginationParams,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -42,6 +42,7 @@ import network.bisq.mobile.presentation.common.notification.NotificationControll
 import network.bisq.mobile.presentation.common.notification.model.NotificationConfig
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
 import network.bisq.mobile.presentation.common.test_utils.FakeMarketPriceServiceFacade
+import network.bisq.mobile.presentation.common.test_utils.FakeTradesServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.price.CreateOfferPricePresenter
@@ -96,55 +97,6 @@ class CreateOfferPricePresenterTest : PlatformPresentationKoinTestBase() {
         override val permitOpeningBrowser: StateFlow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) = Result.success(Unit)
-    }
-
-    private class FakeTradesServiceFacade : TradesServiceFacade {
-        override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
-        override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
-        override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
-        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
-
-        override suspend fun getClosedTradesPaginated(
-            params: PaginationParams,
-            search: String?,
-            sortBy: TradeSort?,
-            outcomeFilter: TradeOutcomeFilter,
-            roleFilter: TradeRoleFilter,
-        ): Result<PaginatedResponse<ClosedTradeListItem>> = Result.success(PaginatedResponse(emptyList(), params.page, params.pageSize, 0L, 0))
-
-        override suspend fun takeOffer(
-            bisqEasyOffer: BisqEasyOfferVO,
-            takersBaseSideAmount: MonetaryVO,
-            takersQuoteSideAmount: MonetaryVO,
-            bitcoinPaymentMethod: String,
-            fiatPaymentMethod: String,
-            takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
-            takeOfferErrorMessage: MutableStateFlow<String?>,
-        ) = Result.success("trade-1")
-
-        override fun selectOpenTrade(tradeId: String) {}
-
-        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmFiatReceipt(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerConfirmFiatSent(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> = Result.success(Unit)
-
-        override suspend fun btcConfirmed(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun exportTradeDate(): Result<Unit> = Result.success(Unit)
-
-        override fun resetSelectedTradeToNull() {}
     }
 
     private class FakeUserProfileServiceFacade : UserProfileServiceFacade {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -52,6 +52,7 @@ import network.bisq.mobile.presentation.common.notification.NotificationControll
 import network.bisq.mobile.presentation.common.notification.model.NotificationConfig
 import network.bisq.mobile.presentation.common.service.OpenTradesNotificationService
 import network.bisq.mobile.presentation.common.test_utils.FakeMarketPriceServiceFacade
+import network.bisq.mobile.presentation.common.test_utils.FakeTradesServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.review.CreateOfferReviewPresenter
@@ -108,56 +109,6 @@ class CreateOfferReviewPresenterTest : PlatformPresentationKoinTestBase() {
         override val permitOpeningBrowser: StateFlow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setPermitOpeningBrowser(value: Boolean) = Result.success(Unit)
-    }
-
-    private class FakeTradesServiceFacade : TradesServiceFacade {
-        override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
-        override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> =
-            MutableStateFlow(emptyList())
-        override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
-        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
-
-        override suspend fun getClosedTradesPaginated(
-            params: PaginationParams,
-            search: String?,
-            sortBy: TradeSort?,
-            outcomeFilter: TradeOutcomeFilter,
-            roleFilter: TradeRoleFilter,
-        ): Result<PaginatedResponse<ClosedTradeListItem>> = Result.success(PaginatedResponse(emptyList(), params.page, params.pageSize, 0L, 0))
-
-        override suspend fun takeOffer(
-            bisqEasyOffer: BisqEasyOfferVO,
-            takersBaseSideAmount: MonetaryVO,
-            takersQuoteSideAmount: MonetaryVO,
-            bitcoinPaymentMethod: String,
-            fiatPaymentMethod: String,
-            takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
-            takeOfferErrorMessage: MutableStateFlow<String?>,
-        ) = Result.success("trade-1")
-
-        override fun selectOpenTrade(tradeId: String) {}
-
-        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerSendsPaymentAccount(paymentAccountData: String) = Result.success(Unit)
-
-        override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String) = Result.success(Unit)
-
-        override suspend fun sellerConfirmFiatReceipt(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerConfirmFiatSent(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmBtcSent(paymentProof: String?) = Result.success(Unit)
-
-        override suspend fun btcConfirmed(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun exportTradeDate(): Result<Unit> = Result.success(Unit)
-
-        override fun resetSelectedTradeToNull() {}
     }
 
     private class FakeUserProfileServiceFacade : UserProfileServiceFacade {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -115,6 +115,7 @@ class CreateOfferReviewPresenterTest : PlatformPresentationKoinTestBase() {
         override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> =
             MutableStateFlow(emptyList())
         override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
+        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
 
         override suspend fun getClosedTradesPaginated(
             params: PaginationParams,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -67,6 +67,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
         override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
         override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
         override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
+        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
 
         override suspend fun getClosedTradesPaginated(
             params: PaginationParams,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -48,6 +48,7 @@ import network.bisq.mobile.presentation.common.service.OpenTradesNotificationSer
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeMarketPriceServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeTradeReadStateRepository
+import network.bisq.mobile.presentation.common.test_utils.FakeTradesServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.take_offer.amount.TakeOfferAmountPresenter
@@ -62,55 +63,6 @@ import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO as Of
 @OptIn(ExperimentalCoroutinesApi::class)
 class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
     // --- Fakes (Android/JVM-friendly) ---
-
-    private class FakeTradesServiceFacade : TradesServiceFacade {
-        override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
-        override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
-        override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
-        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
-
-        override suspend fun getClosedTradesPaginated(
-            params: PaginationParams,
-            search: String?,
-            sortBy: TradeSort?,
-            outcomeFilter: TradeOutcomeFilter,
-            roleFilter: TradeRoleFilter,
-        ): Result<PaginatedResponse<ClosedTradeListItem>> = Result.success(PaginatedResponse(emptyList(), params.page, params.pageSize, 0L, 0))
-
-        override suspend fun takeOffer(
-            bisqEasyOffer: OfferVO,
-            takersBaseSideAmount: MonetaryVO,
-            takersQuoteSideAmount: MonetaryVO,
-            bitcoinPaymentMethod: String,
-            fiatPaymentMethod: String,
-            takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
-            takeOfferErrorMessage: MutableStateFlow<String?>,
-        ): Result<String> = Result.success("trade-1")
-
-        override fun selectOpenTrade(tradeId: String) {}
-
-        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmFiatReceipt(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerConfirmFiatSent(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> = Result.success(Unit)
-
-        override suspend fun btcConfirmed(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun exportTradeDate(): Result<Unit> = Result.success(Unit)
-
-        override fun resetSelectedTradeToNull() {}
-    }
 
     private class FakeSettingsServiceFacade : SettingsServiceFacade {
         override suspend fun getSettings() = Result.success(settingsVODemoObj)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -24,6 +24,7 @@ import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeMarketPriceServiceFacade
+import network.bisq.mobile.presentation.common.test_utils.FakeTradesServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.OfferTestFactory
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
@@ -34,57 +35,6 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
-    private class FakeTradesServiceFacade(
-        private val takeOfferResult: Result<String> = Result.success("trade-1"),
-    ) : TradesServiceFacade {
-        override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
-        override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
-        override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
-        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
-
-        override suspend fun getClosedTradesPaginated(
-            params: PaginationParams,
-            search: String?,
-            sortBy: TradeSort?,
-            outcomeFilter: TradeOutcomeFilter,
-            roleFilter: TradeRoleFilter,
-        ): Result<PaginatedResponse<ClosedTradeListItem>> = Result.success(PaginatedResponse(emptyList(), params.page, params.pageSize, 0L, 0))
-
-        override suspend fun takeOffer(
-            bisqEasyOffer: BisqEasyOfferVO,
-            takersBaseSideAmount: MonetaryVO,
-            takersQuoteSideAmount: MonetaryVO,
-            bitcoinPaymentMethod: String,
-            fiatPaymentMethod: String,
-            takeOfferStatus: MutableStateFlow<TakeOfferStatus?>,
-            takeOfferErrorMessage: MutableStateFlow<String?>,
-        ): Result<String> = takeOfferResult
-
-        override fun selectOpenTrade(tradeId: String) {}
-
-        override suspend fun rejectTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun cancelTrade(reason: AnalyticsEvent.Trade.InterruptReason): Result<Unit> = Result.success(Unit)
-
-        override suspend fun closeTrade(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerSendsPaymentAccount(paymentAccountData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerSendBitcoinPaymentData(bitcoinPaymentData: String): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmFiatReceipt(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun buyerConfirmFiatSent(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun sellerConfirmBtcSent(paymentProof: String?): Result<Unit> = Result.success(Unit)
-
-        override suspend fun btcConfirmed(): Result<Unit> = Result.success(Unit)
-
-        override suspend fun exportTradeDate(): Result<Unit> = Result.success(Unit)
-
-        override fun resetSelectedTradeToNull() {}
-    }
-
     @Test
     fun selectOfferToTake_fixedAmountSpec_noAmountRange() {
         // Arrange: USD market at $100,000/BTC

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -40,6 +40,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         override val selectedTrade: StateFlow<TradeItemPresentationModel?> = MutableStateFlow(null)
         override val openTradeItems: StateFlow<List<TradeItemPresentationModel>> = MutableStateFlow(emptyList())
         override val closedTradesChangeTick: StateFlow<Int> = MutableStateFlow(0)
+        override val openTradesSynced: StateFlow<Boolean> = MutableStateFlow(true)
 
         override suspend fun getClosedTradesPaginated(
             params: PaginationParams,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
@@ -15,6 +15,7 @@ import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMock
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -73,6 +74,10 @@ class TradeChatPresenterIconLoadingTest : PlatformPresentationKoinTestBase() {
 
             val tradesServiceFacade = mockk<TradesServiceFacade>(relaxed = true)
             every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(trade)
+            // The presenter retries the lookup on every open-trades update; the stubbed selectedTrade
+            // resolves on the replayed current value, so the list content itself does not matter here.
+            every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+            every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
 
             val mockImage = mockk<PlatformImage>()
             val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
@@ -81,11 +86,14 @@ class TradeChatPresenterIconLoadingTest : PlatformPresentationKoinTestBase() {
 
             val mainPresenter = MainPresenterTestFactory.create()
 
+            val tradeChatMessagesServiceFacade = mockk<TradeChatMessagesServiceFacade>(relaxed = true)
+            every { tradeChatMessagesServiceFacade.chatMessagesSynced } returns MutableStateFlow(true)
+
             val presenter =
                 TradeChatPresenter(
                     mainPresenter = mainPresenter,
                     tradesServiceFacade = tradesServiceFacade,
-                    tradeChatMessagesServiceFacade = mockk(relaxed = true),
+                    tradeChatMessagesServiceFacade = tradeChatMessagesServiceFacade,
                     settingsRepository = mockk<SettingsRepository>(relaxed = true),
                     tradeReadStateRepository = mockk<TradeReadStateRepository>(relaxed = true),
                     userProfileServiceFacade = userProfileServiceFacade,

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterIconLoadingTest.kt
@@ -73,11 +73,9 @@ class TradeChatPresenterIconLoadingTest : PlatformPresentationKoinTestBase() {
             every { trade.bisqEasyOpenTradeChannelModel } returns channelModel
 
             val tradesServiceFacade = mockk<TradesServiceFacade>(relaxed = true)
-            every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(trade)
-            // The presenter retries the lookup on every open-trades update; the stubbed selectedTrade
-            // resolves on the replayed current value, so the list content itself does not matter here.
-            every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+            every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(listOf(trade))
             every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
+            every { tradesServiceFacade.openTradesSyncFailed } returns MutableStateFlow(false)
 
             val mockImage = mockk<PlatformImage>()
             val userProfileServiceFacade = mockk<UserProfileServiceFacade>(relaxed = true)
@@ -88,6 +86,7 @@ class TradeChatPresenterIconLoadingTest : PlatformPresentationKoinTestBase() {
 
             val tradeChatMessagesServiceFacade = mockk<TradeChatMessagesServiceFacade>(relaxed = true)
             every { tradeChatMessagesServiceFacade.chatMessagesSynced } returns MutableStateFlow(true)
+            every { tradeChatMessagesServiceFacade.chatMessagesSyncFailed } returns MutableStateFlow(false)
 
             val presenter =
                 TradeChatPresenter(

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterTest.kt
@@ -7,7 +7,10 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel
 import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
@@ -21,6 +24,7 @@ import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TradeChatPresenterTest : PresentationKoinTestBase() {
@@ -34,6 +38,9 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
     private val messageDeliveryServiceFacade: MessageDeliveryServiceFacade = mockk(relaxed = true)
     private lateinit var presenter: TradeChatPresenter
 
+    /** Drives whether the node has delivered the trade chat messages. */
+    private val chatMessagesSynced = MutableStateFlow(false)
+
     override fun beforeStartKoin() {
         super.beforeStartKoin()
         globalUiManager = GlobalUiManager(testDispatcher)
@@ -41,6 +48,8 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
 
     override fun onKoinReady() {
         every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
+        every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
+        every { tradeChatMessagesServiceFacade.chatMessagesSynced } returns chatMessagesSynced
         every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
         every { settingsRepository.data } returns MutableStateFlow(mockk(relaxed = true))
 
@@ -91,6 +100,51 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
         }
 
     @Test
+    fun `loading holds while the trade chat messages have not arrived`() =
+        runTest {
+            val messages = givenTradeWithMessages()
+
+            presenter.initialize("tid")
+            runCurrent()
+
+            assertTrue(presenter.isLoading.value, "Messages have not arrived yet")
+
+            messages.value = setOf(mockk<BisqEasyOpenTradeMessage>(relaxed = true))
+            runCurrent()
+
+            assertFalse(presenter.isLoading.value)
+        }
+
+    @Test
+    fun `loading stops on an empty chat once the messages have synced`() =
+        runTest {
+            givenTradeWithMessages()
+
+            presenter.initialize("tid")
+            runCurrent()
+
+            assertTrue(presenter.isLoading.value, "Nothing has been delivered yet")
+
+            chatMessagesSynced.value = true
+            runCurrent()
+
+            assertFalse(presenter.isLoading.value)
+        }
+
+    @Test
+    fun `loading stops when the trade is not found so the dialog is not hidden behind the spinner`() =
+        runTest {
+            every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+            every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
+
+            presenter.initialize("tid")
+            advanceUntilIdle()
+
+            assertFalse(presenter.isLoading.value)
+            assertTrue(presenter.showTradeNotFoundDialog.value)
+        }
+
+    @Test
     fun `confirmed ignore user calls ignoreUserProfile`() =
         runTest {
             coEvery { userProfileServiceFacade.ignoreUserProfile("peer-1") } returns Unit
@@ -113,4 +167,20 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
 
             coVerify { userProfileServiceFacade.undoIgnoreUserProfile("peer-2") }
         }
+
+    /** A trade the facade can resolve, with a channel whose messages the caller drives. */
+    private fun givenTradeWithMessages(): MutableStateFlow<Set<BisqEasyOpenTradeMessage>> {
+        val messages = MutableStateFlow<Set<BisqEasyOpenTradeMessage>>(emptySet())
+        val channel = mockk<BisqEasyOpenTradeChannel>(relaxed = true)
+        every { channel.chatMessages } returns messages
+
+        val trade = mockk<TradeItemPresentationModel>(relaxed = true)
+        every { trade.tradeId } returns "tid"
+        every { trade.bisqEasyOpenTradeChannelModel } returns channel
+
+        every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(listOf(trade))
+        every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
+        every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(trade)
+        return messages
+    }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenterTest.kt
@@ -38,8 +38,9 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
     private val messageDeliveryServiceFacade: MessageDeliveryServiceFacade = mockk(relaxed = true)
     private lateinit var presenter: TradeChatPresenter
 
-    /** Drives whether the node has delivered the trade chat messages. */
+    /** Drive whether the node has delivered the trade chat messages, or cannot deliver them at all. */
     private val chatMessagesSynced = MutableStateFlow(false)
+    private val chatMessagesSyncFailed = MutableStateFlow(false)
 
     override fun beforeStartKoin() {
         super.beforeStartKoin()
@@ -49,7 +50,9 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
     override fun onKoinReady() {
         every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
         every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
+        every { tradesServiceFacade.openTradesSyncFailed } returns MutableStateFlow(false)
         every { tradeChatMessagesServiceFacade.chatMessagesSynced } returns chatMessagesSynced
+        every { tradeChatMessagesServiceFacade.chatMessagesSyncFailed } returns chatMessagesSyncFailed
         every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
         every { settingsRepository.data } returns MutableStateFlow(mockk(relaxed = true))
 
@@ -131,6 +134,22 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
             assertFalse(presenter.isLoading.value)
         }
 
+    /** On the client a subscribe that fails once is only retried on the next reconnect. */
+    @Test
+    fun `loading stops when the chat messages are not coming because their subscription failed`() =
+        runTest {
+            givenTradeWithMessages()
+
+            presenter.initialize("tid")
+            runCurrent()
+            assertTrue(presenter.isLoading.value, "Nothing has been delivered yet")
+
+            chatMessagesSyncFailed.value = true
+            runCurrent()
+
+            assertFalse(presenter.isLoading.value)
+        }
+
     @Test
     fun `loading stops when the trade is not found so the dialog is not hidden behind the spinner`() =
         runTest {
@@ -180,7 +199,6 @@ class TradeChatPresenterTest : PresentationKoinTestBase() {
 
         every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(listOf(trade))
         every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
-        every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(trade)
         return messages
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
@@ -20,6 +20,7 @@ import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -43,6 +44,10 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
     override fun onKoinReady() {
         I18nSupport.initialize("en")
         every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+        // The presenter now retries the lookup on every open-trades update; the stubbed selectedTrade
+        // resolves on the replayed current value, so the list content itself does not matter here.
+        every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+        every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
     }
 
     private fun runPresenterTest(block: suspend TestScope.() -> Unit) =
@@ -74,6 +79,19 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
         scrollScope = scope
         presenter.initialize("tid", ScrollState(0), scope)
     }
+
+    @Test
+    fun `a trade missing once the open trades synced raises the not found dialog`() =
+        runPresenterTest {
+            // onKoinReady leaves the open trades empty and synced, so the lookup can only come up empty.
+            every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
+
+            createAndInitializePresenter()
+            runCurrent()
+
+            assertTrue(presenter.showTradeNotFoundDialog.value)
+            assertNull(presenter.selectedTrade.value)
+        }
 
     @Test
     fun `a trade stuck in INIT past the threshold is flagged out of sync`() =

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -44,10 +45,14 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
     override fun onKoinReady() {
         I18nSupport.initialize("en")
         every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
-        // The presenter now retries the lookup on every open-trades update; the stubbed selectedTrade
-        // resolves on the replayed current value, so the list content itself does not matter here.
-        every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(emptyList())
+        // The presenter resolves the trade from the open trades once they have synced, so each test
+        // says which trades are open.
         every { tradesServiceFacade.openTradesSynced } returns MutableStateFlow(true)
+        every { tradesServiceFacade.openTradesSyncFailed } returns MutableStateFlow(false)
+    }
+
+    private fun givenOpenTrades(vararg trades: TradeItemPresentationModel) {
+        every { tradesServiceFacade.openTradeItems } returns MutableStateFlow(trades.toList())
     }
 
     private fun runPresenterTest(block: suspend TestScope.() -> Unit) =
@@ -83,8 +88,8 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
     @Test
     fun `a trade missing once the open trades synced raises the not found dialog`() =
         runPresenterTest {
-            // onKoinReady leaves the open trades empty and synced, so the lookup can only come up empty.
-            every { tradesServiceFacade.selectedTrade } returns MutableStateFlow(null)
+            // Synced and empty, so the lookup can only come up empty.
+            givenOpenTrades()
 
             createAndInitializePresenter()
             runCurrent()
@@ -98,7 +103,7 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
         runPresenterTest {
             val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
             // The harness pins takeOfferDate far in the past, so an INIT trade is stuck right away.
-            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            givenOpenTrades(harness.selectedTrade.value!!)
 
             createAndInitializePresenter()
             runCurrent()
@@ -112,7 +117,7 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
             val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
             val tradeModel = harness.selectedTrade.value!!.bisqEasyTradeModel
             every { tradeModel.takeOfferDate } returns DateUtils.now()
-            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            givenOpenTrades(harness.selectedTrade.value!!)
 
             createAndInitializePresenter()
             runCurrent()
@@ -124,7 +129,7 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
     fun `a stuck trade leaving INIT clears the flag`() =
         runPresenterTest {
             val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
-            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            givenOpenTrades(harness.selectedTrade.value!!)
 
             createAndInitializePresenter()
             runCurrent()
@@ -140,7 +145,7 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
     fun `unattaching the view resets the flag`() =
         runPresenterTest {
             val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
-            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            givenOpenTrades(harness.selectedTrade.value!!)
 
             createAndInitializePresenter()
             runCurrent()
@@ -150,5 +155,26 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
             runCurrent()
 
             assertFalse(presenter.isTradeOutOfSync.value)
+        }
+
+    /**
+     * A singleTop re-navigation keeps the presenter, so the reset in initialize is all that stands
+     * between the previous trade's panes and the next trade's first state.
+     */
+    @Test
+    fun `re-initialising clears the previous trade's panes before the next trade resolves`() =
+        runPresenterTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            harness.tradeStateFlow.value = BisqEasyTradeStateEnum.REJECTED
+            givenOpenTrades(harness.selectedTrade.value!!)
+
+            createAndInitializePresenter()
+            runCurrent()
+            assertTrue(presenter.tradeAbortedBoxVisible.value)
+
+            presenter.initialize("other", ScrollState(0), scrollScope!!)
+
+            assertFalse(presenter.tradeAbortedBoxVisible.value)
+            assertFalse(presenter.tradeProcessBoxVisible.value)
         }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -48,7 +48,9 @@ class NavigationManagerImpl(
 
     // The job waiting to open the deep link held while startup is still on the splash. A newer link
     // cancels it, whether it arrives on the splash or opens after the splash settled, so a held link
-    // never navigates on top of a newer one.
+    // never navigates on top of a newer one. Arrival order is kept because the splash check and the
+    // swap of this slot run on the single-threaded scope with no suspension point between them; the
+    // navigation itself is serialized by navMutex like every other call on the controllers.
     private var heldDeepLink: Job? = null
 
     // External scope, but we always dispatch to Main when touching NavController.

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
+import network.bisq.mobile.domain.utils.resultCatching
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.TabNavRoute
 import kotlin.reflect.KClass
@@ -246,14 +247,14 @@ class NavigationManagerImpl(
             val navUri = NavUri(uri)
             if (rootNavController.graph.hasDeepLink(navUri)) {
                 navMutex.withLock {
-                    runCatching {
+                    resultCatching {
                         val navOptions =
                             navOptions {
                                 launchSingleTop = true
                             }
                         rootNavController.navigate(navUri, navOptions)
                     }.onFailure { e ->
-                        log.e(e) { "Failed to navigate from uri $uri via root graph" }
+                        log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via root graph" }
                     }
                 }
                 return@launch
@@ -264,7 +265,7 @@ class NavigationManagerImpl(
             val tabNavController = getTabNavController() ?: return@launch
             navMutex.withLock {
                 if (!tabNavController.graph.hasDeepLink(navUri)) return@withLock
-                runCatching {
+                resultCatching {
                     val navOptions =
                         navOptions {
                             popUpTo(NavRoute.HomeScreenGraphKey) {
@@ -275,7 +276,7 @@ class NavigationManagerImpl(
                         }
                     tabNavController.navigate(navUri, navOptions)
                 }.onFailure { e ->
-                    log.e(e) { "Failed to navigate from uri $uri via tab graph" }
+                    log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via tab graph" }
                 }
             }
         }
@@ -302,13 +303,13 @@ class NavigationManagerImpl(
             null -> {
                 // Navigating blind could stack the target on a splash that is not ready; a link that is
                 // not opened is the lesser harm.
-                log.w { "Dropping deep link $uri, cannot tell whether startup is still on the splash" }
+                log.w { "Dropping deep link ${uri.deepLinkRoute()}, cannot tell whether startup is still on the splash" }
                 return false
             }
             true -> Unit
         }
 
-        log.i { "Holding deep link $uri until startup leaves the splash" }
+        log.i { "Holding deep link ${uri.deepLinkRoute()} until startup leaves the splash" }
         pendingDeepLinkUri.value = uri
         // Follows the current controller rather than capturing one: a controller replaced during
         // startup stops emitting, and a captured one would leave the link waiting forever.
@@ -319,26 +320,33 @@ class NavigationManagerImpl(
                 .first { !it.destination.hasRoute<NavRoute.Splash>() }
 
         if (!pendingDeepLinkUri.compareAndSet(uri, null)) {
-            log.i { "Dropping deep link $uri, superseded by a newer one" }
+            log.i { "Dropping deep link ${uri.deepLinkRoute()}, superseded by a newer one" }
             return false
         }
 
         val reachedMainScreen = settled.destination.hasRoute<NavRoute.TabContainer>()
         if (!reachedMainScreen) {
-            log.i { "Dropping deep link $uri, startup landed on ${settled.destination.route} instead of the main screen" }
+            log.i { "Dropping deep link ${uri.deepLinkRoute()}, startup landed on ${settled.destination.route} instead of the main screen" }
         }
         return reachedMainScreen
     }
 
     // A missing controller or destination means the host is not composed yet, which only happens on
     // startup. Null when the controller cannot answer at all.
-    private fun isAtSplash(): Boolean? =
-        runCatching {
+    private suspend fun isAtSplash(): Boolean? =
+        resultCatching {
             val destination = rootNavControllerFlow.value?.currentBackStackEntry?.destination
             destination == null || destination.hasRoute<NavRoute.Splash>()
         }.onFailure { e ->
             log.e(e) { "Failed to determine if at splash (nav graph may not be ready yet)" }
         }.getOrNull()
+
+    /**
+     * Deep links reach [navigateFromUri] from outside the app and carry ids (a trade, a channel, a
+     * profile) after the route. Diagnostics only need to know which route was held or dropped, so the
+     * id never reaches the log.
+     */
+    private fun String.deepLinkRoute(): String = substringAfter("://").substringBefore('/')
 
     override fun navigateBack(onCompleted: (() -> Unit)?) {
         scope.launch {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -8,11 +8,13 @@ import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.NavUri
 import androidx.navigation.navOptions
 import androidx.navigation.toRoute
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -23,6 +25,7 @@ import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.TabNavRoute
 import kotlin.reflect.KClass
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class NavigationManagerImpl(
     val coroutineJobsManager: CoroutineJobsManager,
 ) : NavigationManager,
@@ -40,6 +43,9 @@ class NavigationManagerImpl(
 
     // Single mutex to serialize all calls that touch NavController.
     private val navMutex = Mutex()
+
+    // Deep link held while the app is still on the splash screen. Last one wins.
+    private val pendingDeepLinkUri = MutableStateFlow<String?>(null)
 
     // External scope, but we always dispatch to Main when touching NavController.
     private val scope get() = coroutineJobsManager.getScope()
@@ -231,10 +237,15 @@ class NavigationManagerImpl(
 
     override fun navigateFromUri(uri: String) {
         scope.launch {
+            if (!awaitStartupSettled(uri)) return@launch
+
+            // Fetched after the wait, not before: startup can replace the controller (the activity is
+            // recreated, the host recomposes), and navigating on the one that was current when the link
+            // arrived would navigate a controller that is no longer on screen.
             val rootNavController = getRootNavController() ?: return@launch
             val navUri = NavUri(uri)
-            navMutex.withLock {
-                if (rootNavController.graph.hasDeepLink(navUri)) {
+            if (rootNavController.graph.hasDeepLink(navUri)) {
+                navMutex.withLock {
                     runCatching {
                         val navOptions =
                             navOptions {
@@ -244,35 +255,90 @@ class NavigationManagerImpl(
                     }.onFailure { e ->
                         log.e(e) { "Failed to navigate from uri $uri via root graph" }
                     }
-                } else if (isAtMainScreen()) {
-                    // Tab controller acquisition moved outside lock
                 }
+                return@launch
             }
-            // Only acquire tab controller if root didn't handle the deep link and we're at main screen
-            if (!rootNavController.graph.hasDeepLink(navUri) && isAtMainScreen()) {
-                val tabNavController = getTabNavController() ?: return@launch
-                navMutex.withLock {
-                    if (tabNavController.graph.hasDeepLink(navUri)) {
-                        runCatching {
-                            val navOptions =
-                                navOptions {
-                                    popUpTo(NavRoute.HomeScreenGraphKey) {
-                                        saveState = true
-                                    }
-                                    launchSingleTop = true
-                                    restoreState = true
-                                }
-                            tabNavController.navigate(navUri, navOptions)
-                        }.onFailure { e ->
-                            log.e(e) { "Failed to navigate from uri $uri via tab graph" }
+
+            if (!isAtMainScreen()) return@launch
+
+            val tabNavController = getTabNavController() ?: return@launch
+            navMutex.withLock {
+                if (!tabNavController.graph.hasDeepLink(navUri)) return@withLock
+                runCatching {
+                    val navOptions =
+                        navOptions {
+                            popUpTo(NavRoute.HomeScreenGraphKey) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
                         }
-                    } else {
-                        // Deep link not handled by tab graph; ignore.
-                    }
+                    tabNavController.navigate(navUri, navOptions)
+                }.onFailure { e ->
+                    log.e(e) { "Failed to navigate from uri $uri via tab graph" }
                 }
             }
         }
     }
+
+    /**
+     * Holds a deep link that arrives while startup is still on the splash screen. Navigating right away
+     * would stack the target on top of a splash that has not connected yet, so its presenter would read
+     * empty state and back would return to the splash.
+     *
+     * Returns true once startup lands on the main screen and [uri] is still the link to open. Returns
+     * false when startup goes elsewhere (agreement, onboarding, profile creation) or when a newer deep
+     * link supersedes this one. A warm start returns true immediately, so nothing changes for a link
+     * that arrives with the app already up.
+     *
+     * The wait is unbounded on purpose. There is nothing to time out against: the user is looking at a
+     * splash they cannot navigate away from, so the link cannot go stale against a competing intent,
+     * and startup that never finishes ends in a restart that takes this coroutine with it. A bound
+     * would only discard a link that startup was still going to honour.
+     */
+    private suspend fun awaitStartupSettled(uri: String): Boolean {
+        when (isAtSplash()) {
+            false -> return true
+            null -> {
+                // Navigating blind could stack the target on a splash that is not ready; a link that is
+                // not opened is the lesser harm.
+                log.w { "Dropping deep link $uri, cannot tell whether startup is still on the splash" }
+                return false
+            }
+            true -> Unit
+        }
+
+        log.i { "Holding deep link $uri until startup leaves the splash" }
+        pendingDeepLinkUri.value = uri
+        // Follows the current controller rather than capturing one: a controller replaced during
+        // startup stops emitting, and a captured one would leave the link waiting forever.
+        val settled =
+            rootNavControllerFlow
+                .filterNotNull()
+                .flatMapLatest { it.currentBackStackEntryFlow }
+                .first { !it.destination.hasRoute<NavRoute.Splash>() }
+
+        if (!pendingDeepLinkUri.compareAndSet(uri, null)) {
+            log.i { "Dropping deep link $uri, superseded by a newer one" }
+            return false
+        }
+
+        val reachedMainScreen = settled.destination.hasRoute<NavRoute.TabContainer>()
+        if (!reachedMainScreen) {
+            log.i { "Dropping deep link $uri, startup landed on ${settled.destination.route} instead of the main screen" }
+        }
+        return reachedMainScreen
+    }
+
+    // A missing controller or destination means the host is not composed yet, which only happens on
+    // startup. Null when the controller cannot answer at all.
+    private fun isAtSplash(): Boolean? =
+        runCatching {
+            val destination = rootNavControllerFlow.value?.currentBackStackEntry?.destination
+            destination == null || destination.hasRoute<NavRoute.Splash>()
+        }.onFailure { e ->
+            log.e(e) { "Failed to determine if at splash (nav graph may not be ready yet)" }
+        }.getOrNull()
 
     override fun navigateBack(onCompleted: (() -> Unit)?) {
         scope.launch {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavUri
 import androidx.navigation.navOptions
 import androidx.navigation.toRoute
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,8 +46,10 @@ class NavigationManagerImpl(
     // Single mutex to serialize all calls that touch NavController.
     private val navMutex = Mutex()
 
-    // Deep link held while the app is still on the splash screen. Last one wins.
-    private val pendingDeepLinkUri = MutableStateFlow<String?>(null)
+    // The job waiting to open the deep link held while startup is still on the splash. A newer link
+    // cancels it, whether it arrives on the splash or opens after the splash settled, so a held link
+    // never navigates on top of a newer one.
+    private var heldDeepLink: Job? = null
 
     // External scope, but we always dispatch to Main when touching NavController.
     private val scope get() = coroutineJobsManager.getScope()
@@ -238,45 +241,17 @@ class NavigationManagerImpl(
 
     override fun navigateFromUri(uri: String) {
         scope.launch {
-            if (!awaitStartupSettled(uri)) return@launch
-
-            // Fetched after the wait, not before: startup can replace the controller (the activity is
-            // recreated, the host recomposes), and navigating on the one that was current when the link
-            // arrived would navigate a controller that is no longer on screen.
-            val rootNavController = getRootNavController() ?: return@launch
-            val navUri = NavUri(uri)
-            if (rootNavController.graph.hasDeepLink(navUri)) {
-                navMutex.withLock {
-                    resultCatching {
-                        val navOptions =
-                            navOptions {
-                                launchSingleTop = true
-                            }
-                        rootNavController.navigate(navUri, navOptions)
-                    }.onFailure { e ->
-                        log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via root graph" }
-                    }
+            when (isAtSplash()) {
+                true -> holdDeepLink(uri)
+                false -> {
+                    // Anything still held is older than this link, so it must not open on top of it.
+                    dropHeldDeepLink()
+                    openDeepLink(uri)
                 }
-                return@launch
-            }
-
-            if (!isAtMainScreen()) return@launch
-
-            val tabNavController = getTabNavController() ?: return@launch
-            navMutex.withLock {
-                if (!tabNavController.graph.hasDeepLink(navUri)) return@withLock
-                resultCatching {
-                    val navOptions =
-                        navOptions {
-                            popUpTo(NavRoute.HomeScreenGraphKey) {
-                                saveState = true
-                            }
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    tabNavController.navigate(navUri, navOptions)
-                }.onFailure { e ->
-                    log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via tab graph" }
+                null -> {
+                    // Navigating blind could stack the target on a splash that is not ready; a link that is
+                    // not opened is the lesser harm.
+                    log.w { "Dropping deep link ${uri.deepLinkRoute()}, cannot tell whether startup is still on the splash" }
                 }
             }
         }
@@ -285,32 +260,37 @@ class NavigationManagerImpl(
     /**
      * Holds a deep link that arrives while startup is still on the splash screen. Navigating right away
      * would stack the target on top of a splash that has not connected yet, so its presenter would read
-     * empty state and back would return to the splash.
+     * empty state and back would return to the splash. A warm start never comes here, so nothing
+     * changes for a link that arrives with the app already up.
      *
-     * Returns true once startup lands on the main screen and [uri] is still the link to open. Returns
-     * false when startup goes elsewhere (agreement, onboarding, profile creation) or when a newer deep
-     * link supersedes this one. A warm start returns true immediately, so nothing changes for a link
-     * that arrives with the app already up.
+     * A newer link supersedes the held one without asking whether the newer one can open: which link the
+     * user wants is settled by their last action, and whether a graph declares it cannot be known before
+     * the graphs exist. A link nothing declares opens nothing, on a warm start just the same.
+     */
+    private fun holdDeepLink(uri: String) {
+        log.i { "Holding deep link ${uri.deepLinkRoute()} until startup leaves the splash" }
+        dropHeldDeepLink()
+        heldDeepLink = scope.launch { openDeepLinkWhenSettled(uri) }
+    }
+
+    private fun dropHeldDeepLink() {
+        heldDeepLink?.takeIf { it.isActive }?.let { held ->
+            log.i { "Dropping the held deep link, superseded by a newer one" }
+            held.cancel()
+        }
+        heldDeepLink = null
+    }
+
+    /**
+     * Opens [uri] once startup lands on the main screen, and drops it when startup goes elsewhere
+     * (agreement, onboarding, profile creation).
      *
      * The wait is unbounded on purpose. There is nothing to time out against: the user is looking at a
      * splash they cannot navigate away from, so the link cannot go stale against a competing intent,
      * and startup that never finishes ends in a restart that takes this coroutine with it. A bound
      * would only discard a link that startup was still going to honour.
      */
-    private suspend fun awaitStartupSettled(uri: String): Boolean {
-        when (isAtSplash()) {
-            false -> return true
-            null -> {
-                // Navigating blind could stack the target on a splash that is not ready; a link that is
-                // not opened is the lesser harm.
-                log.w { "Dropping deep link ${uri.deepLinkRoute()}, cannot tell whether startup is still on the splash" }
-                return false
-            }
-            true -> Unit
-        }
-
-        log.i { "Holding deep link ${uri.deepLinkRoute()} until startup leaves the splash" }
-        pendingDeepLinkUri.value = uri
+    private suspend fun openDeepLinkWhenSettled(uri: String) {
         // Follows the current controller rather than capturing one: a controller replaced during
         // startup stops emitting, and a captured one would leave the link waiting forever.
         val settled =
@@ -318,17 +298,57 @@ class NavigationManagerImpl(
                 .filterNotNull()
                 .flatMapLatest { it.currentBackStackEntryFlow }
                 .first { !it.destination.hasRoute<NavRoute.Splash>() }
-
-        if (!pendingDeepLinkUri.compareAndSet(uri, null)) {
-            log.i { "Dropping deep link ${uri.deepLinkRoute()}, superseded by a newer one" }
-            return false
-        }
-
-        val reachedMainScreen = settled.destination.hasRoute<NavRoute.TabContainer>()
-        if (!reachedMainScreen) {
+        if (!settled.destination.hasRoute<NavRoute.TabContainer>()) {
             log.i { "Dropping deep link ${uri.deepLinkRoute()}, startup landed on ${settled.destination.route} instead of the main screen" }
+            return
         }
-        return reachedMainScreen
+        openDeepLink(uri)
+    }
+
+    /**
+     * Opens [uri] on the root graph, else on the tab graph once the main screen is up, else nowhere.
+     * Fetches the controllers itself rather than taking them from the caller: startup can replace them
+     * (the activity is recreated, the host recomposes), and a controller captured before a wait would
+     * be one that is no longer on screen.
+     */
+    private suspend fun openDeepLink(uri: String) {
+        val navUri = NavUri(uri)
+        val rootNavController = getRootNavController() ?: return
+        if (rootNavController.graph.hasDeepLink(navUri)) {
+            navMutex.withLock {
+                resultCatching {
+                    val navOptions =
+                        navOptions {
+                            launchSingleTop = true
+                        }
+                    rootNavController.navigate(navUri, navOptions)
+                }.onFailure { e ->
+                    log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via root graph" }
+                }
+            }
+            return
+        }
+
+        val tabNavController = if (isAtMainScreen()) getTabNavController() else null
+        if (tabNavController == null || !tabNavController.graph.hasDeepLink(navUri)) {
+            log.w { "Dropping deep link ${uri.deepLinkRoute()}, no graph on screen declares it" }
+            return
+        }
+        navMutex.withLock {
+            resultCatching {
+                val navOptions =
+                    navOptions {
+                        popUpTo(NavRoute.HomeScreenGraphKey) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                tabNavController.navigate(navUri, navOptions)
+            }.onFailure { e ->
+                log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via tab graph" }
+            }
+        }
     }
 
     // A missing controller or destination means the host is not composed yet, which only happens on

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
@@ -2,11 +2,13 @@ package network.bisq.mobile.presentation.trade.trade_chat
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -23,6 +25,7 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.i
 import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.message_delivery.MessageDeliveryServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.trades.selectOpenTradeWhenSynced
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.data.utils.PlatformImage
 import network.bisq.mobile.domain.repository.SettingsRepository
@@ -47,6 +50,15 @@ class TradeChatPresenter(
 ) : BasePresenter(mainPresenter) {
     private val _selectedTrade = MutableStateFlow<TradeItemPresentationModel?>(null)
     val selectedTrade: StateFlow<TradeItemPresentationModel?> = _selectedTrade.asStateFlow()
+
+    /**
+     * True until there is something to render: the trade has to resolve, and its messages arrive over
+     * a subscription that on a cold start can land well after the screen opened. An empty message list
+     * on its own cannot be told apart from a chat that has not loaded, so the screen state comes from
+     * this flag and the flag from [TradeChatMessagesServiceFacade.chatMessagesSynced].
+     */
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
     private val _sortedChatMessages: MutableStateFlow<List<BisqEasyOpenTradeMessage>> =
         MutableStateFlow(listOf())
@@ -114,66 +126,87 @@ class TradeChatPresenter(
     private val observedChatMessages =
         MutableStateFlow<Set<BisqEasyOpenTradeMessage>>(emptySet())
 
+    private var tradeJob: Job? = null
+
     fun initialize(tradeId: String) {
-        tradesServiceFacade.selectOpenTrade(tradeId)
-        _selectedTrade.value = tradesServiceFacade.selectedTrade.value
+        // Reset with the job: re-initialising resolves another trade, and until it does, the previous
+        // trade's messages and its not-found dialog do not describe what the screen is showing.
+        _isLoading.value = true
+        _showTradeNotFoundDialog.value = false
+        _selectedTrade.value = null
 
-        val currentTrade = _selectedTrade.value
-        if (currentTrade == null) {
-            log.w { "TradeChatPresenter.initialize called but selectedTrade is null - skipping flow collection" }
-            _showTradeNotFoundDialog.value = true
-            return
-        }
-
-        val bisqEasyOpenTradeChannelModel = currentTrade.bisqEasyOpenTradeChannelModel
-        // cancel notifications of chat related to this trade
-        notificationController.cancel(NotificationIds.getNewChatMessageId(currentTrade.shortTradeId))
-
-        presenterScope.launch {
-            bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
-                observedChatMessages.update {
-                    val newMessages = messages - it
-                    newMessages.forEach { m ->
-                        m.addMessageDeliveryStatusObserver(messageDeliveryServiceFacade)
-                    }
-                    messages
+        tradeJob?.cancel()
+        tradeJob =
+            presenterScope.launch {
+                val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
+                _selectedTrade.value = currentTrade
+                if (currentTrade == null) {
+                    log.w { "TradeChatPresenter.initialize found no trade $tradeId once the open trades synced - skipping flow collection" }
+                    _isLoading.value = false
+                    _showTradeNotFoundDialog.value = true
+                    return@launch
                 }
-            }
-        }
 
-        presenterScope.launch {
-            ignoredProfileIds
-                .combine(bisqEasyOpenTradeChannelModel.chatMessages) { ignoredIds, messages ->
-                    messages
-                        .filter { message ->
-                            when (message.chatMessageType) {
-                                ChatMessageTypeEnum.TEXT, ChatMessageTypeEnum.TAKE_BISQ_EASY_OFFER ->
-                                    !ignoredIds.contains(
-                                        message.senderUserProfileId,
-                                    )
+                val bisqEasyOpenTradeChannelModel = currentTrade.bisqEasyOpenTradeChannelModel
+                // cancel notifications of chat related to this trade
+                notificationController.cancel(NotificationIds.getNewChatMessageId(currentTrade.shortTradeId))
 
-                                else -> true
+                // Children of the trade's job, not of presenterScope: re-initialising with another trade
+                // cancels them along with the wait that started them.
+                launch {
+                    bisqEasyOpenTradeChannelModel.chatMessages
+                        .combine(tradeChatMessagesServiceFacade.chatMessagesSynced) { messages, synced ->
+                            messages.isNotEmpty() || synced
+                        }.first { it }
+                    _isLoading.value = false
+                }
+
+                launch {
+                    bisqEasyOpenTradeChannelModel.chatMessages.collect { messages ->
+                        observedChatMessages.update {
+                            val newMessages = messages - it
+                            newMessages.forEach { m ->
+                                m.addMessageDeliveryStatusObserver(messageDeliveryServiceFacade)
                             }
-                        }.toList()
-                        .sortedByDescending { it.date }
-                }.collect { messages ->
-                    _sortedChatMessages.value = messages
-                    // Load user profile icons off the main thread to avoid
-                    // blocking UI rendering (iOS CA Fence hang prevention)
-                    withContext(Dispatchers.IO) {
-                        for (message in messages) {
-                            val userProfile = message.senderUserProfile
-                            if (_userProfileIconByProfileId.value[userProfile.id] == null) {
-                                val image =
-                                    userProfileServiceFacade.getUserProfileIcon(
-                                        userProfile,
-                                    )
-                                _userProfileIconByProfileId.update { it + (userProfile.id to image) }
-                            }
+                            messages
                         }
                     }
                 }
-        }
+
+                launch {
+                    ignoredProfileIds
+                        .combine(bisqEasyOpenTradeChannelModel.chatMessages) { ignoredIds, messages ->
+                            messages
+                                .filter { message ->
+                                    when (message.chatMessageType) {
+                                        ChatMessageTypeEnum.TEXT, ChatMessageTypeEnum.TAKE_BISQ_EASY_OFFER ->
+                                            !ignoredIds.contains(
+                                                message.senderUserProfileId,
+                                            )
+
+                                        else -> true
+                                    }
+                                }.toList()
+                                .sortedByDescending { it.date }
+                        }.collect { messages ->
+                            _sortedChatMessages.value = messages
+                            // Load user profile icons off the main thread to avoid
+                            // blocking UI rendering (iOS CA Fence hang prevention)
+                            withContext(Dispatchers.IO) {
+                                for (message in messages) {
+                                    val userProfile = message.senderUserProfile
+                                    if (_userProfileIconByProfileId.value[userProfile.id] == null) {
+                                        val image =
+                                            userProfileServiceFacade.getUserProfileIcon(
+                                                userProfile,
+                                            )
+                                        _userProfileIconByProfileId.update { it + (userProfile.id to image) }
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
     }
 
     override fun onViewUnattaching() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
@@ -130,10 +130,14 @@ class TradeChatPresenter(
 
     fun initialize(tradeId: String) {
         // Reset with the job: re-initialising resolves another trade, and until it does, the previous
-        // trade's messages and its not-found dialog do not describe what the screen is showing.
+        // trade's messages and its not-found dialog do not describe what the screen is showing. The
+        // delivery-status observers go with them: cancelling the job stops the collector but leaves the
+        // observers on the previous trade's messages, and onViewUnattaching only runs on leaving.
         _isLoading.value = true
         _showTradeNotFoundDialog.value = false
         _selectedTrade.value = null
+        _sortedChatMessages.value = listOf()
+        clearObservedChatMessages()
 
         tradeJob?.cancel()
         tradeJob =
@@ -141,7 +145,7 @@ class TradeChatPresenter(
                 val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
                 _selectedTrade.value = currentTrade
                 if (currentTrade == null) {
-                    log.w { "TradeChatPresenter.initialize found no trade $tradeId once the open trades synced - skipping flow collection" }
+                    log.w { "TradeChatPresenter.initialize found no trade ${tradeId.take(8)} once the open trades synced - skipping flow collection" }
                     _isLoading.value = false
                     _showTradeNotFoundDialog.value = true
                     return@launch
@@ -211,11 +215,15 @@ class TradeChatPresenter(
 
     override fun onViewUnattaching() {
         _userProfileIconByProfileId.update { emptyMap() }
+        clearObservedChatMessages()
+        super.onViewUnattaching()
+    }
+
+    private fun clearObservedChatMessages() {
         observedChatMessages.update {
             it.forEach { m -> m.removeMessageDeliveryStatusObserver(messageDeliveryServiceFacade) }
             emptySet()
         }
-        super.onViewUnattaching()
     }
 
     fun sendChatMessage(text: String) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatPresenter.kt
@@ -55,7 +55,8 @@ class TradeChatPresenter(
      * True until there is something to render: the trade has to resolve, and its messages arrive over
      * a subscription that on a cold start can land well after the screen opened. An empty message list
      * on its own cannot be told apart from a chat that has not loaded, so the screen state comes from
-     * this flag and the flag from [TradeChatMessagesServiceFacade.chatMessagesSynced].
+     * this flag, and the flag from [TradeChatMessagesServiceFacade.chatMessagesSynced] or, when the
+     * messages are not coming at all, [TradeChatMessagesServiceFacade.chatMessagesSyncFailed].
      */
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -145,7 +146,7 @@ class TradeChatPresenter(
                 val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
                 _selectedTrade.value = currentTrade
                 if (currentTrade == null) {
-                    log.w { "TradeChatPresenter.initialize found no trade ${tradeId.take(8)} once the open trades synced - skipping flow collection" }
+                    log.w { "TradeChatPresenter.initialize could not resolve trade ${tradeId.take(8)}: absent from the synced open trades, or the sync failed - skipping flow collection" }
                     _isLoading.value = false
                     _showTradeNotFoundDialog.value = true
                     return@launch
@@ -158,10 +159,23 @@ class TradeChatPresenter(
                 // Children of the trade's job, not of presenterScope: re-initialising with another trade
                 // cancels them along with the wait that started them.
                 launch {
-                    bisqEasyOpenTradeChannelModel.chatMessages
-                        .combine(tradeChatMessagesServiceFacade.chatMessagesSynced) { messages, synced ->
-                            messages.isNotEmpty() || synced
-                        }.first { it }
+                    // True once there is something to render, false once there is not going to be,
+                    // null while it is still undecided.
+                    val delivered =
+                        combine(
+                            bisqEasyOpenTradeChannelModel.chatMessages,
+                            tradeChatMessagesServiceFacade.chatMessagesSynced,
+                            tradeChatMessagesServiceFacade.chatMessagesSyncFailed,
+                        ) { messages, synced, failed ->
+                            when {
+                                messages.isNotEmpty() || synced -> true
+                                failed -> false
+                                else -> null
+                            }
+                        }.first { it != null }
+                    if (delivered == false) {
+                        log.w { "Chat messages for trade ${tradeId.take(8)} are not coming, their subscription failed - rendering what has arrived" }
+                    }
                     _isLoading.value = false
                 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.launch
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.components.LoadingState
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIcon
 import network.bisq.mobile.presentation.common.ui.components.molecules.TopBar
 import network.bisq.mobile.presentation.common.ui.components.molecules.chat.trade.TradePeerLeftMessageBox
@@ -44,6 +45,7 @@ fun TradeChatScreen(tradeId: String) {
     val showChatRulesWarnBox by presenter.showChatRulesWarnBox.collectAsState()
     val readCount by presenter.readCount.collectAsState()
     val showTradeNotFoundDialog by presenter.showTradeNotFoundDialog.collectAsState()
+    val isLoading by presenter.isLoading.collectAsState()
     val showReportUserDialog by presenter.showReportUserDialog.collectAsState()
     val reportUserTradeMessage by presenter.reportUserTradeMessage.collectAsState()
     val reportUserMessage by presenter.reportUserMessage.collectAsState()
@@ -69,7 +71,12 @@ fun TradeChatScreen(tradeId: String) {
             )
         },
     ) {
-        if (readCount == -1) {
+        if (isLoading) {
+            // Ahead of the read-count branch, mirroring PrivateChatScreen: the trade has to resolve and
+            // its messages have to arrive before there is anything to render. The Box bounds
+            // LoadingState, which fills its parent and would otherwise push the input field off screen.
+            Box(modifier = Modifier.weight(1f)) { LoadingState() }
+        } else if (readCount == -1) {
             // empty placeholder until we know the readCount
             // this helps simplify logic inside the ChatMessageList
             // for providing better UX

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_chat/TradeChatScreen.kt
@@ -61,7 +61,7 @@ fun TradeChatScreen(tradeId: String) {
         quotedMessage = quotedMessage,
         placeholder = "chat.message.input.prompt".i18n(),
         onCloseReply = { presenter.onReply(null) },
-        sendEnabled = isSendChatMessageEnabled,
+        sendEnabled = isSendChatMessageEnabled && selectedTrade != null,
         topBar = {
             TopBar(
                 title =

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -127,6 +127,10 @@ class OpenTradePresenter(
         _selectedTrade.value = null
         _isInMediation.value = false
         _isTradeOutOfSync.value = false
+        // The chat row renders as soon as the trade is published, which happens before its collector
+        // runs, so these would carry the previous trade's numbers into the new one.
+        msgCount.value = 0
+        _lastChatMsg.value = null
 
         tradeJob?.cancel()
         tradeJob =
@@ -134,7 +138,7 @@ class OpenTradePresenter(
                 val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
                 _selectedTrade.value = currentTrade
                 if (currentTrade == null) {
-                    log.w { "OpenTradePresenter.initialize found no trade $tradeId once the open trades synced - skipping flow collection" }
+                    log.w { "OpenTradePresenter.initialize found no trade ${tradeId.take(8)} once the open trades synced - skipping flow collection" }
                     _showTradeNotFoundDialog.value = true
                     return@launch
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.presentation.trade.trade_detail
 import androidx.compose.foundation.ScrollState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +28,7 @@ import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTrad
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum.REJECTED
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.trades.selectOpenTradeWhenSynced
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
 import network.bisq.mobile.domain.utils.TimeUtils
@@ -109,62 +111,77 @@ class OpenTradePresenter(
 
     private var _coroutineScope: CoroutineScope? = null
 
+    private var tradeJob: Job? = null
+
     fun initialize(
         tradeId: String,
         scrollState: ScrollState,
         uiScope: CoroutineScope,
     ) {
-        tradesServiceFacade.selectOpenTrade(tradeId)
-        _selectedTrade.value = tradesServiceFacade.selectedTrade.value
         _tradePaneScrollState.value = scrollState
         _coroutineScope = uiScope
 
-        val currentTrade = _selectedTrade.value
-        if (currentTrade == null) {
-            log.w { "OpenTradePresenter.initialize called but selectedTrade is null - skipping flow collection" }
-            _showTradeNotFoundDialog.value = true
-            return
-        }
+        // Reset with the job: re-initialising resolves another trade, and until it does, the previous
+        // trade's details and its not-found dialog do not describe what the screen is showing.
+        _showTradeNotFoundDialog.value = false
+        _selectedTrade.value = null
+        _isInMediation.value = false
+        _isTradeOutOfSync.value = false
 
-        presenterScope.launch {
-            currentTrade.bisqEasyTradeModel.tradeState.collect(::tradeStateChanged)
-        }
-
-        presenterScope.launch {
-            // The ticker keeps re-evaluating while the trade sits in INIT, so a trade that
-            // crosses the threshold with the screen open starts showing the pane without a
-            // state change; a trade stuck for days shows it immediately.
-            currentTrade.bisqEasyTradeModel.tradeState
-                .combine(TimeUtils.tickerFlow(OUT_OF_SYNC_RECHECK_MS)) { state, _ -> state }
-                .collect {
-                    _isTradeOutOfSync.value = TradeOutOfSyncDetector.isOutOfSync(currentTrade.bisqEasyTradeModel)
+        tradeJob?.cancel()
+        tradeJob =
+            presenterScope.launch {
+                val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
+                _selectedTrade.value = currentTrade
+                if (currentTrade == null) {
+                    log.w { "OpenTradePresenter.initialize found no trade $tradeId once the open trades synced - skipping flow collection" }
+                    _showTradeNotFoundDialog.value = true
+                    return@launch
                 }
-        }
 
-        presenterScope.launch {
-            isUserIgnored
-                .combine(currentTrade.bisqEasyOpenTradeChannelModel.chatMessages) { isIgnored, messages ->
-                    if (isIgnored) {
-                        messages.filter {
-                            when (it.chatMessageType) {
-                                ChatMessageTypeEnum.TEXT, ChatMessageTypeEnum.TAKE_BISQ_EASY_OFFER -> it.senderUserProfileId != currentTrade.peersUserProfile.id
-                                else -> true
-                            }
+                // Children of the trade's job, not of presenterScope: re-initialising with another
+                // trade cancels them along with the wait that started them.
+                launch {
+                    currentTrade.bisqEasyTradeModel.tradeState.collect(::tradeStateChanged)
+                }
+
+                launch {
+                    // The ticker keeps re-evaluating while the trade sits in INIT, so a trade that
+                    // crosses the threshold with the screen open starts showing the pane without a
+                    // state change; a trade stuck for days shows it immediately.
+                    currentTrade.bisqEasyTradeModel.tradeState
+                        .combine(TimeUtils.tickerFlow(OUT_OF_SYNC_RECHECK_MS)) { state, _ -> state }
+                        .collect {
+                            _isTradeOutOfSync.value = TradeOutOfSyncDetector.isOutOfSync(currentTrade.bisqEasyTradeModel)
                         }
-                    } else {
-                        messages
-                    }
-                }.collect {
-                    msgCount.update { _ -> it.size }
-                    _lastChatMsg.update { _ -> it.maxByOrNull { msg -> msg.date } }
                 }
-        }
 
-        presenterScope.launch {
-            currentTrade.bisqEasyOpenTradeChannelModel.isInMediation.collect {
-                _isInMediation.value = it
+                launch {
+                    isUserIgnored
+                        .combine(currentTrade.bisqEasyOpenTradeChannelModel.chatMessages) { isIgnored, messages ->
+                            if (isIgnored) {
+                                messages.filter {
+                                    when (it.chatMessageType) {
+                                        ChatMessageTypeEnum.TEXT, ChatMessageTypeEnum.TAKE_BISQ_EASY_OFFER ->
+                                            it.senderUserProfileId != currentTrade.peersUserProfile.id
+                                        else -> true
+                                    }
+                                }
+                            } else {
+                                messages
+                            }
+                        }.collect {
+                            msgCount.update { _ -> it.size }
+                            _lastChatMsg.update { _ -> it.maxByOrNull { msg -> msg.date } }
+                        }
+                }
+
+                launch {
+                    currentTrade.bisqEasyOpenTradeChannelModel.isInMediation.collect {
+                        _isInMediation.value = it
+                    }
+                }
             }
-        }
     }
 
     override fun onViewUnattaching() {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -127,6 +127,10 @@ class OpenTradePresenter(
         _selectedTrade.value = null
         _isInMediation.value = false
         _isTradeOutOfSync.value = false
+        // A singleTop re-navigation from a rejected trade to another would otherwise show the first
+        // one's interrupted pane on the second until its state collector fires.
+        _tradeAbortedBoxVisible.value = false
+        _tradeProcessBoxVisible.value = false
         // The chat row renders as soon as the trade is published, which happens before its collector
         // runs, so these would carry the previous trade's numbers into the new one.
         msgCount.value = 0
@@ -138,7 +142,7 @@ class OpenTradePresenter(
                 val currentTrade = tradesServiceFacade.selectOpenTradeWhenSynced(tradeId)
                 _selectedTrade.value = currentTrade
                 if (currentTrade == null) {
-                    log.w { "OpenTradePresenter.initialize found no trade ${tradeId.take(8)} once the open trades synced - skipping flow collection" }
+                    log.w { "OpenTradePresenter.initialize could not resolve trade ${tradeId.take(8)}: absent from the synced open trades, or the sync failed - skipping flow collection" }
                     _showTradeNotFoundDialog.value = true
                     return@launch
                 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.isBuy
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.BarcodeScannerView
+import network.bisq.mobile.presentation.common.ui.components.LoadingState
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqButtonType
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
@@ -130,6 +131,14 @@ fun OpenTradeScreen(tradeId: String) {
                         focusManager.clearFocus()
                     },
         ) {
+            // initialize() waits out an open-trades sync that can still be arriving after a cold-start
+            // deep link, so the trade is null for a moment before it resolves or the not-found dialog
+            // takes over. Outside the scrolling Column: LoadingState fills its parent, which needs the
+            // bounded height only the Box has. The Column renders nothing meanwhile.
+            if (selectedTrade == null && !showTradeNotFoundDialog) {
+                LoadingState()
+            }
+
             Column(
                 modifier =
                     Modifier


### PR DESCRIPTION

Fixes #1729.

## The problem

With the app killed, opening a deep link, or tapping a push notification which builds the same `ACTION_VIEW` intent, navigated to the target screen immediately, on top of the still-bootstrapping splash. The app had not connected yet (Tor on the node build, the websocket on Connect), so the target presenter ran against empty state, and pressing back returned to the splash, still connecting.

This is not specific to any one route. `NavigationManagerImpl.navigateFromUri` is route-agnostic and the root `NavHost` starts at `NavRoute.Splash`, so `OpenTrade`, `TradeChat` and `PrivateChat` all behaved the same way.

## What changed

### 1. The navigation gate

`navigateFromUri` holds a link that arrives while the root destination is still `Splash`, and navigates only once startup settles on `TabContainer`. If startup lands anywhere else, such as the user agreement, onboarding, profile creation or the trusted-node setup, the link is dropped, because without a profile there is nothing to open. A newer link supersedes an older pending one. Warm starts return immediately, so a link that arrives with the app already up behaves exactly as before.

**The wait is unbounded, on purpose.** There is nothing to time out against. The user is looking at a splash they cannot navigate away from, so the pending link has no competing intent to go stale against, and a startup that never finishes ends in a restart that takes the coroutine with it. A bound could only ever discard a link that startup was still going to honour, which is the same silent-drop failure this PR exists to fix. The cost of waiting is one suspended coroutine holding a string.

The wait follows the current controller through `rootNavControllerFlow` rather than capturing the one that was current when the link arrived. Startup can replace the controller when the activity is recreated, and a captured controller stops emitting, which would leave the link waiting forever and doing nothing. The controller used for the actual navigation is fetched after the wait, for the same reason.

If the controller cannot report where startup is at all, the link is dropped rather than fired blind, since navigating blind is the failure this PR is fixing.

### 2. Trade and chat data: a sync signal rather than a grace period

Reaching the main screen means bootstrap completed, but on the Connect build the trades and their chat messages can still be arriving. Both trade presenters read a synchronous snapshot of them, and `OpenTradePresenter` raised its trade-not-found dialog immediately, with no grace period at all.

A fixed grace period cannot solve this, because it is wrong in both directions. Too short and the UI lies: on a cold start, trade chat messages land around ten seconds after the screen opens. Too long and a trade that really is gone stalls before saying so. The underlying problem is that an empty collection means "not delivered yet" and "empty" at the same time, and only the data layer knows which.

So both facades publish the distinction:

- `TradesServiceFacade.openTradesSynced`, backed in `BaseTradesServiceFacade`. The client sets it on the `ModificationType.REPLACE` snapshot it already keys on. `WebSocketClientImpl.subscribe` synthesises that event on every successful subscribe, so it is guaranteed to arrive. The node sets it at the end of `activate()`, where the bisq2 `CollectionObserver`s have already replayed the existing collection synchronously while binding.
- `TradeChatMessagesServiceFacade.chatMessagesSynced`, set by the client after the first trade-chat payload is applied to the channels, and by the node in `activate()` for the same reason.

`selectOpenTradeWhenSynced` waits on the first of those. Either the trade resolves, or the trades sync without it, in which case it really is gone. An existing trade is never reported as no longer available, and a stale notification for a closed trade says so at once instead of after a fixed stall. The lookup goes through the facade rather than a local `find`, so the client's short-trade-id fallback keeps working, and it runs in the `first { }` predicate rather than the `combine` transform, which can be called for values that never reach the decision.

### 3. Loading state on the trade screens

Both trade screens rendered a blank body during those waits, which was fine when the lookup was synchronous. They now render `LoadingState` inside the scaffold, so the top bar and its back button stay live, and in trade chat so does the message input. This follows the precedent `PrivateChatScreen` already set.

`OpenTradeScreen` derives its loading state from the trade and the not-found dialog. `TradeChatPresenter` carries an explicit `isLoading` flag instead, because its messages arrive separately and an empty list on its own cannot be told apart from a chat that has not loaded. The flag is driven by `chatMessagesSynced`.

## Notes on the shape of the change

`initialize` is not a suspend function on either presenter. Each launches into `presenterScope` and keeps a `tradeJob` it cancels on re-initialisation, resetting the state that describes the previous trade along with it, which is what `PrivateChatPresenter` does. Keeping it non-suspend leaves cancellation with the presenter rather than splitting it between the composition scope and `presenterScope`.

## Acceptance criteria from #1729

- [x] Cold-start deep link or notification tap shows the splash normally and navigates to the target only after the app reaches the main screen; back from the target goes to the main screen, not the splash.
- [x] A deep link to an existing trade or conversation no longer shows "not found / no longer available" because connecting took longer than a grace period.
- [x] If startup lands on onboarding instead of the main screen, the pending URI is discarded.
- [x] Warm-start deep links behave exactly as today.

## Testing

Unit tests pass across `shared:domain`, `shared:presentation`, `apps:clientApp` and `apps:nodeApp`; ktlint clean. Diff coverage against `upstream/main` is **90%**, above the project's 80% threshold (`./gradlew koverPRCheck`).

New coverage: the cold-start gate (waits then navigates, discards on onboarding, does not fire while startup stays on the splash, last link wins, drops when the splash state cannot be determined), `selectOpenTradeWhenSynced` (resolves immediately, resolves on a later sync update, reports absent once synced, keeps waiting while unsynced), the trade chat loading flag, the trade-not-found path, and the client's `REPLACE` snapshot setting `openTradesSynced` while an incremental update does not.

What is still uncovered, for transparency: the two Compose screens' loading branches, which are UI code, and the ignored-user message filter in both trade presenters, which this PR only re-indented. Nothing covers the tab-graph deep-link path after a cold start, only the root-graph path, and the node's `activate()` setting `openTradesSynced` is argued from the bisq2 observer semantics rather than asserted by a test. The iOS targets were not built. The changed code is `commonMain` and the client facade is shared, so iOS takes the same path, but that is reasoning rather than verification.

Verified on device for the reported scenario: notification tap with the app killed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loading indicators while trade details and trade chats synchronize.
  * Trade and chat views now wait for initial data before showing “not found” or empty states.
  * Added synchronization status and failure handling for open trades and trade messages.
  * Deep links received during the splash screen are queued until startup reaches the main screen.
  * Improved trade selection when data arrives during synchronization.

* **Bug Fixes**
  * Prevented stale trade or chat content from appearing during re-initialization.
  * Improved handling of missing trades and superseded startup deep links.
  * Prevented sending chat messages before a trade is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->