### PR TITLE
bugfix/fix_push_notifications_key_pair_rotation_too_fast_causing_notif_loss_in_certain_cases

### DIFF
--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -209,6 +209,11 @@ class BisqFirebaseMessagingService :
                     log.i { "Push decrypted with the previous key generation (sent before the last rotation)" }
                 }
                 return plaintext
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Not a key mismatch: a cancelled caller must propagate, not fall through to
+                // the next candidate. Inert on the plain FCM callback thread, load-bearing the
+                // day this runs inside a coroutine.
+                throw e
             } catch (e: Exception) {
                 lastFailure = e
             }

--- a/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
+++ b/apps/clientApp/src/androidMain/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingService.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import network.bisq.mobile.client.main.ClientMainActivity
-import network.bisq.mobile.data.crypto.readPushNotificationKeyBase64
+import network.bisq.mobile.data.crypto.readPushNotificationKeyCandidatesBase64
 import network.bisq.mobile.data.utils.ResourceUtils
 import network.bisq.mobile.domain.utils.Logging
 import network.bisq.mobile.i18n.i18n
@@ -151,8 +151,8 @@ class BisqFirebaseMessagingService :
             log.w { "FCM message had no 'encrypted' data field — dropping" }
             return
         }
-        val keyBase64 = readPushNotificationKeyBase64()
-        if (keyBase64.isNullOrBlank()) {
+        val keyCandidates = readPushNotificationKeyCandidatesBase64().filter { it.isNotBlank() }
+        if (keyCandidates.isEmpty()) {
             log.w { "No push notification symmetric key on device — dropping" }
             return
         }
@@ -169,16 +169,14 @@ class BisqFirebaseMessagingService :
         //    peer username, etc.). Logging the exception would leak that to
         //    logcat / crash reporters. We log only a sanitized static message
         //    in that branch.
+        //
+        // Candidates are tried in order (current key first, then the previous
+        // generation): the app rotates its key on every registration, so a push
+        // encrypted just before a rotation — or queued by FCM while the app was
+        // closed — arrives under the displaced key. One generation of skew is
+        // the tolerated window; anything older is genuinely undecryptable.
         val plaintext =
-            try {
-                decryptAesGcm(
-                    ciphertextBase64 = encryptedBase64,
-                    keyBase64 = keyBase64,
-                )
-            } catch (e: Exception) {
-                log.e(e) { "Failed to decrypt push notification — dropping" }
-                return
-            }
+            decryptWithCandidates(encryptedBase64, keyCandidates) ?: return
 
         val payload =
             try {
@@ -191,6 +189,32 @@ class BisqFirebaseMessagingService :
             }
 
         showNotification(PushNotification.from(payload))
+    }
+
+    /**
+     * Tries each key generation in order and returns the first successful plaintext, or null
+     * after logging when none decrypts. Logs never carry key material — only which generation
+     * matched, which is exactly the diagnostic that pinned down the key-skew loss.
+     */
+    @VisibleForTesting
+    internal fun decryptWithCandidates(
+        encryptedBase64: String,
+        keyCandidates: List<String>,
+    ): String? {
+        var lastFailure: Exception? = null
+        keyCandidates.forEachIndexed { index, keyBase64 ->
+            try {
+                val plaintext = decryptAesGcm(ciphertextBase64 = encryptedBase64, keyBase64 = keyBase64)
+                if (index > 0) {
+                    log.i { "Push decrypted with the previous key generation (sent before the last rotation)" }
+                }
+                return plaintext
+            } catch (e: Exception) {
+                lastFailure = e
+            }
+        }
+        log.e(lastFailure) { "Failed to decrypt push notification with any of ${keyCandidates.size} key generation(s) — dropping" }
+        return null
     }
 
     /**

--- a/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
+++ b/apps/clientApp/src/androidUnitTest/kotlin/network/bisq/mobile/client/common/domain/service/push_notification/BisqFirebaseMessagingServiceTest.kt
@@ -67,6 +67,56 @@ class BisqFirebaseMessagingServiceTest {
         assertEquals(plaintext, decrypted)
     }
 
+    /**
+     * The two-key window: a push encrypted with the key generation the last rotation displaced
+     * must still decrypt via the previous-key candidate — that is exactly the queued-FCM /
+     * restart-during-trade loss the window exists to prevent.
+     */
+    @Test
+    fun `decryptWithCandidates falls back to the previous key generation`() {
+        val plaintext = """{"id":"abc-123","title":"Trade update","message":"hello"}"""
+        val oldKeyBytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val newKeyBytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val combinedBase64 =
+            Base64.encodeToString(nonce + aesGcmEncrypt(plaintext.toByteArray(Charsets.UTF_8), oldKeyBytes, nonce), Base64.NO_WRAP)
+
+        val decrypted =
+            BisqFirebaseMessagingService().decryptWithCandidates(
+                encryptedBase64 = combinedBase64,
+                keyCandidates =
+                    listOf(
+                        Base64.encodeToString(newKeyBytes, Base64.NO_WRAP),
+                        Base64.encodeToString(oldKeyBytes, Base64.NO_WRAP),
+                    ),
+            )
+
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `decryptWithCandidates returns null when no key generation matches`() {
+        val plaintext = "irrelevant"
+        val keyBytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val wrongA = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val wrongB = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val combinedBase64 =
+            Base64.encodeToString(nonce + aesGcmEncrypt(plaintext.toByteArray(Charsets.UTF_8), keyBytes, nonce), Base64.NO_WRAP)
+
+        val decrypted =
+            BisqFirebaseMessagingService().decryptWithCandidates(
+                encryptedBase64 = combinedBase64,
+                keyCandidates =
+                    listOf(
+                        Base64.encodeToString(wrongA, Base64.NO_WRAP),
+                        Base64.encodeToString(wrongB, Base64.NO_WRAP),
+                    ),
+            )
+
+        assertNull(decrypted)
+    }
+
     @Test
     fun `decryptAesGcm rejects payloads shorter than the nonce`() {
         val tooShort = Base64.encodeToString(ByteArray(8), Base64.NO_WRAP)

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
@@ -1,5 +1,6 @@
 package network.bisq.mobile.client.common.domain.access.utils
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -36,21 +37,28 @@ object HeaderRedaction {
         }
 
     /**
-     * Redacts the values of sensitive fields inside a JSON request body. Untouched when the body
-     * mentions none of them; fails closed to [UNPARSEABLE_PAYLOAD] when it mentions one but cannot
-     * be parsed well enough to redact it precisely.
+     * Redacts the values of sensitive fields inside a JSON request body.
+     *
+     * Parses BEFORE deciding anything: the parser decodes JSON escapes, so a field name written
+     * as `deviceToken` still matches structurally — a substring pre-check on the raw string
+     * would not see it and would echo the secret. A blank body (GET requests) has nothing to
+     * parse or leak; any other body that cannot be parsed fails closed to [UNPARSEABLE_PAYLOAD].
      */
     fun redactSensitiveBodyFields(body: String): String {
-        if (sensitiveBodyFieldNames.none { body.contains(it, ignoreCase = true) }) return body
+        if (body.isBlank()) return body
         return try {
             val element = lenientJson.parseToJsonElement(body)
             if (element !is JsonObject) return UNPARSEABLE_PAYLOAD
+            if (element.keys.none { isSensitiveBodyField(it) }) return body
             JsonObject(
                 element.mapValues { (key, value) ->
                     if (isSensitiveBodyField(key)) JsonPrimitive(REDACTED) else value
                 },
             ).toString()
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
+            // Fail closed: never echo an unparseable payload that may contain credentials.
             UNPARSEABLE_PAYLOAD
         }
     }
@@ -67,17 +75,22 @@ object HeaderRedaction {
         }
 
     fun redactRawJsonForLogging(jsonString: String): String {
-        // Fast path: nothing sensitive is even mentioned, echo unchanged.
-        val mentionsSensitive =
-            sensitiveHeaderNames.any { jsonString.contains(it, ignoreCase = true) } ||
-                sensitiveBodyFieldNames.any { jsonString.contains(it, ignoreCase = true) }
-        if (!mentionsSensitive) return jsonString
-
         return try {
+            // Parse first, decide after: escape sequences in key names are only visible to the
+            // parser, so any pre-parse substring check can be sidestepped. When nothing sensitive
+            // is found STRUCTURALLY, the original string is returned byte-identical.
             val element = lenientJson.parseToJsonElement(jsonString)
             if (element !is JsonObject) return UNPARSEABLE_PAYLOAD
+
+            val headersElement = element["headers"] as? JsonObject
+            val hasSensitiveHeaders = headersElement?.keys?.any { isSensitiveHeader(it) } == true
+            val bodyElement = element["body"] as? JsonPrimitive
+            val redactedBody = if (bodyElement?.isString == true) redactSensitiveBodyFields(bodyElement.content) else null
+            val bodyChanged = redactedBody != null && redactedBody != bodyElement?.content
+            if (!hasSensitiveHeaders && !bodyChanged) return jsonString
+
             val redacted = element.toMutableMap()
-            (element["headers"] as? JsonObject)?.let { headersElement ->
+            if (hasSensitiveHeaders && headersElement != null) {
                 redacted["headers"] =
                     JsonObject(
                         headersElement.mapValues { (key, value) ->
@@ -85,12 +98,12 @@ object HeaderRedaction {
                         },
                     )
             }
-            (element["body"] as? JsonPrimitive)?.let { bodyElement ->
-                if (bodyElement.isString) {
-                    redacted["body"] = JsonPrimitive(redactSensitiveBodyFields(bodyElement.content))
-                }
+            if (bodyChanged && redactedBody != null) {
+                redacted["body"] = JsonPrimitive(redactedBody)
             }
             JsonObject(redacted).toString()
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             // Fail closed: never echo an unparseable payload that may contain credentials.
             UNPARSEABLE_PAYLOAD

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
@@ -7,7 +7,14 @@ import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketMess
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiRequest
 
 /**
- * Redacts sensitive auth headers for log output only. Wire payloads must stay unchanged.
+ * Redacts sensitive auth headers AND sensitive request-body fields for log output only.
+ * Wire payloads must stay unchanged.
+ *
+ * The body fields matter as much as the headers: the mobile-device registration body carries
+ * the FCM/APNs device token (a stable per-install identifier) and the push-notification
+ * symmetric key — logging it verbatim hands anyone with logcat access the key that decrypts
+ * every relayed push. `onNewToken` refuses to log even a token prefix; this keeps the WS
+ * request log to the same standard.
  */
 object HeaderRedaction {
     const val REDACTED = "***"
@@ -15,37 +22,75 @@ object HeaderRedaction {
 
     private val sensitiveHeaderNames = setOf(Headers.CLIENT_ID, Headers.SESSION_ID)
 
+    private val sensitiveBodyFieldNames = setOf("deviceToken", "symmetricKeyBase64")
+
     private val lenientJson = Json { ignoreUnknownKeys = true }
 
     private fun isSensitiveHeader(name: String): Boolean = sensitiveHeaderNames.any { it.equals(name, ignoreCase = true) }
+
+    private fun isSensitiveBodyField(name: String): Boolean = sensitiveBodyFieldNames.any { it.equals(name, ignoreCase = true) }
 
     fun redactSensitiveHeaders(headers: Map<String, String>): Map<String, String> =
         headers.mapValues { (name, value) ->
             if (isSensitiveHeader(name)) REDACTED else value
         }
 
+    /**
+     * Redacts the values of sensitive fields inside a JSON request body. Untouched when the body
+     * mentions none of them; fails closed to [UNPARSEABLE_PAYLOAD] when it mentions one but cannot
+     * be parsed well enough to redact it precisely.
+     */
+    fun redactSensitiveBodyFields(body: String): String {
+        if (sensitiveBodyFieldNames.none { body.contains(it, ignoreCase = true) }) return body
+        return try {
+            val element = lenientJson.parseToJsonElement(body)
+            if (element !is JsonObject) return UNPARSEABLE_PAYLOAD
+            JsonObject(
+                element.mapValues { (key, value) ->
+                    if (isSensitiveBodyField(key)) JsonPrimitive(REDACTED) else value
+                },
+            ).toString()
+        } catch (_: Exception) {
+            UNPARSEABLE_PAYLOAD
+        }
+    }
+
     fun redactForLogging(message: WebSocketMessage): String =
         when (message) {
             is WebSocketRestApiRequest ->
-                message.copy(headers = redactSensitiveHeaders(message.headers)).toString()
+                message
+                    .copy(
+                        headers = redactSensitiveHeaders(message.headers),
+                        body = redactSensitiveBodyFields(message.body),
+                    ).toString()
             else -> message.toString()
         }
 
     fun redactRawJsonForLogging(jsonString: String): String {
+        // Fast path: nothing sensitive is even mentioned, echo unchanged.
+        val mentionsSensitive =
+            sensitiveHeaderNames.any { jsonString.contains(it, ignoreCase = true) } ||
+                sensitiveBodyFieldNames.any { jsonString.contains(it, ignoreCase = true) }
+        if (!mentionsSensitive) return jsonString
+
         return try {
             val element = lenientJson.parseToJsonElement(jsonString)
-            if (element !is JsonObject) return jsonString
-            val headersElement = element["headers"] ?: return jsonString
-            if (headersElement !is JsonObject) return jsonString
-            if (headersElement.keys.none { isSensitiveHeader(it) }) return jsonString
-
-            val redactedHeaders =
-                JsonObject(
-                    headersElement.mapValues { (key, value) ->
-                        if (isSensitiveHeader(key)) JsonPrimitive(REDACTED) else value
-                    },
-                )
-            JsonObject(element.toMutableMap().apply { put("headers", redactedHeaders) }).toString()
+            if (element !is JsonObject) return UNPARSEABLE_PAYLOAD
+            val redacted = element.toMutableMap()
+            (element["headers"] as? JsonObject)?.let { headersElement ->
+                redacted["headers"] =
+                    JsonObject(
+                        headersElement.mapValues { (key, value) ->
+                            if (isSensitiveHeader(key)) JsonPrimitive(REDACTED) else value
+                        },
+                    )
+            }
+            (element["body"] as? JsonPrimitive)?.let { bodyElement ->
+                if (bodyElement.isString) {
+                    redacted["body"] = JsonPrimitive(redactSensitiveBodyFields(bodyElement.content))
+                }
+            }
+            JsonObject(redacted).toString()
         } catch (_: Exception) {
             // Fail closed: never echo an unparseable payload that may contain credentials.
             UNPARSEABLE_PAYLOAD

--- a/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
+++ b/apps/clientApp/src/commonMain/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedaction.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketMessage
 import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiRequest
+import network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiResponse
 
 /**
  * Redacts sensitive auth headers AND sensitive request-body fields for log output only.
@@ -43,6 +44,11 @@ object HeaderRedaction {
      * as `deviceToken` still matches structurally — a substring pre-check on the raw string
      * would not see it and would echo the secret. A blank body (GET requests) has nothing to
      * parse or leak; any other body that cannot be parsed fails closed to [UNPARSEABLE_PAYLOAD].
+     *
+     * Deliberately TOP-LEVEL keys only: every request body today is a flat object (the
+     * registration payload included). An endpoint that ever nests these fields inside a wrapper
+     * object needs this extended to recurse — until then the shallow scan keeps the cost of a
+     * log line bounded.
      */
     fun redactSensitiveBodyFields(body: String): String {
         if (body.isBlank()) return body
@@ -63,6 +69,31 @@ object HeaderRedaction {
         }
     }
 
+    /**
+     * Best-effort redaction for a RESPONSE body, which unlike request bodies is often plain text
+     * (e.g. "Device registered successfully" or a validation-error message). A JSON object body
+     * is redacted structurally like a request body; plain text passes through unless it mentions
+     * a sensitive field name — a validation error that echoes the registration payload — in
+     * which case the whole body fails closed.
+     *
+     * Like the request-body redaction, this matches by KEY NAME: a JSON body that embeds a
+     * secret value inside a differently-named field is not caught. Accepted limitation, same as
+     * the shallow-scan note on [redactSensitiveBodyFields].
+     */
+    fun redactResponseBodyForLogging(body: String): String {
+        if (body.isBlank()) return body
+        val parsed =
+            try {
+                lenientJson.parseToJsonElement(body)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            }
+        if (parsed is JsonObject) return redactSensitiveBodyFields(body)
+        return if (sensitiveBodyFieldNames.any { body.contains(it, ignoreCase = true) }) UNPARSEABLE_PAYLOAD else body
+    }
+
     fun redactForLogging(message: WebSocketMessage): String =
         when (message) {
             is WebSocketRestApiRequest ->
@@ -71,6 +102,8 @@ object HeaderRedaction {
                         headers = redactSensitiveHeaders(message.headers),
                         body = redactSensitiveBodyFields(message.body),
                     ).toString()
+            is WebSocketRestApiResponse ->
+                message.copy(body = redactResponseBodyForLogging(message.body)).toString()
             else -> message.toString()
         }
 

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
@@ -73,6 +73,36 @@ class HeaderRedactionTest {
         assertTrue(redacted.contains("fbac8e"), redacted)
     }
 
+    /**
+     * The parser decodes JSON escapes, so a field name spelled with escape sequences resolves to
+     * the same key — a raw-string substring check would miss it and echo the secret. Regression
+     * for the parse-before-deciding rule.
+     */
+    @Test
+    fun `an escaped body field name is still redacted`() {
+        // The raw string keeps the escape sequence intact; the JSON parser decodes
+        // "deviceToken" to "deviceToken" — only a parse-first check can see that.
+        val body = """{"\u0064eviceToken": "secret-token", "deviceId": "fbac8e"}"""
+
+        val redacted = HeaderRedaction.redactSensitiveBodyFields(body)
+
+        assertFalse(redacted.contains("secret-token"), redacted)
+        assertTrue(redacted.contains("fbac8e"), redacted)
+    }
+
+    @Test
+    fun `an escaped header name is still redacted in the raw json path`() {
+        // "Bisq-Session-Id" decodes to "Bisq-Session-Id".
+        val raw =
+            """{"type":"WebSocketRestApiRequest","requestId":"r1","method":"GET","path":"/api/v1/settings",""" +
+                """"body":"","headers":{"Bisq-Session-\u0049d":"$sessionSecret","X-Custom":"keep-me"}}"""
+
+        val redacted = HeaderRedaction.redactRawJsonForLogging(raw)
+
+        assertFalse(redacted.contains(sessionSecret), redacted)
+        assertTrue(redacted.contains("keep-me"), redacted)
+    }
+
     @Test
     fun `a body without sensitive fields passes through unchanged`() {
         val body = """{"offerId": "o1", "amount": 42}"""

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
@@ -104,6 +104,35 @@ class HeaderRedactionTest {
     }
 
     @Test
+    fun `a response echoing registration fields is redacted`() {
+        val response =
+            network.bisq.mobile.client.common.domain.websocket.messages.WebSocketRestApiResponse(
+                requestId = "r1",
+                statusCode = 400,
+                body = """{"error": "invalid", "deviceToken": "secret-token"}""",
+            )
+
+        val redacted = HeaderRedaction.redactForLogging(response)
+
+        assertFalse(redacted.contains("secret-token"), redacted)
+        assertTrue(redacted.contains("invalid"), redacted)
+    }
+
+    @Test
+    fun `a plain-text response body without sensitive mentions passes through`() {
+        val body = "Device registered successfully"
+
+        assertEquals(body, HeaderRedaction.redactResponseBodyForLogging(body))
+    }
+
+    @Test
+    fun `a plain-text response body mentioning a sensitive field fails closed`() {
+        val body = "Invalid deviceToken: cLnCjmwCTp6UBis7vTTwga"
+
+        assertEquals(HeaderRedaction.UNPARSEABLE_PAYLOAD, HeaderRedaction.redactResponseBodyForLogging(body))
+    }
+
+    @Test
     fun `a body without sensitive fields passes through unchanged`() {
         val body = """{"offerId": "o1", "amount": 42}"""
 

--- a/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
+++ b/apps/clientApp/src/commonTest/kotlin/network/bisq/mobile/client/common/domain/access/utils/HeaderRedactionTest.kt
@@ -28,6 +28,65 @@ class HeaderRedactionTest {
         assertEquals("application/json", redacted["Content-Type"])
     }
 
+    /**
+     * The mobile-device registration body carries the FCM/APNs device token and the
+     * push-notification symmetric key — the credential that decrypts every relayed push.
+     * The WS request log must hold them to the same standard as the auth headers.
+     */
+    @Test
+    fun `redactRawJsonForLogging redacts the device token and symmetric key inside the body`() {
+        val deviceToken = "cLnCjmwCTp6UBis7vTTwga:APA91bFVqqlapuBmY"
+        val symmetricKey = "FpYYhmDr9/9seiRnIpCyZsABqyXTfnDrLnErdEo4U2s="
+        val raw =
+            """{"type":"WebSocketRestApiRequest","requestId":"r1","method":"POST",""" +
+                """"path":"/api/v1/mobile-devices/registrations",""" +
+                """"body":"{\"deviceId\": \"fbac8e\", \"deviceToken\": \"$deviceToken\", """ +
+                """\"symmetricKeyBase64\": \"$symmetricKey\", \"platform\": \"ANDROID\"}",""" +
+                """"headers":{"Bisq-Session-Id":"$sessionSecret"}}"""
+
+        val redacted = HeaderRedaction.redactRawJsonForLogging(raw)
+
+        assertFalse(redacted.contains(deviceToken), redacted)
+        assertFalse(redacted.contains(symmetricKey), redacted)
+        assertFalse(redacted.contains(sessionSecret), redacted)
+        // Non-sensitive fields survive so the log stays useful.
+        assertTrue(redacted.contains("fbac8e"), redacted)
+        assertTrue(redacted.contains("ANDROID"), redacted)
+    }
+
+    @Test
+    fun `redactForLogging redacts sensitive body fields on requests`() {
+        val request =
+            WebSocketRestApiRequest(
+                requestId = "r1",
+                method = "POST",
+                path = "/api/v1/mobile-devices/registrations",
+                body = """{"deviceToken": "secret-token", "symmetricKeyBase64": "secret-key", "deviceId": "fbac8e"}""",
+                headers = mapOf(Headers.SESSION_ID to sessionSecret),
+            )
+
+        val redacted = HeaderRedaction.redactForLogging(request)
+
+        assertFalse(redacted.contains("secret-token"), redacted)
+        assertFalse(redacted.contains("secret-key"), redacted)
+        assertFalse(redacted.contains(sessionSecret), redacted)
+        assertTrue(redacted.contains("fbac8e"), redacted)
+    }
+
+    @Test
+    fun `a body without sensitive fields passes through unchanged`() {
+        val body = """{"offerId": "o1", "amount": 42}"""
+
+        assertEquals(body, HeaderRedaction.redactSensitiveBodyFields(body))
+    }
+
+    @Test
+    fun `a sensitive-looking but unparseable body fails closed`() {
+        val body = """deviceToken=not-json-at-all"""
+
+        assertEquals(HeaderRedaction.UNPARSEABLE_PAYLOAD, HeaderRedaction.redactSensitiveBodyFields(body))
+    }
+
     @Test
     fun `redactSensitiveHeaders redacts lowercase and mixed-case session and client ids`() {
         val headers =

--- a/iosClient/BisqNotificationService/NotificationService.swift
+++ b/iosClient/BisqNotificationService/NotificationService.swift
@@ -27,6 +27,11 @@ class NotificationService: UNNotificationServiceExtension {
     private static let NSE_BREADCRUMB_KEY = "nse_last_invocation"
     private static let KEYCHAIN_SERVICE = "network.bisq.mobile"
     private static let KEYCHAIN_ACCOUNT = "push_notification_symmetric_key"
+    // The key generation the app's last rotation displaced (PushNotificationKeyStore keeps it).
+    // Tried after the current key: a push encrypted just before a re-registration — or queued by
+    // APNs while the app was closed — arrives under the displaced key. One generation of skew is
+    // the deliberate tolerance; mirrors the Android FCM service's candidate loop.
+    private static let KEYCHAIN_ACCOUNT_PREVIOUS = "push_notification_symmetric_key_previous"
     // Resolved at build time from Info.plist via $(AppIdentifierPrefix).
     // Falls back to nil (default keychain group) if the plist key is missing,
     // though that would fail for NSE since it has a different default group.
@@ -64,7 +69,8 @@ class NotificationService: UNNotificationServiceExtension {
 
         os_log("NSE: encrypted payload found (%{public}d bytes)", log: log, type: .info, encryptedData.count)
 
-        guard let keyData = retrieveSymmetricKey() else {
+        let keyCandidates = retrieveSymmetricKeyCandidates()
+        guard !keyCandidates.isEmpty else {
             os_log("NSE: keychain retrieval failed — showing fallback", log: log, type: .error)
             writeBreadcrumb(stage: "keychain_retrieval_failed")
             bestAttemptContent.title = "Bisq"
@@ -73,10 +79,10 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
 
-        os_log("NSE: symmetric key retrieved (%{public}d bytes)", log: log, type: .info, keyData.count)
+        os_log("NSE: %{public}d symmetric key generation(s) retrieved", log: log, type: .info, keyCandidates.count)
 
         do {
-            let decryptedData = try decryptAESGCM(data: encryptedData, keyData: keyData)
+            let decryptedData = try decryptWithCandidates(data: encryptedData, keyCandidates: keyCandidates)
             let payload = try JSONDecoder().decode(NotificationPayload.self, from: decryptedData)
 
             // Interpret the payload once; the banner, the tap destination and the userInfo below
@@ -354,6 +360,28 @@ class NotificationService: UNNotificationServiceExtension {
 
     // MARK: - Decryption
 
+    /// Tries each key generation in order (current first, then previous) and returns the first
+    /// successful plaintext; rethrows the last failure when none decrypts. Logs never carry key
+    /// material — only which generation matched.
+    private func decryptWithCandidates(data: Data, keyCandidates: [Data]) throws -> Data {
+        var lastError: Error?
+        for (index, keyData) in keyCandidates.enumerated() {
+            do {
+                let decrypted = try decryptAESGCM(data: data, keyData: keyData)
+                if index > 0 {
+                    os_log("NSE: decrypted with the previous key generation (sent before the last rotation)",
+                           log: log, type: .info)
+                    writeBreadcrumb(stage: "decrypt_previous_generation")
+                }
+                return decrypted
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? NSError(domain: "NSE", code: -2,
+                                   userInfo: [NSLocalizedDescriptionKey: "No key candidates"])
+    }
+
     private func decryptAESGCM(data: Data, keyData: Data) throws -> Data {
         guard data.count >= NotificationService.NONCE_SIZE + NotificationService.TAG_SIZE else {
             throw NSError(domain: "NSE", code: -1,
@@ -373,7 +401,19 @@ class NotificationService: UNNotificationServiceExtension {
 
     // MARK: - Keychain
 
-    private func retrieveSymmetricKey() -> Data? {
+    /// Current key first, then the previous generation when one exists.
+    private func retrieveSymmetricKeyCandidates() -> [Data] {
+        var candidates: [Data] = []
+        if let current = retrieveSymmetricKey(account: NotificationService.KEYCHAIN_ACCOUNT) {
+            candidates.append(current)
+        }
+        if let previous = retrieveSymmetricKey(account: NotificationService.KEYCHAIN_ACCOUNT_PREVIOUS, logMissing: false) {
+            candidates.append(previous)
+        }
+        return candidates
+    }
+
+    private func retrieveSymmetricKey(account: String, logMissing: Bool = true) -> Data? {
         // Note: kSecAttrAccessible is intentionally NOT included in the search query.
         // It is a storage attribute, not a search filter. Including it causes
         // SecItemCopyMatching to silently return errSecItemNotFound if there is
@@ -383,7 +423,7 @@ class NotificationService: UNNotificationServiceExtension {
         // than the main app. Without it, the NSE searches its own group and finds nothing.
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: NotificationService.KEYCHAIN_ACCOUNT,
+            kSecAttrAccount as String: account,
             kSecAttrService as String: NotificationService.KEYCHAIN_SERVICE,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
@@ -398,7 +438,9 @@ class NotificationService: UNNotificationServiceExtension {
         if status == errSecSuccess, let data = result as? Data {
             return data
         }
-        os_log("NSE: SecItemCopyMatching returned status %{public}d", log: log, type: .error, status)
+        if logMissing {
+            os_log("NSE: SecItemCopyMatching returned status %{public}d", log: log, type: .error, status)
+        }
         return nil
     }
 }

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.swift
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.swift
@@ -6,6 +6,11 @@ public class PushNotificationKeyStore: NSObject {
     private static let KEY_SIZE = 32 // AES-256
     private static let SERVICE_NAME = "network.bisq.mobile"
     private static let KEY_ACCOUNT = "push_notification_symmetric_key"
+    // The key generation the last rotation displaced. The NSE tries it after the current key:
+    // a push encrypted just before a rotation (or queued by APNs while the app was closed)
+    // is otherwise undecryptable the moment the app re-registers. One generation of skew is
+    // the deliberate window; mirrors the Android SharedPrefsKeyStore's previous slot.
+    static let KEY_ACCOUNT_PREVIOUS = "push_notification_symmetric_key_previous"
 
     // Keychain access group shared between main app and NSE.
     // Must be explicitly specified in queries so that both the main app process and
@@ -42,14 +47,19 @@ public class PushNotificationKeyStore: NSObject {
         }
     }
 
-    /// Rotates the symmetric key: deletes the old key and generates a fresh one.
-    /// Called on each device re-registration to limit the exposure window if a key
-    /// is ever compromised. Returns the new key as Base64.
+    /// Rotates the symmetric key: the displaced key moves to the previous slot (see
+    /// KEY_ACCOUNT_PREVIOUS) before a fresh one is generated and stored. Called on each
+    /// device re-registration to limit the exposure window if a key is ever compromised.
+    /// Returns the new key as Base64.
     @objc public func rotateKeyBase64WithError(_ error: NSErrorPointer) -> String? {
         do {
-            deleteKey()
+            if let displaced = PushNotificationKeyStore.retrieveKeyData() {
+                deleteKey(account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
+                try storeKey(displaced, account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
+            }
+            deleteKey(account: PushNotificationKeyStore.KEY_ACCOUNT)
             let keyData = try generateKey()
-            try storeKey(keyData)
+            try storeKey(keyData, account: PushNotificationKeyStore.KEY_ACCOUNT)
             return keyData.base64EncodedString()
         } catch let keyError as NSError {
             error?.pointee = keyError
@@ -59,10 +69,10 @@ public class PushNotificationKeyStore: NSObject {
 
     // MARK: - Internal (also used by NSE via direct Keychain read)
 
-    static func retrieveKeyData() -> Data? {
+    static func retrieveKeyData(account: String = KEY_ACCOUNT) -> Data? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: KEY_ACCOUNT,
+            kSecAttrAccount as String: account,
             kSecAttrService as String: SERVICE_NAME,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
@@ -113,10 +123,10 @@ public class PushNotificationKeyStore: NSObject {
         return keyData
     }
 
-    private func storeKey(_ keyData: Data) throws {
+    private func storeKey(_ keyData: Data, account: String = PushNotificationKeyStore.KEY_ACCOUNT) throws {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: PushNotificationKeyStore.KEY_ACCOUNT,
+            kSecAttrAccount as String: account,
             kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
             kSecValueData as String: keyData,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -132,10 +142,10 @@ public class PushNotificationKeyStore: NSObject {
         }
     }
 
-    private func deleteKey() {
+    private func deleteKey(account: String = PushNotificationKeyStore.KEY_ACCOUNT) {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: PushNotificationKeyStore.KEY_ACCOUNT,
+            kSecAttrAccount as String: account,
             kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
         ]
         if let group = PushNotificationKeyStore.ACCESS_GROUP {

--- a/iosClient/iosClient/interop/PushNotificationKeyStore.swift
+++ b/iosClient/iosClient/interop/PushNotificationKeyStore.swift
@@ -51,19 +51,55 @@ public class PushNotificationKeyStore: NSObject {
     /// KEY_ACCOUNT_PREVIOUS) before a fresh one is generated and stored. Called on each
     /// device re-registration to limit the exposure window if a key is ever compromised.
     /// Returns the new key as Base64.
+    ///
+    /// Every step is verified: deletes must succeed (or find nothing), and each store is read
+    /// back and compared before the key is returned. Without the read-back, a silently failed
+    /// delete followed by SecItemAdd's errSecDuplicateItem would report success while the
+    /// Keychain still holds the OLD key — the registration would then hand the node a key this
+    /// device cannot decrypt with, which is precisely the divergence this rotation must never
+    /// create.
     @objc public func rotateKeyBase64WithError(_ error: NSErrorPointer) -> String? {
         do {
             if let displaced = PushNotificationKeyStore.retrieveKeyData() {
-                deleteKey(account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
-                try storeKey(displaced, account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
+                try deleteKeyChecked(account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
+                try storeKeyChecked(displaced, account: PushNotificationKeyStore.KEY_ACCOUNT_PREVIOUS)
             }
-            deleteKey(account: PushNotificationKeyStore.KEY_ACCOUNT)
+            try deleteKeyChecked(account: PushNotificationKeyStore.KEY_ACCOUNT)
             let keyData = try generateKey()
-            try storeKey(keyData, account: PushNotificationKeyStore.KEY_ACCOUNT)
+            try storeKeyChecked(keyData, account: PushNotificationKeyStore.KEY_ACCOUNT)
             return keyData.base64EncodedString()
         } catch let keyError as NSError {
             error?.pointee = keyError
             return nil
+        }
+    }
+
+    /// Stores and then reads back, throwing when the Keychain does not hold exactly [keyData]
+    /// afterwards — this is what turns a duplicate-item "success" over a stale value into a
+    /// visible failure.
+    private func storeKeyChecked(_ keyData: Data, account: String) throws {
+        try storeKey(keyData, account: account)
+        guard PushNotificationKeyStore.retrieveKeyData(account: account) == keyData else {
+            throw NSError(domain: "PushNotificationKeyStore", code: -10,
+                          userInfo: [NSLocalizedDescriptionKey: "Stored key read-back mismatch for account \(account)"])
+        }
+    }
+
+    /// Deletes, accepting only success or item-not-found; any other status would leave a stale
+    /// item behind that the following SecItemAdd could silently collide with.
+    private func deleteKeyChecked(account: String) throws {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
+        ]
+        if let group = PushNotificationKeyStore.ACCESS_GROUP {
+            query[kSecAttrAccessGroup as String] = group
+        }
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw NSError(domain: "PushNotificationKeyStore", code: Int(status),
+                          userInfo: [NSLocalizedDescriptionKey: "Failed to delete key for account \(account): \(status)"])
         }
     }
 
@@ -142,15 +178,4 @@ public class PushNotificationKeyStore: NSObject {
         }
     }
 
-    private func deleteKey(account: String = PushNotificationKeyStore.KEY_ACCOUNT) {
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: account,
-            kSecAttrService as String: PushNotificationKeyStore.SERVICE_NAME,
-        ]
-        if let group = PushNotificationKeyStore.ACCESS_GROUP {
-            query[kSecAttrAccessGroup as String] = group
-        }
-        SecItemDelete(query as CFDictionary)
-    }
 }

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
@@ -3,6 +3,7 @@ package network.bisq.mobile.data.crypto
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CancellationException
 import network.bisq.mobile.data.utils.AndroidAppContext
 import network.bisq.mobile.domain.utils.getLogger
 import java.security.SecureRandom
@@ -72,6 +73,7 @@ actual fun getOrCreatePushNotificationKeyBase64(): String? =
         store.put(base64)
         base64
     }.onFailure {
+        if (it is CancellationException) throw it
         // Callers only see a null and abort registration, so without this the reason
         // (Keystore refusal, failed commit) never reaches the logs. The exceptions carry
         // no key material, so they are safe to log in full.
@@ -90,6 +92,7 @@ fun readPushNotificationKeyBase64(): String? =
     runCatching {
         pushNotificationKeyStoreFactory().get()
     }.onFailure {
+        if (it is CancellationException) throw it
         // Distinguishes "never registered" from "the Keystore blew up" in the field, which
         // the messaging service cannot tell apart once this returns null.
         log.e(it) { "Failed to read the push notification key; treating it as absent" }
@@ -99,14 +102,34 @@ fun readPushNotificationKeyBase64(): String? =
  * The decryption candidates for `BisqFirebaseMessagingService`, current key first, then the
  * previous generation when one exists. Trying both is what keeps a push encrypted before a
  * rotation — and delivered after it — decryptable; see [PushNotificationKeyStore.getPrevious].
+ *
+ * The two slots are read INDEPENDENTLY: the previous blob is moved as-is on rotation, so a
+ * Keystore whose wrapping key was regenerated mid-rotation can leave it permanently
+ * un-unwrappable while the current key stays perfectly valid. One shared failure scope would
+ * let that poisoned previous slot take the current key down with it — dropping every push the
+ * valid key could decrypt, a strictly worse outage than the skew loss this window exists to fix.
  */
-fun readPushNotificationKeyCandidatesBase64(): List<String> =
-    runCatching {
-        val store = pushNotificationKeyStoreFactory()
-        listOfNotNull(store.get(), store.getPrevious())
-    }.onFailure {
-        log.e(it) { "Failed to read the push notification key candidates; treating them as absent" }
-    }.getOrDefault(emptyList())
+fun readPushNotificationKeyCandidatesBase64(): List<String> {
+    val store =
+        runCatching { pushNotificationKeyStoreFactory() }
+            .onFailure {
+                if (it is CancellationException) throw it
+                log.e(it) { "Failed to create the push notification key store; treating keys as absent" }
+            }.getOrNull() ?: return emptyList()
+    val current =
+        runCatching { store.get() }
+            .onFailure {
+                if (it is CancellationException) throw it
+                log.e(it) { "Failed to read the current push notification key; treating it as absent" }
+            }.getOrNull()
+    val previous =
+        runCatching { store.getPrevious() }
+            .onFailure {
+                if (it is CancellationException) throw it
+                log.e(it) { "Failed to read the previous push notification key; continuing with the current one" }
+            }.getOrNull()
+    return listOfNotNull(current, previous)
+}
 
 /**
  * Wraps bytes with a non-exportable key so the result can live in plain storage.

--- a/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
+++ b/shared/domain/src/androidMain/kotlin/network/bisq/mobile/data/crypto/PushNotificationKey.android.kt
@@ -14,6 +14,7 @@ private val log = getLogger("PushNotificationKey")
 private const val KEY_SIZE_BYTES = 32 // AES-256
 private const val PREFS_FILE = "bisq_push_notification_key"
 private const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
+private const val PREF_KEY_WRAPPED_PREVIOUS = "wrapped_symmetric_key_previous_base64"
 private const val WRAPPING_KEY_ALIAS = "network.bisq.mobile.push_notification_key_wrapper"
 
 /**
@@ -26,6 +27,14 @@ interface PushNotificationKeyStore {
     fun put(base64: String)
 
     fun get(): String?
+
+    /**
+     * The key generation that [put] displaced, or null when there has been at most one.
+     * Decryption tries it after the current key: a push encrypted just before a rotation
+     * (or queued by FCM/APNs while the app was closed) is otherwise undecryptable the moment
+     * the app re-registers. One generation of skew is the deliberate window.
+     */
+    fun getPrevious(): String? = null
 }
 
 /**
@@ -87,6 +96,19 @@ fun readPushNotificationKeyBase64(): String? =
     }.getOrNull()
 
 /**
+ * The decryption candidates for `BisqFirebaseMessagingService`, current key first, then the
+ * previous generation when one exists. Trying both is what keeps a push encrypted before a
+ * rotation — and delivered after it — decryptable; see [PushNotificationKeyStore.getPrevious].
+ */
+fun readPushNotificationKeyCandidatesBase64(): List<String> =
+    runCatching {
+        val store = pushNotificationKeyStoreFactory()
+        listOfNotNull(store.get(), store.getPrevious())
+    }.onFailure {
+        log.e(it) { "Failed to read the push notification key candidates; treating them as absent" }
+    }.getOrDefault(emptyList())
+
+/**
  * Wraps bytes with a non-exportable key so the result can live in plain storage.
  * Production goes through the Android Keystore; unit tests substitute a trivial
  * transform because Robolectric cannot emulate `AndroidKeyStore`.
@@ -133,18 +155,36 @@ internal class SharedPrefsKeyStore(
     @OptIn(ExperimentalEncodingApi::class)
     override fun put(base64: String) {
         val wrapped = Base64.encode(wrapper.wrap(base64.toByteArray(Charsets.UTF_8)))
+        // The displaced key moves to the previous slot AS ITS WRAPPED BLOB — no unwrap/rewrap
+        // round trip through the Keystore, and the move rides the same atomic commit as the
+        // new key so the two slots can never describe three generations.
+        val displaced = prefs.getString(PREF_KEY_WRAPPED, null)
         // commit() (synchronous) rather than apply() (async): the symmetric
         // key is registered with the trusted node immediately after this
         // returns. If apply() were used and the process died before the
         // write hit disk, the server and device would diverge on the key
         // and decryption would silently fail.
-        val ok = prefs.edit().putString(PREF_KEY_WRAPPED, wrapped).commit()
+        val ok =
+            prefs
+                .edit()
+                .apply {
+                    if (displaced != null) {
+                        putString(PREF_KEY_WRAPPED_PREVIOUS, displaced)
+                    }
+                    putString(PREF_KEY_WRAPPED, wrapped)
+                }.commit()
         check(ok) { "Failed to persist push notification symmetric key" }
     }
 
     @OptIn(ExperimentalEncodingApi::class)
-    override fun get(): String? {
-        val wrapped = prefs.getString(PREF_KEY_WRAPPED, null) ?: return null
+    override fun get(): String? = unwrapPref(PREF_KEY_WRAPPED)
+
+    @OptIn(ExperimentalEncodingApi::class)
+    override fun getPrevious(): String? = unwrapPref(PREF_KEY_WRAPPED_PREVIOUS)
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun unwrapPref(prefKey: String): String? {
+        val wrapped = prefs.getString(prefKey, null) ?: return null
         return wrapper.unwrap(Base64.decode(wrapped)).toString(Charsets.UTF_8)
     }
 }

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
@@ -118,6 +118,20 @@ class PushNotificationKeyAndroidTest {
         assertTrue(readPushNotificationKeyCandidatesBase64().isEmpty())
     }
 
+    /**
+     * The previous blob is moved as-is on rotation, so a Keystore whose wrapping key was
+     * regenerated mid-rotation can leave it permanently un-unwrappable while the current key
+     * stays valid. The reads are isolated precisely so that a poisoned previous slot cannot
+     * take the current key down with it — that would drop every push the valid key could
+     * decrypt, a worse outage than the skew loss the two-key window exists to fix.
+     */
+    @Test
+    fun `a corrupt previous slot does not take the current key down with it`() {
+        pushNotificationKeyStoreFactory = { CorruptPreviousKeyStore("current-key") }
+
+        assertEquals(listOf("current-key"), readPushNotificationKeyCandidatesBase64())
+    }
+
     private class InMemoryKeyStore : PushNotificationKeyStore {
         private var stored: String? = null
         private var previous: String? = null
@@ -130,6 +144,16 @@ class PushNotificationKeyAndroidTest {
         override fun get(): String? = stored
 
         override fun getPrevious(): String? = previous
+    }
+
+    private class CorruptPreviousKeyStore(
+        private val current: String,
+    ) : PushNotificationKeyStore {
+        override fun put(base64: String) = Unit
+
+        override fun get(): String = current
+
+        override fun getPrevious(): String = throw IllegalStateException("AEADBadTagException: previous blob wrapped under a defunct Keystore key")
     }
 
     private class ThrowingKeyStore : PushNotificationKeyStore {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/PushNotificationKeyAndroidTest.kt
@@ -96,14 +96,40 @@ class PushNotificationKeyAndroidTest {
         assertNull(read)
     }
 
+    @Test
+    fun `candidates list the current key first and the displaced generation second`() {
+        val first = getOrCreatePushNotificationKeyBase64()
+        val second = getOrCreatePushNotificationKeyBase64()
+
+        assertEquals(listOf(second, first), readPushNotificationKeyCandidatesBase64())
+    }
+
+    @Test
+    fun `candidates hold only the current key before any rotation`() {
+        val only = getOrCreatePushNotificationKeyBase64()
+
+        assertEquals(listOf(only), readPushNotificationKeyCandidatesBase64())
+    }
+
+    @Test
+    fun `candidates are empty when the underlying store throws`() {
+        pushNotificationKeyStoreFactory = { ThrowingKeyStore() }
+
+        assertTrue(readPushNotificationKeyCandidatesBase64().isEmpty())
+    }
+
     private class InMemoryKeyStore : PushNotificationKeyStore {
         private var stored: String? = null
+        private var previous: String? = null
 
         override fun put(base64: String) {
+            previous = stored
             stored = base64
         }
 
         override fun get(): String? = stored
+
+        override fun getPrevious(): String? = previous
     }
 
     private class ThrowingKeyStore : PushNotificationKeyStore {

--- a/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/SharedPrefsKeyStoreTest.kt
+++ b/shared/domain/src/androidUnitTest/kotlin/network/bisq/mobile/data/crypto/SharedPrefsKeyStoreTest.kt
@@ -11,6 +11,7 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -28,6 +29,8 @@ class SharedPrefsKeyStoreTest {
         const val PREFS_FILE = "bisq_push_notification_key"
         const val PREF_KEY_WRAPPED = "wrapped_symmetric_key_base64"
         const val KEY = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+        const val KEY2 = "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8="
+        const val KEY3 = "QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl8="
     }
 
     private val context: Context get() = RuntimeEnvironment.getApplication()
@@ -52,6 +55,55 @@ class SharedPrefsKeyStoreTest {
         store.put(KEY)
 
         assertEquals(KEY, store.get())
+    }
+
+    @Test
+    fun `there is no previous generation before the first rotation`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+
+        store.put(KEY)
+
+        assertNull(store.getPrevious())
+    }
+
+    /**
+     * The displaced key must stay readable for one generation: a push encrypted just before a
+     * rotation (or queued by FCM while the app was closed) arrives under it, and dropping it on
+     * rotation is exactly the notification loss the two-key window exists to prevent.
+     */
+    @Test
+    fun `rotation keeps the displaced key readable as the previous generation`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+
+        store.put(KEY)
+        store.put(KEY2)
+
+        assertEquals(KEY2, store.get())
+        assertEquals(KEY, store.getPrevious())
+    }
+
+    @Test
+    fun `a second rotation shifts the one-generation window`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+
+        store.put(KEY)
+        store.put(KEY2)
+        store.put(KEY3)
+
+        assertEquals(KEY3, store.get())
+        assertEquals(KEY2, store.getPrevious())
+    }
+
+    @Test
+    fun `the previous generation is never written in plaintext`() {
+        val store = SharedPrefsKeyStore(context, XorWrapper)
+
+        store.put(KEY)
+        store.put(KEY2)
+
+        val allValues = prefs.all.values.joinToString()
+        assertFalse(allValues.contains(KEY), "displaced key must stay wrapped at rest")
+        assertFalse(allValues.contains(KEY2), "current key must stay wrapped at rest")
     }
 
     @Test


### PR DESCRIPTION
 - resolves #1835
 - avoided immediately discarding previous relay push notifications key pair when a new one is registered, to be able to decrypt messages sent using the previous related public key. Implementation provided for both android and ios + tests
 - cleanup bisq2 side still needed (trusted node), created separate issue for it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Push notifications now remain decryptable across one symmetric-key rotation on Android and iOS.
  - The app retains the previous notification key temporarily to support messages sent during key transitions.

- **Security Improvements**
  - Sensitive request-body values, including device tokens, symmetric keys, and session identifiers, are now redacted from diagnostic logs.
  - Malformed payloads containing sensitive fields are handled conservatively to prevent accidental exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->