### PR TITLE
refactor/migrate_low_risk_low_complexity_presenters_to_mvip_ui_arch

### DIFF
--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreenUiTest.kt
@@ -40,12 +40,10 @@ class ClientSupportScreenUiTest : ClientInjectComposeUiTestBase() {
     override fun onBeforeKoinStart() {
         mainPresenter = mockk(relaxed = true)
         clientPresenter = mockk(relaxed = true)
-        // The debug panel branches on these. A relaxed mock hands back an erased Object for a
-        // StateFlow<Boolean>, which only blows up where the value is actually read — so leaving them
+        // The debug panel branches on this. A relaxed mock hands back an erased Object for a
+        // StateFlow, which only blows up where the value is actually read — so leaving it
         // unstubbed is a ClassCastException that fires in the debug build and nowhere else.
-        every { clientPresenter.deviceToken } returns MutableStateFlow(null)
-        every { clientPresenter.isDeviceRegistered } returns MutableStateFlow(false)
-        every { clientPresenter.tokenRequestInProgress } returns MutableStateFlow(false)
+        every { clientPresenter.uiState } returns MutableStateFlow(ClientSupportUiState())
     }
 
     override fun additionalModules(): List<Module> =

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportPresenter.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.client.common.presentation.support
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.bisq.mobile.data.service.push_notification.PushNotificationServiceFacade
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
@@ -22,14 +23,8 @@ class ClientSupportPresenter(
     mainPresenter: MainPresenter,
     private val pushNotificationServiceFacade: PushNotificationServiceFacade,
 ) : BasePresenter(mainPresenter) {
-    private val _deviceToken = MutableStateFlow<String?>(null)
-    val deviceToken: StateFlow<String?> = _deviceToken.asStateFlow()
-
-    private val _isDeviceRegistered = MutableStateFlow(false)
-    val isDeviceRegistered: StateFlow<Boolean> = _isDeviceRegistered.asStateFlow()
-
-    private val _tokenRequestInProgress = MutableStateFlow(false)
-    val tokenRequestInProgress: StateFlow<Boolean> = _tokenRequestInProgress.asStateFlow()
+    private val _uiState = MutableStateFlow(ClientSupportUiState())
+    val uiState: StateFlow<ClientSupportUiState> = _uiState.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
@@ -37,20 +32,30 @@ class ClientSupportPresenter(
         // Observe push notification state
         presenterScope.launch {
             pushNotificationServiceFacade.deviceToken.collect { token ->
-                _deviceToken.value = token
+                _uiState.update { it.copy(deviceToken = token) }
             }
         }
 
         presenterScope.launch {
             pushNotificationServiceFacade.isDeviceRegistered.collect { registered ->
-                _isDeviceRegistered.value = registered
+                _uiState.update { it.copy(isDeviceRegistered = registered) }
             }
         }
     }
 
-    fun onRequestDeviceToken() {
+    fun onAction(action: ClientSupportUiAction) {
+        when (action) {
+            ClientSupportUiAction.OnRequestDeviceToken -> onRequestDeviceToken()
+            is ClientSupportUiAction.OnCopyToken -> {
+                copyToClipboard(action.token)
+                showSnackbar("Token copied to clipboard")
+            }
+        }
+    }
+
+    private fun onRequestDeviceToken() {
         presenterScope.launch {
-            _tokenRequestInProgress.value = true
+            _uiState.update { it.copy(tokenRequestInProgress = true) }
             try {
                 val result = pushNotificationServiceFacade.registerForPushNotifications()
                 if (result.isSuccess) {
@@ -63,14 +68,9 @@ class ClientSupportPresenter(
                 val errorMessage = e.message ?: "Unknown error"
                 showSnackbar("Error: $errorMessage", type = SnackbarType.ERROR)
             } finally {
-                _tokenRequestInProgress.value = false
+                _uiState.update { it.copy(tokenRequestInProgress = false) }
             }
         }
-    }
-
-    fun onCopyToken(token: String) {
-        copyToClipboard(token)
-        showSnackbar("Token copied to clipboard")
     }
 }
 

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportPresenter.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportPresenter.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.presentation.support
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -64,6 +65,10 @@ class ClientSupportPresenter(
                     val errorMessage = result.exceptionOrNull()?.message ?: "Unknown error"
                     showSnackbar("Failed to get device token: $errorMessage", type = SnackbarType.ERROR)
                 }
+            } catch (e: CancellationException) {
+                // Ours (the screen closed mid-request): rethrow so structured cancellation holds
+                // and no snackbar is raised at a screen that is no longer there.
+                throw e
             } catch (e: Exception) {
                 val errorMessage = e.message ?: "Unknown error"
                 showSnackbar("Error: $errorMessage", type = SnackbarType.ERROR)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportScreen.kt
@@ -32,6 +32,7 @@ import network.bisq.mobile.presentation.common.ui.utils.ExcludeFromCoverage
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
 import network.bisq.mobile.presentation.settings.support.SupportChannelLink
 import network.bisq.mobile.presentation.settings.support.SupportPresenter
+import network.bisq.mobile.presentation.settings.support.SupportUiAction
 import network.bisq.mobile.presentation.settings.support.SupportWeblink
 import org.koin.compose.koinInject
 
@@ -51,13 +52,15 @@ fun ClientSupportScreen(
     RememberPresenterLifecycle(supportPresenter)
     RememberPresenterLifecycle(clientPresenter)
 
-    val reportUrl by supportPresenter.reportUrl.collectAsState()
-    val isSupportChannelAvailable by supportPresenter.isSupportChannelAvailable.collectAsState()
+    val supportUiState by supportPresenter.uiState.collectAsState()
+    val reportUrl = supportUiState.reportUrl
+    val isSupportChannelAvailable = supportUiState.isSupportChannelAvailable
 
     // Client-specific push notification state
-    val deviceToken by clientPresenter.deviceToken.collectAsState()
-    val isDeviceRegistered by clientPresenter.isDeviceRegistered.collectAsState()
-    val tokenRequestInProgress by clientPresenter.tokenRequestInProgress.collectAsState()
+    val clientUiState by clientPresenter.uiState.collectAsState()
+    val deviceToken = clientUiState.deviceToken
+    val isDeviceRegistered = clientUiState.isDeviceRegistered
+    val tokenRequestInProgress = clientUiState.tokenRequestInProgress
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.more.support".i18n(), showUserAvatar = false) },
@@ -73,7 +76,7 @@ fun ClientSupportScreen(
         )
         if (isSupportChannelAvailable) {
             BisqGap.V2()
-            SupportChannelLink(onClick = { supportPresenter.onOpenSupportChannel() })
+            SupportChannelLink(onClick = { supportPresenter.onAction(SupportUiAction.OnOpenSupportChannel) })
         }
         BisqGap.V2()
         // Caption so the external links read as one named, secondary group — with or without the
@@ -177,7 +180,7 @@ fun ClientSupportScreen(
             ) {
                 BisqButton(
                     text = if (tokenRequestInProgress) "Requesting..." else "Request Device Token",
-                    onClick = { clientPresenter.onRequestDeviceToken() },
+                    onClick = { clientPresenter.onAction(ClientSupportUiAction.OnRequestDeviceToken) },
                     type = BisqButtonType.Outline,
                     disabled = tokenRequestInProgress,
                 )
@@ -187,7 +190,7 @@ fun ClientSupportScreen(
                         text = "Copy Token",
                         onClick = {
                             deviceToken?.let { token ->
-                                clientPresenter.onCopyToken(token)
+                                clientPresenter.onAction(ClientSupportUiAction.OnCopyToken(token))
                             }
                         },
                         type = BisqButtonType.Outline,

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportUiAction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportUiAction.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.client.common.presentation.support
+
+sealed interface ClientSupportUiAction {
+    data object OnRequestDeviceToken : ClientSupportUiAction
+
+    data class OnCopyToken(
+        val token: String,
+    ) : ClientSupportUiAction
+}

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportUiState.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/presentation/support/ClientSupportUiState.kt
@@ -1,0 +1,8 @@
+package network.bisq.mobile.client.common.presentation.support
+
+/** Push-notification debugging state for the client's Support screen. */
+data class ClientSupportUiState(
+    val deviceToken: String? = null,
+    val isDeviceRegistered: Boolean = false,
+    val tokenRequestInProgress: Boolean = false,
+)

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/guide/GuidePresentersTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/guide/GuidePresentersTest.kt
@@ -1,0 +1,122 @@
+package network.bisq.mobile.presentation.guide
+
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import network.bisq.mobile.data.service.settings.SettingsServiceFacade
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideOverviewPresenter
+import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideProcessPresenter
+import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideSecurityPresenter
+import network.bisq.mobile.presentation.guide.trade_guide.TradeGuideTradeRulesPresenter
+import network.bisq.mobile.presentation.guide.wallet_guide.WalletGuideDownloadPresenter
+import network.bisq.mobile.presentation.guide.wallet_guide.WalletGuideIntroPresenter
+import network.bisq.mobile.presentation.guide.wallet_guide.WalletGuideNewPresenter
+import network.bisq.mobile.presentation.guide.wallet_guide.WalletGuideReceivingPresenter
+import network.bisq.mobile.presentation.main.MainPresenter
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The guide wizards' whole contract is navigation, so one class covers all eight step
+ * presenters: every step's [GuideUiAction.OnNextClick] goes to the declared next route (or pops
+ * the wizard at its end), every [GuideUiAction.OnPrevClick] goes back, and the trade-rules step
+ * confirms the rules exactly when they were not confirmed before.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GuidePresentersTest : PresentationKoinTestBase() {
+    private lateinit var mainPresenter: MainPresenter
+    private lateinit var settingsServiceFacade: SettingsServiceFacade
+    private val tradeRulesConfirmed = MutableStateFlow(false)
+
+    override fun onKoinReady() {
+        mainPresenter = mockk(relaxed = true)
+        settingsServiceFacade = mockk(relaxed = true)
+        tradeRulesConfirmed.value = false
+        every { settingsServiceFacade.tradeRulesConfirmed } returns tradeRulesConfirmed
+    }
+
+    @Test
+    fun `every step's next goes to its declared next route`() =
+        runTest {
+            val forwardSteps: List<Pair<(GuideUiAction) -> Unit, NavRoute>> =
+                listOf(
+                    TradeGuideOverviewPresenter(mainPresenter)::onAction to NavRoute.TradeGuideSecurity,
+                    TradeGuideSecurityPresenter(mainPresenter)::onAction to NavRoute.TradeGuideProcess,
+                    TradeGuideProcessPresenter(mainPresenter)::onAction to NavRoute.TradeGuideTradeRules,
+                    WalletGuideIntroPresenter(mainPresenter)::onAction to NavRoute.WalletGuideDownload,
+                    WalletGuideDownloadPresenter(mainPresenter)::onAction to NavRoute.WalletGuideNewWallet,
+                    WalletGuideNewPresenter(mainPresenter)::onAction to NavRoute.WalletGuideReceiving,
+                )
+
+            forwardSteps.forEach { (onAction, expectedRoute) ->
+                onAction(GuideUiAction.OnNextClick)
+                advanceUntilIdle()
+                verify { navigationManager.navigate(expectedRoute, any(), any()) }
+            }
+        }
+
+    @Test
+    fun `every step's prev navigates back`() =
+        runTest {
+            val steps: List<(GuideUiAction) -> Unit> =
+                listOf(
+                    TradeGuideOverviewPresenter(mainPresenter)::onAction,
+                    TradeGuideSecurityPresenter(mainPresenter)::onAction,
+                    TradeGuideProcessPresenter(mainPresenter)::onAction,
+                    TradeGuideTradeRulesPresenter(mainPresenter, settingsServiceFacade)::onAction,
+                    WalletGuideIntroPresenter(mainPresenter)::onAction,
+                    WalletGuideDownloadPresenter(mainPresenter)::onAction,
+                    WalletGuideNewPresenter(mainPresenter)::onAction,
+                    WalletGuideReceivingPresenter(mainPresenter)::onAction,
+                )
+
+            steps.forEach { it(GuideUiAction.OnPrevClick) }
+            advanceUntilIdle()
+
+            verify(exactly = steps.size) { navigationManager.navigateBack(any()) }
+        }
+
+    @Test
+    fun `the wallet guide's last step pops the wizard instead of stacking a page`() =
+        runTest {
+            WalletGuideReceivingPresenter(mainPresenter).onAction(GuideUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            verify { navigationManager.navigateBackTo(NavRoute.WalletGuideIntro, true, false) }
+            verify(exactly = 0) { navigationManager.navigate(any(), any(), any()) }
+        }
+
+    @Test
+    fun `trade rules next confirms the rules when not yet confirmed and leaves the guide`() =
+        runTest {
+            val presenter = TradeGuideTradeRulesPresenter(mainPresenter, settingsServiceFacade)
+            assertFalse(presenter.uiState.value.tradeRulesConfirmed)
+
+            presenter.onAction(GuideUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { settingsServiceFacade.confirmTradeRules(true) }
+            verify { navigationManager.navigateBackTo(NavRoute.TradeGuideSecurity, true, false) }
+        }
+
+    @Test
+    fun `trade rules next does not re-confirm already confirmed rules`() =
+        runTest {
+            tradeRulesConfirmed.value = true
+            val presenter = TradeGuideTradeRulesPresenter(mainPresenter, settingsServiceFacade)
+            assertTrue(presenter.uiState.value.tradeRulesConfirmed)
+
+            presenter.onAction(GuideUiAction.OnNextClick)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { settingsServiceFacade.confirmTradeRules(any()) }
+            verify { navigationManager.navigateBackTo(NavRoute.TradeGuideSecurity, true, false) }
+        }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/report_user/ReportUserPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/report_user/ReportUserPresenterTest.kt
@@ -35,7 +35,7 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
             )
         presenter.onViewAttached()
         presenter.initialize(reportedUser)
-        presenter.onMessageChange("This user violated chat rules")
+        presenter.onAction(ReportUserUiAction.OnMessageChange("This user violated chat rules"))
     }
 
     override fun onTearDown() {
@@ -55,8 +55,8 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
                 Result.success(Unit)
             }
 
-            presenter.onReportClick()
-            presenter.onReportClick()
+            presenter.onAction(ReportUserUiAction.OnReportClick)
+            presenter.onAction(ReportUserUiAction.OnReportClick)
             runCurrent()
 
             coVerify(exactly = 1) { userProfileServiceFacade.reportUserProfile(reportedUser, any()) }
@@ -73,7 +73,7 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
             coEvery { userProfileServiceFacade.reportUserProfile(any(), any()) } returns
                 Result.failure(RuntimeException("network error"))
 
-            presenter.onReportClick()
+            presenter.onAction(ReportUserUiAction.OnReportClick)
             advanceUntilIdle()
 
             assertTrue(presenter.isReportActionEnabled.value)
@@ -95,7 +95,7 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
             coEvery { userProfileServiceFacade.reportUserProfile(any(), any()) } returns
                 Result.success(Unit)
 
-            presenter.onReportClick()
+            presenter.onAction(ReportUserUiAction.OnReportClick)
             advanceUntilIdle()
 
             assertTrue(presenter.isReportActionEnabled.value)
@@ -122,9 +122,9 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
         runTest {
             coEvery { userProfileServiceFacade.reportUserProfile(any(), any()) } returns
                 Result.failure(RuntimeException("network error"))
-            presenter.onMessageChange(PADDED_MESSAGE)
+            presenter.onAction(ReportUserUiAction.OnMessageChange(PADDED_MESSAGE))
 
-            presenter.onReportClick()
+            presenter.onAction(ReportUserUiAction.OnReportClick)
             advanceUntilIdle()
 
             coVerify(exactly = 1) { userProfileServiceFacade.reportUserProfile(reportedUser, TRIMMED_MESSAGE) }
@@ -139,9 +139,9 @@ class ReportUserPresenterTest : PresentationKoinTestBase() {
                     mainPresenter = mainPresenter,
                     userProfileServiceFacade = userProfileServiceFacade,
                 )
-            uninitializedPresenter.onMessageChange("report text")
+            uninitializedPresenter.onAction(ReportUserUiAction.OnMessageChange("report text"))
 
-            uninitializedPresenter.onReportClick()
+            uninitializedPresenter.onAction(ReportUserUiAction.OnReportClick)
             advanceUntilIdle()
 
             coVerify(exactly = 0) { userProfileServiceFacade.reportUserProfile(any(), any()) }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreenUiTest.kt
@@ -38,7 +38,7 @@ class ReputationScreenUiTest : PresentationKoinComposeTestBase() {
 
     override fun onKoinReady() {
         reputationPresenter = mockk(relaxed = true)
-        every { reputationPresenter.profileId } returns MutableStateFlow("abc123-profile-id")
+        every { reputationPresenter.uiState } returns MutableStateFlow(ReputationUiState(profileId = "abc123-profile-id"))
     }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenterTest.kt
@@ -70,7 +70,7 @@ class SupportPresenterTest : PresentationKoinTestBase() {
         runTest {
             val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
 
-            assertTrue(presenter.isSupportChannelAvailable.value)
+            assertTrue(presenter.uiState.value.isSupportChannelAvailable)
         }
 
     /**
@@ -86,7 +86,7 @@ class SupportPresenterTest : PresentationKoinTestBase() {
         runTest {
             val presenter = createPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
 
-            assertTrue(presenter.isSupportChannelAvailable.value)
+            assertTrue(presenter.uiState.value.isSupportChannelAvailable)
         }
 
     /**
@@ -98,7 +98,7 @@ class SupportPresenterTest : PresentationKoinTestBase() {
         runTest {
             val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.CONTACTS))
 
-            assertFalse(presenter.isSupportChannelAvailable.value)
+            assertFalse(presenter.uiState.value.isSupportChannelAvailable)
         }
 
     /**
@@ -117,12 +117,12 @@ class SupportPresenterTest : PresentationKoinTestBase() {
                     // a backend requirement is the only thing that moves that set after construction.
                     requiredFeatures = mapOf(CommunitySegment.DISCUSSIONS to Feature.PRIVATE_CHAT),
                 )
-            assertTrue(presenter.isSupportChannelAvailable.value)
+            assertTrue(presenter.uiState.value.isSupportChannelAvailable)
 
             capabilities.value = BackendCapabilities.UNAVAILABLE
             advanceUntilIdle()
 
-            assertFalse(presenter.isSupportChannelAvailable.value)
+            assertFalse(presenter.uiState.value.isSupportChannelAvailable)
         }
 
     @Test
@@ -130,7 +130,7 @@ class SupportPresenterTest : PresentationKoinTestBase() {
         runTest {
             val presenter = createAttachedPresenter(enabled = setOf(CommunitySegment.DISCUSSIONS))
 
-            presenter.onOpenSupportChannel()
+            presenter.onAction(SupportUiAction.OnOpenSupportChannel)
             advanceUntilIdle()
 
             verify { navigationManager.navigate(NavRoute.SupportChannel, any(), any()) }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenterTest.kt
@@ -33,8 +33,8 @@ class UserAgreementPresenterTest : PresentationKoinTestBase() {
                 Result.success(Unit)
             }
 
-            presenter.onAcceptTerms()
-            presenter.onAcceptTerms()
+            presenter.onAction(UserAgreementUiAction.OnAcceptTerms)
+            presenter.onAction(UserAgreementUiAction.OnAcceptTerms)
             advanceUntilIdle()
 
             coVerify(exactly = 1) { settingsServiceFacade.confirmTacAccepted(true) }
@@ -47,7 +47,7 @@ class UserAgreementPresenterTest : PresentationKoinTestBase() {
             coEvery { settingsServiceFacade.confirmTacAccepted(true) } returns
                 Result.failure(RuntimeException("network"))
 
-            presenter.onAcceptTerms()
+            presenter.onAction(UserAgreementUiAction.OnAcceptTerms)
             advanceUntilIdle()
 
             assertTrue(presenter.isAcceptTermsEnabled.value)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/utils/BisqLinks.kt
@@ -7,6 +7,7 @@ object BisqLinks {
     const val FREQUENTLY_ASKED_QUESTIONS_URL = "https://bisq.wiki/Frequently_asked_questions"
     const val REPUTATION_WIKI_URL = "https://bisq.wiki/Reputation"
     const val BUILD_REPUTATION_WIKI_URL = "https://bisq.wiki/Reputation#How_to_Build_Reputation"
+    const val BLUE_WALLET_URL = "https://bluewallet.io"
     const val BLUE_WALLET_TUTORIAL_1_URL = "https://www.youtube.com/watch?v=NqY3wBhloH4"
     const val BLUE_WALLET_TUTORIAL_2_URL = "https://www.youtube.com/watch?v=imMX7i4qpmg"
     const val BISQ_MOBILE_GH = "https://github.com/bisq-network/bisq-mobile"

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/GuideUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/GuideUiAction.kt
@@ -1,0 +1,15 @@
+package network.bisq.mobile.presentation.guide
+
+/**
+ * The one action vocabulary shared by every step of the trade and wallet guides: each step is a
+ * wizard page whose only interactions are the scaffold's prev/next. One shared interface instead
+ * of eight per-screen copies — the screens have no per-step actions to diverge on (external links
+ * on guide pages go through `LinkButton`, which owns the confirmation flow itself). A step that
+ * ever grows a real screen-specific action graduates to its own `XxxUiAction` per the standard
+ * convention.
+ */
+sealed interface GuideUiAction {
+    data object OnPrevClick : GuideUiAction
+
+    data object OnNextClick : GuideUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverview.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverview.kt
@@ -10,6 +10,7 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -18,8 +19,8 @@ fun TradeGuideOverview() {
     RememberPresenterLifecycle(presenter)
 
     TradeGuideOverviewContent(
-        prevClick = presenter::prevClick,
-        nextClick = presenter::overviewNextClick,
+        prevClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextClick = { presenter.onAction(GuideUiAction.OnNextClick) },
     )
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverviewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideOverviewPresenter.kt
@@ -2,16 +2,16 @@ package network.bisq.mobile.presentation.guide.trade_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class TradeGuideOverviewPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun overviewNextClick() {
-        navigateTo(NavRoute.TradeGuideSecurity)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.TradeGuideSecurity)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcess.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -26,8 +27,8 @@ fun TradeGuideProcess() {
         title = title,
         stepIndex = 3,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::processNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         horizontalAlignment = Alignment.Start,
     ) {
         BisqText.H3Light("bisqEasy.tradeGuide.process.headline".i18n())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcessPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideProcessPresenter.kt
@@ -2,21 +2,16 @@ package network.bisq.mobile.presentation.guide.trade_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class TradeGuideProcessPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun processNextClick() {
-        navigateTo(NavRoute.TradeGuideTradeRules)
-    }
-
-    fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.TradeGuideTradeRules)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurity.kt
@@ -13,6 +13,7 @@ import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.PreviewEnvironment
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -21,8 +22,8 @@ fun TradeGuideSecurity() {
     RememberPresenterLifecycle(presenter)
 
     TradeGuideSecurityContent(
-        prevClick = presenter::prevClick,
-        nextClick = presenter::securityNextClick,
+        prevClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextClick = { presenter.onAction(GuideUiAction.OnNextClick) },
     )
 }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurityPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideSecurityPresenter.kt
@@ -2,17 +2,16 @@ package network.bisq.mobile.presentation.guide.trade_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class TradeGuideSecurityPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun securityNextClick() {
-        navigateTo(NavRoute.TradeGuideProcess)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.TradeGuideProcess)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRules.kt
@@ -17,6 +17,7 @@ import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenW
 import network.bisq.mobile.presentation.common.ui.theme.BisqTheme
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -24,7 +25,10 @@ fun TradeGuideTradeRules() {
     val presenter: TradeGuideTradeRulesPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val userAgreed by presenter.tradeRulesConfirmed.collectAsState()
+    val userAgreed =
+        presenter.uiState
+            .collectAsState()
+            .value.tradeRulesConfirmed
     val isTradeRulesNextEnabled by presenter.isTradeRulesNextEnabled.collectAsState()
     var localUserAgreed by remember(userAgreed) { mutableStateOf(userAgreed) }
 
@@ -34,8 +38,8 @@ fun TradeGuideTradeRules() {
         title = title,
         stepIndex = 4,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::tradeRulesNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         nextButtonText = "mobile.action.finish".i18n(),
         nextDisabled = !localUserAgreed || !isTradeRulesNextEnabled,
         horizontalAlignment = Alignment.Start,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRulesPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRulesPresenter.kt
@@ -1,36 +1,49 @@
 package network.bisq.mobile.presentation.guide.trade_guide
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class TradeGuideTradeRulesPresenter(
     mainPresenter: MainPresenter,
     private val settingsServiceFacade: SettingsServiceFacade,
 ) : BasePresenter(mainPresenter) {
-    val tradeRulesConfirmed: StateFlow<Boolean> get() = settingsServiceFacade.tradeRulesConfirmed
+    val uiState: StateFlow<TradeGuideTradeRulesUiState> =
+        settingsServiceFacade.tradeRulesConfirmed
+            .map { TradeGuideTradeRulesUiState(tradeRulesConfirmed = it) }
+            .stateIn(
+                presenterScope,
+                SharingStarted.Eagerly,
+                TradeGuideTradeRulesUiState(tradeRulesConfirmed = settingsServiceFacade.tradeRulesConfirmed.value),
+            )
 
     private val _isTradeRulesNextEnabled = MutableStateFlow(true)
     val isTradeRulesNextEnabled: StateFlow<Boolean> = _isTradeRulesNextEnabled.asStateFlow()
 
-    fun prevClick() {
-        navigateBack()
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> onTradeRulesNext()
+        }
     }
 
-    fun tradeRulesNextClick() {
+    private fun onTradeRulesNext() {
         guardedSuspendAction(
             _isTradeRulesNextEnabled,
             "tradeRulesNextClick",
             reEnableGuardOnComplete = false,
         ) {
             try {
-                val isConfirmed = tradeRulesConfirmed.first()
+                val isConfirmed = settingsServiceFacade.tradeRulesConfirmed.first()
                 if (!isConfirmed) {
                     settingsServiceFacade.confirmTradeRules(true)
                 }
@@ -41,9 +54,5 @@ class TradeGuideTradeRulesPresenter(
                 throw e
             }
         }
-    }
-
-    fun navigateSecurityLearnMore() {
-        navigateToUrl(BisqLinks.BISQ_EASY_WIKI_URL)
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRulesUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/trade_guide/TradeGuideTradeRulesUiState.kt
@@ -1,0 +1,7 @@
+package network.bisq.mobile.presentation.guide.trade_guide
+
+/** @param tradeRulesConfirmed whether the user already accepted the trade rules — the screen
+ *  then labels next as plain navigation instead of an acceptance. */
+data class TradeGuideTradeRulesUiState(
+    val tradeRulesConfirmed: Boolean = false,
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownload.kt
@@ -11,7 +11,9 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.button.LinkButton
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
+import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -25,8 +27,8 @@ fun WalletGuideDownload() {
         title = title,
         stepIndex = 2,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::downloadNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         horizontalAlignment = Alignment.Start,
     ) {
         BisqText.H3Light("bisqEasy.walletGuide.download.headline".i18n())
@@ -39,7 +41,7 @@ fun WalletGuideDownload() {
 
         LinkButton(
             "bisqEasy.walletGuide.download.link".i18n(),
-            link = presenter.blueWalletLink,
+            link = BisqLinks.BLUE_WALLET_URL,
         )
 
         BisqGap.V2()

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownloadPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideDownloadPresenter.kt
@@ -2,22 +2,16 @@ package network.bisq.mobile.presentation.guide.wallet_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class WalletGuideDownloadPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    val blueWalletLink = "https://bluewallet.io"
-
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun downloadNextClick() {
-        navigateTo(NavRoute.WalletGuideNewWallet)
-    }
-
-    fun navigateToBlueWallet() {
-        navigateToUrl(blueWalletLink)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.WalletGuideNewWallet)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideIntro.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideIntro.kt
@@ -7,6 +7,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.BisqText
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -20,8 +21,8 @@ fun WalletGuideIntro() {
         title = title,
         stepIndex = 1,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::introNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         horizontalAlignment = Alignment.Start,
     ) {
         BisqText.H3Light("bisqEasy.walletGuide.intro.headline".i18n())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideIntroPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideIntroPresenter.kt
@@ -2,16 +2,16 @@ package network.bisq.mobile.presentation.guide.wallet_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class WalletGuideIntroPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun introNextClick() {
-        navigateTo(NavRoute.WalletGuideDownload)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.WalletGuideDownload)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideNewPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideNewPresenter.kt
@@ -2,16 +2,16 @@ package network.bisq.mobile.presentation.guide.wallet_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class WalletGuideNewPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun newWalletNextClick() {
-        navigateTo(NavRoute.WalletGuideReceiving)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            GuideUiAction.OnNextClick -> navigateTo(NavRoute.WalletGuideReceiving)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideNewWallet.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideNewWallet.kt
@@ -11,6 +11,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.DynamicImage
 import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGap
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -24,8 +25,8 @@ fun WalletGuideNewWallet() {
         title = title,
         stepIndex = 3,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::newWalletNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         horizontalAlignment = Alignment.Start,
     ) {
         BisqText.H3Light("bisqEasy.walletGuide.createWallet.headline".i18n())

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceiving.kt
@@ -23,6 +23,7 @@ import network.bisq.mobile.presentation.common.ui.components.atoms.layout.BisqGa
 import network.bisq.mobile.presentation.common.ui.components.layout.MultiScreenWizardScaffold
 import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecycle
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import org.koin.compose.koinInject
 
 @Composable
@@ -44,8 +45,8 @@ fun WalletGuideReceiving() {
         title = title,
         stepIndex = 4,
         stepsLength = 4,
-        prevOnClick = presenter::prevClick,
-        nextOnClick = presenter::receivingNextClick,
+        prevOnClick = { presenter.onAction(GuideUiAction.OnPrevClick) },
+        nextOnClick = { presenter.onAction(GuideUiAction.OnNextClick) },
         nextButtonText = "action.close".i18n(),
         horizontalAlignment = Alignment.Start,
     ) {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceivingPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/guide/wallet_guide/WalletGuideReceivingPresenter.kt
@@ -2,25 +2,18 @@ package network.bisq.mobile.presentation.guide.wallet_guide
 
 import network.bisq.mobile.presentation.common.ui.base.BasePresenter
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
-import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
+import network.bisq.mobile.presentation.guide.GuideUiAction
 import network.bisq.mobile.presentation.main.MainPresenter
 
 class WalletGuideReceivingPresenter(
     mainPresenter: MainPresenter,
 ) : BasePresenter(mainPresenter) {
-    fun prevClick() {
-        navigateBack()
-    }
-
-    fun receivingNextClick() {
-        navigateBackTo(NavRoute.WalletGuideIntro, true, false)
-    }
-
-    fun navigateToBlueWalletTutorial1() {
-        navigateToUrl(BisqLinks.BLUE_WALLET_TUTORIAL_1_URL)
-    }
-
-    fun navigateToBlueWalletTutorial2() {
-        navigateToUrl(BisqLinks.BLUE_WALLET_TUTORIAL_2_URL)
+    fun onAction(action: GuideUiAction) {
+        when (action) {
+            GuideUiAction.OnPrevClick -> navigateBack()
+            // The guide's last step: leaving forward pops the whole wizard rather than stacking
+            // a fifth page, so back from wherever the user came from does not replay the guide.
+            GuideUiAction.OnNextClick -> navigateBackTo(NavRoute.WalletGuideIntro, true, false)
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserDialog.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserDialog.kt
@@ -63,8 +63,8 @@ fun ReportUserDialog(
     ReportUserDialogContent(
         state = state,
         isReportActionEnabled = isReportActionEnabled,
-        onMessageChange = presenter::onMessageChange,
-        onReportClick = presenter::onReportClick,
+        onMessageChange = { presenter.onAction(ReportUserUiAction.OnMessageChange(it)) },
+        onReportClick = { presenter.onAction(ReportUserUiAction.OnReportClick) },
         onDismiss = onReportSuccess,
     )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserPresenter.kt
@@ -42,7 +42,14 @@ class ReportUserPresenter(
         reportMessage?.let { onMessageChange(it) }
     }
 
-    fun onMessageChange(message: String) {
+    fun onAction(action: ReportUserUiAction) {
+        when (action) {
+            is ReportUserUiAction.OnMessageChange -> onMessageChange(action.message)
+            ReportUserUiAction.OnReportClick -> onReportClick()
+        }
+    }
+
+    private fun onMessageChange(message: String) {
         _uiState.update {
             it.copy(
                 message = message,
@@ -57,7 +64,7 @@ class ReportUserPresenter(
      * off the dismiss path: `ReportUserDialog` wires its Cancel button to the same callback as
      * [ReportUserEffect.ReportSuccess], and only this side can tell the two apart.
      */
-    fun onReportClick() {
+    private fun onReportClick() {
         if (!_uiState.value.isReportMessageValid) return
         guardedSuspendAction(_isReportActionEnabled, "onReportClick", showLoadingOverlay = false) {
             _uiState.update { it.copy(isLoading = true) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/report_user/ReportUserUiAction.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.report_user
+
+sealed interface ReportUserUiAction {
+    data class OnMessageChange(
+        val message: String,
+    ) : ReportUserUiAction
+
+    data object OnReportClick : ReportUserUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationPresenter.kt
@@ -14,12 +14,12 @@ open class ReputationPresenter(
     mainPresenter: MainPresenter,
     val userProfileServiceFacade: UserProfileServiceFacade,
 ) : BasePresenter(mainPresenter) {
-    val profileId: StateFlow<String> =
+    val uiState: StateFlow<ReputationUiState> =
         userProfileServiceFacade.selectedUserProfile
-            .map { it?.id ?: "data.na".i18n() }
+            .map { ReputationUiState(profileId = it?.id ?: "data.na".i18n()) }
             .stateIn(
                 presenterScope,
                 SharingStarted.Lazily,
-                "data.na".i18n(),
+                ReputationUiState(profileId = "data.na".i18n()),
             )
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationScreen.kt
@@ -55,7 +55,10 @@ fun ReputationScreen() {
     val presenter: ReputationPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val profileId by presenter.profileId.collectAsState()
+    val profileId =
+        presenter.uiState
+            .collectAsState()
+            .value.profileId
     var selectedWebLink by remember { mutableStateOf<String?>(null) }
 
     BisqScrollScaffold(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/reputation/ReputationUiState.kt
@@ -1,0 +1,6 @@
+package network.bisq.mobile.presentation.settings.reputation
+
+/** Display-only screen: the profile id the user builds reputation against; no actions to model. */
+data class ReputationUiState(
+    val profileId: String = "",
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportPresenter.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import network.bisq.mobile.domain.service.community.CommunityHubService
 import network.bisq.mobile.domain.service.community.CommunitySegment
 import network.bisq.mobile.domain.utils.DeviceInfoProvider
@@ -22,48 +23,41 @@ class SupportPresenter(
     private val deviceInfoProvider: DeviceInfoProvider,
     private val communityHubService: CommunityHubService,
 ) : BasePresenter(mainPresenter) {
-    // Seeded synchronously from the service's current value (stateIn Eagerly), the way
-    // CommunityHubPresenter seeds its own state: this presenter is a Koin factory behind
+    // Availability seeded synchronously from the service's current value (stateIn Eagerly), the
+    // way CommunityHubPresenter seeds its own state: this presenter is a Koin factory behind
     // RememberPresenterLifecycle, so the Help screen builds a fresh one every time it enters
     // composition, and a flag that only fills in onViewAttached pops the entry in a frame late on
     // every return from the Support channel.
-    private val _isSupportChannelAvailable =
-        MutableStateFlow(CommunitySegment.DISCUSSIONS in communityHubService.liveSegments.value)
-
-    /**
-     * Offers the in-app Support channel when DISCUSSIONS is live — a proxy for public chat being
-     * served, exact only once [CommunityHubService.REQUIRED_FEATURES] carries a DISCUSSIONS entry.
-     * Register that entry when shipping public chat on Connect, or every Connect build offers a
-     * channel its node may not serve. Exact predicate: `PublicChatServiceFacade.isSupported`.
-     */
-    val isSupportChannelAvailable: StateFlow<Boolean> = _isSupportChannelAvailable.asStateFlow()
-
-    protected val _reportUrl: MutableStateFlow<String> = MutableStateFlow("")
-    val reportUrl: StateFlow<String> = _reportUrl.asStateFlow()
+    //
+    // The Support channel is offered when DISCUSSIONS is live — a proxy for public chat being
+    // served through [CommunityHubService.REQUIRED_FEATURES]. Exact predicate:
+    // `PublicChatServiceFacade.isSupported`.
+    private val _uiState =
+        MutableStateFlow(
+            SupportUiState(isSupportChannelAvailable = CommunitySegment.DISCUSSIONS in communityHubService.liveSegments.value),
+        )
+    val uiState: StateFlow<SupportUiState> = _uiState.asStateFlow()
 
     override fun onViewAttached() {
         super.onViewAttached()
 
         communityHubService.liveSegments
-            .onEach { _isSupportChannelAvailable.value = CommunitySegment.DISCUSSIONS in it }
-            .launchIn(presenterScope)
+            .onEach { live ->
+                _uiState.update { it.copy(isSupportChannelAvailable = CommunitySegment.DISCUSSIONS in live) }
+            }.launchIn(presenterScope)
 
         val versionInfo = versionProvider.getVersionInfo(isDemo(), isIOS())
         val deviceInfo = deviceInfoProvider.getDeviceInfo()
 
         val body = "mobile.support.troubleShooting.github.body".i18n(versionInfo, deviceInfo)
-        _reportUrl.value = BisqLinks.BISQ_MOBILE_GH_ISSUES + "/new?body=" + body.urlEncode()
+        _uiState.update { it.copy(reportUrl = BisqLinks.BISQ_MOBILE_GH_ISSUES + "/new?body=" + body.urlEncode()) }
     }
 
-    fun onOpenSupportChannel() {
-        navigateTo(NavRoute.SupportChannel)
-    }
-
-    fun onRestartApp() {
-        restartApp()
-    }
-
-    fun onTerminateApp() {
-        terminateApp()
+    fun onAction(action: SupportUiAction) {
+        when (action) {
+            SupportUiAction.OnOpenSupportChannel -> navigateTo(NavRoute.SupportChannel)
+            SupportUiAction.OnRestartApp -> restartApp()
+            SupportUiAction.OnTerminateApp -> terminateApp()
+        }
     }
 }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportScreen.kt
@@ -36,8 +36,9 @@ fun SupportScreen() {
     val presenter: SupportPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val reportUrl by presenter.reportUrl.collectAsState()
-    val isSupportChannelAvailable by presenter.isSupportChannelAvailable.collectAsState()
+    val uiState by presenter.uiState.collectAsState()
+    val reportUrl = uiState.reportUrl
+    val isSupportChannelAvailable = uiState.isSupportChannelAvailable
 
     BisqScrollScaffold(
         topBar = { TopBar("mobile.more.support".i18n(), showUserAvatar = false) },
@@ -53,7 +54,7 @@ fun SupportScreen() {
         )
         if (isSupportChannelAvailable) {
             BisqGap.V2()
-            SupportChannelLink(onClick = { presenter.onOpenSupportChannel() })
+            SupportChannelLink(onClick = { presenter.onAction(SupportUiAction.OnOpenSupportChannel) })
         }
         BisqGap.V2()
         // Caption so the external links read as one named, secondary group — with or without the
@@ -148,12 +149,12 @@ fun SupportScreen() {
             ) {
                 BisqButton(
                     text = "mobile.support.connectivity.restart".i18n(),
-                    onClick = { presenter.onRestartApp() },
+                    onClick = { presenter.onAction(SupportUiAction.OnRestartApp) },
                     type = BisqButtonType.Outline,
                 )
                 BisqButton(
                     text = "mobile.support.connectivity.shutdown".i18n(),
-                    onClick = { presenter.onTerminateApp() },
+                    onClick = { presenter.onAction(SupportUiAction.OnTerminateApp) },
                     type = BisqButtonType.Outline,
                 )
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportUiAction.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.settings.support
+
+sealed interface SupportUiAction {
+    data object OnOpenSupportChannel : SupportUiAction
+
+    data object OnRestartApp : SupportUiAction
+
+    data object OnTerminateApp : SupportUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/settings/support/SupportUiState.kt
@@ -1,0 +1,11 @@
+package network.bisq.mobile.presentation.settings.support
+
+/**
+ * @param reportUrl the prefilled GitHub issue URL (version + device info in the body).
+ * @param isSupportChannelAvailable whether the in-app Support channel entry renders — live only
+ *   while the hub's Discussions segment is (see the presenter for why that proxy).
+ */
+data class SupportUiState(
+    val reportUrl: String = "",
+    val isSupportChannelAvailable: Boolean = false,
+)

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementPresenter.kt
@@ -17,17 +17,20 @@ open class UserAgreementPresenter(
     IAgreementPresenter {
     override fun analyticsScreenEvent(): AnalyticsEvent.ScreenOpened = AnalyticsEvent.ScreenOpened.UserAgreement
 
-    private val _accepted = MutableStateFlow(false)
-    override val isAccepted: StateFlow<Boolean> = _accepted.asStateFlow()
+    private val _uiState = MutableStateFlow(UserAgreementUiState())
+    override val uiState: StateFlow<UserAgreementUiState> = _uiState.asStateFlow()
 
     private val _isAcceptTermsEnabled = MutableStateFlow(true)
     override val isAcceptTermsEnabled: StateFlow<Boolean> = _isAcceptTermsEnabled.asStateFlow()
 
-    override fun onAccepted(accepted: Boolean) {
-        _accepted.value = accepted
+    override fun onAction(action: UserAgreementUiAction) {
+        when (action) {
+            is UserAgreementUiAction.OnAcceptedChange -> _uiState.value = UserAgreementUiState(isAccepted = action.accepted)
+            UserAgreementUiAction.OnAcceptTerms -> onAcceptTerms()
+        }
     }
 
-    override fun onAcceptTerms() {
+    private fun onAcceptTerms() {
         guardedSuspendAction(
             _isAcceptTermsEnabled,
             "onAcceptTerms",

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementScreen.kt
@@ -25,12 +25,10 @@ import network.bisq.mobile.presentation.common.ui.utils.RememberPresenterLifecyc
 import org.koin.compose.koinInject
 
 interface IAgreementPresenter : ViewPresenter {
-    val isAccepted: StateFlow<Boolean>
+    val uiState: StateFlow<UserAgreementUiState>
     val isAcceptTermsEnabled: StateFlow<Boolean>
 
-    fun onAccepted(accepted: Boolean)
-
-    fun onAcceptTerms()
+    fun onAction(action: UserAgreementUiAction)
 }
 
 @Composable
@@ -38,7 +36,10 @@ fun UserAgreementScreen() {
     val presenter: IAgreementPresenter = koinInject()
     RememberPresenterLifecycle(presenter)
 
-    val isAccepted by presenter.isAccepted.collectAsState()
+    val isAccepted =
+        presenter.uiState
+            .collectAsState()
+            .value.isAccepted
     val isAcceptTermsEnabled by presenter.isAcceptTermsEnabled.collectAsState()
 
     // TODO: Enhancement phase: To add a language dropdown, so as to render the agreement in supported languages
@@ -51,7 +52,7 @@ fun UserAgreementScreen() {
             ) {
                 BisqCheckbox(
                     checked = isAccepted,
-                    onCheckedChange = { presenter.onAccepted(it) },
+                    onCheckedChange = { presenter.onAction(UserAgreementUiAction.OnAcceptedChange(it)) },
                     label = "tac.confirm".i18n(),
                     modifier = Modifier.semantics { contentDescription = "agreement_accept_checkbox" },
                 )
@@ -59,7 +60,7 @@ fun UserAgreementScreen() {
                     text = "tac.accept".i18n(),
                     disabled = !isAccepted || !isAcceptTermsEnabled,
                     fullWidth = true,
-                    onClick = { presenter.onAcceptTerms() },
+                    onClick = { presenter.onAction(UserAgreementUiAction.OnAcceptTerms) },
                     modifier = Modifier.semantics { contentDescription = "agreement_accept_button" },
                 )
             }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementUiAction.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementUiAction.kt
@@ -1,0 +1,9 @@
+package network.bisq.mobile.presentation.startup.user_agreement
+
+sealed interface UserAgreementUiAction {
+    data class OnAcceptedChange(
+        val accepted: Boolean,
+    ) : UserAgreementUiAction
+
+    data object OnAcceptTerms : UserAgreementUiAction
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementUiState.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/startup/user_agreement/UserAgreementUiState.kt
@@ -1,0 +1,6 @@
+package network.bisq.mobile.presentation.startup.user_agreement
+
+/** @param isAccepted the checkbox state; accepting the terms is only enabled while it is set. */
+data class UserAgreementUiState(
+    val isAccepted: Boolean = false,
+)


### PR DESCRIPTION
 - migrate low risk / low complexity screens (8 guides + report to moderator, reputation and user agreement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Streamlined navigation throughout the wallet and trade guides while preserving previous/next-step behavior.
  - Improved consistency for Support, Reputation, User Agreement, reporting, and client-support screens.
  - Client-support status and device-token information are now presented through a unified screen state.
  - Support and reporting interactions use more consistent action handling.

- **Bug Fixes**
  - Added coverage for guide navigation, trade-rules confirmation, reporting, support, reputation, and user-agreement flows.
  - Added a shared Blue Wallet link for wallet setup resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->