### PR TITLE
Release/connect 0.9.0

### DIFF
--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.9.0'
+    spec.version                  = '0.9.1'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/apps/clientApp/clientApp.podspec
+++ b/apps/clientApp/clientApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'clientApp'
-    spec.version                  = '0.8.3'
+    spec.version                  = '0.9.0'
     spec.homepage                 = 'X'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,13 +37,13 @@ node.name=Bisq Easy
 node.android.version=0.13.1
 
 client.name=Bisq Connect
-client.android.version=0.9.0
-client.ios.version=0.9.0
+client.android.version=0.9.1
+client.ios.version=0.9.1
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=51
-client.android.version.code=33
+client.ios.version.code=52
+client.android.version.code=34
 node.android.version.code=51
 
 # Logging

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,19 +31,19 @@ android.enableR8.fullMode=true
 android.enableJetifier=false
 
 # Versioning
-shared.version=0.20.1
+shared.version=0.30.0
 
 node.name=Bisq Easy
 node.android.version=0.13.1
 
 client.name=Bisq Connect
-client.android.version=0.8.3
-client.ios.version=0.8.3
+client.android.version=0.9.0
+client.ios.version=0.9.0
 
 # Release
 ## Bump up after uploading to store for each build, and same with versioning above
-client.ios.version.code=50
-client.android.version.code=32
+client.ios.version.code=51
+client.android.version.code=33
 node.android.version.code=51
 
 # Logging

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,10 +15,10 @@ bisq-api = "2.1.12"
 # nodeApp embeds). Scheme: <bisq2-api>.<umbrel-build>[-rcN].
 # Bump the 4th part for Umbrel-app changes on the same api version; reset to .1 when bisq-api bumps.
 # Editing this line on main triggers the "Release Umbrel images" workflow to build + push.
-umbrel-image-version = "2.1.12.0"
+umbrel-image-version = "2.1.12.1"
 # Update this commit hash when bisq2 to mark the exact commit recommended for power-user's usage
 # This is helpful for keeping track of
-bisq-api-commit = "a1f8db129d2a1a473d249ff19120f701c1a3be58"
+bisq-api-commit = "fb9849bd5dd83174d11806e8d404141464d4911e"
 
 # -------------------- Kotlin & JetBrains --------------------
 kotlin = "2.4.0"

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.8.3
-APP_VERSION_CODE=50
+APP_VERSION=0.9.0
+APP_VERSION_CODE=51

--- a/iosClient/Configuration/Config.xcconfig
+++ b/iosClient/Configuration/Config.xcconfig
@@ -3,5 +3,5 @@ BUNDLE_ID=network.bisq.mobile.ios
 APP_NAME=Bisq Connect
 
 // Version - synced from gradle.properties by Gradle task :apps:clientApp:syncIosVersion
-APP_VERSION=0.9.0
-APP_VERSION_CODE=51
+APP_VERSION=0.9.1
+APP_VERSION_CODE=52

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.9.0):
+  - clientApp (0.9.1):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 57af0e4db714eef7382d666fb9ee16cdd359a849
+  clientApp: 6ae504946ce0012daea226d70cfaac6f6743db69
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: 8d93920cde8ce2552d1843a5bf3d9bc57f80d1b2

--- a/iosClient/Podfile.lock
+++ b/iosClient/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.8.3):
+  - clientApp (0.9.0):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: a63c8c5343d69d0402e95e503d6974046a090447
+  clientApp: 57af0e4db714eef7382d666fb9ee16cdd359a849
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: 8d93920cde8ce2552d1843a5bf3d9bc57f80d1b2

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Local Podspecs/clientApp.podspec.json
+++ b/iosClient/Pods/Local Podspecs/clientApp.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "clientApp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "X",
   "source": {
     "http": ""

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.9.0):
+  - clientApp (0.9.1):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: 57af0e4db714eef7382d666fb9ee16cdd359a849
+  clientApp: 6ae504946ce0012daea226d70cfaac6f6743db69
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: 8d93920cde8ce2552d1843a5bf3d9bc57f80d1b2

--- a/iosClient/Pods/Manifest.lock
+++ b/iosClient/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - clientApp (0.8.3):
+  - clientApp (0.9.0):
     - Sentry (= 8.58.2)
   - Sentry (8.58.2):
     - Sentry/Core (= 8.58.2)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../apps/clientApp"
 
 SPEC CHECKSUMS:
-  clientApp: a63c8c5343d69d0402e95e503d6974046a090447
+  clientApp: 57af0e4db714eef7382d666fb9ee16cdd359a849
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
 
 PODFILE CHECKSUM: 8d93920cde8ce2552d1843a5bf3d9bc57f80d1b2

--- a/shared/domain/domain.podspec
+++ b/shared/domain/domain.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'domain'
-    spec.version                  = '0.20.1'
+    spec.version                  = '0.30.0'
     spec.homepage                 = 'https://github.com/bisq-network/bisq-mobile'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/shared/presentation/presentation.podspec
+++ b/shared/presentation/presentation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'presentation'
-    spec.version                  = '0.20.1'
+    spec.version                  = '0.30.0'
     spec.homepage                 = 'https://github.com/bisq-network/bisq-mobile'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/peer_profile/PeerProfileOffersSectionUiTest.kt
+++ b/shared/presentation/src/androidUnitTest/kotlin/network/bisq/mobile/presentation/peer_profile/PeerProfileOffersSectionUiTest.kt
@@ -117,6 +117,29 @@ class PeerProfileOffersSectionUiTest : BisqComposeUiTestBase() {
 
     private fun contactHeader() = "mobile.peerProfile.offers.sectionTitleContactOnly".i18n("Alice")
 
+    /**
+     * Regression: the section must live INSIDE the profile body's scrollable column — a sibling
+     * placed after it renders as a fixed block below the scroll area, without the body's
+     * horizontal padding. `assertIsDisplayed` alone cannot catch that (a fixed block still
+     * displays); the ancestor-with-scroll assertion pins the structure.
+     */
+    @Test
+    fun `the section renders inside the scrollable profile body`() {
+        render(stateWithOffers(hasTradedBefore = true))
+
+        composeTestRule
+            .onNode(
+                androidx.compose.ui.test
+                    .hasText(tradedHeader())
+                    .and(
+                        androidx.compose.ui.test.hasAnyAncestor(
+                            androidx.compose.ui.test
+                                .hasScrollAction(),
+                        ),
+                    ),
+            ).assertExists()
+    }
+
     @Test
     fun `a traded peer gets the Trade again header with the offer count`() {
         render(stateWithOffers(hasTradedBefore = true))

--- a/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/peer_profile/PeerProfileScreen.kt
+++ b/shared/presentation/src/commonMain/kotlin/network/bisq/mobile/presentation/peer_profile/PeerProfileScreen.kt
@@ -309,7 +309,6 @@ private fun PeerProfileBody(
                 onEditClick = { onAction(PeerProfileUiAction.OnEditContactDetailsClick) },
             )
         }
-
         // TODO putting it last for now, we should consider this first but the action buttons need a redesign
         // like vertical icon based buttons right after the reputation
         if (uiState.showPeerOffersSection) {


### PR DESCRIPTION
- contribs to #1843 
- bugfix: trade again section is fixed at the bottom, wrong horizontal padding and out of the scrollable scope
- releases dockerized bisq2-api version `2.1.12.1`
- updated metadata and bump up versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated iOS and Android client releases to version 0.9.1.
  - Updated shared components to version 0.30.0.
  - Incremented mobile build numbers for the new client release.
  - Updated the macOS/iOS package release metadata to match version 0.9.1.

- **Tests**
  - Added coverage confirming that offers appear within the scrollable peer profile content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->