### PR TITLE
refactor/extract_take_offer_elegibility_gating_and_wizard_routing_into_coordinator_for_reusal

### DIFF
--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/analytics/ScreenAnalyticsCoverageTest.kt
@@ -504,6 +504,7 @@ class ScreenAnalyticsCoverageTest : PlatformPresentationKoinTestBase() {
             marketPriceServiceFacade,
             mockk(relaxed = true),
             FakeConfigServiceFacade(),
+            mockk(relaxed = true),
         ).also { it.selectOfferToTake(OfferItemPresentationModel(OfferTestFactory.makeOfferDto())) }
 
     // ============== Test-only presenters =============================

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferAmountPresenterTest.kt
@@ -302,7 +302,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Select offer
             val dto = makeOfferDto()
@@ -369,7 +369,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Select offer
             val dto = makeOfferDto()
@@ -412,7 +412,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Select offer
             val dto = makeOfferDto()
@@ -452,7 +452,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Select offer
             val dto = makeOfferDto()
@@ -487,7 +487,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Create an offer with MXN market (which has no price data)
             val amountSpec = QuoteSideRangeAmountSpecVO(minAmount = 10_0000L, maxAmount = 100_0000L)
@@ -561,7 +561,7 @@ class TakeOfferAmountPresenterTest : PlatformPresentationKoinTestBase() {
             val mainPresenter = makeMainPresenter()
             val tradesServiceFacade = FakeTradesServiceFacade()
             val takeOfferCoordinator =
-                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+                TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             // Select offer
             val dto = makeOfferDto()

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -1,5 +1,8 @@
 package network.bisq.mobile.presentation.offer.take_offer
 
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -8,11 +11,15 @@ import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.replicated.common.currency.MarketVOFactory
 import network.bisq.mobile.data.replicated.common.monetary.MonetaryVO
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOFactory
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideRangeAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVO
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.data.replicated.presentation.open_trades.TradeItemPresentationModel
+import network.bisq.mobile.data.replicated.user.profile.createMockUserProfile
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
+import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.trades.TakeOfferStatus
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
 import network.bisq.mobile.domain.analytics.AnalyticsEvent
@@ -22,15 +29,19 @@ import network.bisq.mobile.domain.model.trade.ClosedTradeListItem
 import network.bisq.mobile.domain.model.trade.TradeOutcomeFilter
 import network.bisq.mobile.domain.model.trade.TradeRoleFilter
 import network.bisq.mobile.domain.model.trade.TradeSort
+import network.bisq.mobile.i18n.I18nSupport
+import network.bisq.mobile.i18n.i18n
 import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeMarketPriceServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.FakeTradesServiceFacade
 import network.bisq.mobile.presentation.common.test_utils.OfferTestFactory
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.test.mocks.SettingsRepositoryMock
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -50,7 +61,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer with fixed amount
         val fixedAmountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
@@ -87,7 +98,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
             val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
             val tradesServiceFacade = FakeTradesServiceFacade(Result.failure(RuntimeException("node rejected the request")))
-            val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+            val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
             val fixedAmountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
             val dto = OfferTestFactory.makeOfferDto(amountSpec = fixedAmountSpec)
@@ -115,7 +126,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer with wide range (100_000 to 5_000_000)
         // Trade limits: MIN $6 = 60_000, MAX $600 = 6_000_000
@@ -146,7 +157,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer where range collapses after clamping
         // Offer range: 1_070_000 to 1_075_000 (difference = 5_000, which is < 10_000 slider step)
@@ -173,7 +184,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, emptyMap())
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer with range spec
         val rangeSpec = QuoteSideRangeAmountSpecVO(minAmount = 100_000L, maxAmount = 5_000_000L)
@@ -202,7 +213,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer where min > max trade limit
         // Trade limits: MIN $6 = 60_000, MAX $600 = 6_000_000
@@ -234,7 +245,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, prices)
 
         val tradesServiceFacade = FakeTradesServiceFacade()
-        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade())
+        val presenter = TakeOfferCoordinator(marketPriceServiceFacade, tradesServiceFacade, FakeConfigServiceFacade(), mockk(relaxed = true))
 
         // Act: Select offer with wide range and 2 quote payment methods
         val rangeSpec = QuoteSideRangeAmountSpecVO(minAmount = 100_000L, maxAmount = 5_000_000L)
@@ -253,5 +264,166 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         assertTrue(presenter.showAmountScreen())
         assertTrue(presenter.showPaymentMethodsScreen())
         assertEquals(3, presenter.totalSteps)
+    }
+
+    // ---- firstScreen + checkTakeOfferEligibility, extracted from OfferbookPresenter (#1631) so
+    // ---- every take-offer entry point (offerbook, peer profile) shares one gate and one routing.
+
+    @Test
+    fun firstScreen_rangeOffer_startsAtAmountScreen() {
+        val coordinator = makeCoordinator()
+        val rangeSpec = QuoteSideRangeAmountSpecVO(minAmount = 100_000L, maxAmount = 5_000_000L)
+        coordinator.selectOfferToTake(OfferItemPresentationModel(OfferTestFactory.makeOfferDto(amountSpec = rangeSpec)))
+
+        assertEquals(NavRoute.TakeOfferTradeAmount, coordinator.firstScreen())
+    }
+
+    @Test
+    fun firstScreen_fixedAmountSingleMethods_startsAtReview() {
+        val coordinator = makeCoordinator()
+        val fixedSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
+        coordinator.selectOfferToTake(OfferItemPresentationModel(OfferTestFactory.makeOfferDto(amountSpec = fixedSpec)))
+
+        assertEquals(NavRoute.TakeOfferReviewTrade, coordinator.firstScreen())
+    }
+
+    @Test
+    fun firstScreen_fixedAmountMultiplePaymentMethods_startsAtPaymentMethod() {
+        val coordinator = makeCoordinator()
+        val fixedSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
+        val dto = OfferTestFactory.makeOfferDto(amountSpec = fixedSpec, paymentMethods = listOf("SEPA", "Wise"))
+        coordinator.selectOfferToTake(OfferItemPresentationModel(dto))
+
+        assertEquals(NavRoute.TakeOfferPaymentMethod, coordinator.firstScreen())
+    }
+
+    @Test
+    fun firstScreen_fixedAmountMultipleSettlementMethods_startsAtSettlementMethod() {
+        val coordinator = makeCoordinator()
+        val fixedSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L)
+        val dto = OfferTestFactory.makeOfferDto(amountSpec = fixedSpec, btcMethods = listOf("MAIN_CHAIN", "LN"))
+        coordinator.selectOfferToTake(OfferItemPresentationModel(dto))
+
+        assertEquals(NavRoute.TakeOfferSettlementMethod, coordinator.firstScreen())
+    }
+
+    /** SELL offer: the maker is the seller, so it is the MAKER's score that must satisfy the amount. */
+    @Test
+    fun checkTakeOfferEligibility_sellOffer_makerScoreSufficient_isEligible() =
+        runTest {
+            val reputationServiceFacade = mockk<ReputationServiceFacade>(relaxed = true)
+            coEvery { reputationServiceFacade.getReputation(any()) } returns
+                Result.success(ReputationScoreVO(totalScore = 1_000_000L, fiveSystemScore = 5.0, ranking = 1))
+            val coordinator = makeCoordinator(reputationServiceFacade)
+            // $50 fixed → required score 50 × requiredReputationScorePerUsd (> 0)
+            val dto =
+                OfferTestFactory.makeOfferDto(
+                    amountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L),
+                    direction = DirectionEnum.SELL,
+                )
+
+            val result =
+                coordinator.checkTakeOfferEligibility(
+                    OfferItemPresentationModel(dto),
+                    createMockUserProfile("me"),
+                )
+
+            assertEquals(TakeOfferEligibility.Eligible, result)
+            // The maker's id from OfferTestFactory is "id"; my own profile must NOT be queried.
+            coVerify(exactly = 1) { reputationServiceFacade.getReputation("id") }
+            coVerify(exactly = 0) { reputationServiceFacade.getReputation("me") }
+        }
+
+    @Test
+    fun checkTakeOfferEligibility_sellOffer_makerScoreTooLow_buyerWarning() =
+        runTest {
+            I18nSupport.initialize("en")
+            val reputationServiceFacade = mockk<ReputationServiceFacade>(relaxed = true)
+            coEvery { reputationServiceFacade.getReputation(any()) } returns
+                Result.success(ReputationScoreVO(totalScore = 0L, fiveSystemScore = 0.0, ranking = 0))
+            val coordinator = makeCoordinator(reputationServiceFacade)
+            val dto =
+                OfferTestFactory.makeOfferDto(
+                    amountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L),
+                    direction = DirectionEnum.SELL,
+                )
+
+            val result =
+                coordinator.checkTakeOfferEligibility(
+                    OfferItemPresentationModel(dto),
+                    createMockUserProfile("me"),
+                )
+
+            assertIs<TakeOfferEligibility.NotEnoughReputation>(result)
+            assertFalse(result.isSellerAsTakerWarning)
+            assertEquals("chat.message.takeOffer.buyer.invalidOffer.headline".i18n(), result.headline)
+            assertTrue(result.message.isNotBlank())
+        }
+
+    /** BUY offer: the taker would sell, so it is MY score that must satisfy the amount. */
+    @Test
+    fun checkTakeOfferEligibility_buyOffer_myScoreTooLow_sellerAsTakerWarning() =
+        runTest {
+            I18nSupport.initialize("en")
+            val reputationServiceFacade = mockk<ReputationServiceFacade>(relaxed = true)
+            coEvery { reputationServiceFacade.getReputation(any()) } returns
+                Result.success(ReputationScoreVO(totalScore = 0L, fiveSystemScore = 0.0, ranking = 0))
+            val coordinator = makeCoordinator(reputationServiceFacade)
+            val dto =
+                OfferTestFactory.makeOfferDto(
+                    amountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L),
+                    direction = DirectionEnum.BUY,
+                )
+
+            val result =
+                coordinator.checkTakeOfferEligibility(
+                    OfferItemPresentationModel(dto),
+                    createMockUserProfile("me"),
+                )
+
+            assertIs<TakeOfferEligibility.NotEnoughReputation>(result)
+            assertTrue(result.isSellerAsTakerWarning)
+            assertEquals("chat.message.takeOffer.seller.insufficientScore.headline".i18n(), result.headline)
+            coVerify(exactly = 1) { reputationServiceFacade.getReputation("me") }
+        }
+
+    /**
+     * A failed reputation lookup counts as score 0 — the strict policy the offerbook shipped with
+     * (the "not cached yet" allowance is deliberately commented out there). Documented here so a
+     * future policy change flips a test, not silently both entry points.
+     */
+    @Test
+    fun checkTakeOfferEligibility_reputationLookupFailure_treatsScoreAsZero() =
+        runTest {
+            I18nSupport.initialize("en")
+            val reputationServiceFacade = mockk<ReputationServiceFacade>(relaxed = true)
+            coEvery { reputationServiceFacade.getReputation(any()) } returns
+                Result.failure(RuntimeException("Reputation of user id not cached yet"))
+            val coordinator = makeCoordinator(reputationServiceFacade)
+            val dto =
+                OfferTestFactory.makeOfferDto(
+                    amountSpec = QuoteSideFixedAmountSpecVO(amount = 500_000L),
+                    direction = DirectionEnum.SELL,
+                )
+
+            val result =
+                coordinator.checkTakeOfferEligibility(
+                    OfferItemPresentationModel(dto),
+                    createMockUserProfile("me"),
+                )
+
+            assertIs<TakeOfferEligibility.NotEnoughReputation>(result)
+        }
+
+    private fun makeCoordinator(reputationServiceFacade: ReputationServiceFacade = mockk(relaxed = true)): TakeOfferCoordinator {
+        val settingsRepo = SettingsRepositoryMock()
+        val marketPriceServiceFacade = FakeMarketPriceServiceFacade(settingsRepo, OfferTestFactory.usdPrices())
+        return TakeOfferCoordinator(
+            marketPriceServiceFacade,
+            FakeTradesServiceFacade(),
+            FakeConfigServiceFacade(),
+            reputationServiceFacade,
+            computationDispatcher = testDispatcher,
+        )
     }
 }

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinatorTest.kt
@@ -266,7 +266,7 @@ class TakeOfferCoordinatorTest : PlatformPresentationKoinTestBase() {
         assertEquals(3, presenter.totalSteps)
     }
 
-    // ---- firstScreen + checkTakeOfferEligibility, extracted from OfferbookPresenter (#1631) so
+    // ---- firstScreen + checkTakeOfferEligibility, extracted from OfferbookPresenter so
     // ---- every take-offer entry point (offerbook, peer profile) shares one gate and one routing.
 
     @Test

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenterGuardedActionsTest.kt
@@ -40,11 +40,14 @@ import network.bisq.mobile.presentation.common.test_utils.FakeConfigServiceFacad
 import network.bisq.mobile.presentation.common.test_utils.MainPresenterTestFactory
 import network.bisq.mobile.presentation.common.test_utils.TestApplicationLifecycleService
 import network.bisq.mobile.presentation.common.ui.base.GlobalUiManager
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
+import network.bisq.mobile.presentation.offer.take_offer.TakeOfferEligibility
 import network.bisq.mobile.test.presentation.coroutines.PlatformPresentationKoinTestBase
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -191,6 +194,49 @@ class OfferbookPresenterGuardedActionsTest : PlatformPresentationKoinTestBase() 
             advanceUntilIdle()
 
             coVerify(exactly = 0) { takeOfferCoordinator.selectOfferToTake(any()) }
+            verify(exactly = 0) { navigationManager.navigate(any(), any(), any()) }
+        }
+
+    @Test
+    fun `takeOffer on eligible offer starts the wizard at the coordinator's first screen`() =
+        runTest {
+            val otherOffer = makeOffer(id = "other-offer", isMy = false)
+            val takeOfferCoordinator = mockk<TakeOfferCoordinator>(relaxed = true)
+            coEvery { takeOfferCoordinator.checkTakeOfferEligibility(any(), any()) } returns TakeOfferEligibility.Eligible
+            every { takeOfferCoordinator.firstScreen() } returns NavRoute.TakeOfferReviewTrade
+
+            val presenter = buildPresenter(offers = listOf(otherOffer), takeOfferCoordinator = takeOfferCoordinator)
+            setSelectedOffer(presenter, otherOffer)
+            invokeTakeOffer(presenter)
+            advanceUntilIdle()
+
+            verify(exactly = 1) { takeOfferCoordinator.selectOfferToTake(otherOffer) }
+            verify { navigationManager.navigate(NavRoute.TakeOfferReviewTrade, any(), any()) }
+        }
+
+    @Test
+    fun `takeOffer without enough reputation shows the dialog and re-enables the guard`() =
+        runTest {
+            val otherOffer = makeOffer(id = "other-offer", isMy = false)
+            val takeOfferCoordinator = mockk<TakeOfferCoordinator>(relaxed = true)
+            coEvery { takeOfferCoordinator.checkTakeOfferEligibility(any(), any()) } returns
+                TakeOfferEligibility.NotEnoughReputation(
+                    headline = "headline",
+                    message = "message",
+                    isSellerAsTakerWarning = true,
+                )
+
+            val presenter = buildPresenter(offers = listOf(otherOffer), takeOfferCoordinator = takeOfferCoordinator)
+            setSelectedOffer(presenter, otherOffer)
+            invokeTakeOffer(presenter)
+            advanceUntilIdle()
+
+            assertTrue(presenter.showNotEnoughReputationDialog.value)
+            assertTrue(presenter.isTakeOfferEnabled.value)
+            assertEquals("headline", presenter.notEnoughReputationHeadline)
+            assertEquals("message", presenter.notEnoughReputationMessage)
+            assertTrue(presenter.isReputationWarningForSellerAsTaker)
+            verify(exactly = 0) { takeOfferCoordinator.selectOfferToTake(any()) }
             verify(exactly = 0) { navigationManager.navigate(any(), any(), any()) }
         }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/common/di/PresentationModule.kt
@@ -149,7 +149,7 @@ val presentationModule =
         factory<OfferbookMarketPresenter> { OfferbookMarketPresenter(get(), get(), get(), get(), get(), get(), get()) }
 
         // Take offer
-        single { TakeOfferCoordinator(get(), get(), get()) }
+        single { TakeOfferCoordinator(get(), get(), get(), get()) }
         factory { TakeOfferAmountPresenter(get(), get(), get(), get()) }
         factory { TakeOfferPaymentMethodPresenter(get(), get()) }
         factory { TakeOfferReviewPresenter(get(), get(), get(), get()) }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
@@ -1,6 +1,9 @@
 package network.bisq.mobile.presentation.offer.take_offer
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.model.market.MarketPriceItem
 import network.bisq.mobile.data.replicated.common.monetary.CoinVO
 import network.bisq.mobile.data.replicated.common.monetary.CoinVOFactory
@@ -12,19 +15,30 @@ import network.bisq.mobile.data.replicated.common.monetary.FiatVOFactory.from
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVO
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOExtensions.toBaseSideMonetary
 import network.bisq.mobile.data.replicated.common.monetary.PriceQuoteVOExtensions.toQuoteSideMonetary
+import network.bisq.mobile.data.replicated.offer.DirectionEnum
+import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.mirror
 import network.bisq.mobile.data.replicated.offer.amount.spec.BaseSideFixedAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.amount.spec.QuoteSideFixedAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.amount.spec.RangeAmountSpecVO
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMaxAmount
+import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMinAmount
 import network.bisq.mobile.data.replicated.offer.price.spec.PriceSpecVOExtensions.getPriceQuoteVO
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
+import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
+import network.bisq.mobile.data.replicated.user.reputation.ReputationScoreVO
 import network.bisq.mobile.data.service.config.ConfigServiceFacade
 import network.bisq.mobile.data.service.market_price.MarketPriceServiceFacade
+import network.bisq.mobile.data.service.reputation.ReputationServiceFacade
 import network.bisq.mobile.data.service.trades.TakeOfferStatus
 import network.bisq.mobile.data.service.trades.TradesServiceFacade
+import network.bisq.mobile.domain.formatters.AmountFormatter
 import network.bisq.mobile.domain.service.trades.ExpectedTradeProtocolRejection
 import network.bisq.mobile.domain.utils.BisqEasyTradeAmountLimits
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.i18n.i18n
+import network.bisq.mobile.presentation.common.ui.navigation.NavRoute
+import network.bisq.mobile.presentation.common.ui.utils.BisqLinks
 
 /**
  * Coordinates the multi-step "Take Offer" wizard flow.
@@ -51,6 +65,8 @@ class TakeOfferCoordinator(
     private val marketPriceServiceFacade: MarketPriceServiceFacade,
     private val tradesServiceFacade: TradesServiceFacade,
     private val configServiceFacade: ConfigServiceFacade,
+    private val reputationServiceFacade: ReputationServiceFacade,
+    private val computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : Logging {
     class TakeOfferModel {
         lateinit var offerItemPresentationVO: OfferItemPresentationModel
@@ -163,6 +179,137 @@ class TakeOfferCoordinator(
     fun showSettlementMethodsScreen(): Boolean = takeOfferModel.hasMultipleBaseSidePaymentMethods
 
     fun showAmountScreen(): Boolean = takeOfferModel.hasAmountRange
+
+    /**
+     * The wizard step the flow starts on for the offer selected via [selectOfferToTake] — steps
+     * that need no user input are skipped. Pure mapping: navigating there stays with the caller.
+     */
+    fun firstScreen(): NavRoute =
+        when {
+            showAmountScreen() -> NavRoute.TakeOfferTradeAmount
+            showPaymentMethodsScreen() -> NavRoute.TakeOfferPaymentMethod
+            showSettlementMethodsScreen() -> NavRoute.TakeOfferSettlementMethod
+            else -> NavRoute.TakeOfferReviewTrade
+        }
+
+    /**
+     * Reputation-based eligibility for taking [item], shared by every surface that can start the
+     * take-offer flow (offerbook, peer profile) so the rule cannot drift between entry points.
+     *
+     * The seller's score is the one that must cover the offer amount:
+     * - SELL offer → the maker sells, the MAKER's score is checked.
+     * - BUY offer → the taker (this user) would sell, so [userProfile]'s own score is checked.
+     *
+     * A failed lookup counts as score 0 (strict policy; the "not cached yet" allowance is
+     * deliberately disabled). Does not touch [takeOfferModel] — safe to call before
+     * [selectOfferToTake].
+     */
+    suspend fun checkTakeOfferEligibility(
+        item: OfferItemPresentationModel,
+        userProfile: UserProfileVO,
+    ): TakeOfferEligibility =
+        withContext(computationDispatcher) {
+            val bisqEasyOffer = item.bisqEasyOffer
+            val limits = configServiceFacade.tradeAmountLimits.value
+            val requiredReputationScoreForMaxOrFixed =
+                BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(
+                    marketPriceServiceFacade,
+                    bisqEasyOffer,
+                    limits,
+                )
+            require(requiredReputationScoreForMaxOrFixed != null) { "requiredReputationScoreForMaxOrFixedAmount is null" }
+            val requiredReputationScoreForMinOrFixed =
+                BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinOrFixedAmount(
+                    marketPriceServiceFacade,
+                    bisqEasyOffer,
+                    limits,
+                )
+            require(requiredReputationScoreForMinOrFixed != null) { "requiredReputationScoreForMinAmount is null" }
+
+            val market = bisqEasyOffer.market
+            val quoteCurrencyCode = market.quoteCurrencyCode
+            val minFiatAmount: String =
+                AmountFormatter.formatAmount(
+                    FiatVOFactory.from(bisqEasyOffer.getFixedOrMinAmount(), quoteCurrencyCode),
+                    useLowPrecision = true,
+                    withCode = true,
+                )
+            val maxFiatAmount: String =
+                AmountFormatter.formatAmount(
+                    FiatVOFactory.from(bisqEasyOffer.getFixedOrMaxAmount(), quoteCurrencyCode),
+                    useLowPrecision = true,
+                    withCode = true,
+                )
+
+            // For BUY offers: The maker wants to buy Bitcoin, so the taker (me) becomes the seller
+            // For SELL offers: The maker wants to sell Bitcoin, so the maker becomes the seller
+            val userProfileId =
+                if (bisqEasyOffer.direction == DirectionEnum.SELL) {
+                    bisqEasyOffer.makerNetworkId.pubKey.id // Offer maker is seller (wants to sell Bitcoin)
+                } else {
+                    userProfile.id // I am seller (taker selling to maker who wants to buy)
+                }
+
+            val reputationResult: Result<ReputationScoreVO> = reputationServiceFacade.getReputation(userProfileId)
+
+            val sellersScore: Long = reputationResult.getOrNull()?.totalScore ?: 0
+            val isReputationNotCached = reputationResult.exceptionOrNull()?.message?.contains("not cached yet") == true
+
+            reputationResult.exceptionOrNull()?.let { exception ->
+                log.w("Exception at reputationServiceFacade.getReputation", exception)
+                if (isReputationNotCached) {
+                    log.i { "Reputation not cached yet for user $userProfileId, allowing offer to be taken" }
+                }
+            }
+
+            val isAmountRangeOffer = bisqEasyOffer.amountSpec is RangeAmountSpecVO
+
+            // val canBuyerTakeOffer = isReputationNotCached || sellersScore >= requiredReputationScoreForMinOrFixed
+            val canBuyerTakeOffer = sellersScore >= requiredReputationScoreForMinOrFixed
+            if (canBuyerTakeOffer) {
+                TakeOfferEligibility.Eligible
+            } else {
+                val link = "hyperlinks.openInBrowser.attention".i18n(BisqLinks.REPUTATION_WIKI_URL)
+                val takersDirection = bisqEasyOffer.direction.mirror
+                val isSellerAsTakerWarning = takersDirection == DirectionEnum.SELL
+                val headline: String
+                val message: String
+                if (takersDirection == DirectionEnum.BUY) {
+                    // SELL offer: Maker wants to sell Bitcoin, so they are the seller
+                    // Taker (me) wants to buy Bitcoin - checking if seller has enough reputation
+                    val learnMore = "mobile.reputation.learnMoreAtWiki".i18n()
+                    headline = "chat.message.takeOffer.buyer.invalidOffer.headline".i18n()
+                    val warningKey =
+                        if (isAmountRangeOffer) {
+                            "chat.message.takeOffer.buyer.invalidOffer.rangeAmount.text"
+                        } else {
+                            "chat.message.takeOffer.buyer.invalidOffer.fixedAmount.text"
+                        }
+
+                    message = warningKey.i18n(
+                        sellersScore,
+                        if (isAmountRangeOffer) requiredReputationScoreForMinOrFixed else requiredReputationScoreForMaxOrFixed,
+                        if (isAmountRangeOffer) minFiatAmount else maxFiatAmount,
+                    ) + "\n\n" + learnMore + "\n\n" + link
+                } else {
+                    // BUY offer: Maker wants to buy Bitcoin, so taker becomes the seller
+                    // Taker (me) wants to sell Bitcoin - checking if I have enough reputation
+                    headline = "chat.message.takeOffer.seller.insufficientScore.headline".i18n()
+                    val warningKey =
+                        if (isAmountRangeOffer) {
+                            "chat.message.takeOffer.seller.insufficientScore.rangeAmount.warning"
+                        } else {
+                            "chat.message.takeOffer.seller.insufficientScore.fixedAmount.warning"
+                        }
+                    message = warningKey.i18n(
+                        sellersScore,
+                        if (isAmountRangeOffer) requiredReputationScoreForMinOrFixed else requiredReputationScoreForMaxOrFixed,
+                        if (isAmountRangeOffer) minFiatAmount else maxFiatAmount,
+                    ) + "\n\n" + "mobile.reputation.warning.navigateToReputation".i18n()
+                }
+                TakeOfferEligibility.NotEnoughReputation(headline, message, isSellerAsTakerWarning)
+            }
+        }
 
     fun commitAmount(
         priceQuote: PriceQuoteVO,

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferCoordinator.kt
@@ -1,7 +1,10 @@
 package network.bisq.mobile.presentation.offer.take_offer
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.model.market.MarketPriceItem
@@ -252,13 +255,20 @@ class TakeOfferCoordinator(
 
             val reputationResult: Result<ReputationScoreVO> = reputationServiceFacade.getReputation(userProfileId)
 
+            // The facades wrap failures in a Result, so a cancelled round trip surfaces as a
+            // failure value — rethrow it instead of degrading cancellation to "score 0"
+            // (same guard as OfferbookPresenter.getMyReputation / BisqEasyTradeAmountLimits).
+            if (reputationResult.exceptionOrNull() is CancellationException) {
+                currentCoroutineContext().ensureActive()
+            }
+
             val sellersScore: Long = reputationResult.getOrNull()?.totalScore ?: 0
             val isReputationNotCached = reputationResult.exceptionOrNull()?.message?.contains("not cached yet") == true
 
             reputationResult.exceptionOrNull()?.let { exception ->
                 log.w("Exception at reputationServiceFacade.getReputation", exception)
                 if (isReputationNotCached) {
-                    log.i { "Reputation not cached yet for user $userProfileId, allowing offer to be taken" }
+                    log.i { "Reputation not cached yet for the checked seller, allowing offer to be taken" }
                 }
             }
 

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferEligibility.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offer/take_offer/TakeOfferEligibility.kt
@@ -1,0 +1,20 @@
+package network.bisq.mobile.presentation.offer.take_offer
+
+/**
+ * Result of the reputation-based take-offer eligibility check
+ * ([TakeOfferCoordinator.checkTakeOfferEligibility]).
+ *
+ * [NotEnoughReputation] carries the ready-to-render dialog copy because the wording depends on
+ * which side is the seller (see the check itself) — computing it where the scores are at hand
+ * keeps every entry point (offerbook, peer profile) showing identical explanations.
+ */
+sealed class TakeOfferEligibility {
+    data object Eligible : TakeOfferEligibility()
+
+    data class NotEnoughReputation(
+        val headline: String,
+        val message: String,
+        /** True when the taker would be the seller (BUY offer) — their own score is the one lacking. */
+        val isSellerAsTakerWarning: Boolean,
+    ) : TakeOfferEligibility()
+}

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -677,10 +677,14 @@ open class OfferbookPresenter(
                         }
                     }
                 } catch (e: Exception) {
+                    // Cancellation must propagate — swallowing it here would keep a dead
+                    // coroutine's error handling running (and hide the cancellation itself).
+                    if (e is CancellationException) throw e
                     log.e("checkTakeOfferEligibility call failed", e)
                     _isTakeOfferEnabled.value = true
                 }
             }.onFailure {
+                if (it is CancellationException) throw it
                 log.e(it) { "Failed to take offer ${item.offerId}" }
                 showSnackbar(
                     "mobile.bisqEasy.offerbook.unableToTakeOffer".i18n(item.offerId),
@@ -814,6 +818,7 @@ open class OfferbookPresenter(
                 // Show the dialog
                 _showNotEnoughReputationDialog.value = true
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.e("showReputationRequirementInfo call failed", e)
             }
         }

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/offerbook/OfferbookPresenter.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import network.bisq.mobile.data.model.offerbook.OfferbookFilterConfig
 import network.bisq.mobile.data.model.offerbook.OfferbookMarket
 import network.bisq.mobile.data.replicated.common.currency.MarketVOExtensions.marketCodes
@@ -30,8 +29,6 @@ import network.bisq.mobile.data.replicated.offer.DirectionEnum
 import network.bisq.mobile.data.replicated.offer.DirectionEnumExtensions.mirror
 import network.bisq.mobile.data.replicated.offer.amount.spec.FixedAmountSpecVO
 import network.bisq.mobile.data.replicated.offer.amount.spec.RangeAmountSpecVO
-import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMaxAmount
-import network.bisq.mobile.data.replicated.offer.bisq_easy.BisqEasyOfferVOExtensions.getFixedOrMinAmount
 import network.bisq.mobile.data.replicated.presentation.offerbook.OfferItemPresentationModel
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVO
 import network.bisq.mobile.data.replicated.user.profile.UserProfileVOExtension.id
@@ -62,6 +59,7 @@ import network.bisq.mobile.presentation.common.ui.utils.i18NPaymentMethod
 import network.bisq.mobile.presentation.main.MainPresenter
 import network.bisq.mobile.presentation.offer.create_offer.CreateOfferCoordinator
 import network.bisq.mobile.presentation.offer.take_offer.TakeOfferCoordinator
+import network.bisq.mobile.presentation.offer.take_offer.TakeOfferEligibility
 
 open class OfferbookPresenter(
     private val mainPresenter: MainPresenter,
@@ -667,23 +665,19 @@ open class OfferbookPresenter(
                 val selectedProfile = selectedUserProfile.value
                 require(selectedProfile != null)
                 try {
-                    if (canTakeOffer(item, selectedProfile)) {
-                        takeOfferCoordinator.selectOfferToTake(item)
-                        if (takeOfferCoordinator.showAmountScreen()) {
-                            navigateTo(NavRoute.TakeOfferTradeAmount)
-                        } else if (takeOfferCoordinator.showPaymentMethodsScreen()) {
-                            navigateTo(NavRoute.TakeOfferPaymentMethod)
-                        } else if (takeOfferCoordinator.showSettlementMethodsScreen()) {
-                            navigateTo(NavRoute.TakeOfferSettlementMethod)
-                        } else {
-                            navigateTo(NavRoute.TakeOfferReviewTrade)
+                    when (val eligibility = takeOfferCoordinator.checkTakeOfferEligibility(item, selectedProfile)) {
+                        is TakeOfferEligibility.Eligible -> {
+                            takeOfferCoordinator.selectOfferToTake(item)
+                            navigateTo(takeOfferCoordinator.firstScreen())
                         }
-                    } else {
-                        showReputationRequirementInfo(item)
-                        _isTakeOfferEnabled.value = true
+                        is TakeOfferEligibility.NotEnoughReputation -> {
+                            applyNotEnoughReputation(eligibility)
+                            _showNotEnoughReputationDialog.value = true
+                            _isTakeOfferEnabled.value = true
+                        }
                     }
                 } catch (e: Exception) {
-                    log.e("canTakeOffer call failed", e)
+                    log.e("checkTakeOfferEligibility call failed", e)
                     _isTakeOfferEnabled.value = true
                 }
             }.onFailure {
@@ -698,109 +692,11 @@ open class OfferbookPresenter(
         }
     }
 
-    private suspend fun canTakeOffer(
-        item: OfferItemPresentationModel,
-        userProfile: UserProfileVO,
-    ): Boolean =
-        withContext(computationDispatcher) {
-            val bisqEasyOffer = item.bisqEasyOffer
-            val limits = configServiceFacade.tradeAmountLimits.value
-            val requiredReputationScoreForMaxOrFixed =
-                BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(
-                    marketPriceServiceFacade,
-                    bisqEasyOffer,
-                    limits,
-                )
-            require(requiredReputationScoreForMaxOrFixed != null) { "requiredReputationScoreForMaxOrFixedAmount is null" }
-            val requiredReputationScoreForMinOrFixed =
-                BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinOrFixedAmount(
-                    marketPriceServiceFacade,
-                    bisqEasyOffer,
-                    limits,
-                )
-            require(requiredReputationScoreForMinOrFixed != null) { "requiredReputationScoreForMinAmount is null" }
-
-            val market = bisqEasyOffer.market
-            val quoteCurrencyCode = market.quoteCurrencyCode
-            val minFiatAmount: String =
-                AmountFormatter.formatAmount(
-                    FiatVOFactory.from(bisqEasyOffer.getFixedOrMinAmount(), quoteCurrencyCode),
-                    useLowPrecision = true,
-                    withCode = true,
-                )
-            val maxFiatAmount: String =
-                AmountFormatter.formatAmount(
-                    FiatVOFactory.from(bisqEasyOffer.getFixedOrMaxAmount(), quoteCurrencyCode),
-                    useLowPrecision = true,
-                    withCode = true,
-                )
-
-            // For BUY offers: The maker wants to buy Bitcoin, so the taker (me) becomes the seller
-            // For SELL offers: The maker wants to sell Bitcoin, so the maker becomes the seller
-            val userProfileId =
-                if (bisqEasyOffer.direction == DirectionEnum.SELL) {
-                    bisqEasyOffer.makerNetworkId.pubKey.id // Offer maker is seller (wants to sell Bitcoin)
-                } else {
-                    userProfile.id // I am seller (taker selling to maker who wants to buy)
-                }
-
-            val reputationResult: Result<ReputationScoreVO> = reputationServiceFacade.getReputation(userProfileId)
-
-            val sellersScore: Long = reputationResult.getOrNull()?.totalScore ?: 0
-            val isReputationNotCached = reputationResult.exceptionOrNull()?.message?.contains("not cached yet") == true
-
-            reputationResult.exceptionOrNull()?.let { exception ->
-                log.w("Exception at reputationServiceFacade.getReputation", exception)
-                if (isReputationNotCached) {
-                    log.i { "Reputation not cached yet for user $userProfileId, allowing offer to be taken" }
-                }
-            }
-
-            val isAmountRangeOffer = bisqEasyOffer.amountSpec is RangeAmountSpecVO
-
-            // val canBuyerTakeOffer = isReputationNotCached || sellersScore >= requiredReputationScoreForMinOrFixed
-            val canBuyerTakeOffer = sellersScore >= requiredReputationScoreForMinOrFixed
-            if (!canBuyerTakeOffer) {
-                val link = "hyperlinks.openInBrowser.attention".i18n(BisqLinks.REPUTATION_WIKI_URL)
-                val takersDirection = bisqEasyOffer.direction.mirror
-                isReputationWarningForSellerAsTaker = takersDirection == DirectionEnum.SELL
-                if (takersDirection == DirectionEnum.BUY) {
-                    // SELL offer: Maker wants to sell Bitcoin, so they are the seller
-                    // Taker (me) wants to buy Bitcoin - checking if seller has enough reputation
-                    val learnMore = "mobile.reputation.learnMoreAtWiki".i18n()
-                    notEnoughReputationHeadline = "chat.message.takeOffer.buyer.invalidOffer.headline".i18n()
-                    val warningKey =
-                        if (isAmountRangeOffer) {
-                            "chat.message.takeOffer.buyer.invalidOffer.rangeAmount.text"
-                        } else {
-                            "chat.message.takeOffer.buyer.invalidOffer.fixedAmount.text"
-                        }
-
-                    notEnoughReputationMessage = warningKey.i18n(
-                        sellersScore,
-                        if (isAmountRangeOffer) requiredReputationScoreForMinOrFixed else requiredReputationScoreForMaxOrFixed,
-                        if (isAmountRangeOffer) minFiatAmount else maxFiatAmount,
-                    ) + "\n\n" + learnMore + "\n\n" + link
-                } else {
-                    // BUY offer: Maker wants to buy Bitcoin, so taker becomes the seller
-                    // Taker (me) wants to sell Bitcoin - checking if I have enough reputation
-                    notEnoughReputationHeadline = "chat.message.takeOffer.seller.insufficientScore.headline".i18n()
-                    val warningKey =
-                        if (isAmountRangeOffer) {
-                            "chat.message.takeOffer.seller.insufficientScore.rangeAmount.warning"
-                        } else {
-                            "chat.message.takeOffer.seller.insufficientScore.fixedAmount.warning"
-                        }
-                    notEnoughReputationMessage = warningKey.i18n(
-                        sellersScore,
-                        if (isAmountRangeOffer) requiredReputationScoreForMinOrFixed else requiredReputationScoreForMaxOrFixed,
-                        if (isAmountRangeOffer) minFiatAmount else maxFiatAmount,
-                    ) + "\n\n" + "mobile.reputation.warning.navigateToReputation".i18n()
-                }
-            }
-
-            canBuyerTakeOffer
-        }
+    private fun applyNotEnoughReputation(result: TakeOfferEligibility.NotEnoughReputation) {
+        notEnoughReputationHeadline = result.headline
+        notEnoughReputationMessage = result.message
+        isReputationWarningForSellerAsTaker = result.isSellerAsTakerWarning
+    }
 
     private fun deselectOffer() {
         selectedOffer = null
@@ -945,7 +841,10 @@ open class OfferbookPresenter(
         item: OfferItemPresentationModel,
         userProfile: UserProfileVO,
     ) {
-        canTakeOffer(item, userProfile)
+        val eligibility = takeOfferCoordinator.checkTakeOfferEligibility(item, userProfile)
+        if (eligibility is TakeOfferEligibility.NotEnoughReputation) {
+            applyNotEnoughReputation(eligibility)
+        }
     }
 
     fun onTradeRestrictingAlertAction(action: AlertNotificationUiAction) {


### PR DESCRIPTION
 - contribs to #1631 
 - canTakeOffer moved from OfferbookPresenter to checkTakeOfferEligibility, returning a sealed TakeOfferEligibility with the dialog copy
 - firstScreen() encapsulates the amount/payment/settlement/review routing
 - no behavior change; drops the double eligibility computation on the ineligible path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reputation-based eligibility checks before users take an offer.
  - Displays localized guidance when reputation is insufficient, including seller-as-taker warnings.
  - Routes users to the appropriate first step in the take-offer flow based on offer requirements.
  - Eligible users now proceed directly to the relevant take-offer screen.

- **Tests**
  - Added coverage for offer-flow routing, reputation eligibility, insufficient-reputation messaging, and guarded take-offer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->