### PR TITLE
fix: deep-link follow-ups from #1821 and trade chat notification replay on cold start

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.android.kt
@@ -32,7 +32,7 @@ val androidClientDomainModule =
         } bind NotificationController::class
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
         single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
+            OpenTradesNotificationService(get(), get(), get(), get(), get(), get())
         }
         single {
             PrivateChatNotificationService(get(), get(), get())

--- a/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
+++ b/apps/clientApp/src/iosMain/kotlin/network/bisq/mobile/client/common/di/ClientDomainModule.ios.kt
@@ -33,7 +33,7 @@ val iosClientDomainModule =
         single { NotificationControllerImpl(get()) } bind NotificationController::class
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
         single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
+            OpenTradesNotificationService(get(), get(), get(), get(), get(), get())
         }
         single {
             PrivateChatNotificationService(get(), get(), get())

--- a/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
+++ b/apps/nodeApp/src/androidMain/kotlin/network/bisq/mobile/node/common/di/NodeDomainModule.kt
@@ -290,7 +290,7 @@ val androidNodeDomainModule =
         single { ForegroundServiceControllerImpl(get()) } bind ForegroundServiceController::class
 
         single {
-            OpenTradesNotificationService(get(), get(), get(), get(), get())
+            OpenTradesNotificationService(get(), get(), get(), get(), get(), get())
         }
 
         single {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceChatSyncTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceChatSyncTest.kt
@@ -74,6 +74,11 @@ class OpenTradesNotificationServiceChatSyncTest : PresentationKoinTestBase() {
             )
     }
 
+    override fun onTearDown() {
+        foregroundServiceController.dispose()
+        super.onTearDown()
+    }
+
     @Test
     fun `chat history that lands after a cold start does not notify`() =
         runTest {

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceChatSyncTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceChatSyncTest.kt
@@ -1,0 +1,247 @@
+package network.bisq.mobile.presentation.common.service
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.createMockBisqEasyOpenTradeMessage
+import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.replicated.trade.bisq_easy.BisqEasyTradeModel
+import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.service.ForegroundDetector
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
+import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.presentation.common.notification.ForegroundServiceController
+import network.bisq.mobile.presentation.common.notification.NotificationController
+import network.bisq.mobile.presentation.common.notification.model.NotificationBuilder
+import network.bisq.mobile.test.presentation.coroutines.PresentationKoinTestBase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers issue #1829: on a cold start the trades arrive before their chat history, so a chat baseline
+ * taken when the trade appears reads 0 and the history landing later notified once per trade.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OpenTradesNotificationServiceChatSyncTest : PresentationKoinTestBase() {
+    private val notificationController: NotificationController = mockk(relaxed = true)
+    private val tradesServiceFacade: TradesServiceFacade = mockk(relaxed = true)
+    private val tradeChatMessagesServiceFacade: TradeChatMessagesServiceFacade = mockk(relaxed = true)
+    private val userProfileServiceFacade: UserProfileServiceFacade = mockk(relaxed = true)
+    private val appForegroundController: ForegroundDetector = mockk(relaxed = true)
+
+    private val openTrades = MutableStateFlow<List<TradeItemPresentationModel>>(emptyList())
+    private val chatMessagesSynced = MutableStateFlow(false)
+    private val isForeground = MutableStateFlow(true)
+
+    private var notifyCount = 0
+
+    private lateinit var foregroundServiceController: CollectingForegroundServiceController
+    private lateinit var service: OpenTradesNotificationService
+
+    override fun onKoinReady() {
+        I18nSupport.initialize("en")
+        every { tradesServiceFacade.openTradeItems } returns openTrades
+        every { tradeChatMessagesServiceFacade.chatMessagesSynced } returns chatMessagesSynced
+        every { userProfileServiceFacade.ignoredProfileIds } returns MutableStateFlow(emptySet())
+        every { appForegroundController.isForeground } returns isForeground
+        every { notificationController.notify(any<NotificationBuilder.() -> Unit>()) } answers { notifyCount++ }
+
+        foregroundServiceController = CollectingForegroundServiceController(CoroutineScope(SupervisorJob() + testDispatcher))
+        service =
+            OpenTradesNotificationService(
+                notificationController = notificationController,
+                foregroundServiceController = foregroundServiceController,
+                tradesServiceFacade = tradesServiceFacade,
+                tradeChatMessagesServiceFacade = tradeChatMessagesServiceFacade,
+                userProfileServiceFacade = userProfileServiceFacade,
+                appForegroundController = appForegroundController,
+                dispatcher = testDispatcher,
+            )
+    }
+
+    @Test
+    fun `chat history that lands after a cold start does not notify`() =
+        runTest {
+            // Given - the service observes while the trades are still on their way
+            val first = tradeWithChat("trade-1")
+            val second = tradeWithChat("trade-2")
+            goBackground()
+
+            // When - the trades arrive with empty channels, then the history snapshot lands
+            openTrades.value = listOf(first.trade, second.trade)
+            advanceUntilIdle()
+            first.messages.value = peerMessages("trade-1", 3)
+            second.messages.value = peerMessages("trade-2", 1)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+
+            // Then
+            assertEquals(0, notifyCount, "everything present at the first sync is history")
+        }
+
+    @Test
+    fun `a peer message arriving after the first sync notifies once for its trade`() =
+        runTest {
+            val first = tradeWithChat("trade-1")
+            val second = tradeWithChat("trade-2")
+            goBackground()
+            openTrades.value = listOf(first.trade, second.trade)
+            first.messages.value = peerMessages("trade-1", 3)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+
+            first.messages.value = peerMessages("trade-1", 4)
+            advanceUntilIdle()
+
+            assertEquals(1, notifyCount)
+        }
+
+    @Test
+    fun `a sync that fails first does not disarm notifications once it later succeeds`() =
+        runTest {
+            val trade = tradeWithChat("trade-1")
+            goBackground()
+            openTrades.value = listOf(trade.trade)
+            advanceUntilIdle()
+
+            // When - the first sync never comes, then a reconnect delivers history and a newer message
+            chatMessagesSynced.value = false
+            advanceUntilIdle()
+            trade.messages.value = peerMessages("trade-1", 2)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+            assertEquals(0, notifyCount, "the late history is still history")
+
+            trade.messages.value = peerMessages("trade-1", 3)
+            advanceUntilIdle()
+
+            assertEquals(1, notifyCount)
+        }
+
+    @Test
+    fun `a message that arrived while sync was down notifies once sync is back`() =
+        runTest {
+            val trade = tradeWithChat("trade-1")
+            goBackground()
+            openTrades.value = listOf(trade.trade)
+            trade.messages.value = peerMessages("trade-1", 2)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+
+            chatMessagesSynced.value = false
+            advanceUntilIdle()
+            trade.messages.value = peerMessages("trade-1", 3)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+
+            assertEquals(1, notifyCount, "the count survives the gap, so the message is new against it")
+        }
+
+    @Test
+    fun `own messages in the history do not count`() =
+        runTest {
+            val trade = tradeWithChat("trade-1")
+            goBackground()
+            openTrades.value = listOf(trade.trade)
+            chatMessagesSynced.value = true
+            advanceUntilIdle()
+
+            trade.messages.value = setOf(createMockBisqEasyOpenTradeMessage(tradeId = "trade-1", senderUserProfile = ME, myUserProfile = ME))
+            advanceUntilIdle()
+
+            assertEquals(0, notifyCount)
+        }
+
+    private class TradeWithChat(
+        val trade: TradeItemPresentationModel,
+        val messages: MutableStateFlow<Set<BisqEasyOpenTradeMessage>>,
+    )
+
+    private fun tradeWithChat(tradeId: String): TradeWithChat {
+        val messages = MutableStateFlow<Set<BisqEasyOpenTradeMessage>>(emptySet())
+        val channel = mockk<BisqEasyOpenTradeChannel>(relaxed = true)
+        every { channel.chatMessages } returns messages
+
+        val tradeModel = mockk<BisqEasyTradeModel>(relaxed = true)
+        every { tradeModel.takeOfferDate } returns 0L
+        every { tradeModel.tradeState } returns MutableStateFlow(BisqEasyTradeStateEnum.INIT)
+        every { tradeModel.paymentAccountData } returns MutableStateFlow<String?>(null)
+        every { tradeModel.bitcoinPaymentData } returns MutableStateFlow<String?>(null)
+
+        val trade = mockk<TradeItemPresentationModel>(relaxed = true)
+        every { trade.tradeId } returns tradeId
+        every { trade.shortTradeId } returns tradeId
+        every { trade.peersUserName } returns "peer"
+        every { trade.bisqEasyTradeModel } returns tradeModel
+        every { trade.bisqEasyOpenTradeChannelModel } returns channel
+        return TradeWithChat(trade, messages)
+    }
+
+    private fun peerMessages(
+        tradeId: String,
+        count: Int,
+    ): Set<BisqEasyOpenTradeMessage> =
+        (1..count)
+            .map { createMockBisqEasyOpenTradeMessage(id = "$tradeId-$it", tradeId = tradeId, senderUserProfile = PEER, myUserProfile = ME) }
+            .toSet()
+
+    private suspend fun TestScope.goBackground() {
+        isForeground.value = false
+        advanceUntilIdle()
+    }
+
+    /** Collects each registered flow on [scope], the way the real Android controller does. */
+    private class CollectingForegroundServiceController(
+        private val scope: CoroutineScope,
+    ) : ForegroundServiceController {
+        private val jobs = mutableMapOf<Flow<*>, Job>()
+
+        override fun startService() {}
+
+        override fun stopService() {}
+
+        override fun refreshNotification() {}
+
+        override fun <T> registerObserver(
+            flow: Flow<T>,
+            onStateChange: suspend (T) -> Unit,
+        ) {
+            jobs[flow] = scope.launch { flow.collect { onStateChange(it) } }
+        }
+
+        override fun unregisterObserver(flow: Flow<*>) {
+            jobs.remove(flow)?.cancel()
+        }
+
+        override fun unregisterObservers() {
+            jobs.values.forEach { it.cancel() }
+            jobs.clear()
+        }
+
+        override fun isServiceRunning(): Boolean = true
+
+        override fun dispose() {
+            scope.cancel()
+        }
+    }
+
+    private companion object {
+        val ME = createMockUserProfile("me")
+        val PEER = createMockUserProfile("peer")
+    }
+}

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceLifecycleTest.kt
@@ -50,6 +50,7 @@ class OpenTradesNotificationServiceLifecycleTest : PresentationKoinTestBase() {
                 notificationController = notificationController,
                 foregroundServiceController = foregroundServiceController,
                 tradesServiceFacade = tradesServiceFacade,
+                tradeChatMessagesServiceFacade = mockk(relaxed = true),
                 userProfileServiceFacade = userProfileServiceFacade,
                 appForegroundController = appForegroundController,
             )

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceStateTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationServiceStateTest.kt
@@ -42,6 +42,7 @@ class OpenTradesNotificationServiceStateTest : PresentationKoinTestBase() {
                 notificationController = notificationController,
                 foregroundServiceController = foregroundServiceController,
                 tradesServiceFacade = tradesServiceFacade,
+                tradeChatMessagesServiceFacade = mockk(relaxed = true),
                 userProfileServiceFacade = userProfileServiceFacade,
                 appForegroundController = appForegroundController,
             )

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -284,7 +284,7 @@ class NavigationManagerImplTest {
             advanceUntilIdle()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then - verify error was logged
@@ -447,7 +447,7 @@ class NavigationManagerImplTest {
             advanceUntilIdle()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then - verify root controller did NOT navigate, but tab controller did
@@ -484,7 +484,7 @@ class NavigationManagerImplTest {
             advanceUntilIdle()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then - verify error was logged
@@ -610,7 +610,7 @@ class NavigationManagerImplTest {
             advanceUntilIdle()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then - verify root controller navigated via deep link
@@ -626,14 +626,14 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
+            val mockNavUri = mockRootDeepLink(mockController, "bisq://test")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
             runCurrent()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             runCurrent()
 
             // Then - nothing is stacked on top of the splash
@@ -654,14 +654,14 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
+            val mockNavUri = mockRootDeepLink(mockController, "bisq://test")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
             runCurrent()
 
             // When - startup routes to onboarding instead of the main screen
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             runCurrent()
             destinations.settleOn(destinationOf<NavRoute.Onboarding>())
             runCurrent()
@@ -677,14 +677,14 @@ class NavigationManagerImplTest {
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
+            val mockNavUri = mockRootDeepLink(mockController, "bisq://test")
             mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
             runCurrent()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then
@@ -699,15 +699,15 @@ class NavigationManagerImplTest {
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
             val (firstNavUri, secondNavUri) =
-                mockRootDeepLinks(mockController, "https://bisq.network/first", "https://bisq.network/second")
+                mockRootDeepLinks(mockController, "bisq://first", "bisq://second")
             val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
 
             navigationManager.setRootNavController(mockController)
             runCurrent()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/first")
-            navigationManager.navigateFromUri("https://bisq.network/second")
+            navigationManager.navigateFromUri("bisq://first")
+            navigationManager.navigateFromUri("bisq://second")
             runCurrent()
             destinations.settleOn(destinationOf<NavRoute.TabContainer>())
             runCurrent()
@@ -730,8 +730,8 @@ class NavigationManagerImplTest {
             val heldNavUri = mockk<NavUri>(relaxed = true)
             val laterNavUri = mockk<NavUri>(relaxed = true)
             mockkStatic(::NavUri)
-            every { NavUri("https://bisq.network/held") } returns heldNavUri
-            every { NavUri("https://bisq.network/later") } returns laterNavUri
+            every { NavUri("bisq://held") } returns heldNavUri
+            every { NavUri("bisq://later") } returns laterNavUri
             // The held link is one only the tab graph declares, the way the trades tab is
             every { mockController.graph } returns mockRootGraph
             every { mockRootGraph.hasDeepLink(laterNavUri) } returns true
@@ -743,11 +743,11 @@ class NavigationManagerImplTest {
             runCurrent()
 
             // When - the held link waits, startup settles, and a newer link opens before the tab is up
-            navigationManager.navigateFromUri("https://bisq.network/held")
+            navigationManager.navigateFromUri("bisq://held")
             runCurrent()
             destinations.settleOn(destinationOf<NavRoute.TabContainer>())
             runCurrent()
-            navigationManager.navigateFromUri("https://bisq.network/later")
+            navigationManager.navigateFromUri("bisq://later")
             runCurrent()
             navigationManager.setTabNavController(mockTabController)
             runCurrent()
@@ -758,20 +758,93 @@ class NavigationManagerImplTest {
         }
 
     @Test
+    fun `when uri has a foreign scheme then it is dropped without touching the controller`() =
+        runTest(testDispatcher) {
+            // Given - the app is up and would open any link the root graph declares
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            mockkStatic(::NavUri)
+            every { NavUri(any<String>()) } returns mockk(relaxed = true)
+            every { mockController.graph.hasDeepLink(any<NavUri>()) } returns true
+            mockCurrentDestinations(mockController, destinationOf<NavRoute.TabContainer>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("https://example.com/test")
+            advanceUntilIdle()
+
+            // Then
+            verify(exactly = 0) { mockController.navigate(any<NavUri>(), any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when a foreign uri arrives on splash then the held deep link still navigates`() =
+        runTest(testDispatcher) {
+            // Given
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val heldNavUri = mockRootDeepLink(mockController, "bisq://held")
+            val destinations = mockCurrentDestinations(mockController, destinationOf<NavRoute.Splash>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When - noise the platform forwarded unfiltered arrives after the held link
+            navigationManager.navigateFromUri("bisq://held")
+            navigationManager.navigateFromUri("https://example.com/noise")
+            navigationManager.navigateFromUri("not a uri")
+            runCurrent()
+            destinations.settleOn(destinationOf<NavRoute.TabContainer>())
+            runCurrent()
+
+            // Then - noise cannot supersede a link that could open
+            verify(exactly = 1) { mockController.navigate(heldNavUri, any<NavOptions>()) }
+        }
+
+    @Test
+    fun `when root graph is not set then deep link is dropped and error is logged`() =
+        runTest(testDispatcher) {
+            // Given - the controller is on the main screen but its graph getter still throws
+            val (_, navigationManager, testLogs) = createTestSetup()
+            val mockController = mockk<NavHostController>(relaxed = true)
+            mockkStatic(::NavUri)
+            every { NavUri(any<String>()) } returns mockk(relaxed = true)
+            every { mockController.graph } throws IllegalStateException("You must call setGraph() first")
+            mockCurrentDestinations(mockController, destinationOf<NavRoute.TabContainer>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("bisq://OpenTrade/trade-id")
+            advanceUntilIdle()
+
+            // Then - the failure is logged with the route only, and nothing is navigated
+            verify(exactly = 0) { mockController.navigate(any<NavUri>(), any<NavOptions>()) }
+            val logged = testLogs.single { it.contains("Failed to check whether the graph declares") }
+            assertTrue(logged.contains("OpenTrade"), "Should name the route: $logged")
+            assertFalse(logged.contains("trade-id"), "Should not leak the id: $logged")
+        }
+
+    @Test
     fun `when splash state cannot be determined then deep link is dropped`() =
         runTest(testDispatcher) {
             // Given - the controller cannot report where startup is
             val jobsManager = TestCoroutineJobsManager(testDispatcher)
             val navigationManager = NavigationManagerImpl(jobsManager)
             val mockController = mockk<NavHostController>(relaxed = true)
-            val mockNavUri = mockRootDeepLink(mockController, "https://bisq.network/test")
+            val mockNavUri = mockRootDeepLink(mockController, "bisq://test")
             every { mockController.currentBackStackEntry } throws IllegalStateException("Graph not ready")
 
             navigationManager.setRootNavController(mockController)
             runCurrent()
 
             // When
-            navigationManager.navigateFromUri("https://bisq.network/test")
+            navigationManager.navigateFromUri("bisq://test")
             advanceUntilIdle()
 
             // Then - nothing is navigated blind

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -781,6 +781,27 @@ class NavigationManagerImplTest {
         }
 
     @Test
+    fun `when the scheme is upper case then the deep link still opens`() =
+        runTest(testDispatcher) {
+            // Given - iOS matches a registered scheme case-insensitively, so this reaches the app
+            val jobsManager = TestCoroutineJobsManager(testDispatcher)
+            val navigationManager = NavigationManagerImpl(jobsManager)
+            val mockController = mockk<NavHostController>(relaxed = true)
+            val mockNavUri = mockRootDeepLink(mockController, "BISQ://TabMyTrades")
+            mockCurrentDestinations(mockController, destinationOf<NavRoute.TabContainer>())
+
+            navigationManager.setRootNavController(mockController)
+            runCurrent()
+
+            // When
+            navigationManager.navigateFromUri("BISQ://TabMyTrades")
+            advanceUntilIdle()
+
+            // Then
+            verify(exactly = 1) { mockController.navigate(mockNavUri, any<NavOptions>()) }
+        }
+
+    @Test
     fun `when a foreign uri arrives on splash then the held deep link still navigates`() =
         runTest(testDispatcher) {
             // Given

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImplTest.kt
@@ -844,11 +844,10 @@ class NavigationManagerImplTest {
             navigationManager.navigateFromUri("bisq://OpenTrade/trade-id")
             advanceUntilIdle()
 
-            // Then - the failure is logged with the route only, and nothing is navigated
+            // Then - the failure is logged without echoing the uri, and nothing is navigated
             verify(exactly = 0) { mockController.navigate(any<NavUri>(), any<NavOptions>()) }
             val logged = testLogs.single { it.contains("Failed to check whether the graph declares") }
-            assertTrue(logged.contains("OpenTrade"), "Should name the route: $logged")
-            assertFalse(logged.contains("trade-id"), "Should not leak the id: $logged")
+            assertFalse(logged.contains("OpenTrade") || logged.contains("trade-id"), "Should not echo the uri: $logged")
         }
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferPricePresenterTest.kt
@@ -20,6 +20,7 @@ import network.bisq.mobile.data.replicated.settings.settingsVODemoObj
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.service.ForegroundDetector
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
@@ -219,6 +220,7 @@ class CreateOfferPricePresenterTest : PlatformPresentationKoinTestBase() {
                 notificationController,
                 foregroundServiceController,
                 tradesServiceFacade,
+                mockk<TradeChatMessagesServiceFacade>(relaxed = true),
                 userProfileServiceFacade,
                 foregroundDetector,
             )

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/create_offer/CreateOfferReviewPresenterTest.kt
@@ -28,6 +28,7 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.service.ForegroundDetector
 import network.bisq.mobile.data.service.bootstrap.ApplicationBootstrapFacade
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
@@ -233,6 +234,7 @@ class CreateOfferReviewPresenterTest : PlatformPresentationKoinTestBase() {
                 notificationController,
                 foregroundServiceController,
                 tradesServiceFacade,
+                mockk<TradeChatMessagesServiceFacade>(relaxed = true),
                 userProfileServiceFacade,
                 foregroundDetector,
             )

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.presentation.offer.take_offer
 
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +28,7 @@ import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
 import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.ForegroundDetector
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.settings.SettingsServiceFacade
 import network.bisq.mobile.data.service.trades.TakeOfferStatus
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
@@ -219,6 +221,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
                 notificationController,
                 foregroundServiceController,
                 tradesServiceFacade,
+                mockk<TradeChatMessagesServiceFacade>(relaxed = true),
                 userProfileServiceFacade,
                 foregroundDetector,
             )

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
@@ -1,7 +1,9 @@
 package network.bisq.mobile.presentation.common.service
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -20,6 +24,7 @@ import network.bisq.mobile.data.replicated.chat.bisq_easy.open_trades.BisqEasyOp
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
 import network.bisq.mobile.data.replicated.trade.bisq_easy.protocol.BisqEasyTradeStateEnum
 import network.bisq.mobile.data.service.ForegroundDetector
+import network.bisq.mobile.data.service.chat.trade.TradeChatMessagesServiceFacade
 import network.bisq.mobile.data.service.offers.OffersServiceFacade
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.data.service.user_profile.UserProfileServiceFacade
@@ -49,8 +54,11 @@ class OpenTradesNotificationService(
     private val notificationController: NotificationController,
     private val foregroundServiceController: ForegroundServiceController,
     private val tradesServiceFacade: TradesServiceFacade,
+    private val tradeChatMessagesServiceFacade: TradeChatMessagesServiceFacade,
     private val userProfileServiceFacade: UserProfileServiceFacade,
     private val appForegroundController: ForegroundDetector,
+    // Injectable so tests can drive the debounce and the observers on their virtual-time dispatcher.
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : Logging {
     private val observedTradeIds = mutableSetOf<String>()
 
@@ -58,10 +66,12 @@ class OpenTradesNotificationService(
     // This set prevents duplicate notifications for the same trade
     private val notifiedPaymentInfo = mutableSetOf<String>()
     private val perTradeFlows = mutableMapOf<String, MutableList<Flow<*>>>()
+
+    // Absent until the first synced snapshot for the trade has been seen; see observeChatMessages.
     private val perTradePeerMessageCount = mutableMapOf<String, Int>()
     private val stateMutex = Mutex()
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private var lifecycleObserverJob: Job? = null
 
     @Volatile
@@ -356,17 +366,18 @@ class OpenTradesNotificationService(
 
     /**
      * Helper function to register a flow observer for a specific trade
-     * Skips initial value and only emits on actual state changes
+     * Only emits on actual changes, and by default skips the current value as well
      */
     private suspend fun <T> registerTradeFlowObserver(
         trade: TradeItemPresentationModel,
         flow: Flow<T>,
+        skipCurrentValue: Boolean = true,
         onStateChange: suspend (T) -> Unit,
     ) {
         val changeFlow =
             flow
                 .distinctUntilChanged() // Only emit when state actually changes
-                .drop(1) // Skip the initial/current value
+                .drop(if (skipCurrentValue) 1 else 0)
         foregroundServiceController.registerObserver(changeFlow, onStateChange)
         val stillObserved =
             stateMutex.withLock {
@@ -459,29 +470,39 @@ class OpenTradesNotificationService(
         }
     }
 
+    /**
+     * Notifies on an increase in peer messages over the last count seen, where the first count is
+     * taken from the first synced snapshot rather than from whatever the channel holds when the
+     * observer is registered. On a cold start the trades arrive before their chat history does, so a
+     * baseline taken at registration reads 0 and the history landing seconds later would notify once
+     * per trade. Everything present when the data layer first reports sync is history; every increase
+     * after that is new.
+     *
+     * While sync is off (not yet delivered, or failed) the channel is not observed at all, so nothing
+     * can be counted against a baseline that does not exist yet. A failed sync therefore only pauses
+     * notifications: the observer resumes as soon as sync later succeeds, and the count kept across
+     * the gap means messages that arrived during it still notify.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun observeChatMessages(trade: TradeItemPresentationModel) {
-        // Initialize chat message count
-        val initialCount = getUnignoredMessageCount(trade.bisqEasyOpenTradeChannelModel.chatMessages.value)
-        stateMutex.withLock {
-            perTradePeerMessageCount[trade.shortTradeId] = initialCount
-        }
-
-        // Register observer for chat message changes
+        val syncedChatMessages =
+            tradeChatMessagesServiceFacade.chatMessagesSynced.flatMapLatest { synced ->
+                if (synced) trade.bisqEasyOpenTradeChannelModel.chatMessages else emptyFlow()
+            }
         registerTradeFlowObserver(
             trade,
-            trade.bisqEasyOpenTradeChannelModel.chatMessages,
+            syncedChatMessages,
+            skipCurrentValue = false,
         ) { newChatMessages ->
             log.d { "Chat messages updated for trade ${trade.shortTradeId}" }
             val currentPeerMsgCount = getUnignoredMessageCount(newChatMessages)
 
-            var shouldNotify = false
-            stateMutex.withLock {
-                val lastCount = perTradePeerMessageCount[trade.shortTradeId] ?: 0
-                if (currentPeerMsgCount > lastCount) {
-                    shouldNotify = true
+            val shouldNotify =
+                stateMutex.withLock {
+                    val lastCount = perTradePeerMessageCount[trade.shortTradeId]
+                    perTradePeerMessageCount[trade.shortTradeId] = currentPeerMsgCount
+                    lastCount != null && currentPeerMsgCount > lastCount
                 }
-                perTradePeerMessageCount[trade.shortTradeId] = currentPeerMsgCount
-            }
 
             if (shouldNotify) {
                 notify(

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/service/OpenTradesNotificationService.kt
@@ -366,7 +366,9 @@ class OpenTradesNotificationService(
 
     /**
      * Helper function to register a flow observer for a specific trade
-     * Only emits on actual changes, and by default skips the current value as well
+     * Only emits on actual changes, and by default skips the current value as well: for trade state
+     * and payment data the current value is what the user already saw. Chat is the exception, its
+     * first value is the baseline the later counts are compared against (see [observeChatMessages]).
      */
     private suspend fun <T> registerTradeFlowObserver(
         trade: TradeItemPresentationModel,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import network.bisq.mobile.domain.utils.CoroutineJobsManager
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.domain.utils.resultCatching
+import network.bisq.mobile.presentation.common.ui.navigation.NAV_BASE_PATH
 import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.common.ui.navigation.TabNavRoute
 import kotlin.reflect.KClass
@@ -242,6 +243,13 @@ class NavigationManagerImpl(
     }
 
     override fun navigateFromUri(uri: String) {
+        // The platforms forward whatever the intent carried, unfiltered. Only our own scheme can match a
+        // graph, and turning a foreign uri away here keeps it from superseding a held link it could
+        // never replace, and keeps its content out of the logs below.
+        if (!uri.startsWith(NAV_BASE_PATH)) {
+            log.w { "Dropping deep link, scheme is not $NAV_BASE_PATH" }
+            return
+        }
         scope.launch {
             when (isAtSplash()) {
                 true -> holdDeepLink(uri)
@@ -316,7 +324,7 @@ class NavigationManagerImpl(
     private suspend fun openDeepLink(uri: String) {
         val navUri = NavUri(uri)
         val rootNavController = getRootNavController() ?: return
-        if (rootNavController.graph.hasDeepLink(navUri)) {
+        if (rootNavController.declaresDeepLink(navUri, uri)) {
             navMutex.withLock {
                 resultCatching {
                     val navOptions =
@@ -332,7 +340,7 @@ class NavigationManagerImpl(
         }
 
         val tabNavController = if (isAtMainScreen()) getTabNavController() else null
-        if (tabNavController == null || !tabNavController.graph.hasDeepLink(navUri)) {
+        if (tabNavController == null || !tabNavController.declaresDeepLink(navUri, uri)) {
             log.w { "Dropping deep link ${uri.deepLinkRoute()}, no graph on screen declares it" }
             return
         }
@@ -353,6 +361,17 @@ class NavigationManagerImpl(
         }
     }
 
+    // The graph getter throws until the host sets one; a link that cannot be checked is dropped like
+    // one nothing declares.
+    private suspend fun NavHostController.declaresDeepLink(
+        navUri: NavUri,
+        uri: String,
+    ): Boolean =
+        resultCatching { graph.hasDeepLink(navUri) }
+            .onFailure { e ->
+                log.e(e) { "Failed to check whether the graph declares ${uri.deepLinkRoute()} (nav graph may not be ready yet)" }
+            }.getOrDefault(false)
+
     // A missing controller or destination means the host is not composed yet, which only happens on
     // startup. Null when the controller cannot answer at all.
     private suspend fun isAtSplash(): Boolean? =
@@ -365,10 +384,10 @@ class NavigationManagerImpl(
 
     /**
      * Deep links reach [navigateFromUri] from outside the app and carry ids (a trade, a channel, a
-     * profile) after the route. Diagnostics only need to know which route was held or dropped, so the
-     * id never reaches the log.
+     * profile) after the route, as a path segment or a query. Diagnostics only need to know which
+     * route was held or dropped, so nothing past the route reaches the log.
      */
-    private fun String.deepLinkRoute(): String = substringAfter("://").substringBefore('/')
+    private fun String.deepLinkRoute(): String = substringAfter("://", missingDelimiterValue = "").takeWhile { it !in "/?#" }
 
     override fun navigateBack(onCompleted: (() -> Unit)?) {
         scope.launch {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -245,8 +245,9 @@ class NavigationManagerImpl(
     override fun navigateFromUri(uri: String) {
         // The platforms forward whatever the intent carried, unfiltered. Only our own scheme can match a
         // graph, and turning a foreign uri away here keeps it from superseding a held link it could
-        // never replace, and keeps its content out of the logs below. Case-insensitive because iOS
-        // matches a registered scheme that way and the nav graphs do too.
+        // never replace. Case-insensitive because iOS matches a registered scheme that way and the nav
+        // graphs do too. No log here or below echoes any part of the uri: it stays untrusted input
+        // until a graph accepts it, and the ids after the route are what the user is about to look at.
         if (!uri.startsWith(NAV_BASE_PATH, ignoreCase = true)) {
             log.w { "Dropping deep link, scheme is not $NAV_BASE_PATH" }
             return
@@ -262,7 +263,7 @@ class NavigationManagerImpl(
                 null -> {
                     // Navigating blind could stack the target on a splash that is not ready; a link that is
                     // not opened is the lesser harm.
-                    log.w { "Dropping deep link ${uri.deepLinkRoute()}, cannot tell whether startup is still on the splash" }
+                    log.w { "Dropping deep link, cannot tell whether startup is still on the splash" }
                 }
             }
         }
@@ -279,7 +280,7 @@ class NavigationManagerImpl(
      * the graphs exist. A link nothing declares opens nothing, on a warm start just the same.
      */
     private fun holdDeepLink(uri: String) {
-        log.i { "Holding deep link ${uri.deepLinkRoute()} until startup leaves the splash" }
+        log.i { "Holding deep link until startup leaves the splash" }
         dropHeldDeepLink()
         heldDeepLink = scope.launch { openDeepLinkWhenSettled(uri) }
     }
@@ -310,7 +311,7 @@ class NavigationManagerImpl(
                 .flatMapLatest { it.currentBackStackEntryFlow }
                 .first { !it.destination.hasRoute<NavRoute.Splash>() }
         if (!settled.destination.hasRoute<NavRoute.TabContainer>()) {
-            log.i { "Dropping deep link ${uri.deepLinkRoute()}, startup landed on ${settled.destination.route} instead of the main screen" }
+            log.i { "Dropping deep link, startup landed on ${settled.destination.route} instead of the main screen" }
             return
         }
         openDeepLink(uri)
@@ -325,7 +326,7 @@ class NavigationManagerImpl(
     private suspend fun openDeepLink(uri: String) {
         val navUri = NavUri(uri)
         val rootNavController = getRootNavController() ?: return
-        if (rootNavController.declaresDeepLink(navUri, uri)) {
+        if (rootNavController.declaresDeepLink(navUri)) {
             navMutex.withLock {
                 resultCatching {
                     val navOptions =
@@ -334,15 +335,15 @@ class NavigationManagerImpl(
                         }
                     rootNavController.navigate(navUri, navOptions)
                 }.onFailure { e ->
-                    log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via root graph" }
+                    log.e(e) { "Failed to navigate from uri via root graph" }
                 }
             }
             return
         }
 
         val tabNavController = if (isAtMainScreen()) getTabNavController() else null
-        if (tabNavController == null || !tabNavController.declaresDeepLink(navUri, uri)) {
-            log.w { "Dropping deep link ${uri.deepLinkRoute()}, no graph on screen declares it" }
+        if (tabNavController == null || !tabNavController.declaresDeepLink(navUri)) {
+            log.w { "Dropping deep link, no graph on screen declares it" }
             return
         }
         navMutex.withLock {
@@ -357,20 +358,17 @@ class NavigationManagerImpl(
                     }
                 tabNavController.navigate(navUri, navOptions)
             }.onFailure { e ->
-                log.e(e) { "Failed to navigate from uri ${uri.deepLinkRoute()} via tab graph" }
+                log.e(e) { "Failed to navigate from uri via tab graph" }
             }
         }
     }
 
     // The graph getter throws until the host sets one; a link that cannot be checked is dropped like
     // one nothing declares.
-    private suspend fun NavHostController.declaresDeepLink(
-        navUri: NavUri,
-        uri: String,
-    ): Boolean =
+    private suspend fun NavHostController.declaresDeepLink(navUri: NavUri): Boolean =
         resultCatching { graph.hasDeepLink(navUri) }
             .onFailure { e ->
-                log.e(e) { "Failed to check whether the graph declares ${uri.deepLinkRoute()} (nav graph may not be ready yet)" }
+                log.e(e) { "Failed to check whether the graph declares the deep link (nav graph may not be ready yet)" }
             }.getOrDefault(false)
 
     // A missing controller or destination means the host is not composed yet, which only happens on
@@ -382,13 +380,6 @@ class NavigationManagerImpl(
         }.onFailure { e ->
             log.e(e) { "Failed to determine if at splash (nav graph may not be ready yet)" }
         }.getOrNull()
-
-    /**
-     * Deep links reach [navigateFromUri] from outside the app and carry ids (a trade, a channel, a
-     * profile) after the route, as a path segment or a query. Diagnostics only need to know which
-     * route was held or dropped, so nothing past the route reaches the log.
-     */
-    private fun String.deepLinkRoute(): String = substringAfter("://", missingDelimiterValue = "").takeWhile { it !in "/?#" }
 
     override fun navigateBack(onCompleted: (() -> Unit)?) {
         scope.launch {

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/ui/navigation/manager/NavigationManagerImpl.kt
@@ -245,8 +245,9 @@ class NavigationManagerImpl(
     override fun navigateFromUri(uri: String) {
         // The platforms forward whatever the intent carried, unfiltered. Only our own scheme can match a
         // graph, and turning a foreign uri away here keeps it from superseding a held link it could
-        // never replace, and keeps its content out of the logs below.
-        if (!uri.startsWith(NAV_BASE_PATH)) {
+        // never replace, and keeps its content out of the logs below. Case-insensitive because iOS
+        // matches a registered scheme that way and the nav graphs do too.
+        if (!uri.startsWith(NAV_BASE_PATH, ignoreCase = true)) {
             log.w { "Dropping deep link, scheme is not $NAV_BASE_PATH" }
             return
         }


### PR DESCRIPTION
Follow-up to #1821. Shared code only, so everything here applies to the client app and the node app on Android and iOS.

Closes #1829

## 1. Deep links: reject foreign schemes before they can supersede a held link

Addresses the remaining review comments on #1821.

- **Scheme check at the mouth of `navigateFromUri`.** Both Android manifests and the iOS `Info.plist` register only the `bisq` scheme, and push notification routes are built from the same `NAV_BASE_PATH` constant, so a uri that does not start with it can never match a graph. Such a uri is now dropped before anything else runs. This closes the edge where a foreign or malformed uri arriving on the splash cancelled a held link it could never replace. The check is case-insensitive, because iOS matches a registered scheme that way and AndroidX `NavDeepLink` patterns do too.
- **No log echoes any part of the uri.** Until a graph accepts it the uri is untrusted input from the platform, and the route segment is no exception. The hold, drop and failure logs now say what happened to the link without quoting it, which also removes the old `deepLinkRoute` helper. The one log that names a destination takes it from the graph (where startup landed), not from the intent.
- **Guarded graph access.** Both `graph.hasDeepLink` calls go through a `declaresDeepLink` helper on the file's existing `resultCatching` pattern. An unset graph is logged and treated as "nothing declares it", instead of escaping as an `IllegalStateException`.

Not done: the snackbar for a superseding link that then cannot open. That is a UX change and belongs in its own PR.

## 2. Trade chat notifications: take the baseline from the first synced snapshot

Root cause confirmed as described in #1829. `OpenTradesNotificationService.observeChatMessages` took its per-trade baseline from the channel at observer registration. On a cold start the trades arrive before their chat history, so the baseline read 0 and the history landing seconds later posted one "new message" notification per trade.

- The chat observer now only collects a trade's channel while `TradeChatMessagesServiceFacade.chatMessagesSynced` is true. The first emission it sees is the synced snapshot, which sets the baseline without notifying. Every increase after that notifies.
- The count map stays empty until that first synced snapshot, instead of being pre-filled with 0 at registration.
- A failed sync only pauses the observer. It resumes when sync later succeeds, and the count kept across the gap means a message that arrived during a disconnect still notifies on reconnect.
- The service dispatcher is injectable with a `Dispatchers.Default` default, matching `PrivateChatNotificationService`, so tests can drive the debounce on virtual time.
- The three DI modules and the existing test constructors were updated for the new dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved open-trade chat notifications so messages are evaluated after synchronization, avoiding alerts for existing history while reliably notifying about new peer messages.
  - Prevented duplicate or incorrect notifications when synchronization is interrupted and later restored.
  - Improved deep-link handling by rejecting unsupported schemes and safely handling malformed or unrecognized links.
  - Deep links are now processed consistently regardless of letter casing, while navigation errors are handled without exposing sensitive link details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->