### PR TITLE
fix(nodeApp): keep peer-state collector alive when a snapshot throws

### DIFF
--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
@@ -183,11 +183,23 @@ class NodeNetworkServiceFacade(
             }
     }
 
-    /** The only writer of [_numConnections], [_connectedPeers] and [_myNodeInfo]; runs on one coroutine. */
+    /**
+     * The only writer of [_numConnections], [_connectedPeers] and [_myNodeInfo]; runs on one coroutine.
+     *
+     * Best-effort: the bisq2 getters read here race the node's network threads (#1796: the Node 0.10.0 jar,
+     * before bisq2 fix 6707f25 / PR #4894, threw ConcurrentModificationException from ConnectionMetrics).
+     * A throw escaping here would end this collector for the rest of the session and show a "Coroutine
+     * operation failed" panel, so log and skip; the next tick re-snapshots everything. The three flows are
+     * not atomic (_numConnections is written first); only _connectedPeers is never half-written.
+     */
     private fun refreshPeerState() {
-        updateNumConnections()
-        updateConnectedPeers()
-        updateMyNodeInfo()
+        try {
+            updateNumConnections()
+            updateConnectedPeers()
+            updateMyNodeInfo()
+        } catch (e: Exception) {
+            log.e(e) { "Peer state refresh failed; keeping the collector alive for the next tick" }
+        }
     }
 
     override fun onConnection(connection: Connection) {

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacade.kt
@@ -10,6 +10,7 @@ import bisq.network.p2p.node.CloseReason
 import bisq.network.p2p.node.Connection
 import bisq.network.p2p.node.Node
 import bisq.network.p2p.services.peer_group.PeerGroupService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -197,6 +198,8 @@ class NodeNetworkServiceFacade(
             updateNumConnections()
             updateConnectedPeers()
             updateMyNodeInfo()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log.e(e) { "Peer state refresh failed; keeping the collector alive for the next tick" }
         }

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacadeTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacadeTest.kt
@@ -187,19 +187,22 @@ class NodeNetworkServiceFacadeTest : NodeKoinIntegrationTestBase() {
             activateFacade()
             assertEquals(1, facade.connectedPeers.value.size)
 
-            // When reading a peer's metrics blows up mid-snapshot (#1796: on the Node 0.10.0 jar, before bisq2
-            // fix 6707f25, ConnectionMetrics iterated a TreeMap its network threads were mutating)
+            // When a second peer connects but reading a peer's metrics blows up mid-snapshot (#1796: on the
+            // Node 0.10.0 jar, before bisq2 fix 6707f25, ConnectionMetrics iterated a TreeMap its network
+            // threads were mutating)
+            every { node.allActiveConnections } answers { Stream.of(connection, secondConnection) }
+            every { node.numConnections } returns 2
             every { metrics.sentBytes } throws ConcurrentModificationException()
             facade.onConnection(secondConnection)
             advanceUntilIdle()
 
-            // Then the list keeps its previous snapshot rather than a half-written one
+            // Then the count (written before the mapping) stays live while the list keeps its previous
+            // snapshot rather than a half-written one
+            assertEquals(2, facade.numConnections.value)
             assertEquals(1, facade.connectedPeers.value.size)
 
             // And once the metrics read again, the very next tick refreshes — the single collector is alive
             every { metrics.sentBytes } returns 100L
-            every { node.allActiveConnections } answers { Stream.of(connection, secondConnection) }
-            every { node.numConnections } returns 2
             facade.onConnection(secondConnection)
             advanceUntilIdle()
             assertEquals(2, facade.connectedPeers.value.size)

--- a/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacadeTest.kt
+++ b/apps/nodeApp/src/androidUnitTest/kotlin/network/bisq/mobile/node/common/domain/service/network/NodeNetworkServiceFacadeTest.kt
@@ -26,8 +26,9 @@ import kotlin.test.assertTrue
 
 /**
  * Covers the peer-state refresh lifecycle: a single collector coroutine owns every write, the sampled
- * metrics arm only runs while something collects [NodeNetworkServiceFacade.connectedPeers], and the
- * connect/disconnect arm stays live regardless (it feeds the network status indicator).
+ * metrics arm only runs while something collects [NodeNetworkServiceFacade.connectedPeers], the
+ * connect/disconnect arm stays live regardless (it feeds the network status indicator), and a snapshot
+ * that throws (bisq2 metrics race, #1796) does not end the collector.
  */
 class NodeNetworkServiceFacadeTest : NodeKoinIntegrationTestBase() {
     // Comfortably past METRICS_REFRESH_INTERVAL_MS so a sampled tick has certainly had its chance.
@@ -175,6 +176,32 @@ class NodeNetworkServiceFacadeTest : NodeKoinIntegrationTestBase() {
             advanceUntilIdle()
 
             // Then both the list and the count follow — this arm must not be gated on subscribers
+            assertEquals(2, facade.connectedPeers.value.size)
+            assertEquals(2, facade.numConnections.value)
+        }
+
+    @Test
+    fun `when a snapshot throws then the collector survives and the next tick refreshes`() =
+        runTest {
+            // Given an activated facade holding one peer
+            activateFacade()
+            assertEquals(1, facade.connectedPeers.value.size)
+
+            // When reading a peer's metrics blows up mid-snapshot (#1796: on the Node 0.10.0 jar, before bisq2
+            // fix 6707f25, ConnectionMetrics iterated a TreeMap its network threads were mutating)
+            every { metrics.sentBytes } throws ConcurrentModificationException()
+            facade.onConnection(secondConnection)
+            advanceUntilIdle()
+
+            // Then the list keeps its previous snapshot rather than a half-written one
+            assertEquals(1, facade.connectedPeers.value.size)
+
+            // And once the metrics read again, the very next tick refreshes — the single collector is alive
+            every { metrics.sentBytes } returns 100L
+            every { node.allActiveConnections } answers { Stream.of(connection, secondConnection) }
+            every { node.numConnections } returns 2
+            facade.onConnection(secondConnection)
+            advanceUntilIdle()
             assertEquals(2, facade.connectedPeers.value.size)
             assertEquals(2, facade.numConnections.value)
         }


### PR DESCRIPTION
 - Fixes item 1 in https://github.com/bisq-network/bisq-mobile/issues/1796

 - The ConcurrentModificationException is already fixed in bisq2 [PR #4894](https://github.com/bisq-network/bisq2/pull/4894) (6707f25cd5, TreeMap → ConcurrentSkipListMap).
 - On mobile side, the escaping exception ended the single peer-state collector coroutine for the rest of the session. refreshPeerState() now catches, logs and skips a failed snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Network monitoring now continues refreshing when a peer or node status update encounters a temporary error.
  - Prevents monitoring from stopping or displaying a coroutine failure panel after a transient snapshot issue.
  - Connection counts remain current while the last valid peer list is retained during recovery.
  - Monitoring cancellation now completes cleanly without being mistaken for a refresh failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->