### PR TITLE
add Support chat links to error, out-of-sync, and mediation states

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePaneUiTest.kt
@@ -1,0 +1,87 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InterruptedTradePaneUiTest : PresentationKoinComposeTestBase() {
+    private lateinit var presenter: InterruptedTradePresenter
+    private lateinit var onOpenSupportChannel: () -> Unit
+
+    private val openSupportChannel get() = "mobile.community.support.openChannel".i18n()
+
+    override fun additionalModules(): List<Module> =
+        listOf(
+            module {
+                factory<InterruptedTradePresenter> { presenter }
+            },
+        )
+
+    override fun onKoinReady() {
+        presenter = mockk(relaxed = true)
+        onOpenSupportChannel = mockk(relaxed = true)
+        every { presenter.interruptionInfoVisible } returns MutableStateFlow(false)
+        every { presenter.interruptedTradeInfo } returns MutableStateFlow("")
+        every { presenter.errorMessageVisible } returns MutableStateFlow(true)
+        every { presenter.isInMediation } returns MutableStateFlow(false)
+        every { presenter.reportToMediatorButtonVisible } returns MutableStateFlow(false)
+        every { presenter.showNoMediatorAvailableWarningDialog } returns MutableStateFlow(false)
+        every { presenter.showMediationRequestedDialog } returns MutableStateFlow(false)
+        every { presenter.isCloseTradeEnabled } returns MutableStateFlow(true)
+        every { presenter.isReportToMediatorEnabled } returns MutableStateFlow(true)
+        every { presenter.errorMessage } returns "simulated error"
+    }
+
+    private fun renderPane(showSupportChannel: Boolean) {
+        setTestContent {
+            InterruptedTradePane(
+                showSupportChannel = showSupportChannel,
+                onOpenSupportChannel = onOpenSupportChannel,
+            )
+        }
+    }
+
+    @Test
+    fun `error state shows and opens the support channel`() {
+        renderPane(showSupportChannel = true)
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("action.close".i18n()).assertIsDisplayed()
+        assertEquals(
+            composeTestRule.onNodeWithText(openSupportChannel).getUnclippedBoundsInRoot().top,
+            composeTestRule.onNodeWithText("action.close".i18n()).getUnclippedBoundsInRoot().top,
+        )
+        composeTestRule.onNodeWithText(openSupportChannel).performClick()
+
+        verify(exactly = 1) { onOpenSupportChannel() }
+    }
+
+    @Test
+    fun `error state hides the support channel when unavailable`() {
+        renderPane(showSupportChannel = false)
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
+    }
+
+    @Test
+    fun `cancelled state does not show the support channel`() {
+        every { presenter.interruptionInfoVisible } returns MutableStateFlow(true)
+        every { presenter.interruptedTradeInfo } returns MutableStateFlow("cancelled")
+        every { presenter.errorMessageVisible } returns MutableStateFlow(false)
+
+        renderPane(showSupportChannel = true)
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePaneUiTest.kt
@@ -75,6 +75,15 @@ class InterruptedTradePaneUiTest : PresentationKoinComposeTestBase() {
     }
 
     @Test
+    fun `error state hides the support channel while in mediation`() {
+        every { presenter.isInMediation } returns MutableStateFlow(true)
+
+        renderPane(showSupportChannel = true)
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
+    }
+
+    @Test
     fun `cancelled state does not show the support channel`() {
         every { presenter.interruptionInfoVisible } returns MutableStateFlow(true)
         every { presenter.interruptedTradeInfo } returns MutableStateFlow("cancelled")

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePresenterTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.data.service.mediation.MediationServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
@@ -19,10 +20,12 @@ import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
 import network.bisq.mobile.presentation.common.ui.error.GenericErrorHandler
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.trade.trade_detail.InterruptedTradePresenter
+import network.bisq.mobile.presentation.trade.trade_detail.createTradeDetailsHeaderTestHarness
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class InterruptedTradePresenterTest : PresentationKoinTestBase() {
@@ -171,6 +174,39 @@ class InterruptedTradePresenterTest : PresentationKoinTestBase() {
 
             coVerify { mediationServiceFacade.reportToMediator(tradeItem) }
             assertEquals(true, presenter.showMediationRequestedDialog.value)
+        }
+
+    @Test
+    fun `FAILED state shows an error message`() {
+        assertErrorMessageVisible(BisqEasyTradeStateEnum.FAILED)
+    }
+
+    @Test
+    fun `FAILED_AT_PEER state shows an error message`() {
+        assertErrorMessageVisible(BisqEasyTradeStateEnum.FAILED_AT_PEER)
+    }
+
+    private fun assertErrorMessageVisible(state: BisqEasyTradeStateEnum) =
+        runTest {
+            val harness = createTradeDetailsHeaderTestHarness(isSeller = false)
+            val tradeModel = harness.selectedTrade.value!!.bisqEasyTradeModel
+            every { tradesServiceFacade.selectedTrade } returns harness.selectedTrade
+            every { tradeModel.errorMessage } returns MutableStateFlow("simulated")
+            every { tradeModel.peersErrorMessage } returns MutableStateFlow("simulated")
+
+            val presenter =
+                InterruptedTradePresenter(
+                    mainPresenter,
+                    tradesServiceFacade,
+                    mediationServiceFacade,
+                    tradeReadStateRepository,
+                )
+
+            presenter.onViewAttached()
+            harness.tradeStateFlow.value = state
+
+            assertTrue(presenter.errorMessageVisible.value)
+            presenter.onViewUnattaching()
         }
 
     // Helper: simple polling wait

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/MediationBannerUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/MediationBannerUiTest.kt
@@ -1,0 +1,43 @@
+package network.bisq.mobile.presentation.trade.trade_detail
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.mockk
+import io.mockk.verify
+import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.test.presentation.compose.PresentationKoinComposeTestBase
+import kotlin.test.Test
+
+class MediationBannerUiTest : PresentationKoinComposeTestBase() {
+    private val openSupportChannel get() = "mobile.community.support.openChannel".i18n()
+
+    @Test
+    fun `mediation banner shows and opens the support channel when available`() {
+        val onOpenSupportChannel = mockk<() -> Unit>(relaxed = true)
+
+        setTestContent {
+            MediationBanner(
+                showSupportChannel = true,
+                onOpenSupportChannel = onOpenSupportChannel,
+            )
+        }
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertIsDisplayed()
+        composeTestRule.onNodeWithText(openSupportChannel).performClick()
+
+        verify(exactly = 1) { onOpenSupportChannel() }
+    }
+
+    @Test
+    fun `mediation banner hides the support channel when unavailable`() {
+        setTestContent {
+            MediationBanner(
+                showSupportChannel = false,
+                onOpenSupportChannel = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenterTest.kt
@@ -1,25 +1,34 @@
 package network.bisq.mobile.presentation.trade.trade_detail
 
 import androidx.compose.foundation.ScrollState
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.navOptions
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
+import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.domain.utils.DateUtils
 import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.fixtures.testCommunityHubService
 import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -71,15 +80,28 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
             }
         }
 
-    private fun createAndInitializePresenter() {
+    private fun TestScope.createPresenter(
+        enabledSegments: Set<CommunitySegment> = setOf(CommunitySegment.DISCUSSIONS),
+    ) {
         presenter =
             OpenTradePresenter(
                 mainPresenter,
                 tradeReadStateRepository,
                 tradesServiceFacade,
                 userProfileServiceFacade,
+                testCommunityHubService(
+                    enabled = enabledSegments,
+                    requiredFeatures = emptyMap(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                ),
                 tradeFlowPresenter,
             )
+    }
+
+    private fun TestScope.createAndInitializePresenter(
+        enabledSegments: Set<CommunitySegment> = setOf(CommunitySegment.DISCUSSIONS),
+    ) {
+        createPresenter(enabledSegments)
         val scope = CoroutineScope(testDispatcher + SupervisorJob())
         scrollScope = scope
         presenter.initialize("tid", ScrollState(0), scope)
@@ -123,6 +145,39 @@ class OpenTradePresenterTest : PresentationKoinTestBase() {
             runCurrent()
 
             assertFalse(presenter.isTradeOutOfSync.value)
+        }
+
+    @Test
+    fun `support channel is available when discussions is live`() =
+        runPresenterTest {
+            createPresenter(enabledSegments = setOf(CommunitySegment.DISCUSSIONS))
+
+            assertTrue(presenter.isSupportChannelAvailable.value)
+        }
+
+    @Test
+    fun `support channel is withheld when discussions is not live`() =
+        runPresenterTest {
+            createPresenter(enabledSegments = setOf(CommunitySegment.CONTACTS))
+
+            assertFalse(presenter.isSupportChannelAvailable.value)
+        }
+
+    @Test
+    fun `opening support channel pushes it without changing back stack options`() =
+        runPresenterTest {
+            createPresenter()
+
+            presenter.onOpenSupportChannel()
+            runCurrent()
+
+            val setup = slot<NavOptionsBuilder.() -> Unit>()
+            verify { navigationManager.navigate(NavRoute.SupportChannel, capture(setup), any()) }
+
+            val navOptions = navOptions(setup.captured)
+            assertEquals(-1, navOptions.popUpToId)
+            assertEquals(null, navOptions.popUpToRoute)
+            assertFalse(navOptions.shouldLaunchSingleTop())
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
@@ -75,5 +75,6 @@ class TradeOutOfSyncPaneUiTest : PresentationKoinComposeTestBase() {
 
         composeTestRule.onNodeWithText(headline).assertExists()
         composeTestRule.onNodeWithText(reportToMediator).assertDoesNotExist()
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPaneUiTest.kt
@@ -14,15 +14,18 @@ class TradeOutOfSyncPaneUiTest : PresentationKoinComposeTestBase() {
     private val headline get() = "mobile.bisqEasy.openTrades.outOfSync.headline".i18n()
     private val openChat get() = "mobile.bisqEasy.openTrades.outOfSync.openChat".i18n()
     private val reportToMediator get() = "bisqEasy.openTrades.reportToMediator".i18n()
+    private val openSupportChannel get() = "mobile.community.support.openChannel".i18n()
 
     private fun renderPane(
         isTradeOutOfSync: Boolean,
         isInMediation: Boolean = false,
+        showSupportChannel: Boolean = true,
     ): Pair<OpenTradePresenter, TradeDetailsHeaderPresenter> {
         val presenter = mockk<OpenTradePresenter>(relaxed = true)
         val headerPresenter = mockk<TradeDetailsHeaderPresenter>(relaxed = true)
         every { presenter.isTradeOutOfSync } returns MutableStateFlow(isTradeOutOfSync)
         every { presenter.isInMediation } returns MutableStateFlow(isInMediation)
+        every { presenter.isSupportChannelAvailable } returns MutableStateFlow(showSupportChannel)
 
         setTestContent {
             TradeOutOfSyncPane(presenter = presenter, headerPresenter = headerPresenter)
@@ -44,10 +47,26 @@ class TradeOutOfSyncPaneUiTest : PresentationKoinComposeTestBase() {
     }
 
     @Test
+    fun `an out of sync trade opens the support channel`() {
+        val (presenter, _) = renderPane(isTradeOutOfSync = true)
+
+        composeTestRule.onNodeWithText(openSupportChannel).performClick()
+        verify { presenter.onOpenSupportChannel() }
+    }
+
+    @Test
     fun `a trade in sync renders nothing`() {
         renderPane(isTradeOutOfSync = false)
 
         composeTestRule.onNodeWithText(headline).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the support channel is hidden when it is unavailable`() {
+        renderPane(isTradeOutOfSync = true, showSupportChannel = false)
+
+        composeTestRule.onNodeWithText(headline).assertExists()
+        composeTestRule.onNodeWithText(openSupportChannel).assertDoesNotExist()
     }
 
     @Test

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -210,7 +210,7 @@ val presentationModule =
         factory { TradeDetailsHeaderPresenter(get(), get(), get(), get(), get()) }
         factory { InterruptedTradePresenter(get(), get(), get(), get()) }
         factory { TradeFlowPresenter(get(), get(), get()) }
-        factory { OpenTradePresenter(get(), get(), get(), get(), get()) }
+        factory { OpenTradePresenter(get(), get(), get(), get(), get(), get()) }
 
         factory { TradeChatPresenter(get(), get(), get(), get(), get(), get(), get(), get()) }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -169,13 +169,17 @@ fun SupportScreen() {
  * [SupportWeblink] — there is no URL to open, so there is no leaving-the-app confirmation to show.
  */
 @Composable
-fun SupportChannelLink(onClick: () -> Unit) {
+fun SupportChannelLink(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     BisqButton(
+        modifier = modifier,
         text = "mobile.community.support.openChannel".i18n(),
         onClick = onClick,
         type = BisqButtonType.Outline,
         fullWidth = true,
-        leftIcon = { ChatIcon(modifier = Modifier.size(16.dp)) },
+        leftIcon = { ChatIcon(modifier = Modifier.size(32.dp)) },
     )
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
@@ -27,10 +27,14 @@ import network.bisq.mobile.presentation.common.ui.components.molecules.dialog.Wa
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.EMPTY_STRING
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.settings.support.SupportChannelLink
 import org.koin.compose.koinInject
 
 @Composable
-fun InterruptedTradePane() {
+fun InterruptedTradePane(
+    showSupportChannel: Boolean,
+    onOpenSupportChannel: () -> Unit,
+) {
     val presenter: InterruptedTradePresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
@@ -83,6 +87,13 @@ fun InterruptedTradePane() {
                     .height(IntrinsicSize.Max),
             horizontalArrangement = Arrangement.End,
         ) {
+            if (errorMessageVisible && showSupportChannel) {
+                SupportChannelLink(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    onClick = onOpenSupportChannel,
+                )
+                BisqGap.H1()
+            }
             if (!isInMediation && reportToMediatorButtonVisible) {
                 BisqButton(
                     modifier = Modifier.fillMaxHeight(),

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/InterruptedTradePane.kt
@@ -87,7 +87,7 @@ fun InterruptedTradePane(
                     .height(IntrinsicSize.Max),
             horizontalArrangement = Arrangement.End,
         ) {
-            if (errorMessageVisible && showSupportChannel) {
+            if (errorMessageVisible && showSupportChannel && !isInMediation) {
                 SupportChannelLink(
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                     onClick = onOpenSupportChannel,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/MediationBanner.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/MediationBanner.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -18,27 +17,42 @@ import androidx.compose.ui.unit.dp
 import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.icons.WarningIconGrey
+import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
+import network.bisq.mobile.presentation.settings.support.SupportChannelLink
 
 @Composable
-fun MediationBanner() {
+fun MediationBanner(
+    showSupportChannel: Boolean,
+    onOpenSupportChannel: () -> Unit,
+) {
     Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .fillMaxWidth()
-                .clip(shape = RoundedCornerShape(12.dp))
-                .background(color = BisqTheme.colors.yellow),
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.Top,
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(shape = RoundedCornerShape(12.dp))
+                    .background(color = BisqTheme.colors.yellow),
         ) {
-            WarningIconGrey(modifier = Modifier.size(20.dp).offset(y = 2.dp))
-            BisqText.BaseRegular(
-                text = "mobile.openTrades.inMediation.banner".i18n(),
-                color = BisqTheme.colors.dark_grey50,
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                WarningIconGrey(modifier = Modifier.size(20.dp).offset(y = 2.dp))
+                BisqText.BaseRegular(
+                    text = "mobile.openTrades.inMediation.banner".i18n(),
+                    color = BisqTheme.colors.dark_grey50,
+                )
+            }
+        }
+
+        if (showSupportChannel) {
+            BisqGap.V1()
+            SupportChannelLink(
+                onClick = onOpenSupportChannel,
             )
         }
     }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradePresenter.kt
@@ -31,6 +31,8 @@ import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.trades.selectOpenTradeWhenSynced
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
 import network.bisq.mobile.domain.repository.TradeReadStateRepository
+import network.bisq.mobile.domain.service.community.CommunityHubService
+import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.domain.utils.TimeUtils
 import network.bisq.mobile.domain.utils.TradeOutOfSyncDetector
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
@@ -43,6 +45,7 @@ class OpenTradePresenter(
     tradeReadStateRepository: TradeReadStateRepository,
     private val tradesServiceFacade: TradesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
+    private val communityHubService: CommunityHubService,
     val tradeFlowPresenter: TradeFlowPresenter,
 ) : BasePresenter(mainPresenter) {
     private companion object {
@@ -63,6 +66,15 @@ class OpenTradePresenter(
 
     private val _isTradeOutOfSync: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isTradeOutOfSync: StateFlow<Boolean> = _isTradeOutOfSync.asStateFlow()
+
+    val isSupportChannelAvailable: StateFlow<Boolean> =
+        communityHubService.liveSegments
+            .map { CommunitySegment.DISCUSSIONS in it }
+            .stateIn(
+                presenterScope,
+                SharingStarted.Eagerly,
+                CommunitySegment.DISCUSSIONS in communityHubService.liveSegments.value,
+            )
 
     private val _showTradeNotFoundDialog = MutableStateFlow(false)
     val showTradeNotFoundDialog: StateFlow<Boolean> = _showTradeNotFoundDialog.asStateFlow()
@@ -209,6 +221,10 @@ class OpenTradePresenter(
                 log.w { "onOpenChat: tradeId is blank, ignoring navigation" }
             }
         } ?: log.w { "onOpenChat: tradeId is null, ignoring navigation" }
+    }
+
+    fun onOpenSupportChannel() {
+        navigateTo(NavRoute.SupportChannel)
     }
 
     private fun tradeStateChanged(state: BisqEasyTradeStateEnum?) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/OpenTradeScreen.kt
@@ -70,6 +70,7 @@ fun OpenTradeScreen(tradeId: String) {
     val tradeAbortedBoxVisible by presenter.tradeAbortedBoxVisible.collectAsState()
     val tradeProcessBoxVisible by presenter.tradeProcessBoxVisible.collectAsState()
     val isInMediation by presenter.isInMediation.collectAsState()
+    val isSupportChannelAvailable by presenter.isSupportChannelAvailable.collectAsState()
     val tradeCloseType by headerPresenter.tradeCloseType.collectAsState()
     val showInterruptionConfirmationDialog by headerPresenter.showInterruptionConfirmationDialog.collectAsState()
     val isAnalyticsEnabled by headerPresenter.isAnalyticsEnabled.collectAsState()
@@ -175,14 +176,20 @@ fun OpenTradeScreen(tradeId: String) {
 
                     if (isInMediation) {
                         BisqGap.V2()
-                        MediationBanner()
+                        MediationBanner(
+                            showSupportChannel = isSupportChannelAvailable,
+                            onOpenSupportChannel = presenter::onOpenSupportChannel,
+                        )
                     }
 
                     TradeOutOfSyncPane(presenter = presenter, headerPresenter = headerPresenter)
 
                     if (tradeAbortedBoxVisible) {
                         BisqGap.V2()
-                        InterruptedTradePane()
+                        InterruptedTradePane(
+                            showSupportChannel = isSupportChannelAvailable,
+                            onOpenSupportChannel = presenter::onOpenSupportChannel,
+                        )
                     }
 
                     if (tradeProcessBoxVisible) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
@@ -50,7 +50,7 @@ fun TradeOutOfSyncPane(
     BisqGap.V2()
     TradeOutOfSyncPaneContent(
         showReportToMediator = !isInMediation,
-        showSupportChannel = isSupportChannelAvailable,
+        showSupportChannel = isSupportChannelAvailable && !isInMediation,
         onOpenChat = presenter::onOpenChat,
         onReportToMediator = headerPresenter::onOpenMediationConfirmationDialog,
         onOpenSupportChannel = presenter::onOpenSupportChannel,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
@@ -28,6 +28,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.theme.BisqUIConstants
 import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
+import network.bisq.mobile.presentation.settings.support.SupportChannelLink
 
 /**
  * Shown when a trade has been sitting in the INIT state past
@@ -42,14 +43,17 @@ fun TradeOutOfSyncPane(
 ) {
     val isTradeOutOfSync by presenter.isTradeOutOfSync.collectAsState()
     val isInMediation by presenter.isInMediation.collectAsState()
+    val isSupportChannelAvailable by presenter.isSupportChannelAvailable.collectAsState()
 
     if (!isTradeOutOfSync) return
 
     BisqGap.V2()
     TradeOutOfSyncPaneContent(
         showReportToMediator = !isInMediation,
+        showSupportChannel = isSupportChannelAvailable,
         onOpenChat = presenter::onOpenChat,
         onReportToMediator = headerPresenter::onOpenMediationConfirmationDialog,
+        onOpenSupportChannel = presenter::onOpenSupportChannel,
     )
 }
 
@@ -61,8 +65,10 @@ fun TradeOutOfSyncPane(
 @Composable
 fun TradeOutOfSyncPaneContent(
     showReportToMediator: Boolean,
+    showSupportChannel: Boolean,
     onOpenChat: () -> Unit,
     onReportToMediator: () -> Unit,
+    onOpenSupportChannel: () -> Unit,
 ) {
     Column(
         modifier =
@@ -113,6 +119,13 @@ fun TradeOutOfSyncPaneContent(
                 )
             }
         }
+
+        if (showSupportChannel) {
+            BisqGap.V1()
+            SupportChannelLink(
+                onClick = onOpenSupportChannel,
+            )
+        }
     }
 }
 
@@ -123,8 +136,10 @@ private fun TradeOutOfSyncPaneContent_Preview() {
     BisqTheme.Preview {
         TradeOutOfSyncPaneContent(
             showReportToMediator = true,
+            showSupportChannel = true,
             onOpenChat = {},
             onReportToMediator = {},
+            onOpenSupportChannel = {},
         )
     }
 }
@@ -136,8 +151,10 @@ private fun TradeOutOfSyncPaneContent_InMediationPreview() {
     BisqTheme.Preview {
         TradeOutOfSyncPaneContent(
             showReportToMediator = false,
+            showSupportChannel = true,
             onOpenChat = {},
             onReportToMediator = {},
+            onOpenSupportChannel = {},
         )
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/trade/trade_detail/TradeOutOfSyncPane.kt
@@ -151,7 +151,7 @@ private fun TradeOutOfSyncPaneContent_InMediationPreview() {
     BisqTheme.Preview {
         TradeOutOfSyncPaneContent(
             showReportToMediator = false,
-            showSupportChannel = true,
+            showSupportChannel = false,
             onOpenChat = {},
             onReportToMediator = {},
             onOpenSupportChannel = {},


### PR DESCRIPTION
 - Fixes https://github.com/bisq-network/bisq-mobile/issues/1810
 - Adds 'Visit the support Channel` (SupportChannelLink) to InterruptedTradePane (FAILED and FAILED_AT_PEER states), TradeOutOfSyncPane and MediationBanner.
 - The chat icon used in the `SupportChannelLink` looked too small @ 16.dp, where it's displayed (in Settings :: Support screen). Increased it to 32.dp now.

To easily replicate these error states, use the following code in `OpenTradePresenter :: initialize()` after the `if (currentTrade == null) {}` block:

        val m = currentTrade.bisqEasyTradeModel
        when ("FAILED") { // FAILED | FAILED_AT_PEER | MEDIATION | OUT_OF_SYNC
            "FAILED" -> {
                m.setErrorMessage("simulated")
                m.setTradeState(BisqEasyTradeStateEnum.FAILED)
            }
            "FAILED_AT_PEER" -> {
                m.setPeersErrorMessage("simulated")
                m.setTradeState(FAILED_AT_PEER)
            }
            "MEDIATION" -> currentTrade.bisqEasyOpenTradeChannelModel.setIsMediator(true) // sets isInMediation
            "OUT_OF_SYNC" -> m.setTradeState(BisqEasyTradeStateEnum.INIT)
        }

Preview in mediation state:
<img width="400" height="800" alt="signal-2026-09-06-15-40-24-999_002" src="https://github.com/user-attachments/assets/80b397e0-c217-42bc-bdd6-7a9e687b1259" />

Preview in Out of sync state:
<img width="400" height="800" alt="signal-2026-09-06-15-40-24-999_003" src="https://github.com/user-attachments/assets/e9adbe78-a9c8-4a08-b800-80af2e72e6dd" />

Preview in Peer failed state:
<img width="400" height="800" alt="signal-2026-09-06-15-40-24-999_004" src="https://github.com/user-attachments/assets/39b26a09-9054-4318-8938-b27ed17735ab" />

Preview in failed state:
<img width="400" height="800" alt="signal-2026-09-06-15-40-24-999" src="https://github.com/user-attachments/assets/bedb1292-cbd8-42c9-ad79-ddbdd3abc2fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support-channel links to interrupted-trade, mediation, and out-of-sync trade views when available.
  - Added navigation to the support channel from trade-related screens.
  - Updated support-channel button styling with a larger chat icon.
  - Added a loading state while trade details are being synchronized.

- **Bug Fixes**
  - Support-channel visibility now reflects availability and relevant trade states.

- **Tests**
  - Added coverage for support-channel visibility, interaction, navigation, and interrupted-trade error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->