### PR TITLE
feat(kscan): replace ML Kit with zxing-cpp on Android

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ android-minSdk = "24"
 # TODO analyse lowering back to API 31 when Bisq2 full J17 support is returned and we can get rid of desugaring
 android-node-minSdk = "33"
 desugar_jdk_libs = "2.1.5"
-android-mlkit-barcode-scanning = "17.3.0"
+zxing-cpp = "3.1.1"
 firebase-bom = "33.7.0"
 google-services-plugin = "4.4.2"
 kotlinx-coroutines-play-services = "1.10.2"
@@ -152,7 +152,7 @@ androidx-datastore-okio = { module = "androidx.datastore:datastore-core-okio", v
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
-android-mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "android-mlkit-barcode-scanning" }
+zxing-cpp-android = { module = "io.github.zxing-cpp:android", version.ref = "zxing-cpp" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines-play-services" }

--- a/shared/kscan/README.md
+++ b/shared/kscan/README.md
@@ -8,3 +8,10 @@ Based on:
 
 - Commit: [754b88e8bf](https://github.com/ismai117/KScan/commit/754b88e8bf3841d608308d5bc3f97b7e208cea65)
 - Release tag: [0.9.2](https://github.com/ismai117/KScan/releases/tag/0.9.2)
+
+Differences from upstream:
+
+- Android decodes with [zxing-cpp](https://github.com/zxing-cpp/zxing-cpp) instead of ML Kit, so
+  every dependency is open source and no Google Play Services libraries are pulled in.
+- ML Kit's auto-zoom suggestions are removed. Zoom is manual only via `ScannerController` or the
+  built-in zoom controls.

--- a/shared/kscan/build.gradle.kts
+++ b/shared/kscan/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
 
     sourceSets {
         androidMain.dependencies {
-            implementation(libs.android.mlkit.barcode.scanning)
+            implementation(libs.zxing.cpp.android)
             implementation(libs.bundles.camera)
         }
         commonMain.dependencies {
@@ -30,6 +30,10 @@ kotlin {
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
             implementation(libs.compose.material.icons.extended)
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.kotlin.test.junit)
+            implementation(libs.junit)
         }
     }
 }

--- a/shared/kscan/consumer-rules.pro
+++ b/shared/kscan/consumer-rules.pro
@@ -1,11 +1,8 @@
 # Consumer ProGuard rules for the KScan library
 # Packaged with the AAR and applied by consuming apps in release builds.
 
-# ML Kit vision barcode (keep internals referenced via reflection)
--keep class com.google.mlkit.** { *; }
--keep class com.google.android.gms.internal.mlkit_vision_barcode** { *; }
--dontwarn com.google.mlkit.**
--dontwarn com.google.android.gms.internal.mlkit_vision_barcode**
+# zxing-cpp ships its own keep rules for the classes its JNI layer reads, so
+# only CameraX needs naming here.
 
 # CameraX core and interop
 -keep class androidx.camera.** { *; }
@@ -13,4 +10,3 @@
 
 # Prevent obfuscation of KScan public API to keep binary compatibility
 -keep class org.ncgroup.kscan.** { *; }
-

--- a/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
+++ b/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.Executor
  * A barcode must be detected twice before it is reported, to filter out misreads.
  */
 class BarcodeAnalyzer(
-    codeTypes: List<BarcodeFormat>,
+    private val codeTypes: List<BarcodeFormat>,
     private val callbackExecutor: Executor,
     private val onSuccess: (List<Barcode>) -> Unit,
     private val onFailed: (Exception) -> Unit,
@@ -60,7 +60,8 @@ class BarcodeAnalyzer(
                 return
             }
 
-        val relevantResults = results.filter { BarcodeFormatMapper.isKnownFormat(it.format) }
+        val relevantResults =
+            results.filter { BarcodeFormatMapper.isRequested(BarcodeFormatMapper.toAppFormat(it.format), codeTypes) }
         if (relevantResults.isNotEmpty()) {
             callbackExecutor.execute { if (!closed) processFoundBarcodes(relevantResults) }
         }
@@ -82,7 +83,7 @@ class BarcodeAnalyzer(
                         rawBytes = rawBytes,
                     )
 
-                if (!filter(barcode)) return
+                if (!filter(barcode)) continue
 
                 hasSuccessfullyProcessedBarcode = true
                 barcodesDetected.clear()

--- a/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
+++ b/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
@@ -1,198 +1,102 @@
 package org.ncgroup.kscan
 
-import androidx.annotation.OptIn
-import androidx.camera.core.Camera
-import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.ZoomSuggestionOptions
-import com.google.mlkit.vision.common.InputImage
+import zxingcpp.BarcodeReader
+import java.util.concurrent.Executor
 
 /**
- * Analyzes camera frames for barcodes using ML Kit.
+ * Analyzes camera frames for barcodes using zxing-cpp.
  *
- * Features duplicate filtering (barcode must be detected twice) and auto-zoom suggestions.
+ * zxing-cpp decodes on the calling thread, so this is bound to a background executor and hands
+ * what it finds to [callbackExecutor]. [filter], [onSuccess] and [onFailed] run there, which keeps
+ * them on the main thread and confines the detection state to it.
+ *
+ * A barcode must be detected twice before it is reported, to filter out misreads.
  */
 class BarcodeAnalyzer(
-    private val getCamera: () -> Camera?,
-    private val codeTypes: List<BarcodeFormat>,
+    codeTypes: List<BarcodeFormat>,
+    private val callbackExecutor: Executor,
     private val onSuccess: (List<Barcode>) -> Unit,
     private val onFailed: (Exception) -> Unit,
     private val filter: (Barcode) -> Boolean,
-    private val onCanceled: () -> Unit,
 ) : ImageAnalysis.Analyzer {
-    private val scannerOptions =
-        BarcodeScannerOptions
-            .Builder()
-            .setBarcodeFormats(BarcodeFormatMapper.toMlKitFormats(codeTypes))
-            .setZoomSuggestionOptions(
-                ZoomSuggestionOptions
-                    .Builder { zoomRatio ->
-                        val camera = getCamera()
-                        val maxZoomRatio =
-                            (
-                                camera
-                                    ?.cameraInfo
-                                    ?.zoomState
-                                    ?.value
-                                    ?.maxZoomRatio ?: 1.0f
-                            ).coerceAtMost(5.0f)
-                        if (zoomRatio <= maxZoomRatio) {
-                            camera?.cameraControl?.setZoomRatio(zoomRatio)
-                            true
-                        } else {
-                            false
-                        }
-                    }.setMaxSupportedZoomRatio(5.0f)
-                    .build(),
-            ).build()
+    private val reader =
+        BarcodeReader(
+            BarcodeReader.Options(
+                formats = BarcodeFormatMapper.toZxingFormats(codeTypes),
+                // Retries close most of the gap to ML Kit on awkward frames; decode time is not the bottleneck
+                tryHarder = true,
+                tryRotate = true,
+                tryInvert = true,
+                tryDownscale = true,
+                // Match ML Kit's displayValue: no HRI formatting of the decoded text
+                textMode = BarcodeReader.TextMode.PLAIN,
+            ),
+        )
 
-    private val scanner = BarcodeScanning.getClient(scannerOptions)
+    // Callback-thread state
     private val barcodesDetected = mutableMapOf<String, Int>()
+
+    // Written on the callback thread, read on the analysis thread
+    @Volatile
     private var hasSuccessfullyProcessedBarcode = false
 
-    @OptIn(ExperimentalGetImage::class)
+    // Callbacks are queued, so the caller can leave before one runs
+    @Volatile
+    private var closed = false
+
     override fun analyze(imageProxy: ImageProxy) {
-        if (hasSuccessfullyProcessedBarcode) {
+        if (closed || hasSuccessfullyProcessedBarcode) {
             imageProxy.close()
             return
         }
 
-        val mediaImage =
-            imageProxy.image ?: run {
-                imageProxy.close()
-                return
-            }
-
-        val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
-
-        scanner
-            .process(image)
-            .addOnSuccessListener { barcodes ->
-                val relevantBarcodes = barcodes.filter { isRequestedFormat(it) }
-                if (relevantBarcodes.isNotEmpty()) {
-                    processFoundBarcodes(relevantBarcodes)
-                    imageProxy.close()
-                } else {
-                    // If no barcodes found, try scanning the inverted image
-                    scanInverted(imageProxy)
-                }
-            }.addOnFailureListener {
-                onFailed(it)
-                imageProxy.close()
-            }.addOnCanceledListener {
-                onCanceled()
-                imageProxy.close()
-            }
-    }
-
-    private fun scanInverted(imageProxy: ImageProxy) {
-        val invertedImage =
+        val results =
             try {
-                createInvertedInputImage(imageProxy)
+                imageProxy.use { reader.read(it) }
             } catch (e: Exception) {
-                // Conversion failed, clean up and exit
-                imageProxy.close()
+                callbackExecutor.execute { if (!closed) onFailed(e) }
                 return
             }
 
-        scanner
-            .process(invertedImage)
-            .addOnSuccessListener { barcodes ->
-                val relevantBarcodes = barcodes.filter { isRequestedFormat(it) }
-                if (relevantBarcodes.isNotEmpty()) {
-                    processFoundBarcodes(relevantBarcodes)
-                }
-            }.addOnFailureListener {
-                onFailed(it)
-            }.addOnCanceledListener {
-                onCanceled()
-            }.addOnCompleteListener {
-                // CRITICAL: Always close the proxy after the final attempt
-                imageProxy.close()
-            }
-    }
-
-    @OptIn(ExperimentalGetImage::class)
-    private fun createInvertedInputImage(imageProxy: ImageProxy): InputImage {
-        val mediaImage = imageProxy.image ?: throw IllegalArgumentException("Image is null")
-        require(mediaImage.planes.isNotEmpty()) { "Image has no planes" }
-
-        val width = mediaImage.width
-        val height = mediaImage.height
-        val yPixelCount = width * height
-        val nv21Bytes = ByteArray(yPixelCount * 3 / 2)
-
-        val yPlane = mediaImage.planes[0]
-        val rowStride = yPlane.rowStride
-        require(rowStride >= width) { "Invalid Y rowStride: $rowStride, width: $width" }
-
-        val yBuffer = yPlane.buffer.duplicate()
-        val rowBytes = ByteArray(width)
-
-        // Bulk-read one row at a time, then invert into output (fewer ByteBuffer.get() calls)
-        for (row in 0 until height) {
-            yBuffer.position(row * rowStride)
-            yBuffer.get(rowBytes, 0, width)
-
-            val outBase = row * width
-            for (col in 0 until width) {
-                nv21Bytes[outBase + col] = (rowBytes[col].toInt() xor 0xFF).toByte()
-            }
+        val relevantResults = results.filter { BarcodeFormatMapper.isKnownFormat(it.format) }
+        if (relevantResults.isNotEmpty()) {
+            callbackExecutor.execute { if (!closed) processFoundBarcodes(relevantResults) }
         }
-
-        // Neutral chroma for grayscale in NV21 (VU interleaved)
-        java.util.Arrays.fill(nv21Bytes, yPixelCount, nv21Bytes.size, 128.toByte())
-
-        return InputImage.fromByteArray(
-            nv21Bytes,
-            width,
-            height,
-            imageProxy.imageInfo.rotationDegrees,
-            InputImage.IMAGE_FORMAT_NV21,
-        )
     }
 
-    private fun processFoundBarcodes(mlKitBarcodes: List<com.google.mlkit.vision.barcode.common.Barcode>) {
+    private fun processFoundBarcodes(results: List<BarcodeReader.Result>) {
         if (hasSuccessfullyProcessedBarcode) return
 
-        for (mlKitBarcode in mlKitBarcodes) {
-            val displayValue = mlKitBarcode.displayValue ?: continue
-            val rawBytes = mlKitBarcode.rawBytes ?: displayValue.encodeToByteArray()
+        for (result in results) {
+            val text = result.text ?: continue
+            val rawBytes = result.bytes ?: text.encodeToByteArray()
 
-            barcodesDetected[displayValue] = (barcodesDetected[displayValue] ?: 0) + 1
-            if ((barcodesDetected[displayValue] ?: 0) >= 2) {
-                val appSpecificFormat = BarcodeFormatMapper.toAppFormat(mlKitBarcode.format)
-                val detectedAppBarcode =
+            barcodesDetected[text] = (barcodesDetected[text] ?: 0) + 1
+            if ((barcodesDetected[text] ?: 0) >= REQUIRED_DETECTIONS) {
+                val barcode =
                     Barcode(
-                        data = displayValue,
-                        format = appSpecificFormat.toString(),
+                        data = text,
+                        format = BarcodeFormatMapper.toAppFormat(result.format).toString(),
                         rawBytes = rawBytes,
                     )
 
-                if (!filter(detectedAppBarcode)) return
+                if (!filter(barcode)) return
 
-                onSuccess(listOf(detectedAppBarcode))
-                barcodesDetected.clear()
                 hasSuccessfullyProcessedBarcode = true
-                break
+                barcodesDetected.clear()
+                onSuccess(listOf(barcode))
+                return
             }
         }
     }
 
-    private fun isRequestedFormat(mlKitBarcode: com.google.mlkit.vision.barcode.common.Barcode): Boolean {
-        if (codeTypes.contains(BarcodeFormat.FORMAT_ALL_FORMATS)) {
-            return BarcodeFormatMapper.isKnownFormat(mlKitBarcode.format)
-        }
-        val appFormat = BarcodeFormatMapper.toAppFormat(mlKitBarcode.format)
-        return codeTypes.contains(appFormat)
+    fun close() {
+        closed = true
     }
 
-    fun close() {
-        scanner.close()
-        barcodesDetected.clear()
-        hasSuccessfullyProcessedBarcode = false
+    private companion object {
+        const val REQUIRED_DETECTIONS = 2
     }
 }

--- a/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
+++ b/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
@@ -47,6 +47,20 @@ internal object BarcodeFormatMapper {
     fun isKnownFormat(zxingFormat: Format): Boolean = toAppFormat(zxingFormat) != BarcodeFormat.TYPE_UNKNOWN
 
     /**
+     * Whether a decoded barcode matches what the caller asked for. Requests that map to no
+     * symbology (e.g. only TYPE_* values) match nothing, as with ML Kit.
+     */
+    fun isRequested(
+        appFormat: BarcodeFormat,
+        codeTypes: List<BarcodeFormat>,
+    ): Boolean {
+        if (codeTypes.isEmpty() || codeTypes.contains(BarcodeFormat.FORMAT_ALL_FORMATS)) {
+            return appFormat != BarcodeFormat.TYPE_UNKNOWN
+        }
+        return codeTypes.contains(appFormat)
+    }
+
+    /**
      * zxing-cpp encodes the symbology in the low byte and the variant in the high byte
      * (e.g. QR_CODE_MODEL_2 belongs to the QR_CODE symbology). Variant ' ' (0x20) is the family itself.
      */

--- a/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
+++ b/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
@@ -1,60 +1,59 @@
 package org.ncgroup.kscan
 
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ALL_FORMATS
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_AZTEC
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODABAR
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_128
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_39
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_93
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_DATA_MATRIX
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ITF
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_PDF417
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_QR_CODE
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UNKNOWN
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_A
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_E
+import zxingcpp.BarcodeReader.Format
 
 /**
- * Maps between app [BarcodeFormat] and ML Kit barcode format integers.
+ * Maps between app [BarcodeFormat] and zxing-cpp [Format].
  */
 internal object BarcodeFormatMapper {
-    private val APP_TO_MLKIT_FORMAT_MAP: Map<BarcodeFormat, Int> =
+    private val APP_TO_ZXING_FORMAT_MAP: Map<BarcodeFormat, Format> =
         mapOf(
-            BarcodeFormat.FORMAT_QR_CODE to FORMAT_QR_CODE,
-            BarcodeFormat.FORMAT_CODE_128 to FORMAT_CODE_128,
-            BarcodeFormat.FORMAT_CODE_39 to FORMAT_CODE_39,
-            BarcodeFormat.FORMAT_CODE_93 to FORMAT_CODE_93,
-            BarcodeFormat.FORMAT_CODABAR to FORMAT_CODABAR,
-            BarcodeFormat.FORMAT_DATA_MATRIX to FORMAT_DATA_MATRIX,
-            BarcodeFormat.FORMAT_EAN_13 to FORMAT_EAN_13,
-            BarcodeFormat.FORMAT_EAN_8 to FORMAT_EAN_8,
-            BarcodeFormat.FORMAT_ITF to FORMAT_ITF,
-            BarcodeFormat.FORMAT_UPC_A to FORMAT_UPC_A,
-            BarcodeFormat.FORMAT_UPC_E to FORMAT_UPC_E,
-            BarcodeFormat.FORMAT_PDF417 to FORMAT_PDF417,
-            BarcodeFormat.FORMAT_AZTEC to FORMAT_AZTEC,
+            BarcodeFormat.FORMAT_QR_CODE to Format.QR_CODE,
+            BarcodeFormat.FORMAT_CODE_128 to Format.CODE_128,
+            BarcodeFormat.FORMAT_CODE_39 to Format.CODE_39,
+            BarcodeFormat.FORMAT_CODE_93 to Format.CODE_93,
+            BarcodeFormat.FORMAT_CODABAR to Format.CODABAR,
+            BarcodeFormat.FORMAT_DATA_MATRIX to Format.DATA_MATRIX,
+            BarcodeFormat.FORMAT_EAN_13 to Format.EAN_13,
+            BarcodeFormat.FORMAT_EAN_8 to Format.EAN_8,
+            BarcodeFormat.FORMAT_ITF to Format.ITF,
+            BarcodeFormat.FORMAT_UPC_A to Format.UPC_A,
+            BarcodeFormat.FORMAT_UPC_E to Format.UPC_E,
+            BarcodeFormat.FORMAT_PDF417 to Format.PDF_417,
+            BarcodeFormat.FORMAT_AZTEC to Format.AZTEC,
         )
 
-    private val MLKIT_TO_APP_FORMAT_MAP: Map<Int, BarcodeFormat> =
-        APP_TO_MLKIT_FORMAT_MAP.entries
-            .associateBy({ it.value }) { it.key }
-            .plus(FORMAT_UNKNOWN to BarcodeFormat.TYPE_UNKNOWN)
+    private val ZXING_TO_APP_FORMAT_MAP: Map<Format, BarcodeFormat> =
+        APP_TO_ZXING_FORMAT_MAP.entries.associateBy({ it.value }) { it.key }
 
-    fun toMlKitFormats(appFormats: List<BarcodeFormat>): Int {
+    val allSupportedFormats: Set<Format> = APP_TO_ZXING_FORMAT_MAP.values.toSet()
+
+    /**
+     * Named rather than left empty for "all formats": an empty set asks zxing-cpp for every
+     * symbology it knows, including ones that would only be decoded to be dropped as unknown.
+     */
+    fun toZxingFormats(appFormats: List<BarcodeFormat>): Set<Format> {
         if (appFormats.isEmpty() || appFormats.contains(BarcodeFormat.FORMAT_ALL_FORMATS)) {
-            return FORMAT_ALL_FORMATS
+            return allSupportedFormats
         }
-
-        return appFormats
-            .mapNotNull { APP_TO_MLKIT_FORMAT_MAP[it] }
-            .distinct()
-            .fold(0) { acc, formatInt -> acc or formatInt }
-            .let { if (it == 0) FORMAT_ALL_FORMATS else it }
+        return appFormats.mapNotNull { APP_TO_ZXING_FORMAT_MAP[it] }.toSet()
     }
 
-    fun toAppFormat(mlKitFormat: Int): BarcodeFormat = MLKIT_TO_APP_FORMAT_MAP[mlKitFormat] ?: BarcodeFormat.TYPE_UNKNOWN
+    fun toAppFormat(zxingFormat: Format): BarcodeFormat =
+        ZXING_TO_APP_FORMAT_MAP[zxingFormat]
+            ?: ZXING_TO_APP_FORMAT_MAP[zxingFormat.symbology()]
+            ?: BarcodeFormat.TYPE_UNKNOWN
 
-    fun isKnownFormat(mlKitFormat: Int): Boolean = MLKIT_TO_APP_FORMAT_MAP.containsKey(mlKitFormat)
+    fun isKnownFormat(zxingFormat: Format): Boolean = toAppFormat(zxingFormat) != BarcodeFormat.TYPE_UNKNOWN
+
+    /**
+     * zxing-cpp encodes the symbology in the low byte and the variant in the high byte
+     * (e.g. QR_CODE_MODEL_2 belongs to the QR_CODE symbology). Variant ' ' (0x20) is the family itself.
+     */
+    private fun Format.symbology(): Format? {
+        val familyValue = (value and 0xFF) or SYMBOLOGY_FAMILY_VARIANT
+        return Format.entries.firstOrNull { it.value == familyValue }
+    }
+
+    private const val SYMBOLOGY_FAMILY_VARIANT = 0x2000
 }

--- a/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
+++ b/shared/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import java.util.concurrent.Executors
 
 @Composable
 actual fun ScannerView(
@@ -61,6 +62,9 @@ actual fun ScannerView(
     var camera: Camera? by remember { mutableStateOf(null) }
     var cameraControl: CameraControl? by remember { mutableStateOf(null) }
     var barcodeAnalyzer: BarcodeAnalyzer? by remember { mutableStateOf(null) }
+    // zxing-cpp decodes on the calling thread, so frames are analyzed off the main thread
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor { Thread(it, "kscan-analysis") } }
+    var imageAnalysis: ImageAnalysis? by remember { mutableStateOf(null) }
 
     var torchEnabled by remember { mutableStateOf(false) }
     var zoomRatio by remember { mutableFloatStateOf(1f) }
@@ -138,18 +142,18 @@ actual fun ScannerView(
                                 ).build(),
                         ).setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                         .build()
+                        .also { imageAnalysis = it }
 
                 imageAnalysis.setAnalyzer(
-                    ContextCompat.getMainExecutor(ctx),
+                    analysisExecutor,
                     BarcodeAnalyzer(
-                        getCamera = { camera },
                         codeTypes = codeTypes,
+                        callbackExecutor = ContextCompat.getMainExecutor(ctx),
                         onSuccess = { scannedBarcodes ->
                             updatedResult(BarcodeResult.OnSuccess(scannedBarcodes.first()))
                             provider.unbind(imageAnalysis)
                         },
                         onFailed = { updatedResult(BarcodeResult.OnFailed(Exception(it))) },
-                        onCanceled = { updatedResult(BarcodeResult.OnCanceled) },
                         filter = filter,
                     ).also { barcodeAnalyzer = it },
                 )
@@ -168,6 +172,7 @@ actual fun ScannerView(
                 previewView
             },
             onRelease = {
+                imageAnalysis?.clearAnalyzer()
                 barcodeAnalyzer?.close()
                 barcodeAnalyzer = null
                 provider.unbindAll()
@@ -177,9 +182,13 @@ actual fun ScannerView(
 
     DisposableEffect(Unit) {
         onDispose {
+            // Detach the analyzer before shutting down the executor it runs on
+            imageAnalysis?.clearAnalyzer()
+            imageAnalysis = null
             barcodeAnalyzer?.close()
             barcodeAnalyzer = null
             cameraProvider?.unbindAll()
+            analysisExecutor.shutdown()
             camera = null
             cameraControl = null
         }

--- a/shared/kscan/src/androidUnitTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
+++ b/shared/kscan/src/androidUnitTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
@@ -59,4 +59,27 @@ class BarcodeFormatMapperTest {
         assertTrue(BarcodeFormatMapper.isKnownFormat(Format.QR_CODE_MODEL_1))
         assertFalse(BarcodeFormatMapper.isKnownFormat(Format.DX_FILM_EDGE))
     }
+
+    @Test
+    fun `GIVEN all formats WHEN isRequested THEN accepts any known format`() {
+        assertTrue(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_EAN_13, emptyList()))
+        assertTrue(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_EAN_13, listOf(BarcodeFormat.FORMAT_ALL_FORMATS)))
+        assertFalse(BarcodeFormatMapper.isRequested(BarcodeFormat.TYPE_UNKNOWN, emptyList()))
+    }
+
+    @Test
+    fun `GIVEN specific formats WHEN isRequested THEN accepts only those`() {
+        val requested = listOf(BarcodeFormat.FORMAT_QR_CODE)
+
+        assertTrue(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_QR_CODE, requested))
+        assertFalse(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_EAN_13, requested))
+    }
+
+    @Test
+    fun `GIVEN type-only request WHEN isRequested THEN rejects known symbologies`() {
+        val requested = listOf(BarcodeFormat.TYPE_URL)
+
+        assertFalse(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_QR_CODE, requested))
+        assertFalse(BarcodeFormatMapper.isRequested(BarcodeFormat.FORMAT_EAN_13, requested))
+    }
 }

--- a/shared/kscan/src/androidUnitTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
+++ b/shared/kscan/src/androidUnitTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
@@ -1,0 +1,62 @@
+package org.ncgroup.kscan
+
+import zxingcpp.BarcodeReader.Format
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BarcodeFormatMapperTest {
+    @Test
+    fun `GIVEN empty list WHEN toZxingFormats THEN returns all supported formats`() {
+        assertEquals(BarcodeFormatMapper.allSupportedFormats, BarcodeFormatMapper.toZxingFormats(emptyList()))
+    }
+
+    @Test
+    fun `GIVEN all formats WHEN toZxingFormats THEN returns all supported formats`() {
+        assertEquals(
+            BarcodeFormatMapper.allSupportedFormats,
+            BarcodeFormatMapper.toZxingFormats(listOf(BarcodeFormat.FORMAT_ALL_FORMATS)),
+        )
+    }
+
+    @Test
+    fun `GIVEN multiple formats WHEN toZxingFormats THEN returns zxing formats`() {
+        val result =
+            BarcodeFormatMapper.toZxingFormats(
+                listOf(BarcodeFormat.FORMAT_QR_CODE, BarcodeFormat.FORMAT_EAN_13, BarcodeFormat.TYPE_URL),
+            )
+
+        assertEquals(setOf(Format.QR_CODE, Format.EAN_13), result)
+    }
+
+    @Test
+    fun `GIVEN exact zxing format WHEN toAppFormat THEN returns app format`() {
+        assertEquals(BarcodeFormat.FORMAT_QR_CODE, BarcodeFormatMapper.toAppFormat(Format.QR_CODE))
+        assertEquals(BarcodeFormat.FORMAT_EAN_13, BarcodeFormatMapper.toAppFormat(Format.EAN_13))
+        assertEquals(BarcodeFormat.FORMAT_UPC_A, BarcodeFormatMapper.toAppFormat(Format.UPC_A))
+        assertEquals(BarcodeFormat.FORMAT_PDF417, BarcodeFormatMapper.toAppFormat(Format.PDF_417))
+    }
+
+    @Test
+    fun `GIVEN symbology variant WHEN toAppFormat THEN returns family app format`() {
+        assertEquals(BarcodeFormat.FORMAT_QR_CODE, BarcodeFormatMapper.toAppFormat(Format.QR_CODE_MODEL_2))
+        assertEquals(BarcodeFormat.FORMAT_QR_CODE, BarcodeFormatMapper.toAppFormat(Format.MICRO_QR_CODE))
+        assertEquals(BarcodeFormat.FORMAT_CODE_39, BarcodeFormatMapper.toAppFormat(Format.CODE_39_EXT))
+        assertEquals(BarcodeFormat.FORMAT_ITF, BarcodeFormatMapper.toAppFormat(Format.ITF_14))
+        assertEquals(BarcodeFormat.FORMAT_PDF417, BarcodeFormatMapper.toAppFormat(Format.COMPACT_PDF_417))
+    }
+
+    @Test
+    fun `GIVEN unsupported zxing format WHEN toAppFormat THEN returns unknown`() {
+        assertEquals(BarcodeFormat.TYPE_UNKNOWN, BarcodeFormatMapper.toAppFormat(Format.MAXI_CODE))
+        assertEquals(BarcodeFormat.TYPE_UNKNOWN, BarcodeFormatMapper.toAppFormat(Format.ISBN))
+        assertEquals(BarcodeFormat.TYPE_UNKNOWN, BarcodeFormatMapper.toAppFormat(Format.NONE))
+    }
+
+    @Test
+    fun `GIVEN formats WHEN isKnownFormat THEN reflects mapping`() {
+        assertTrue(BarcodeFormatMapper.isKnownFormat(Format.QR_CODE_MODEL_1))
+        assertFalse(BarcodeFormatMapper.isKnownFormat(Format.DX_FILM_EDGE))
+    }
+}


### PR DESCRIPTION
Progresses toward f-droid release preparations

Replaces mlkit with zxing-cpp on android. Frames are analyzed on a dedicated thread since zxing-cpp decodes synchronously; filter and result callbacks stay on the main thread.

ML Kit's zoom suggestions (auto-zoom) are removed. The manual inverted-frame pass is dropped in favour of tryInvert.

Final apk size reduction is expected. processes QRCodes up to 7 times faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android barcode scanning now uses the open-source ZXing C++ engine instead of Google ML Kit, reducing reliance on Google Play Services.
  * Barcode detection supports ZXing symbologies and format variants.
  * Frame analysis runs on a dedicated background thread for improved responsiveness.
  * Android scanning now uses manual zoom controls; automatic zoom suggestions are no longer available.

* **Tests**
  * Added coverage for barcode format mapping and supported symbologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->